### PR TITLE
Add accessor to for body Celestial

### DIFF
--- a/ksp_plugin/celestial.hpp
+++ b/ksp_plugin/celestial.hpp
@@ -27,6 +27,7 @@ class Celestial {
   template<typename... Args>
   explicit Celestial(Args&&... args);  // NOLINT(build/c++11)
 
+  Body<Frame> const& body() const;
   bool has_parent() const;
   Celestial const& parent() const;
   Trajectory<Frame> const& history() const;

--- a/ksp_plugin/celestial_body.hpp
+++ b/ksp_plugin/celestial_body.hpp
@@ -12,6 +12,11 @@ Celestial<Frame>::Celestial(Args&&... args)  // NOLINT(build/c++11)
                     std::forward<Args>(args)...)) {}  // NOLINT(build/c++11)
 
 template<typename Frame>
+Body<Frame> const& Celestial<Frame>::body() const {
+  return *body_;
+}
+
+template<typename Frame>
 bool Celestial<Frame>::has_parent() const {
   return parent_ != nullptr;
 }


### PR DESCRIPTION
This is useful when computing trajectories in barycentric reference frames.
