### PR TITLE
Do not crash on revert to VAB

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -296,7 +296,6 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
     if (PluginRunning()) {
       double universal_time = Planetarium.GetUniversalTime();
       double plugin_time = current_time(plugin_);
-      Log.Error("{" + DateTime.Now.Ticks + "," + universal_time + "," + plugin_time + "}");
       if (plugin_time > universal_time) {
         Log.Fatal("Closed Timelike Curve");
       } else if (plugin_time == universal_time) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -296,6 +296,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
     if (PluginRunning()) {
       double universal_time = Planetarium.GetUniversalTime();
       double plugin_time = current_time(plugin_);
+      Log.Error("{" + DateTime.Now.Ticks + "," + universal_time + "," + plugin_time + "}");
       if (plugin_time > universal_time) {
         Log.Fatal("Closed Timelike Curve");
       } else if (plugin_time == universal_time) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -8,7 +8,6 @@ namespace ksp_plugin_adapter {
 
 [KSPScenario(createOptions: ScenarioCreationOptions.AddToAllGames,
              tgtScenes: new GameScenes[]{GameScenes.SPACECENTER,
-                                         GameScenes.EDITOR,
                                          GameScenes.FLIGHT,
                                          GameScenes.TRACKSTATION})]
 public partial class PrincipiaPluginAdapter : ScenarioModule {


### PR DESCRIPTION
Thanks to @diomedea for reporting this!

## Postmortem:
When reverting to VAB, the old save is loaded immediately, but the time is only reset when exiting the VAB. Running Principia in the editor causes it to integrate back to the future, and causes a `FATAL` failure (Closed Timelike Curve) when KSP's time gets reverted.
See the graph below:
Horizontal axis is real time, in hundreds of nanoseconds since `0001-01-01T00:00:00Z` Gregorian.
Vertical axis is KSP time in seconds since the beginning of the game.
Orange is plugin timestamps, blue is KSP timestamps. The difference is highlighted by thick black bars.
Green lines indicate serializations, red lines deserializations.
The first revert is a revert to launch, the second is a revert to VAB. The log ends (with a crash) when exiting the VAB.
![diomedea](https://cloud.githubusercontent.com/assets/2284290/6335628/2501228c-bb9d-11e4-8dc4-f3946e0567b9.png)
