### PR TITLE
simplify unchecked constructor

### DIFF
--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -182,8 +182,7 @@ class not_null {
   // Creates a |not_null<Pointer>| whose |pointer_| equals the given |pointer|,
   // dawg.  The constructor does *not* perform a null check.  Callers must
   // perform one if needed before using it.
-  explicit not_null(pointer const& ptr);
-  explicit not_null(pointer&& ptr);  // NOLINT(build/c++11)
+  explicit not_null(pointer ptr);
 
   pointer pointer_;
 

--- a/base/not_null_body.hpp
+++ b/base/not_null_body.hpp
@@ -11,11 +11,7 @@ namespace principia {
 namespace base {
 
 template<typename Pointer>
-not_null<Pointer>::not_null(pointer const& ptr) : pointer_(ptr) {}
-
-template<typename Pointer>
-not_null<Pointer>::not_null(pointer&& ptr)  // NOLINT(build/c++11)
-    : pointer_(std::move(ptr)) {}
+not_null<Pointer>::not_null(pointer ptr) : pointer_(std::move(ptr)) {}
 
 template<typename Pointer>
 template<typename OtherPointer, typename>


### PR DESCRIPTION
That makes a lot more sense. Non-const parameters are useful now.
