### PR TITLE
Fix constness in Barycentre

### DIFF
--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -58,8 +58,8 @@ class Point {
   friend std::ostream& operator<<(std::ostream& out, Point<V> const& vector);
 
   template<typename V, typename Weight>
-  friend Point<V> Barycentre(std::vector<Point<V>> const& points,
-                             std::vector<Weight> const& weights);
+  friend Point<V> Barycentre(std::vector<Point<V> const> const& points,
+                             std::vector<Weight const> const& weights);
 };
 
 template<typename Vector>
@@ -86,8 +86,8 @@ template<typename Vector>
 std::ostream& operator<<(std::ostream& out, Point<Vector> const& vector);
 
 template<typename Vector, typename Weight>
-Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,
-                         std::vector<Weight> const& weights);
+Point<Vector> Barycentre(std::vector<Point<Vector> const> const& points,
+                         std::vector<Weight const> const& weights);
 
 }  // namespace geometry
 }  // namespace principia

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -90,8 +90,8 @@ std::ostream& operator<<(std::ostream& out, Point<Vector> const& point) {
 }
 
 template<typename Vector, typename Weight>
-Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,
-                         std::vector<Weight> const& weights) {
+Point<Vector> Barycentre(std::vector<Point<Vector> const> const& points,
+                         std::vector<Weight const> const& weights) {
   CHECK_EQ(points.size(), weights.size());
   CHECK(!points.empty());
   // We need 'auto' here because we cannot easily write the type of the product


### PR DESCRIPTION
This is necessary for barycentric reference frames (and it's generally a good idea to be const-correct).
