### PR TITLE
Vessel proto

### DIFF
--- a/ksp_plugin/frames.hpp
+++ b/ksp_plugin/frames.hpp
@@ -12,15 +12,6 @@ using principia::geometry::Position;
 namespace principia {
 namespace ksp_plugin {
 
-enum Tag {
-  kAliceSun,
-  kAliceWorld,
-  kBarycentric,
-  kRendering,
-  kWorld,
-  kWorldSun,
-};
-
 // Universal time 0, time of game creation.
 // Putting the origin here makes the instants we use equal to the corresponding
 // KSP universal time doubles.
@@ -31,11 +22,13 @@ Instant const kUniversalTimeEpoch;
 // nonrotating.
 // The basis is that of Unity's "world space" (this is a left-handed basis).
 // The origin is the ineffable origin of Unity's "world space".
-using World = Frame<Tag, Tag::kWorld, false>;
+using World = Frame<serialization::Frame::PluginTag,
+                    serialization::Frame::WORLD, false>;
 
 // Same as |World| but with the y and z axes switched through the looking-glass:
 // it is a right-handed basis. "We're all mad here. I'm mad. You're mad."
-using AliceWorld = Frame<Tag, Tag::kAliceWorld, false>;
+using AliceWorld = Frame<serialization::Frame::PluginTag,
+                         serialization::Frame::ALICE_WORLD, false>;
 
 // The barycentric reference frame of the solar system.
 // The basis is the basis of |World| at |kUniversalTimeEpoch|.
@@ -43,11 +36,13 @@ using AliceWorld = Frame<Tag, Tag::kAliceWorld, false>;
 // the velocity of the sun at the time of construction as our reference.
 // The origin is the position of the sun at the instant |initial_time| passed at
 // construction.
-using Barycentric = Frame<Tag, Tag::kBarycentric, true>;
+using Barycentric = Frame<serialization::Frame::PluginTag,
+                          serialization::Frame::BARYCENTRIC, true>;
 
 // The frame used for rendering.  Its definition depends on the actual factory
 // function used to create it, see class Transforms.
-using Rendering = Frame<Tag, Tag::kRendering, false>;
+using Rendering = Frame<serialization::Frame::PluginTag,
+                        serialization::Frame::RENDERING, false>;
 
 // A nonrotating referencence frame comoving with the sun with the same axes as
 // |AliceWorld|. Since it is nonrotating (though not inertial), differences
@@ -56,11 +51,13 @@ using Rendering = Frame<Tag, Tag::kRendering, false>;
 // this (frame, basis) pair is inconsistent across instants. Operations should
 // only be performed between simultaneous quantities, then converted to a
 // consistent (frame, basis) pair before use.
-using AliceSun = Frame<Tag, Tag::kAliceSun, false>;
+using AliceSun = Frame<serialization::Frame::PluginTag,
+                       serialization::Frame::ALICE_SUN, false>;
 
 // Same as above, but with same axes as |World| instead of those of
 // |AliceWorld|. The caveats are the same as for |AliceSun|.
-using WorldSun = Frame<Tag, Tag::kWorldSun, false>;
+using WorldSun = Frame<serialization::Frame::PluginTag,
+                       serialization::Frame::WORLD_SUN, false>;
 
 }  // namespace ksp_plugin
 }  // namespace principia

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -22,7 +22,7 @@ class Vessel {
  public:
   Vessel() = delete;
   Vessel(Vessel const&) = delete;
-  Vessel(Vessel&&);
+  Vessel(Vessel&&);  // NOLINT(build/c++11)
   ~Vessel() = default;
 
   // Constructs a vessel whose parent is initially |*parent|.  No transfer of

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -29,7 +29,6 @@ class Vessel {
   // ownership.
   explicit Vessel(not_null<Celestial const*> const parent);
 
-
   // True if, and only if, |history_| is not null.
   bool is_synchronized() const;
   // True if, and only if, |prolongation_| is not null, i.e., if either

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -8,6 +8,7 @@
 #include "physics/massless_body.hpp"
 #include "physics/trajectory.hpp"
 #include "quantities/named_quantities.hpp"
+#include "serialization/ksp_plugin.pb.h"
 
 using principia::physics::MasslessBody;
 using principia::physics::Trajectory;
@@ -65,6 +66,11 @@ class Vessel {
   // The vessel must satisfy |is_synchronized()| and |is_initialized()|,
   // |owned_prolongation_| must be null.
   void ResetProlongation(Instant const& time);
+
+  // The vessel must satisfy |is_initialized()|.
+  void WriteToMessage(not_null<serialization::Vessel*> const message) const;
+  static Vessel ReadFromMessage(serialization::Vessel const& message,
+                                not_null<Celestial const*> const parent);
 
  private:
   MasslessBody const body_;

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -22,12 +22,13 @@ class Vessel {
  public:
   Vessel() = delete;
   Vessel(Vessel const&) = delete;
-  Vessel(Vessel&&) = delete;
+  Vessel(Vessel&&);
   ~Vessel() = default;
 
   // Constructs a vessel whose parent is initially |*parent|.  No transfer of
   // ownership.
   explicit Vessel(not_null<Celestial const*> const parent);
+
 
   // True if, and only if, |history_| is not null.
   bool is_synchronized() const;

--- a/ksp_plugin/vessel_body.hpp
+++ b/ksp_plugin/vessel_body.hpp
@@ -5,6 +5,13 @@
 namespace principia {
 namespace ksp_plugin {
 
+inline Vessel::Vessel(Vessel&& other)  // NOLINT(build/c++11)
+    : body_(),
+      parent_(std::move(other.parent_)),
+      history_(std::move(other.history_)),
+      prolongation_(std::move(other.prolongation_)),
+      owned_prolongation_(std::move(other.owned_prolongation_)) {}
+
 inline Vessel::Vessel(not_null<Celestial const*> const parent)
     : body_(),
       parent_(parent) {}
@@ -111,10 +118,12 @@ inline Vessel Vessel::ReadFromMessage(serialization::Vessel const& message,
         std::make_unique<Trajectory<Barycentric>>(
             Trajectory<Barycentric>::ReadFromMessage(
                 message.owned_prolongation(), &vessel.body_));
+    vessel.prolongation_ = vessel.owned_prolongation_.get();
   } else {
     LOG(FATAL) << "message does not represent an initialized Vessel";
     base::noreturn();
   }
+  return vessel;
 }
 
 }  // namespace ksp_plugin

--- a/ksp_plugin/vessel_body.hpp
+++ b/ksp_plugin/vessel_body.hpp
@@ -102,7 +102,7 @@ inline void Vessel::WriteToMessage(
 inline Vessel Vessel::ReadFromMessage(serialization::Vessel const& message,
                                       not_null<Celestial const*> const parent) {
   Vessel vessel(parent);
-  // NOTE(egg): for now we do not read the |MassiveBody| as can contain no
+  // NOTE(egg): for now we do not read the |MasslessBody| as it can contain no
   // information.
   if (message.has_history_and_prolongation()) {
     vessel.history_ =

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="interface_test.cpp" />
     <ClCompile Include="physics_bubble_test.cpp" />
     <ClCompile Include="plugin_test.cpp" />
+    <ClCompile Include="vessel_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\serialization\serialization.vcxproj">

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
@@ -38,5 +38,8 @@
     <ClCompile Include="physics_bubble_test.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="vessel_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -1,0 +1,97 @@
+
+#include "ksp_plugin/vessel.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using principia::si::Kilogram;
+using principia::si::Metre;
+using principia::si::Second;
+using testing::IsNull;
+using testing::NotNull;
+
+namespace principia {
+namespace ksp_plugin {
+
+class VesselTest : public testing::Test {
+ protected:
+  VesselTest()
+      : parent_(make_not_null_unique<MassiveBody>(1 * Kilogram)),
+        vessel_(make_not_null_unique<Vessel>(&parent_)) {}
+
+  Celestial parent_;
+  not_null<std::unique_ptr<Vessel>> vessel_;
+  DegreesOfFreedom<Barycentric> d1_ =
+      {Barycentric::origin +
+           Displacement<Barycentric>({1 * Metre, 2 * Metre, 3 * Metre}),
+       Velocity<Barycentric>({4 * Metre / Second,
+                              5 * Metre / Second,
+                              6 * Metre / Second})};
+  DegreesOfFreedom<Barycentric> d2_ =
+      {Barycentric::origin +
+           Displacement<Barycentric>({11 * Metre, 12 * Metre, 13 * Metre}),
+       Velocity<Barycentric>({14 * Metre / Second,
+                              15 * Metre / Second,
+                              16 * Metre / Second})};
+  Instant const t1_ = kUniversalTimeEpoch;
+  Instant const t2_ = kUniversalTimeEpoch + 42 * Second;
+};
+
+using VesselDeathTest = VesselTest;
+
+TEST_F(VesselTest, InitializationAndSynchronization) {
+  // TODO(egg): mutable_history() should probably return a |not_null| and check
+  // that |is_initialized()|.  This is even more confusing for the non-mutable
+  // versions, which return a |const&|.
+  EXPECT_FALSE(vessel_->is_initialized());
+  EXPECT_FALSE(vessel_->is_synchronized());
+  EXPECT_THAT(vessel_->mutable_history(), IsNull());
+  EXPECT_THAT(vessel_->mutable_prolongation(), IsNull());
+  vessel_->CreateProlongation(t1_, d1_);
+  EXPECT_TRUE(vessel_->is_initialized());
+  EXPECT_FALSE(vessel_->is_synchronized());
+  EXPECT_THAT(vessel_->mutable_history(), IsNull());
+  EXPECT_THAT(vessel_->mutable_prolongation(), NotNull());
+  vessel_->CreateHistoryAndForkProlongation(t2_, d2_);
+  EXPECT_TRUE(vessel_->is_initialized());
+  EXPECT_TRUE(vessel_->is_synchronized());
+  EXPECT_THAT(vessel_->mutable_history(), NotNull());
+  EXPECT_THAT(vessel_->mutable_prolongation(), NotNull());
+}
+
+TEST_F(VesselDeathTest, SerializationError) {
+  EXPECT_DEATH({
+    serialization::Vessel message;
+    vessel_->WriteToMessage(&message);
+  }, "is_initialized");
+  EXPECT_DEATH({
+    serialization::Vessel message;
+    Vessel::ReadFromMessage(message, &parent_);
+  }, "message does not represent an initialized Vessel");
+}
+
+TEST_F(VesselTest, SerializationSuccess) {
+  serialization::Vessel message;
+  EXPECT_FALSE(message.has_owned_prolongation());
+  EXPECT_FALSE(message.has_history_and_prolongation());
+  vessel_->CreateProlongation(t1_, d1_);
+  vessel_->WriteToMessage(&message);
+  EXPECT_TRUE(message.has_owned_prolongation());
+  EXPECT_FALSE(message.has_history_and_prolongation());
+  vessel_ = make_not_null_unique<Vessel>(
+                Vessel::ReadFromMessage(message, &parent_));
+  EXPECT_TRUE(vessel_->is_initialized());
+  EXPECT_FALSE(vessel_->is_synchronized());
+  vessel_->CreateHistoryAndForkProlongation(t2_, d2_);
+  message.Clear();
+  vessel_->WriteToMessage(&message);
+  EXPECT_FALSE(message.has_owned_prolongation());
+  EXPECT_TRUE(message.has_history_and_prolongation());
+  vessel_ = make_not_null_unique<Vessel>(
+                Vessel::ReadFromMessage(message, &parent_));
+  EXPECT_TRUE(vessel_->is_initialized());
+  EXPECT_TRUE(vessel_->is_synchronized());
+}
+
+}  // namespace ksp_plugin
+}  // namespace principia

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -32,13 +32,19 @@ message Part {
 
 message PhysicsBubble {
   message FullState {
-    // The uint64 is the std::distance from Plugin::vessels_.begin();
-    repeated int64 vessels = 1;
-    map<uint32, Part> parts = 2;
+    message PartIdToPart {
+      required fixed32 part_id = 1;
+      required Part part = 2;
+    }
+    message VesselPointerToDegreesOfFreedom {
+      required Plugin.VesselPointer vessel = 1;
+      required Pair degrees_of_freedom = 2;
+    }
+    repeated Plugin.VesselPointer vessels = 1;
+    repeated PartIdToPart parts = 2;
     required Pair centre_of_mass = 3;
     required Trajectory centre_of_mass_trajectory = 4;
-    // The uint64 is the std::distance from Plugin::vessels_.begin();
-    map<uint64, Pair> from_centre_of_mass = 5;
+    repeated VesselPointerToDegreesOfFreedom from_centre_of_mass = 5;
     required Pair correction = 6;
   }
   required MasslessBody body = 1;
@@ -46,13 +52,25 @@ message PhysicsBubble {
 }
 
 message Plugin {
-  map<string, Vessel> vessels = 1;
-  map<int32, Celestial> celestials = 2;
-  // The uint64 is the std::distance from Plugin::vessels_.begin();
-  repeated uint64 dirty_vessels = 3;
+  message VesselPointer {
+    required uint64 distance_from_vessels_begin = 1;
+  }
+  message CelestialPointer {
+    required uint64 distance_from_celestials_begin = 1;
+  }
+  message GuidToVessel {
+    required string guid = 1;
+    required Vessel vessel = 2;
+  }
+  message IndexToCelestial {
+    required int32 index = 1;
+    required Celestial celestial = 2;
+  }
+  repeated GuidToVessel vessels = 1;
+  repeated IndexToCelestial celestials = 2;
+  repeated VesselPointer dirty_vessels = 3;
   required PhysicsBubble bubble = 4;
   required Quantity planetarium_rotation = 5;
   required Point current_time = 6;
-  // The uint64 is the std::distance from Plugin::celestials_.begin();
-  required uint64 sun = 7;
+  required CelestialPointer sun = 7;
 }

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -6,22 +6,14 @@ import "serialization/quantities.proto";
 
 package principia.serialization;
 
-message HistoryAndProlongation {
-  required Trajectory history = 1;
-  required Trajectory.Pointer prolongation = 2;
-}
-
-message Vessel {
-  required MasslessBody body = 1;
-  oneof trajectory_bundle {
-    HistoryAndProlongation history_and_prolongation = 2;
-    Trajectory owned_prolongation = 3;
-  }
-}
-
 message Celestial {
   required MassiveBody body = 1;
   required HistoryAndProlongation history_and_prolongation = 2;
+}
+
+message HistoryAndProlongation {
+  required Trajectory history = 1;
+  required Trajectory.Pointer prolongation = 2;
 }
 
 message Part {
@@ -36,15 +28,15 @@ message PhysicsBubble {
       required fixed32 part_id = 1;
       required Part part = 2;
     }
-    message VesselPointerToDegreesOfFreedom {
-      required Plugin.VesselPointer vessel = 1;
+    message VesselToDegreesOfFreedom {
+      required string vessel_guid = 1;
       required Pair degrees_of_freedom = 2;
     }
-    repeated Plugin.VesselPointer vessels = 1;
+    repeated string vessel_guids = 1;
     repeated PartIdToPart parts = 2;
     required Pair centre_of_mass = 3;
     required Trajectory centre_of_mass_trajectory = 4;
-    repeated VesselPointerToDegreesOfFreedom from_centre_of_mass = 5;
+    repeated VesselToDegreesOfFreedom from_centre_of_mass = 5;
     required Pair correction = 6;
   }
   required MasslessBody body = 1;
@@ -52,37 +44,31 @@ message PhysicsBubble {
 }
 
 message Plugin {
-  // NOTE(egg): Assuming 32-bit. If we have 2^32 vessels we'll probably
-  // encounter other issues on the way.
-  message VesselPointer {
-    required uint32 distance_from_vessels_begin = 1;
-  }
-  message CelestialPointer {
-    required uint32 distance_from_celestials_begin = 1;
-  }
-  message VesselPointerToParent {
-    required VesselPointer vessel = 1;
-    required CelestialPointer parent = 2;
-  }
-  message CelestialPointerToParent {
-    required CelestialPointer celestial = 1;
-    optional CelestialPointer parent = 2;
-  }
+  // TODO(egg): Find better identifiers for the following |message|s, they are
+  // more than just map entries now.
   message GuidToVessel {
     required string guid = 1;
     required Vessel vessel = 2;
+    required int32 parent_index = 3;
+    required bool dirty = 4;
   }
   message IndexToCelestial {
     required int32 index = 1;
     required Celestial celestial = 2;
+    optional int32 parent_index = 3;
   }
   repeated GuidToVessel vessels = 1;
   repeated IndexToCelestial celestials = 2;
-  repeated VesselPointerToParent vessel_parents = 3;
-  repeated CelestialPointerToParent celestial_parents = 4;
-  repeated VesselPointer dirty_vessels = 5;
-  required PhysicsBubble bubble = 6;
-  required Quantity planetarium_rotation = 7;
-  required Point current_time = 8;
-  required CelestialPointer sun = 9;
+  required PhysicsBubble bubble = 3;
+  required Quantity planetarium_rotation = 4;
+  required Point current_time = 5;
+  required int32 sun_index = 6;
+}
+
+message Vessel {
+  required MasslessBody body = 1;
+  oneof trajectory_bundle {
+    HistoryAndProlongation history_and_prolongation = 2;
+    Trajectory owned_prolongation = 3;
+  }
 }

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -1,0 +1,58 @@
+syntax = "proto2";
+
+import "serialization/geometry.proto";
+import "serialization/physics.proto";
+import "serialization/quantities.proto";
+
+package principia.serialization;
+
+message HistoryAndProlongation {
+  required Trajectory history = 1;
+  required Trajectory.Iterator prolongation = 2;
+}
+
+message Vessel {
+  required MasslessBody body = 1;
+  oneof trajectory_bundle {
+    HistoryAndProlongation history_and_prolongation = 2;
+    Trajectory owned_prolongation = 3;
+  }
+}
+
+message Celestial {
+  required MassiveBody body = 1;
+  required HistoryAndProlongation history_and_prolongation = 2;
+}
+
+message Part {
+  required Pair degrees_of_freedom = 1;
+  required Quantity mass = 2;
+  required Multivector gravitational_acceleration_to_be_applied_by_ksp = 3;
+}
+
+message PhysicsBubble {
+  message FullState {
+    // The uint64 is the std::distance from Plugin::vessels_.begin();
+    repeated int64 vessels = 1;
+    map<uint32, Part> parts = 2;
+    required Pair centre_of_mass = 3;
+    required Trajectory centre_of_mass_trajectory = 4;
+    // The uint64 is the std::distance from Plugin::vessels_.begin();
+    map<uint64, Pair> from_centre_of_mass = 5;
+    required Pair correction = 6;
+  }
+  required MasslessBody body = 1;
+  optional FullState current = 2;
+}
+
+message Plugin {
+  map<string, Vessel> vessels = 1;
+  map<int32, Celestial> celestials = 2;
+  // The uint64 is the std::distance from Plugin::vessels_.begin();
+  repeated uint64 dirty_vessels = 3;
+  required PhysicsBubble bubble = 4;
+  required Quantity planetarium_rotation = 5;
+  required Point current_time = 6;
+  // The uint64 is the std::distance from Plugin::celestials_.begin();
+  required uint64 sun = 7;
+}

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -52,11 +52,21 @@ message PhysicsBubble {
 }
 
 message Plugin {
+  // NOTE(egg): Assuming 32-bit. If we have 2^32 vessels we'll probably
+  // encounter other issues on the way.
   message VesselPointer {
-    required uint64 distance_from_vessels_begin = 1;
+    required uint32 distance_from_vessels_begin = 1;
   }
   message CelestialPointer {
-    required uint64 distance_from_celestials_begin = 1;
+    required uint32 distance_from_celestials_begin = 1;
+  }
+  message VesselPointerToParent {
+    required VesselPointer vessel = 1;
+    required CelestialPointer parent = 2;
+  }
+  message CelestialPointerToParent {
+    required CelestialPointer celestial = 1;
+    optional CelestialPointer parent = 2;
   }
   message GuidToVessel {
     required string guid = 1;
@@ -68,9 +78,11 @@ message Plugin {
   }
   repeated GuidToVessel vessels = 1;
   repeated IndexToCelestial celestials = 2;
-  repeated VesselPointer dirty_vessels = 3;
-  required PhysicsBubble bubble = 4;
-  required Quantity planetarium_rotation = 5;
-  required Point current_time = 6;
-  required CelestialPointer sun = 7;
+  repeated VesselPointerToParent vessel_parents = 3;
+  repeated CelestialPointerToParent celestial_parents = 4;
+  repeated VesselPointer dirty_vessels = 5;
+  required PhysicsBubble bubble = 6;
+  required Quantity planetarium_rotation = 7;
+  required Point current_time = 8;
+  required CelestialPointer sun = 9;
 }

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -8,7 +8,7 @@ package principia.serialization;
 
 message HistoryAndProlongation {
   required Trajectory history = 1;
-  required Trajectory.Iterator prolongation = 2;
+  required Trajectory.Pointer prolongation = 2;
 }
 
 message Vessel {

--- a/serialization/serialization.vcxproj
+++ b/serialization/serialization.vcxproj
@@ -115,6 +115,17 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Filename).pb.h;%(Filename).pb.cc;%(Outputs)</Outputs>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="ksp_plugin.proto">
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(SolutionDir)..\Google\protobuf\vsprojects\Release\protoc" -I"$(SolutionDir)." --cpp_out=.. "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(SolutionDir)..\Google\protobuf\vsprojects\Release\protoc" -I"$(SolutionDir)." --cpp_out=.. "%(FullPath)"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating C++ files for %(FullPath)</Message>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating C++ files for %(FullPath)</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Filename).pb.h;%(Filename).pb.cc;%(Outputs)</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Filename).pb.h;%(Filename).pb.cc;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/serialization/serialization.vcxproj
+++ b/serialization/serialization.vcxproj
@@ -96,11 +96,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="geometry.pb.h" />
+    <ClInclude Include="ksp_plugin.pb.h" />
     <ClInclude Include="physics.pb.h" />
     <ClInclude Include="quantities.pb.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="geometry.pb.cc" />
+    <ClCompile Include="ksp_plugin.pb.cc" />
     <ClCompile Include="physics.pb.cc" />
     <ClCompile Include="quantities.pb.cc" />
   </ItemGroup>

--- a/serialization/serialization.vcxproj.filters
+++ b/serialization/serialization.vcxproj.filters
@@ -37,4 +37,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ksp_plugin.proto" />
+  </ItemGroup>
 </Project>

--- a/serialization/serialization.vcxproj.filters
+++ b/serialization/serialization.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClInclude Include="physics.pb.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ksp_plugin.pb.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="geometry.pb.cc">
@@ -34,6 +37,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="physics.pb.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ksp_plugin.pb.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
`Vessel` serialization, and a big proto file outlining the way forward.

I'm not sure making these big types movable (we started doing that with `Trajectory`) is a good idea. We don't make them move-assignable (otherwise we can't have `const` member variables), so we almost always have to put them in `not_null<std::unique_ptr<T>>`s, which means that factories that return a `T` directly are always used with a `make_not_null_unique<T>`. Moreover, it's easy to break invariants when writing a move constructor: we had to use `swap`s to make sure `Trajectory` was safe (it's still unsafe for past-the end `Iterator`s, although that's a minor issue), here I spent an hour tracking a bug due to a missing `prolongation_(std::move(other.prolongation_)),` which could easily have slipped past testing altogether were `Vessel` not riddled with `CHECK` macros. Note that we can't use default move constructors anyway since MSVC doesn't do those.

Note that we already have `ReadFromMessage`s that return a `not_null<std::unique_ptr<T>>` for `Body` and subclasses (for good reason), so doing so for other high-level types wouldn't introduce style inconsistencies.

Relevant bit of styleguide:
>Make your type copyable/movable if it will be useful, and if it makes sense in the context of the rest of the API. As a rule of thumb, if the behavior (including computational complexity) of a copy isn't immediately obvious to users of your type, your type shouldn't be copyable. If you choose to make it copyable, define both copy operations (constructor and assignment). If your type is copyable and a move operation is more efficient than a copy, define both move operations (constructor and assignment). If your type is not copyable, but the correctness of a move is obvious to users of the type and its fields support it, you may make the type move-only by defining both of the move operations.

>Prefer to define copy and move operations with = default. Defining non-default move operations currently requires a style exception. Remember to review the correctness of any defaulted operations as you would any other code.

>Due to the risk of slicing, avoid providing an assignment operator or public copy/move constructor for a class that's intended to be derived from (and avoid deriving from a class with such members). If your base class needs to be copyable, provide a public virtual Clone() method, and a protected copy constructor that derived classes can use to implement it.

>If you do not want to support copy/move operations on your type, explicitly disable them using = delete or whatever other mechanism your project uses.
