### PR TITLE
Move the using declarations inside namespace principia

### DIFF
--- a/benchmarks/n_body_system.cpp
+++ b/benchmarks/n_body_system.cpp
@@ -30,13 +30,14 @@
 // Must come last to avoid conflicts when defining the CHECK macros.
 #include "benchmark/benchmark.h"
 
-using principia::base::not_null;
-using principia::physics::NBodySystem;
-using principia::quantities::DebugString;
-using principia::si::AstronomicalUnit;
-using principia::testing_utilities::ICRFJ2000Ecliptic;
-
 namespace principia {
+
+using base::not_null;
+using physics::NBodySystem;
+using quantities::DebugString;
+using si::AstronomicalUnit;
+using testing_utilities::ICRFJ2000Ecliptic;
+
 namespace benchmarks {
 
 namespace {

--- a/benchmarks/n_body_system.hpp
+++ b/benchmarks/n_body_system.hpp
@@ -6,11 +6,12 @@
 #include "physics/n_body_system.hpp"
 #include "testing_utilities/solar_system.hpp"
 
-using principia::base::not_null;
-using principia::physics::NBodySystem;
-using principia::testing_utilities::SolarSystem;
-
 namespace principia {
+
+using base::not_null;
+using physics::NBodySystem;
+using testing_utilities::SolarSystem;
+
 namespace benchmarks {
 
 // Simulates the given |solar_system| for 100 years with a 45 min time step.

--- a/benchmarks/n_body_system_body.hpp
+++ b/benchmarks/n_body_system_body.hpp
@@ -7,17 +7,18 @@
 #include "quantities/si.hpp"
 #include "testing_utilities/solar_system.hpp"
 
-using principia::astronomy::JulianYear;
-using principia::base::not_null;
-using principia::integrators::SPRKIntegrator;
-using principia::physics::NBodySystem;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-using principia::si::Minute;
-using principia::testing_utilities::ICRFJ2000Ecliptic;
-using principia::testing_utilities::SolarSystem;
-
 namespace principia {
+
+using astronomy::JulianYear;
+using base::not_null;
+using integrators::SPRKIntegrator;
+using physics::NBodySystem;
+using quantities::Length;
+using quantities::Speed;
+using si::Minute;
+using testing_utilities::ICRFJ2000Ecliptic;
+using testing_utilities::SolarSystem;
+
 namespace benchmarks {
 
 void SimulateSolarSystem(not_null<SolarSystem*> const solar_system) {

--- a/benchmarks/quantities.hpp
+++ b/benchmarks/quantities.hpp
@@ -5,9 +5,10 @@
 #include "base/not_null.hpp"
 #include "quantities/named_quantities.hpp"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace benchmarks {
 
 inline void DimensionfulDiscreteCosineTransform(

--- a/benchmarks/symplectic_partitioned_runge_kutta_integrator.cpp
+++ b/benchmarks/symplectic_partitioned_runge_kutta_integrator.cpp
@@ -25,14 +25,15 @@
 // Must come last to avoid conflicts when defining the CHECK macros.
 #include "benchmark/benchmark.h"
 
-using principia::integrators::SPRKIntegrator;
-using principia::quantities::Abs;
-using principia::quantities::AngularFrequency;
-using principia::quantities::Cos;
-using principia::quantities::Length;
-using principia::quantities::Momentum;
-
 namespace principia {
+
+using integrators::SPRKIntegrator;
+using quantities::Abs;
+using quantities::AngularFrequency;
+using quantities::Cos;
+using quantities::Length;
+using quantities::Momentum;
+
 namespace benchmarks {
 
 void SolveHarmonicOscillatorAndComputeError(

--- a/benchmarks/symplectic_partitioned_runge_kutta_integrator.hpp
+++ b/benchmarks/symplectic_partitioned_runge_kutta_integrator.hpp
@@ -8,12 +8,13 @@
 #include "integrators/symplectic_partitioned_runge_kutta_integrator.hpp"
 #include "quantities/named_quantities.hpp"
 
-using principia::base::not_null;
-using principia::integrators::SPRKIntegrator;
-using principia::quantities::Length;
-using principia::quantities::Momentum;
-
 namespace principia {
+
+using base::not_null;
+using integrators::SPRKIntegrator;
+using quantities::Length;
+using quantities::Momentum;
+
 namespace benchmarks {
 
 inline void SolveHarmonicOscillator(

--- a/benchmarks/symplectic_partitioned_runge_kutta_integrator_body.hpp
+++ b/benchmarks/symplectic_partitioned_runge_kutta_integrator_body.hpp
@@ -8,20 +8,21 @@
 #include "integrators/symplectic_partitioned_runge_kutta_integrator.hpp"
 #include "testing_utilities/numerical_analysis.hpp"
 
-using principia::base::not_null;
-using principia::integrators::SPRKIntegrator;
-using principia::quantities::Length;
-using principia::quantities::Momentum;
-using principia::quantities::SIUnit;
-
 namespace principia {
+
+using base::not_null;
+using integrators::SPRKIntegrator;
+using quantities::Length;
+using quantities::Momentum;
+using quantities::SIUnit;
+using testing_utilities::ComputeHarmonicOscillatorForce;
+using testing_utilities::ComputeHarmonicOscillatorVelocity;
+
 namespace benchmarks {
 
 inline void SolveHarmonicOscillator(
     not_null<std::vector<
         SPRKIntegrator<Length, Momentum>::SystemState>*> const solution) {
-  using principia::testing_utilities::ComputeHarmonicOscillatorForce;
-  using principia::testing_utilities::ComputeHarmonicOscillatorVelocity;
   SPRKIntegrator<Length, Momentum> integrator;
   SPRKIntegrator<Length, Momentum>::Parameters parameters;
 

--- a/geometry/barycentre_calculator_test.cpp
+++ b/geometry/barycentre_calculator_test.cpp
@@ -8,13 +8,13 @@
 #include "quantities/quantities.hpp"
 #include "testing_utilities/almost_equals.hpp"
 
-using principia::geometry::Bivector;
-using principia::quantities::Entropy;
-using principia::quantities::KinematicViscosity;
-using principia::quantities::SIUnit;
-using principia::testing_utilities::AlmostEquals;
-
 namespace principia {
+
+using quantities::Entropy;
+using quantities::KinematicViscosity;
+using quantities::SIUnit;
+using testing_utilities::AlmostEquals;
+
 namespace geometry {
 
 class BarycentreCalculatorTest : public testing::Test {

--- a/geometry/epoch_body.hpp
+++ b/geometry/epoch_body.hpp
@@ -2,9 +2,10 @@
 
 #include "geometry/epoch.hpp"
 
-using principia::si::Day;
-
 namespace principia {
+
+using si::Day;
+
 namespace geometry {
 
 Instant const kJD0  = kJ2000 - 2451545.0 * Day;

--- a/geometry/frame_body.hpp
+++ b/geometry/frame_body.hpp
@@ -8,9 +8,10 @@
 #include "geometry/named_quantities.hpp"
 #include "google/protobuf/descriptor.h"
 
-using principia::base::Fingerprint2011;
-
 namespace principia {
+
+using base::Fingerprint2011;
+
 namespace geometry {
 
 namespace {

--- a/geometry/grassmann.hpp
+++ b/geometry/grassmann.hpp
@@ -9,9 +9,10 @@
 #include "quantities/quantities.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace geometry {
 
 // A multivector of rank |rank| on a three-dimensional real inner product

--- a/geometry/grassmann_test.cpp
+++ b/geometry/grassmann_test.cpp
@@ -19,31 +19,32 @@
 #include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/explicit_operators.hpp"
 
-using principia::astronomy::JulianYear;
-using principia::astronomy::Parsec;
-using principia::constants::SpeedOfLight;
-using principia::quantities::Charge;
-using principia::quantities::Length;
-using principia::quantities::Pressure;
-using principia::quantities::Product;
-using principia::quantities::Speed;
-using principia::quantities::Sqrt;
-using principia::quantities::Time;
-using principia::si::Coulomb;
-using principia::si::Day;
-using principia::si::Metre;
-using principia::si::Pascal;
-using principia::si::Second;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::Times;
-using principia::uk::admiralty::Fathom;
-using principia::uk::Foot;
-using principia::uk::Furlong;
-using principia::uk::Inch;
-using principia::uk::Rod;
-using testing::Eq;
-
 namespace principia {
+
+using astronomy::JulianYear;
+using astronomy::Parsec;
+using constants::SpeedOfLight;
+using quantities::Charge;
+using quantities::Length;
+using quantities::Pressure;
+using quantities::Product;
+using quantities::Speed;
+using quantities::Sqrt;
+using quantities::Time;
+using si::Coulomb;
+using si::Day;
+using si::Metre;
+using si::Pascal;
+using si::Second;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Times;
+using uk::admiralty::Fathom;
+using uk::Foot;
+using uk::Furlong;
+using uk::Inch;
+using uk::Rod;
+using ::testing::Eq;
+
 namespace geometry {
 
 class GrassmannTest : public testing::Test {

--- a/geometry/identity_test.cpp
+++ b/geometry/identity_test.cpp
@@ -12,11 +12,12 @@
 #include "serialization/geometry.pb.h"
 #include "testing_utilities/almost_equals.hpp"
 
-using principia::quantities::Length;
-using principia::si::Metre;
-using testing::Eq;
-
 namespace principia {
+
+using quantities::Length;
+using si::Metre;
+using ::testing::Eq;
+
 namespace geometry {
 
 class IdentityTest : public testing::Test {

--- a/geometry/pair_test.cpp
+++ b/geometry/pair_test.cpp
@@ -12,19 +12,19 @@
 // Define this to check that the illegal operations are actually rejected.
 #undef CHECK_ILLEGAL
 
-using principia::geometry::Vector;
-using principia::quantities::Action;
-using principia::quantities::Angle;
-using principia::quantities::Dimensions;
-using principia::quantities::Energy;
-using principia::quantities::Entropy;
-using principia::quantities::Frequency;
-using principia::quantities::Quantity;
-using principia::quantities::SolidAngle;
-using principia::quantities::Time;
-using principia::quantities::Winding;
-
 namespace principia {
+
+using quantities::Action;
+using quantities::Angle;
+using quantities::Dimensions;
+using quantities::Energy;
+using quantities::Entropy;
+using quantities::Frequency;
+using quantities::Quantity;
+using quantities::SolidAngle;
+using quantities::Time;
+using quantities::Winding;
+
 namespace geometry {
 
 class PairTest : public testing::Test {

--- a/geometry/permutation_test.cpp
+++ b/geometry/permutation_test.cpp
@@ -13,12 +13,13 @@
 #include "serialization/geometry.pb.h"
 #include "testing_utilities/almost_equals.hpp"
 
-using principia::quantities::Length;
-using principia::si::Metre;
-using principia::testing_utilities::AlmostEquals;
-using testing::Eq;
-
 namespace principia {
+
+using quantities::Length;
+using si::Metre;
+using testing_utilities::AlmostEquals;
+using ::testing::Eq;
+
 namespace geometry {
 
 class PermutationTest : public testing::Test {

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -7,9 +7,10 @@
 #include "quantities/quantities.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::quantities::is_quantity;
-
 namespace principia {
+
+using quantities::is_quantity;
+
 namespace geometry {
 
 // Point<Vector> is an affine space on the vector space Vector. Vector should

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -6,12 +6,12 @@
 #include "glog/logging.h"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::Multivector;
-using principia::quantities::Product;
-using principia::quantities::Quantity;
-using principia::quantities::SIUnit;
-
 namespace principia {
+
+using quantities::Product;
+using quantities::Quantity;
+using quantities::SIUnit;
+
 namespace geometry {
 
 template<typename Vector>

--- a/geometry/quaternion_test.cpp
+++ b/geometry/quaternion_test.cpp
@@ -4,10 +4,11 @@
 #include "gtest/gtest.h"
 #include "testing_utilities/algebra.hpp"
 
-using principia::testing_utilities::TestSkewField;
-using testing::Eq;
-
 namespace principia {
+
+using testing_utilities::TestSkewField;
+using ::testing::Eq;
+
 namespace geometry {
 
 class QuaternionTest : public testing::Test {

--- a/geometry/r3_element.hpp
+++ b/geometry/r3_element.hpp
@@ -8,9 +8,10 @@
 #include "quantities/quantities.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace geometry {
 
 // An |R3Element<Scalar>| is an element of Scalar³. |Scalar| should be a vector

--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -6,10 +6,11 @@
 #include "glog/logging.h"
 #include "quantities/quantities.hpp"
 
-using principia::quantities::Quantity;
-using principia::quantities::SIUnit;
-
 namespace principia {
+
+using quantities::Quantity;
+using quantities::SIUnit;
+
 namespace geometry {
 
 template<typename T>

--- a/geometry/r3_element_test.cpp
+++ b/geometry/r3_element_test.cpp
@@ -9,26 +9,27 @@
 #include "testing_utilities/algebra.hpp"
 #include "testing_utilities/explicit_operators.hpp"
 
-using principia::astronomy::JulianYear;
-using principia::astronomy::Parsec;
-using principia::bipm::Knot;
-using principia::constants::SpeedOfLight;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-using principia::quantities::Time;
-using principia::si::Day;
-using principia::si::Hour;
-using principia::si::Kilo;
-using principia::si::Metre;
-using principia::si::Minute;
-using principia::si::Second;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::Times;
-using principia::uk::Furlong;
-using principia::uk::Mile;
-using principia::uk::Rod;
-
 namespace principia {
+
+using astronomy::JulianYear;
+using astronomy::Parsec;
+using bipm::Knot;
+using constants::SpeedOfLight;
+using quantities::Length;
+using quantities::Speed;
+using quantities::Time;
+using si::Day;
+using si::Hour;
+using si::Kilo;
+using si::Metre;
+using si::Minute;
+using si::Second;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Times;
+using uk::Furlong;
+using uk::Mile;
+using uk::Rod;
+
 namespace geometry {
 
 class R3ElementTest : public testing::Test {

--- a/geometry/sign.hpp
+++ b/geometry/sign.hpp
@@ -3,9 +3,10 @@
 #include "base/not_null.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace geometry {
 
 // An element of the multiplicative group ({+1, -1}, *). Useful for instance to

--- a/integrators/symplectic_integrator.hpp
+++ b/integrators/symplectic_integrator.hpp
@@ -4,9 +4,10 @@
 
 #include "quantities/quantities.hpp"
 
-using principia::quantities::Time;
-
 namespace principia {
+
+using quantities::Time;
+
 namespace integrators {
 
 // A simple container for a scalar value and the related error.  The

--- a/integrators/symplectic_partitioned_runge_kutta_integrator.hpp
+++ b/integrators/symplectic_partitioned_runge_kutta_integrator.hpp
@@ -5,9 +5,10 @@
 #include "base/not_null.hpp"
 #include "integrators/symplectic_integrator.hpp"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace integrators {
 
 template<typename Position, typename Momentum>

--- a/integrators/symplectic_partitioned_runge_kutta_integrator_body.hpp
+++ b/integrators/symplectic_partitioned_runge_kutta_integrator_body.hpp
@@ -10,9 +10,10 @@
 // Mixed assemblies are not supported by Unity/Mono.
 #include "glog/logging.h"
 
-using principia::quantities::Quotient;
-
 namespace principia {
+
+using quantities::Quotient;
+
 namespace integrators {
 
 template<typename Position, typename Momentum>

--- a/integrators/symplectic_partitioned_runge_kutta_integrator_test.cpp
+++ b/integrators/symplectic_partitioned_runge_kutta_integrator_test.cpp
@@ -17,31 +17,32 @@
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/statistics.hpp"
 
-using principia::quantities::Abs;
-using principia::quantities::AngularFrequency;
-using principia::quantities::Energy;
-using principia::quantities::Force;
-using principia::quantities::Length;
-using principia::quantities::Mass;
-using principia::quantities::Momentum;
-using principia::quantities::Pow;
-using principia::quantities::Power;
-using principia::quantities::SIUnit;
-using principia::quantities::Speed;
-using principia::quantities::Stiffness;
-using principia::quantities::Time;
-using principia::testing_utilities::BidimensionalDatasetMathematicaInput;
-using principia::testing_utilities::ComputeHarmonicOscillatorForce;
-using principia::testing_utilities::ComputeHarmonicOscillatorVelocity;
-using principia::testing_utilities::PearsonProductMomentCorrelationCoefficient;
-using principia::testing_utilities::Slope;
-using testing::AllOf;
-using testing::Eq;
-using testing::Gt;
-using testing::Lt;
-using testing::Ne;
-
 namespace principia {
+
+using quantities::Abs;
+using quantities::AngularFrequency;
+using quantities::Energy;
+using quantities::Force;
+using quantities::Length;
+using quantities::Mass;
+using quantities::Momentum;
+using quantities::Pow;
+using quantities::Power;
+using quantities::SIUnit;
+using quantities::Speed;
+using quantities::Stiffness;
+using quantities::Time;
+using testing_utilities::BidimensionalDatasetMathematicaInput;
+using testing_utilities::ComputeHarmonicOscillatorForce;
+using testing_utilities::ComputeHarmonicOscillatorVelocity;
+using testing_utilities::PearsonProductMomentCorrelationCoefficient;
+using testing_utilities::Slope;
+using ::testing::AllOf;
+using ::testing::Eq;
+using ::testing::Gt;
+using ::testing::Lt;
+using ::testing::Ne;
+
 namespace integrators {
 
 class SPRKTest : public testing::Test {

--- a/ksp_plugin/celestial.hpp
+++ b/ksp_plugin/celestial.hpp
@@ -11,14 +11,15 @@
 #include "quantities/named_quantities.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
-using principia::base::not_null;
-using principia::physics::Body;
-using principia::physics::DegreesOfFreedom;
-using principia::physics::MassiveBody;
-using principia::physics::Trajectory;
-using principia::quantities::GravitationalParameter;
-
 namespace principia {
+
+using base::not_null;
+using physics::Body;
+using physics::DegreesOfFreedom;
+using physics::MassiveBody;
+using physics::Trajectory;
+using quantities::GravitationalParameter;
+
 namespace ksp_plugin {
 
 // Represents a KSP |CelestialBody|.

--- a/ksp_plugin/frames.hpp
+++ b/ksp_plugin/frames.hpp
@@ -5,11 +5,12 @@
 #include "geometry/frame.hpp"
 #include "geometry/named_quantities.hpp"
 
-using principia::geometry::Frame;
-using principia::geometry::Instant;
-using principia::geometry::Position;
-
 namespace principia {
+
+using geometry::Frame;
+using geometry::Instant;
+using geometry::Position;
+
 namespace ksp_plugin {
 
 // Universal time 0, time of game creation.

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -9,19 +9,17 @@
 #include "base/version.hpp"
 #include "ksp_plugin/part.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::geometry::Displacement;
-using principia::ksp_plugin::AliceSun;
-using principia::ksp_plugin::LineSegment;
-using principia::ksp_plugin::Part;
-using principia::ksp_plugin::PartId;
-using principia::ksp_plugin::RenderedTrajectory;
-using principia::ksp_plugin::World;
-using principia::quantities::Pow;
-using principia::si::Degree;
-using principia::si::Metre;
-using principia::si::Second;
-using principia::si::Tonne;
+namespace principia {
+
+using base::make_not_null_unique;
+using geometry::Displacement;
+using quantities::Pow;
+using si::Degree;
+using si::Metre;
+using si::Second;
+using si::Tonne;
+
+namespace ksp_plugin {
 
 namespace {
 
@@ -337,3 +335,6 @@ double principia__current_time(Plugin const* const plugin) {
 char const* principia__SayHello() {
   return "Hello from native C++!";
 }
+
+}  // namespace ksp_plugin
+}  // namespace principia

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -7,6 +7,9 @@
 #include "physics/transforms.hpp"
 
 namespace principia {
+
+using physics::Transforms;
+
 namespace ksp_plugin {
 
 struct LineAndIterator {
@@ -15,15 +18,6 @@ struct LineAndIterator {
   RenderedTrajectory<World> const rendered_trajectory;
   RenderedTrajectory<World>::const_iterator it;
 };
-
-}  // namespace ksp_plugin
-}  // namespace principia
-
-using principia::ksp_plugin::Barycentric;
-using principia::ksp_plugin::LineAndIterator;
-using principia::ksp_plugin::Plugin;
-using principia::ksp_plugin::Rendering;
-using principia::physics::Transforms;
 
 extern "C"
 struct XYZ {
@@ -265,5 +259,5 @@ double CDECL principia__current_time(Plugin const* const plugin);
 extern "C" DLLEXPORT
 char const* CDECL principia__SayHello();
 
-#undef CDECL
-#undef DLLEXPORT
+}  // namespace ksp_plugin
+}  // namespace principia

--- a/ksp_plugin/mock_plugin.hpp
+++ b/ksp_plugin/mock_plugin.hpp
@@ -6,9 +6,10 @@
 #include "gmock/gmock.h"
 #include "ksp_plugin/plugin.hpp"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace ksp_plugin {
 
 class MockPlugin : public Plugin {

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -11,14 +11,15 @@
 #include "quantities/quantities.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
-using principia::geometry::Position;
-using principia::geometry::Vector;
-using principia::geometry::Velocity;
-using principia::physics::DegreesOfFreedom;
-using principia::quantities::Acceleration;
-using principia::quantities::Mass;
-
 namespace principia {
+
+using geometry::Position;
+using geometry::Vector;
+using geometry::Velocity;
+using physics::DegreesOfFreedom;
+using quantities::Acceleration;
+using quantities::Mass;
+
 namespace ksp_plugin {
 
 // Corresponds to KSP's |Part.flightID|, *not* to |Part.uid|.  C#'s |uint|

--- a/ksp_plugin/physics_bubble.cpp
+++ b/ksp_plugin/physics_bubble.cpp
@@ -14,11 +14,12 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::BarycentreCalculator;
-using principia::geometry::Identity;
-using principia::quantities::Time;
-
 namespace principia {
+
+using geometry::BarycentreCalculator;
+using geometry::Identity;
+using quantities::Time;
+
 namespace ksp_plugin {
 
 PhysicsBubble::PhysicsBubble()

--- a/ksp_plugin/physics_bubble.hpp
+++ b/ksp_plugin/physics_bubble.hpp
@@ -14,11 +14,12 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
-using principia::base::not_null;
-using principia::physics::DegreesOfFreedom;
-using principia::physics::RelativeDegreesOfFreedom;
-
 namespace principia {
+
+using base::not_null;
+using physics::DegreesOfFreedom;
+using physics::RelativeDegreesOfFreedom;
+
 namespace ksp_plugin {
 
 class PhysicsBubble {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -10,11 +10,12 @@
 #include "quantities/named_quantities.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
-using principia::physics::MasslessBody;
-using principia::physics::Trajectory;
-using principia::quantities::GravitationalParameter;
-
 namespace principia {
+
+using physics::MasslessBody;
+using physics::Trajectory;
+using quantities::GravitationalParameter;
+
 namespace ksp_plugin {
 
 // Represents a KSP |Vessel|.

--- a/ksp_plugin_test/celestial_test.cpp
+++ b/ksp_plugin_test/celestial_test.cpp
@@ -4,11 +4,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using principia::si::Kilogram;
-using principia::si::Metre;
-using principia::si::Second;
-
 namespace principia {
+
+using si::Kilogram;
+using si::Metre;
+using si::Second;
+
 namespace ksp_plugin {
 
 class CelestialTest : public testing::Test {

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -7,29 +7,26 @@
 #include "quantities/si.hpp"
 #include "ksp_plugin/mock_plugin.hpp"
 
-using principia::base::check_not_null;
-using principia::geometry::Displacement;
-using principia::geometry::kUnixEpoch;
-using principia::ksp_plugin::AliceSun;
-using principia::ksp_plugin::Index;
-using principia::ksp_plugin::LineSegment;
-using principia::ksp_plugin::MockPlugin;
-using principia::ksp_plugin::Part;
-using principia::ksp_plugin::RenderedTrajectory;
-using principia::ksp_plugin::World;
-using principia::si::Degree;
-using principia::si::Second;
-using principia::si::Tonne;
-using testing::ElementsAre;
-using testing::Eq;
-using testing::ExitedWithCode;
-using testing::IsNull;
-using testing::Pointee;
-using testing::Property;
-using testing::Ref;
-using testing::Return;
-using testing::StrictMock;
-using testing::_;
+namespace principia {
+
+using base::check_not_null;
+using geometry::Displacement;
+using geometry::kUnixEpoch;
+using si::Degree;
+using si::Second;
+using si::Tonne;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::ExitedWithCode;
+using ::testing::IsNull;
+using ::testing::Pointee;
+using ::testing::Property;
+using ::testing::Ref;
+using ::testing::Return;
+using ::testing::StrictMock;
+using ::testing::_;
+
+namespace ksp_plugin {
 
 bool operator==(XYZ const& left, XYZ const& right) {
   return left.x == right.x && left.y == right.y && left.z == right.z;
@@ -38,8 +35,6 @@ bool operator==(XYZ const& left, XYZ const& right) {
 bool operator==(QP const& left, QP const& right) {
   return left.q == right.q && left.p == right.p;
 }
-
-namespace {
 
 char const kVesselGUID[] = "NCC-1701-D";
 
@@ -456,4 +451,5 @@ TEST_F(InterfaceDeathTest, SettersAndGetters) {
   }, ExitedWithCode(kExitCode), kExitMessage);
 }
 
-}  // namespace
+}  // namespace ksp_plugin
+}  // namespace principia

--- a/ksp_plugin_test/part_test.cpp
+++ b/ksp_plugin_test/part_test.cpp
@@ -4,11 +4,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using principia::si::Kilogram;
-using principia::si::Metre;
-using principia::si::Second;
-
 namespace principia {
+
+using si::Kilogram;
+using si::Metre;
+using si::Second;
+
 namespace ksp_plugin {
 
 class PartTest : public testing::Test {

--- a/ksp_plugin_test/physics_bubble_test.cpp
+++ b/ksp_plugin_test/physics_bubble_test.cpp
@@ -19,19 +19,20 @@
 #include "testing_utilities/componentwise.hpp"
 #include "testing_utilities/vanishes_before.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::geometry::Bivector;
-using principia::quantities::Acceleration;
-using principia::quantities::Speed;
-using principia::quantities::SIUnit;
-using principia::quantities::Time;
-using principia::si::Degree;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::Componentwise;
-using principia::testing_utilities::VanishesBefore;
-using testing::ElementsAre;
-
 namespace principia {
+
+using base::make_not_null_unique;
+using geometry::Bivector;
+using quantities::Acceleration;
+using quantities::Speed;
+using quantities::SIUnit;
+using quantities::Time;
+using si::Degree;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Componentwise;
+using testing_utilities::VanishesBefore;
+using ::testing::ElementsAre;
+
 namespace ksp_plugin {
 
 // All the numerical values in the tests below were computed exactly based on

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -19,37 +19,38 @@
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/solar_system.hpp"
 
-using principia::geometry::Bivector;
-using principia::geometry::Permutation;
-using principia::physics::MockNBodySystem;
-using principia::quantities::Abs;
-using principia::quantities::ArcTan;
-using principia::quantities::Sqrt;
-using principia::si::Day;
-using principia::si::Hour;
-using principia::si::Minute;
-using principia::si::Radian;
-using principia::si::AstronomicalUnit;
-using principia::testing_utilities::AbsoluteError;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::Componentwise;
-using principia::testing_utilities::ICRFJ2000Ecliptic;
-using principia::testing_utilities::RelativeError;
-using principia::testing_utilities::SolarSystem;
-using testing::AllOf;
-using testing::Contains;
-using testing::Eq;
-using testing::Ge;
-using testing::Gt;
-using testing::InSequence;
-using testing::Le;
-using testing::Lt;
-using testing::Ref;
-using testing::SizeIs;
-using testing::StrictMock;
-using testing::_;
-
 namespace principia {
+
+using geometry::Bivector;
+using geometry::Permutation;
+using physics::MockNBodySystem;
+using quantities::Abs;
+using quantities::ArcTan;
+using quantities::Sqrt;
+using si::Day;
+using si::Hour;
+using si::Minute;
+using si::Radian;
+using si::AstronomicalUnit;
+using testing_utilities::AbsoluteError;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Componentwise;
+using testing_utilities::ICRFJ2000Ecliptic;
+using testing_utilities::RelativeError;
+using testing_utilities::SolarSystem;
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::Eq;
+using ::testing::Ge;
+using ::testing::Gt;
+using ::testing::InSequence;
+using ::testing::Le;
+using ::testing::Lt;
+using ::testing::Ref;
+using ::testing::SizeIs;
+using ::testing::StrictMock;
+using ::testing::_;
+
 namespace ksp_plugin {
 
 namespace {

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -4,11 +4,12 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using principia::si::Kilogram;
-using principia::si::Metre;
-using principia::si::Second;
-
 namespace principia {
+
+using si::Kilogram;
+using si::Metre;
+using si::Second;
+
 namespace ksp_plugin {
 
 class VesselTest : public testing::Test {

--- a/physics/body.hpp
+++ b/physics/body.hpp
@@ -4,9 +4,10 @@
 #include "base/not_null.hpp"
 #include "serialization/physics.pb.h"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace physics {
 
 class Body {

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -4,12 +4,13 @@
 #include "gtest/gtest.h"
 #include "serialization/geometry.pb.h"
 
-using principia::geometry::Frame;
-using principia::geometry::Normalize;
-using testing::IsNull;
-using testing::NotNull;
-
 namespace principia {
+
+using geometry::Frame;
+using geometry::Normalize;
+using ::testing::IsNull;
+using ::testing::NotNull;
+
 namespace physics {
 
 class BodyTest : public testing::Test {

--- a/physics/degrees_of_freedom.hpp
+++ b/physics/degrees_of_freedom.hpp
@@ -8,12 +8,13 @@
 #include "geometry/point.hpp"
 #include "quantities/named_quantities.hpp"
 
-using principia::geometry::Displacement;
-using principia::geometry::Pair;
-using principia::geometry::Position;
-using principia::geometry::Velocity;
-
 namespace principia {
+
+using geometry::Displacement;
+using geometry::Pair;
+using geometry::Position;
+using geometry::Velocity;
+
 namespace physics {
 
 // This class is analogous to the pair which is its base class, except that it

--- a/physics/degrees_of_freedom_test.cpp
+++ b/physics/degrees_of_freedom_test.cpp
@@ -9,17 +9,18 @@
 #include "quantities/quantities.hpp"
 #include "testing_utilities/componentwise.hpp"
 
-using principia::geometry::Displacement;
-using principia::geometry::Position;
-using principia::geometry::Velocity;
-using principia::quantities::Entropy;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-using principia::quantities::SIUnit;
-using principia::testing_utilities::Componentwise;
-using testing::Eq;
-
 namespace principia {
+
+using geometry::Displacement;
+using geometry::Position;
+using geometry::Velocity;
+using quantities::Entropy;
+using quantities::Length;
+using quantities::Speed;
+using quantities::SIUnit;
+using testing_utilities::Componentwise;
+using ::testing::Eq;
+
 namespace physics {
 
 class DegreesOfFreedomTest : public testing::Test {

--- a/physics/massive_body.hpp
+++ b/physics/massive_body.hpp
@@ -11,10 +11,11 @@
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::quantities::GravitationalParameter;
-using principia::quantities::Mass;
-
 namespace principia {
+
+using quantities::GravitationalParameter;
+using quantities::Mass;
+
 namespace physics {
 
 class MassiveBody : public Body {

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -12,11 +12,12 @@
 #include "quantities/constants.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::constants::GravitationalConstant;
-using principia::geometry::Frame;
-using principia::geometry::ReadFrameFromMessage;
-
 namespace principia {
+
+using constants::GravitationalConstant;
+using geometry::Frame;
+using geometry::ReadFrameFromMessage;
+
 namespace physics {
 
 inline MassiveBody::MassiveBody(

--- a/physics/n_body_system.hpp
+++ b/physics/n_body_system.hpp
@@ -12,15 +12,16 @@
 #include "physics/trajectory.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::base::not_null;
-using principia::geometry::Instant;
-using principia::integrators::SymplecticIntegrator;
-using principia::quantities::Acceleration;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-using principia::quantities::Time;
-
 namespace principia {
+
+using base::not_null;
+using geometry::Instant;
+using integrators::SymplecticIntegrator;
+using quantities::Acceleration;
+using quantities::Length;
+using quantities::Speed;
+using quantities::Time;
+
 namespace physics {
 
 template<typename Frame>

--- a/physics/n_body_system_body.hpp
+++ b/physics/n_body_system_body.hpp
@@ -15,18 +15,19 @@
 #include "physics/oblate_body.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::InnerProduct;
-using principia::geometry::Instant;
-using principia::geometry::R3Element;
-using principia::integrators::SPRKIntegrator;
-using principia::integrators::SymplecticIntegrator;
-using principia::quantities::Acceleration;
-using principia::quantities::Exponentiation;
-using principia::quantities::GravitationalParameter;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-
 namespace principia {
+
+using geometry::InnerProduct;
+using geometry::Instant;
+using geometry::R3Element;
+using integrators::SPRKIntegrator;
+using integrators::SymplecticIntegrator;
+using quantities::Acceleration;
+using quantities::Exponentiation;
+using quantities::GravitationalParameter;
+using quantities::Length;
+using quantities::Speed;
+
 namespace physics {
 
 namespace {

--- a/physics/n_body_system_test.cpp
+++ b/physics/n_body_system_test.cpp
@@ -22,28 +22,29 @@
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/solar_system.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::constants::GravitationalConstant;
-using principia::geometry::Instant;
-using principia::geometry::Point;
-using principia::geometry::Vector;
-using principia::quantities::Angle;
-using principia::quantities::ArcTan;
-using principia::quantities::Area;
-using principia::quantities::Pow;
-using principia::quantities::SIUnit;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::ICRFJ2000Ecliptic;
-using principia::testing_utilities::kSolarSystemBarycentre;
-using principia::testing_utilities::RelativeError;
-using principia::testing_utilities::SolarSystem;
-using principia::si::Degree;
-using principia::si::Minute;
-using testing::Eq;
-using testing::Gt;
-using testing::Lt;
-
 namespace principia {
+
+using base::make_not_null_unique;
+using constants::GravitationalConstant;
+using geometry::Instant;
+using geometry::Point;
+using geometry::Vector;
+using quantities::Angle;
+using quantities::ArcTan;
+using quantities::Area;
+using quantities::Pow;
+using quantities::SIUnit;
+using testing_utilities::AlmostEquals;
+using testing_utilities::ICRFJ2000Ecliptic;
+using testing_utilities::kSolarSystemBarycentre;
+using testing_utilities::RelativeError;
+using testing_utilities::SolarSystem;
+using si::Degree;
+using si::Minute;
+using ::testing::Eq;
+using ::testing::Gt;
+using ::testing::Lt;
+
 namespace physics {
 
 class NBodySystemTest : public testing::Test {

--- a/physics/oblate_body.hpp
+++ b/physics/oblate_body.hpp
@@ -14,13 +14,14 @@
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::Vector;
-using principia::quantities::GravitationalParameter;
-using principia::quantities::Length;
-using principia::quantities::Mass;
-using principia::quantities::Order2ZonalCoefficient;
-
 namespace principia {
+
+using geometry::Vector;
+using quantities::GravitationalParameter;
+using quantities::Length;
+using quantities::Mass;
+using quantities::Order2ZonalCoefficient;
+
 namespace physics {
 
 template<typename Frame>

--- a/physics/trajectory.hpp
+++ b/physics/trajectory.hpp
@@ -12,15 +12,16 @@
 #include "quantities/named_quantities.hpp"
 #include "serialization/physics.pb.h"
 
-using principia::base::not_null;
-using principia::geometry::Instant;
-using principia::geometry::Vector;
-using principia::geometry::Velocity;
-using principia::quantities::Acceleration;
-using principia::quantities::Length;
-using principia::quantities::Speed;
-
 namespace principia {
+
+using base::not_null;
+using geometry::Instant;
+using geometry::Vector;
+using geometry::Velocity;
+using quantities::Acceleration;
+using quantities::Length;
+using quantities::Speed;
+
 namespace physics {
 
 class Body;

--- a/physics/trajectory_body.hpp
+++ b/physics/trajectory_body.hpp
@@ -10,10 +10,11 @@
 #include "glog/logging.h"
 #include "physics/oblate_body.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::geometry::Instant;
-
 namespace principia {
+
+using base::make_not_null_unique;
+using geometry::Instant;
+
 namespace physics {
 
 template<typename Frame>

--- a/physics/trajectory_test.cpp
+++ b/physics/trajectory_test.cpp
@@ -19,28 +19,29 @@
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
 
-using principia::geometry::Frame;
-using principia::geometry::Instant;
-using principia::geometry::Point;
-using principia::geometry::R3Element;
-using principia::geometry::Vector;
-using principia::quantities::Length;
-using principia::quantities::Mass;
-using principia::quantities::Speed;
-using principia::quantities::SIUnit;
-using principia::si::Metre;
-using principia::si::Second;
-using std::placeholders::_1;
-using std::placeholders::_2;
-using std::placeholders::_3;
-using testing::ElementsAre;
-using testing::Eq;
-using testing::Ref;
+namespace principia {
 
-// Note that we cannot have a |using testing::Pair| here as it would conflict
+using geometry::Frame;
+using geometry::Instant;
+using geometry::Point;
+using geometry::R3Element;
+using geometry::Vector;
+using quantities::Length;
+using quantities::Mass;
+using quantities::Speed;
+using quantities::SIUnit;
+using si::Metre;
+using si::Second;
+using ::std::placeholders::_1;
+using ::std::placeholders::_2;
+using ::std::placeholders::_3;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Ref;
+
+// Note that we cannot have a |using ::testing::Pair| here as it would conflict
 // with |principia::geometry::Pair|.
 
-namespace principia {
 namespace physics {
 
 class TrajectoryTest : public testing::Test {

--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -8,9 +8,10 @@
 #include "base/not_null.hpp"
 #include "physics/trajectory.hpp"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace physics {
 
 // This class represent a pair of transformations of a trajectory from

--- a/physics/transforms_body.hpp
+++ b/physics/transforms_body.hpp
@@ -15,21 +15,22 @@
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::geometry::AffineMap;
-using principia::geometry::Bivector;
-using principia::geometry::Displacement;
-using principia::geometry::Identity;
-using principia::geometry::Permutation;
-using principia::geometry::Position;
-using principia::geometry::R3x3Matrix;
-using principia::geometry::Rotation;
-using principia::geometry::Wedge;
-using principia::quantities::AngularFrequency;
-using principia::quantities::Pow;
-using principia::si::Radian;
-
 namespace principia {
+
+using base::make_not_null_unique;
+using geometry::AffineMap;
+using geometry::Bivector;
+using geometry::Displacement;
+using geometry::Identity;
+using geometry::Permutation;
+using geometry::Position;
+using geometry::R3x3Matrix;
+using geometry::Rotation;
+using geometry::Wedge;
+using quantities::AngularFrequency;
+using quantities::Pow;
+using si::Radian;
+
 namespace physics {
 
 namespace {

--- a/physics/transforms_test.cpp
+++ b/physics/transforms_test.cpp
@@ -16,20 +16,21 @@
 #include "testing_utilities/componentwise.hpp"
 #include "testing_utilities/vanishes_before.hpp"
 
-using principia::base::make_not_null_unique;
-using principia::geometry::Frame;
-using principia::quantities::Length;
-using principia::quantities::Mass;
-using principia::quantities::SIUnit;
-using principia::quantities::Speed;
-using principia::quantities::Time;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::Componentwise;
-using principia::testing_utilities::VanishesBefore;
-using testing::Eq;
-using testing::Lt;
-
 namespace principia {
+
+using base::make_not_null_unique;
+using geometry::Frame;
+using quantities::Length;
+using quantities::Mass;
+using quantities::SIUnit;
+using quantities::Speed;
+using quantities::Time;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Componentwise;
+using testing_utilities::VanishesBefore;
+using ::testing::Eq;
+using ::testing::Lt;
+
 namespace physics {
 
 namespace {

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -8,9 +8,10 @@
 #include "base/not_null.hpp"
 #include "serialization/quantities.pb.h"
 
-using principia::base::not_null;
-
 namespace principia {
+
+using base::not_null;
+
 namespace quantities {
 
 template<int64_t LengthExponent, int64_t MassExponent, int64_t TimeExponent,

--- a/quantities/quantities_test.cpp
+++ b/quantities/quantities_test.cpp
@@ -16,45 +16,46 @@
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/vanishes_before.hpp"
 
-using principia::astronomy::EarthMass;
-using principia::astronomy::JulianYear;
-using principia::astronomy::JupiterMass;
-using principia::astronomy::LightYear;
-using principia::astronomy::LunarDistance;
-using principia::astronomy::Parsec;
-using principia::astronomy::SolarMass;
-using principia::constants::ElectronMass;
-using principia::constants::GravitationalConstant;
-using principia::constants::SpeedOfLight;
-using principia::constants::StandardGravity;
-using principia::constants::VacuumPermeability;
-using principia::constants::VacuumPermittivity;
-using principia::si::Ampere;
-using principia::si::AstronomicalUnit;
-using principia::si::Candela;
-using principia::si::Cycle;
-using principia::si::Day;
-using principia::si::Degree;
-using principia::si::Hour;
-using principia::si::Kelvin;
-using principia::si::Kilogram;
-using principia::si::Mega;
-using principia::si::Metre;
-using principia::si::Mole;
-using principia::si::Radian;
-using principia::si::Second;
-using principia::si::Steradian;
-using principia::testing_utilities::AlmostEquals;
-using principia::testing_utilities::RelativeError;
-using principia::testing_utilities::Times;
-using principia::testing_utilities::VanishesBefore;
-using principia::uk::Foot;
-using principia::uk::Furlong;
-using principia::uk::Mile;
-using principia::uk::Rood;
-using testing::Lt;
-
 namespace principia {
+
+using astronomy::EarthMass;
+using astronomy::JulianYear;
+using astronomy::JupiterMass;
+using astronomy::LightYear;
+using astronomy::LunarDistance;
+using astronomy::Parsec;
+using astronomy::SolarMass;
+using constants::ElectronMass;
+using constants::GravitationalConstant;
+using constants::SpeedOfLight;
+using constants::StandardGravity;
+using constants::VacuumPermeability;
+using constants::VacuumPermittivity;
+using si::Ampere;
+using si::AstronomicalUnit;
+using si::Candela;
+using si::Cycle;
+using si::Day;
+using si::Degree;
+using si::Hour;
+using si::Kelvin;
+using si::Kilogram;
+using si::Mega;
+using si::Metre;
+using si::Mole;
+using si::Radian;
+using si::Second;
+using si::Steradian;
+using testing_utilities::AlmostEquals;
+using testing_utilities::RelativeError;
+using testing_utilities::Times;
+using testing_utilities::VanishesBefore;
+using uk::Foot;
+using uk::Furlong;
+using uk::Mile;
+using uk::Rood;
+using ::testing::Lt;
+
 namespace quantities {
 
 class QuantitiesTest : public testing::Test {

--- a/testing_utilities/componentwise.hpp
+++ b/testing_utilities/componentwise.hpp
@@ -11,9 +11,10 @@
 #include "gmock/gmock.h"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::R3Element;
-
 namespace principia {
+
+using geometry::R3Element;
+
 namespace testing_utilities {
 
 template<typename T1Matcher, typename T2Matcher>

--- a/testing_utilities/componentwise_body.hpp
+++ b/testing_utilities/componentwise_body.hpp
@@ -8,11 +8,12 @@
 #include "gmock/gmock.h"
 #include "quantities/quantities.hpp"
 
-using principia::geometry::Point;
-using principia::quantities::Quantity;
-using testing::Matcher;
-
 namespace principia {
+
+using geometry::Point;
+using quantities::Quantity;
+using ::testing::Matcher;
+
 namespace testing_utilities {
 
 namespace {

--- a/testing_utilities/componentwise_test.cpp
+++ b/testing_utilities/componentwise_test.cpp
@@ -14,18 +14,19 @@
 #include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/vanishes_before.hpp"
 
-using principia::geometry::Bivector;
-using principia::geometry::Pair;
-using principia::geometry::R3Element;
-using principia::geometry::Vector;
-using principia::quantities::Action;
-using principia::quantities::Winding;
-using principia::quantities::Length;
-using principia::si::Metre;
-using testing::Eq;
-using testing::Not;
-
 namespace principia {
+
+using geometry::Bivector;
+using geometry::Pair;
+using geometry::R3Element;
+using geometry::Vector;
+using quantities::Action;
+using quantities::Winding;
+using quantities::Length;
+using si::Metre;
+using ::testing::Eq;
+using ::testing::Not;
+
 namespace testing_utilities {
 
 struct World;

--- a/testing_utilities/numerical_analysis.hpp
+++ b/testing_utilities/numerical_analysis.hpp
@@ -6,18 +6,19 @@
 #include "quantities/quantities.hpp"
 #include "quantities/named_quantities.hpp"
 
-using principia::base::not_null;
-using principia::quantities::Force;
-using principia::quantities::Length;
-using principia::quantities::Momentum;
-using principia::quantities::Speed;
-using principia::quantities::Time;
+namespace principia {
+
+using base::not_null;
+using quantities::Force;
+using quantities::Length;
+using quantities::Momentum;
+using quantities::Speed;
+using quantities::Time;
+
+namespace testing_utilities {
 
 // Right-hand sides for various differential equations frequently used to test
 // the properties of integrators.
-
-namespace principia {
-namespace testing_utilities {
 
 // The one-dimensional unit harmonic oscillator,
 // q' = p,  |ComputeHarmonicOscillatorVelocity|,

--- a/testing_utilities/numerical_analysis_body.hpp
+++ b/testing_utilities/numerical_analysis_body.hpp
@@ -5,16 +5,17 @@
 #include "quantities/quantities.hpp"
 #include "quantities/named_quantities.hpp"
 
-using principia::quantities::Force;
-using principia::quantities::Length;
-using principia::quantities::Mass;
-using principia::quantities::Momentum;
-using principia::quantities::SIUnit;
-using principia::quantities::Speed;
-using principia::quantities::Stiffness;
-using principia::quantities::Time;
-
 namespace principia {
+
+using quantities::Force;
+using quantities::Length;
+using quantities::Mass;
+using quantities::Momentum;
+using quantities::SIUnit;
+using quantities::Speed;
+using quantities::Stiffness;
+using quantities::Time;
+
 namespace testing_utilities {
 
 inline void ComputeHarmonicOscillatorForce(

--- a/testing_utilities/solar_system.hpp
+++ b/testing_utilities/solar_system.hpp
@@ -13,10 +13,11 @@
 #include "quantities/si.hpp"
 #include "serialization/geometry.pb.h"
 
-using principia::base::not_null;
-using principia::geometry::Frame;
-
 namespace principia {
+
+using base::not_null;
+using geometry::Frame;
+
 namespace testing_utilities {
 
 // A reference frame with a basis.

--- a/testing_utilities/solar_system_body.hpp
+++ b/testing_utilities/solar_system_body.hpp
@@ -19,32 +19,33 @@
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
 
-using principia::base::check_not_null;
-using principia::base::make_not_null_unique;
-using principia::geometry::Bivector;
-using principia::geometry::Displacement;
-using principia::geometry::Instant;
-using principia::geometry::JulianDate;
-using principia::geometry::Point;
-using principia::geometry::Rotation;
-using principia::geometry::Vector;
-using principia::physics::MassiveBody;
-using principia::physics::NBodySystem;
-using principia::physics::OblateBody;
-using principia::physics::Trajectory;
-using principia::quantities::Angle;
-using principia::quantities::GravitationalParameter;
-using principia::quantities::Pow;
-using principia::quantities::SIUnit;
-using principia::quantities::Time;
-using principia::si::Day;
-using principia::si::Degree;
-using principia::si::Kilo;
-using principia::si::Kilogram;
-using principia::si::Metre;
-using principia::si::Second;
-
 namespace principia {
+
+using base::check_not_null;
+using base::make_not_null_unique;
+using geometry::Bivector;
+using geometry::Displacement;
+using geometry::Instant;
+using geometry::JulianDate;
+using geometry::Point;
+using geometry::Rotation;
+using geometry::Vector;
+using physics::MassiveBody;
+using physics::NBodySystem;
+using physics::OblateBody;
+using physics::Trajectory;
+using quantities::Angle;
+using quantities::GravitationalParameter;
+using quantities::Pow;
+using quantities::SIUnit;
+using quantities::Time;
+using si::Day;
+using si::Degree;
+using si::Kilo;
+using si::Kilogram;
+using si::Metre;
+using si::Second;
+
 namespace testing_utilities {
 
 namespace {

--- a/testing_utilities/solar_system_test.cpp
+++ b/testing_utilities/solar_system_test.cpp
@@ -10,25 +10,26 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "testing_utilities/numerics.hpp"
 
-using principia::geometry::Bivector;
-using principia::geometry::Wedge;
-using principia::physics::RelativeDegreesOfFreedom;
-using principia::physics::Body;
-using principia::physics::NBodySystem;
-using principia::quantities::SpecificAngularMomentum;
-using principia::quantities::SpecificEnergy;
-using principia::quantities::GravitationalParameter;
-using principia::quantities::Mass;
-using principia::quantities::Pow;
-using principia::quantities::Quotient;
-using principia::quantities::Speed;
-using principia::quantities::Sqrt;
-using principia::si::Radian;
-using testing::ElementsAreArray;
-using testing::Lt;
-using testing::Ge;
-
 namespace principia {
+
+using geometry::Bivector;
+using geometry::Wedge;
+using physics::RelativeDegreesOfFreedom;
+using physics::Body;
+using physics::NBodySystem;
+using quantities::SpecificAngularMomentum;
+using quantities::SpecificEnergy;
+using quantities::GravitationalParameter;
+using quantities::Mass;
+using quantities::Pow;
+using quantities::Quotient;
+using quantities::Speed;
+using quantities::Sqrt;
+using si::Radian;
+using ::testing::ElementsAreArray;
+using ::testing::Lt;
+using ::testing::Ge;
+
 namespace testing_utilities {
 
 class SolarSystemTest : public testing::Test {

--- a/testing_utilities/vanishes_before_test.cpp
+++ b/testing_utilities/vanishes_before_test.cpp
@@ -11,11 +11,12 @@
 #include "quantities/numbers.hpp"
 #include "quantities/quantities.hpp"
 
-using principia::bipm::Knot;
-using principia::quantities::Speed;
-using testing::Ne;
-
 namespace principia {
+
+using bipm::Knot;
+using quantities::Speed;
+using ::testing::Ne;
+
 namespace testing_utilities {
 
 class VanishesBeforeTest : public testing::Test {};


### PR DESCRIPTION
For clarity we'll use a leading `::` for the using declarations that reference symbols *not* in `principia`.

Fix #96.