### PR TITLE
Styleguide compliance with respect to integer types.

### DIFF
--- a/geometry/grassmann.hpp
+++ b/geometry/grassmann.hpp
@@ -14,7 +14,7 @@ namespace geometry {
 // space bearing the dimensionality of |Scalar|, i.e., an element of
 // ⋀ⁿ Scalar³. Do not use this type for |rank == 0| (scalars), use the |Scalar|
 // type directly instead.
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 class Multivector;
 
 template<typename Scalar, typename Frame>
@@ -133,84 +133,81 @@ Bivector<quantities::Product<LScalar, RScalar>, Frame> operator*(
     Trivector<LScalar, Frame> const& left,
     Vector<RScalar, Frame> const& right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator+(
     Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator-(
     Multivector<Scalar, Frame, rank> const& right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator+(
     Multivector<Scalar, Frame, rank> const& left,
     Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator-(
     Multivector<Scalar, Frame, rank> const& left,
     Multivector<Scalar, Frame, rank> const& right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator*(
     double const left,
     Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator*(
     Multivector<Scalar, Frame, rank> const& left,
     double const right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank> operator/(
     Multivector<Scalar, Frame, rank> const& left,
     double const right);
 
-template<typename LDimension, typename RScalar, typename Frame,
-         unsigned int rank>
+template<typename LDimension, typename RScalar, typename Frame, int rank>
 Multivector<quantities::Product<quantities::Quantity<LDimension>, RScalar>,
             Frame, rank>
 operator*(quantities::Quantity<LDimension> const& left,
           Multivector<RScalar, Frame, rank> const& right);
 
-template<typename LScalar, typename RDimension, typename Frame,
-         unsigned int rank>
+template<typename LScalar, typename RDimension, typename Frame, int rank>
 Multivector<quantities::Product<LScalar, quantities::Quantity<RDimension>>,
             Frame, rank>
 operator*(Multivector<LScalar, Frame, rank> const& left,
           quantities::Quantity<RDimension> const& right);
 
-template<typename LScalar, typename RDimension, typename Frame,
-         unsigned int rank>
+template<typename LScalar, typename RDimension, typename Frame, int rank>
 Multivector<quantities::Quotient<LScalar, quantities::Quantity<RDimension>>,
             Frame, rank>
 operator/(Multivector<LScalar, Frame, rank> const& left,
           quantities::Quantity<RDimension> const& right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 bool operator==(Multivector<Scalar, Frame, rank> const& left,
                 Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 bool operator!=(Multivector<Scalar, Frame, rank> const& left,
                 Multivector<Scalar, Frame, rank> const& right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank>& operator+=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank>& operator-=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     Multivector<Scalar, Frame, rank> const& right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank>& operator*=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     double const right);
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Multivector<Scalar, Frame, rank>& operator/=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     double const right);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 std::string DebugString(Multivector<Scalar, Frame, rank> const& multivector);
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 std::ostream& operator<<(std::ostream& out,
                          Multivector<Scalar, Frame, rank> const& multivector);
 

--- a/geometry/grassmann_body.hpp
+++ b/geometry/grassmann_body.hpp
@@ -152,19 +152,19 @@ inline Bivector<quantities::Product<LScalar, RScalar>, Frame> operator*(
       left.coordinates() * right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator+(
     Multivector<Scalar, Frame, rank> const& right) {
   return Multivector<Scalar, Frame, rank>(+right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator-(
     Multivector<Scalar, Frame, rank> const& right) {
   return Multivector<Scalar, Frame, rank>(-right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator+(
     Multivector<Scalar, Frame, rank> const& left,
     Multivector<Scalar, Frame, rank> const& right) {
@@ -172,7 +172,7 @@ inline Multivector<Scalar, Frame, rank> operator+(
       left.coordinates() + right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator-(
     Multivector<Scalar, Frame, rank> const& left,
     Multivector<Scalar, Frame, rank> const& right) {
@@ -180,29 +180,28 @@ inline Multivector<Scalar, Frame, rank> operator-(
       left.coordinates() - right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator*(
     double const left,
     Multivector<Scalar, Frame, rank> const& right) {
   return Multivector<Scalar, Frame, rank>(left * right.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator*(
     Multivector<Scalar, Frame, rank> const& left,
     double const right) {
   return Multivector<Scalar, Frame, rank>(left.coordinates() * right);
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank> operator/(
     Multivector<Scalar, Frame, rank> const& left,
     double const right) {
   return Multivector<Scalar, Frame, rank>(left.coordinates() / right);
 }
 
-template<typename LDimension, typename RScalar, typename Frame,
-         unsigned int rank>
+template<typename LDimension, typename RScalar, typename Frame, int rank>
 inline Multivector<
     quantities::Product<quantities::Quantity<LDimension>, RScalar>,
     Frame,
@@ -215,8 +214,7 @@ operator*(quantities::Quantity<LDimension> const& left,
       rank>(left * right.coordinates());
 }
 
-template<typename LScalar, typename RDimension, typename Frame,
-         unsigned int rank>
+template<typename LScalar, typename RDimension, typename Frame, int rank>
 inline Multivector<
     quantities::Product<LScalar, quantities::Quantity<RDimension>>,
     Frame,
@@ -229,8 +227,7 @@ operator*(Multivector<LScalar, Frame, rank> const& left,
       rank>(left.coordinates() * right);
 }
 
-template<typename LScalar, typename RDimension, typename Frame,
-         unsigned int rank>
+template<typename LScalar, typename RDimension, typename Frame, int rank>
 inline Multivector<
     quantities::Quotient<LScalar, quantities::Quantity<RDimension>>,
     Frame,
@@ -243,47 +240,47 @@ operator/(Multivector<LScalar, Frame, rank> const& left,
       rank>(left.coordinates() / right);
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline bool operator==(Multivector<Scalar, Frame, rank> const& left,
                        Multivector<Scalar, Frame, rank> const& right) {
   return left.coordinates() == right.coordinates();
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline bool operator!=(Multivector<Scalar, Frame, rank> const& left,
                        Multivector<Scalar, Frame, rank> const& right) {
   return left.coordinates() != right.coordinates();
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank>& operator+=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     Multivector<Scalar, Frame, rank> const& right) {
   return left = left + right;
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank>& operator-=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     Multivector<Scalar, Frame, rank> const& right) {
   return left = left - right;
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank>& operator*=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     double const right) {
   return left = left * right;
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 inline Multivector<Scalar, Frame, rank>& operator/=(
     Multivector<Scalar, Frame, rank>& left,  // NOLINT(runtime/references)
     double const right) {
   return left = left / right;
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 std::string DebugString(Multivector<Scalar, Frame, rank> const& multivector) {
   // This |using| is required for the |Trivector|, since we need an ambiguity
   // between |geometry::DebugString(R3Element<Scalar> const&)| and
@@ -293,7 +290,7 @@ std::string DebugString(Multivector<Scalar, Frame, rank> const& multivector) {
   return DebugString(multivector.coordinates());
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 std::ostream& operator<<(std::ostream& out,
                          Multivector<Scalar, Frame, rank> const& multivector) {
   out << DebugString(multivector);

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -98,10 +98,10 @@ template<typename D>
 Angle ArcTan(Quantity<D> const& y, Quantity<D> const& x);
 
 std::string DebugString(double const number,
-                        unsigned char const precision = DBL_DIG + 1);
+                        int const precision = DBL_DIG + 1);
 template<typename D>
 std::string DebugString(Quantity<D> const& quantity,
-                        unsigned char const precision = DBL_DIG + 1);
+                        int const precision = DBL_DIG + 1);
 
 template<typename D>
 class Quantity {
@@ -165,7 +165,7 @@ class Quantity {
       Quantity<ArgumentDimensions> const& x);
   friend Angle ArcTan<>(Quantity<D> const& y, Quantity<D> const& x);
 
-  friend std::string DebugString<>(Quantity<D> const&, unsigned char const);
+  friend std::string DebugString<>(Quantity<D> const&, int const);
 };
 
 }  // namespace quantities

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -339,8 +339,7 @@ inline std::string FormatUnit(std::string const& name, int const exponent) {
   }
 }
 
-inline std::string DebugString(double const number,
-                               unsigned char const precision) {
+inline std::string DebugString(double const number, int const precision) {
   char result[50];
 #ifdef _MSC_VER
   unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
@@ -354,8 +353,7 @@ inline std::string DebugString(double const number,
 }
 
 template<typename D>
-std::string DebugString(Quantity<D> const& quantity,
-                        unsigned char const precision) {
+std::string DebugString(Quantity<D> const& quantity, int const precision) {
   return DebugString(quantity.magnitude_, precision) +
       FormatUnit("m", D::Length) + FormatUnit("kg", D::Mass) +
       FormatUnit("s", D::Time) + FormatUnit("A", D::Current) +

--- a/testing_utilities/numerics.hpp
+++ b/testing_utilities/numerics.hpp
@@ -31,7 +31,7 @@ Scalar AbsoluteError(geometry::R3Element<Scalar> const& expected,
                      geometry::R3Element<Scalar> const& actual);
 
 // Uses Multivector.Norm().
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Scalar AbsoluteError(
     geometry::Multivector<Scalar, Frame, rank> const& expected,
     geometry::Multivector<Scalar, Frame, rank> const& actual);
@@ -53,7 +53,7 @@ double RelativeError(geometry::R3Element<Scalar> const& expected,
                      geometry::R3Element<Scalar> const& actual);
 
 // Uses Multivector.Norm().
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 double RelativeError(geometry::Multivector<Scalar, Frame, rank> const& expected,
                      geometry::Multivector<Scalar, Frame, rank> const& actual);
 

--- a/testing_utilities/numerics_body.hpp
+++ b/testing_utilities/numerics_body.hpp
@@ -41,7 +41,7 @@ Scalar AbsoluteError(geometry::R3Element<Scalar> const& expected,
           [](geometry::R3Element<Scalar> const& v) { return v.Norm(); });
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 Scalar AbsoluteError(
     geometry::Multivector<Scalar, Frame, rank> const& expected,
     geometry::Multivector<Scalar, Frame, rank> const& actual) {
@@ -77,7 +77,7 @@ double RelativeError(geometry::R3Element<Scalar> const& expected,
                        [](geometry::R3Element<Scalar> v) { return v.Norm(); });
 }
 
-template<typename Scalar, typename Frame, unsigned int rank>
+template<typename Scalar, typename Frame, int rank>
 double RelativeError(geometry::Multivector<Scalar, Frame, rank> const& expected,
                      geometry::Multivector<Scalar, Frame, rank> const& actual) {
   return RelativeError(


### PR DESCRIPTION
Fix #140.
Changes:
`Multivector` template parameter `unsigned int rank` → `int rank`:

> do not use unsigned types to say a number will never be negative. Instead, use assertions for this.

Formatting function argument `unsigned char const precision` → `int const precision`:

> Of the C integer types, only int should be used. When appropriate, you are welcome to use standard types like size_t and ptrdiff_t.
> We use int very often, for integers we know are not going to be too big, e.g., loop counters. Use plain old int for such things. You should assume that an int is at least 32 bits, but don't assume that it has more than 32 bits. If you need a 64-bit integer type, use int64_t or uint64_t.
