### PR TITLE
Cauchy distribution

### DIFF
--- a/geometry/epoch_body.hpp
+++ b/geometry/epoch_body.hpp
@@ -10,11 +10,11 @@ namespace geometry {
 Instant const kJD0  = kJ2000 - 2451545.0 * Day;
 Instant const kMJD0 = kJ2000 - 51544.5 * Day;
 
-Instant JulianDate(double const days) {
+inline Instant JulianDate(double const days) {
   return kJD0 + days * Day;
 }
 
-Instant ModifiedJulianDate(double const days) {
+inline Instant ModifiedJulianDate(double const days) {
   return kMJD0 + days * Day;
 }
 

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -331,6 +331,10 @@ void principia__AddVesselToNextPhysicsBubble(Plugin* const plugin,
                                                       std::move(vessel_parts));
 }
 
+bool principia__PhysicsBubbleIsEmpty(Plugin const* const plugin) {
+  return CHECK_NOTNULL(plugin)->PhysicsBubbleIsEmpty();
+}
+
 XYZ principia__BubbleDisplacementCorrection(Plugin const* const plugin,
                                             XYZ const sun_position) {
   Displacement<World> const result =

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -259,6 +259,9 @@ void CDECL principia__AddVesselToNextPhysicsBubble(Plugin* const plugin,
                                                    int count);
 
 extern "C" DLLEXPORT
+bool CDECL principia__PhysicsBubbleIsEmpty(Plugin const* const plugin);
+
+extern "C" DLLEXPORT
 XYZ CDECL principia__BubbleDisplacementCorrection(Plugin const* const plugin,
                                                   XYZ const sun_position);
 

--- a/ksp_plugin/mock_plugin.hpp
+++ b/ksp_plugin/mock_plugin.hpp
@@ -102,6 +102,8 @@ class MockPlugin : public Plugin {
                void(GUID const& vessel_guid,
                     std::vector<IdAndOwnedPart> const& parts));
 
+  MOCK_CONST_METHOD0(PhysicsBubbleIsEmpty, bool());
+
   MOCK_CONST_METHOD1(BubbleDisplacementCorrection,
                      Displacement<World>(
                          Position<World> const& sun_world_position));
@@ -109,6 +111,8 @@ class MockPlugin : public Plugin {
   MOCK_CONST_METHOD1(BubbleVelocityCorrection,
                      Velocity<World> (
                          Index const reference_body_index));
+
+  MOCK_CONST_METHOD0(current_time, Instant());
 };
 
 }  // namespace ksp_plugin

--- a/ksp_plugin/physics_bubble.hpp
+++ b/ksp_plugin/physics_bubble.hpp
@@ -57,7 +57,7 @@ class PhysicsBubble {
       PlanetariumRotation const& planetarium_rotation,
       Celestial const& reference_celestial) const;
 
-  // Returns |current_ != nullptr|.
+  // Returns |current_ == nullptr|.
   bool empty() const;
 
   // Returns 0 if |empty()|, 1 otherwise.

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -608,6 +608,11 @@ Displacement<World> Plugin::BubbleDisplacementCorrection(
                                                     sun_world_position));
 }
 
+bool Plugin::PhysicsBubbleIsEmpty() {
+  VLOG(1) << __FUNCTION__;
+  VLOG_AND_RETURN(1, bubble_.empty());
+}
+
 Velocity<World> Plugin::BubbleVelocityCorrection(
     Index const reference_body_index) const {
   VLOG(1) << __FUNCTION__ << '\n' << NAMED(reference_body_index);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -608,7 +608,7 @@ Displacement<World> Plugin::BubbleDisplacementCorrection(
                                                     sun_world_position));
 }
 
-bool Plugin::PhysicsBubbleIsEmpty() {
+bool Plugin::PhysicsBubbleIsEmpty() const {
   VLOG(1) << __FUNCTION__;
   VLOG_AND_RETURN(1, bubble_.empty());
 }

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -210,7 +210,10 @@ class Plugin {
   // already in |next_physics_bubble_->parts|.
   virtual void AddVesselToNextPhysicsBubble(GUID const& vessel_guid,
                                             std::vector<IdAndOwnedPart> parts);
+
+  // Returns |bubble_.empty()|.
   virtual bool PhysicsBubbleIsEmpty() const;
+
   // Computes and returns |current_physics_bubble_->displacement_correction|.
   // This is the |World| shift to be applied to the physics bubble in order for
   // it to be in the correct position.

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -210,7 +210,7 @@ class Plugin {
   // already in |next_physics_bubble_->parts|.
   virtual void AddVesselToNextPhysicsBubble(GUID const& vessel_guid,
                                             std::vector<IdAndOwnedPart> parts);
-  virtual bool PhysicsBubbleIsEmpty();
+  virtual bool PhysicsBubbleIsEmpty() const;
   // Computes and returns |current_physics_bubble_->displacement_correction|.
   // This is the |World| shift to be applied to the physics bubble in order for
   // it to be in the correct position.

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -210,6 +210,7 @@ class Plugin {
   // already in |next_physics_bubble_->parts|.
   virtual void AddVesselToNextPhysicsBubble(GUID const& vessel_guid,
                                             std::vector<IdAndOwnedPart> parts);
+  virtual bool PhysicsBubbleIsEmpty();
   // Computes and returns |current_physics_bubble_->displacement_correction|.
   // This is the |World| shift to be applied to the physics bubble in order for
   // it to be in the correct position.

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -222,7 +222,7 @@ class Plugin {
   virtual Velocity<World> BubbleVelocityCorrection(
       Index const reference_body_index) const;
 
-  Instant current_time() const;
+  virtual Instant current_time() const;
 
  private:
   using GUIDToOwnedVessel = std::map<GUID, not_null<std::unique_ptr<Vessel>>>;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -398,7 +398,7 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
       plugin_state = "not started";
     } else if (!time_is_advancing_) {
       plugin_state = "holding";
-    } else if (!has_inertial_physics_bubble_in_space()) {
+    } else if (PhysicsBubbleIsEmpty(plugin_)) {
       plugin_state = "running";
     } else {
       plugin_state = "managing physics bubble";
@@ -597,7 +597,7 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
   private void ResetPlugin() {
     Cleanup();
     ApplyToBodyTree(body => body.inverseRotThresholdAltitude =
-                                body.maxAtmosphereAltitude);
+                                body.timeWarpAltitudeLimits[1]);
     ResetRenderedTrajectory();
     last_plugin_reset_ = DateTime.Now;
     plugin_ = NewPlugin(Planetarium.GetUniversalTime(),

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -195,9 +195,10 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
   }
 
   private bool is_in_space(Vessel vessel) {
-    return vessel.situation == Vessel.Situations.SUB_ORBITAL ||
-           vessel.situation == Vessel.Situations.ORBITING ||
-           vessel.situation == Vessel.Situations.ESCAPING;
+    return vessel.state != Vessel.State.DEAD &&
+           (vessel.situation == Vessel.Situations.SUB_ORBITAL ||
+            vessel.situation == Vessel.Situations.ORBITING ||
+            vessel.situation == Vessel.Situations.ESCAPING);
   }
 
   private bool is_on_rails_in_space(Vessel vessel) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -42,6 +42,8 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
 
   private DateTime last_plugin_reset_;
 
+  private Krakensbane krakensbane_;
+
   private static bool an_instance_is_loaded_;
 
   PluginAdapter() {
@@ -278,10 +280,11 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
             (Vector3d)BubbleVelocityCorrection(
                           plugin_,
                           active_vessel.orbit.referenceBody.flightGlobalsIndex);
-        Krakensbane krakensbane =
-            (Krakensbane)FindObjectOfType(typeof(Krakensbane));
-        krakensbane.setOffset(displacement_offset);
-        krakensbane.FrameVel += velocity_offset;
+        if (krakensbane_ == null) {
+          krakensbane_ = (Krakensbane)FindObjectOfType(typeof(Krakensbane));
+        }
+        krakensbane_.setOffset(displacement_offset);
+        krakensbane_.FrameVel += velocity_offset;
       }
       if (MapView.MapIsEnabled &&
           active_vessel != null &&

--- a/ksp_plugin_adapter/ksp_plugin_interface.cs
+++ b/ksp_plugin_adapter/ksp_plugin_interface.cs
@@ -198,6 +198,11 @@ public partial class PluginAdapter : UnityEngine.MonoBehaviour {
       int count);
 
   [DllImport(dllName           : kDllPath,
+             EntryPoint        = "principia__PhysicsBubbleIsEmpty",
+             CallingConvention = CallingConvention.Cdecl)]
+  private static extern bool PhysicsBubbleIsEmpty(IntPtr plugin);
+
+  [DllImport(dllName           : kDllPath,
              EntryPoint        = "principia__BubbleDisplacementCorrection",
              CallingConvention = CallingConvention.Cdecl)]
   private static extern XYZ BubbleDisplacementCorrection(IntPtr plugin,

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -392,7 +392,7 @@ TEST_F(InterfaceTest, PhysicsBubble) {
 
   EXPECT_CALL(*plugin_, PhysicsBubbleIsEmpty()).WillOnce(Return(true));
   bool const empty = principia__PhysicsBubbleIsEmpty(plugin_.get());
-  EXPECT_THAT(empty, Eq(true));
+  EXPECT_TRUE(empty);
 }
 
 TEST_F(InterfaceTest, CurrentTime) {

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -1,6 +1,7 @@
 #include "ksp_plugin/interface.hpp"
 
 #include "base/not_null.hpp"
+#include "geometry/epoch.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "quantities/si.hpp"
@@ -8,6 +9,7 @@
 
 using principia::base::check_not_null;
 using principia::geometry::Displacement;
+using principia::geometry::kUnixEpoch;
 using principia::ksp_plugin::AliceSun;
 using principia::ksp_plugin::Index;
 using principia::ksp_plugin::LineSegment;
@@ -16,6 +18,7 @@ using principia::ksp_plugin::Part;
 using principia::ksp_plugin::RenderedTrajectory;
 using principia::ksp_plugin::World;
 using principia::si::Degree;
+using principia::si::Second;
 using principia::si::Tonne;
 using testing::Eq;
 using testing::ElementsAre;
@@ -386,6 +389,16 @@ TEST_F(InterfaceTest, PhysicsBubble) {
   XYZ const velocity =
       principia__BubbleVelocityCorrection(plugin_.get(), kParentIndex);
   EXPECT_THAT(velocity, Eq(XYZ{66, 55, 44}));
+
+  EXPECT_CALL(*plugin_, PhysicsBubbleIsEmpty()).WillOnce(Return(true));
+  bool const empty = principia__PhysicsBubbleIsEmpty(plugin_.get());
+  EXPECT_THAT(empty, Eq(true));
+}
+
+TEST_F(InterfaceTest, CurrentTime) {
+  EXPECT_CALL(*plugin_, current_time()).WillOnce(Return(kUnixEpoch));
+  double const current_time = principia__current_time(plugin_.get());
+  EXPECT_THAT(Instant(current_time * Second), Eq(kUnixEpoch));
 }
 
 }  // namespace


### PR DESCRIPTION
Fix the "crashes crash" bug (due to adding 0-part vessels to the physics bubble), the bug where the plugin would still manage the physics bubble at ground level on bodies without an atmosphere, and the bug where a crashed vessel would keep being simulated.
Improved performance by not calling `FindObjectOfType` at every frame.