### PR TITLE
The transforms should evaluate the trajectories lazily

### DIFF
--- a/ksp_plugin/rendering_frame.cpp
+++ b/ksp_plugin/rendering_frame.cpp
@@ -22,10 +22,13 @@ BodyCentredNonRotatingFrame::ApparentTrajectory(
     Trajectory<Barycentric> const& actual_trajectory) const {
   std::unique_ptr<Trajectory<Barycentric>> result =
       std::make_unique<Trajectory<Barycentric>>(actual_trajectory.body<Body>());
+  Transforms<Barycentric, Rendering, Barycentric>::
+      LazyTrajectory<Barycentric> const body_prolongation =
+          std::bind(&Celestial::prolongation, &body_);
   auto transforms(
       Transforms<Barycentric, Rendering, Barycentric>::BodyCentredNonRotating(
-          body_.prolongation(),
-          body_.prolongation()));
+          body_prolongation,
+          body_prolongation));
   auto actual_it = transforms->first(&actual_trajectory);
   auto body_it = body_.prolongation().on_or_after(actual_it.time());
 
@@ -63,12 +66,18 @@ BarycentricRotatingFrame::ApparentTrajectory(
     Trajectory<Barycentric> const& actual_trajectory) const {
   std::unique_ptr<Trajectory<Barycentric>> result =
       std::make_unique<Trajectory<Barycentric>>(actual_trajectory.body<Body>());
+  Transforms<Barycentric, Rendering, Barycentric>::
+      LazyTrajectory<Barycentric> const primary_prolongation =
+          std::bind(&Celestial::prolongation, &primary_);
+  Transforms<Barycentric, Rendering, Barycentric>::
+      LazyTrajectory<Barycentric> const secondary_prolongation =
+          std::bind(&Celestial::prolongation, &secondary_);
   auto transforms(
       Transforms<Barycentric, Rendering, Barycentric>::BarycentricRotating(
-          primary_.prolongation(),
-          primary_.prolongation(),
-          secondary_.prolongation(),
-          secondary_.prolongation()));
+          primary_prolongation,
+          primary_prolongation,
+          secondary_prolongation,
+          secondary_prolongation));
   auto actual_it = transforms->first(&actual_trajectory);
   auto primary_it = primary_.prolongation().on_or_after(actual_it.time());
   auto secondary_it = secondary_.prolongation().on_or_after(actual_it.time());

--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <utility>
@@ -19,12 +20,16 @@ class Transforms {
                 "Both FromFrame and ToFrame must be inertial");
 
  public:
+  //TODO(phl):comment
+  template<typename Frame>
+  using LazyTrajectory = std::function<Trajectory<Frame> const&()>;
+
   // A factory method where |ThroughFrame| is defined as follows: it has the
   // same axes as |FromFrame| and the body of |centre_trajectory| is the origin
   // of |ThroughFrame|.
   static std::unique_ptr<Transforms> BodyCentredNonRotating(
-      Trajectory<FromFrame> const& from_centre_trajectory,
-      Trajectory<ToFrame> const& to_centre_trajectory);
+      LazyTrajectory<FromFrame> const& from_centre_trajectory,
+      LazyTrajectory<ToFrame> const& to_centre_trajectory);
 
   // A factory method where |ThroughFrame| is defined as follows: its X axis
   // goes from the primary to the secondary bodies, its Y axis is in the plane
@@ -33,10 +38,10 @@ class Transforms {
   // that it is right-handed.  The barycentre of the bodies is the origin of
   // |ThroughFrame|.
   static std::unique_ptr<Transforms> BarycentricRotating(
-      Trajectory<FromFrame> const& from_primary_trajectory,
-      Trajectory<ToFrame> const& to_primary_trajectory,
-      Trajectory<FromFrame> const& from_secondary_trajectory,
-      Trajectory<ToFrame> const& to_secondary_trajectory);
+      LazyTrajectory<FromFrame> const& from_primary_trajectory,
+      LazyTrajectory<ToFrame> const& to_primary_trajectory,
+      LazyTrajectory<FromFrame> const& from_secondary_trajectory,
+      LazyTrajectory<ToFrame> const& to_secondary_trajectory);
 
   typename Trajectory<FromFrame>::template TransformingIterator<ThroughFrame>
   first(Trajectory<FromFrame> const* from_trajectory);

--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -20,7 +20,11 @@ class Transforms {
                 "Both FromFrame and ToFrame must be inertial");
 
  public:
-  //TODO(phl):comment
+  // The trajectories are evaluated lazily because they may be extended or
+  // deallocated/reallocated between the time when the transforms are created
+  // and the time when they are applied.  Thus, the lambdas couldn't capture the
+  // trajectories by value nor by reference.  Instead, they capture a copy of a
+  // function that accesses the trajectories.
   template<typename Frame>
   using LazyTrajectory = std::function<Trajectory<Frame> const&()>;
 

--- a/physics/transforms_test.cpp
+++ b/physics/transforms_test.cpp
@@ -51,6 +51,14 @@ class TransformsTest : public testing::Test {
     body2_from_ = std::make_unique<Trajectory<From>>(*body2_);
     body1_to_ = std::make_unique<Trajectory<To>>(*body1_);
     body2_to_ = std::make_unique<Trajectory<To>>(*body2_);
+    body1_from_fn_ =
+        [this]() -> Trajectory<From> const& { return *this->body1_from_; };
+    body2_from_fn_ =
+        [this]() -> Trajectory<From> const& { return *this->body2_from_; };
+    body1_to_fn_ =
+        [this]() -> Trajectory<To> const& { return *this->body1_to_; };
+    body2_to_fn_ =
+        [this]() -> Trajectory<To> const& { return *this->body2_to_; };
 
     // The various bodies move have both a position and a velocity that
     // increases linearly with time.  This is not a situation that's physically
@@ -99,6 +107,10 @@ class TransformsTest : public testing::Test {
   std::unique_ptr<Trajectory<From>> body2_from_;
   std::unique_ptr<Trajectory<To>> body1_to_;
   std::unique_ptr<Trajectory<To>> body2_to_;
+  Transforms<From, Through, To>::LazyTrajectory<From> body1_from_fn_;
+  Transforms<From, Through, To>::LazyTrajectory<From> body2_from_fn_;
+  Transforms<From, Through, To>::LazyTrajectory<To> body1_to_fn_;
+  Transforms<From, Through, To>::LazyTrajectory<To> body2_to_fn_;
   std::unique_ptr<Trajectory<From>> satellite_from_;
 
   std::unique_ptr<Transforms<From, Through, To>> transforms_;
@@ -108,7 +120,7 @@ class TransformsTest : public testing::Test {
 // test verifies that we get the expected result both in |Through| and in |To|.
 TEST_F(TransformsTest, BodyCentredNonRotating) {
   transforms_ = Transforms<From, Through, To>::BodyCentredNonRotating(
-                    *body1_from_, *body1_to_);
+                    body1_from_fn_, body1_to_fn_);
   Trajectory<Through> body1_through(*body1_);
 
   int i = 1;
@@ -159,8 +171,8 @@ TEST_F(TransformsTest, BodyCentredNonRotating) {
 // Check that the computations we do match those done using Mathematica.
 TEST_F(TransformsTest, SatelliteBarycentricRotating) {
   transforms_ = Transforms<From, Through, To>::BarycentricRotating(
-                    *body1_from_, *body1_to_,
-                    *body2_from_, *body2_to_);
+                    body1_from_fn_, body1_to_fn_,
+                    body2_from_fn_, body2_to_fn_);
   Trajectory<Through> satellite_through(satellite_);
 
   int i = 1;
@@ -232,8 +244,8 @@ TEST_F(TransformsTest, SatelliteBarycentricRotating) {
 // centre of the coordinates.
 TEST_F(TransformsTest, BodiesBarycentricRotating) {
   transforms_ = Transforms<From, Through, To>::BarycentricRotating(
-                    *body1_from_, *body1_to_,
-                    *body2_from_, *body2_to_);
+                    body1_from_fn_, body1_to_fn_,
+                    body2_from_fn_, body2_to_fn_);
   Trajectory<Through> body1_through(*body1_);
   Trajectory<Through> body2_through(*body2_);
 


### PR DESCRIPTION
Mostly, that's because they access the prolongation and the prolongation constantly gets deallocated and reallocated.