### PR TITLE
Monitoring the caching of transforms.

### DIFF
--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -68,11 +68,30 @@ class Transforms {
   typename Trajectory<FromFrame>::template Transform<ThroughFrame> first_;
   typename Trajectory<ThroughFrame>::template Transform<ToFrame> second_;
 
+  // A simple cache with no eviction, which monitors the hit rate.
+  template<typename Frame1, typename Frame2>
+  class Cache {
+   public:
+    bool Lookup(not_null<Trajectory<Frame1> const*> const trajectory,
+                Instant const& time,
+                not_null<DegreesOfFreedom<Frame2>**> degrees_of_freedom);
+
+    void Insert(not_null<Trajectory<Frame1> const*> const trajectory,
+                Instant const& time,
+                DegreesOfFreedom<Frame2> const& degrees_of_freedom);
+
+   private:
+    std::map<std::pair<not_null<Trajectory<Frame1> const*>, Instant const>,
+             DegreesOfFreedom<Frame2>> map_;
+    std::map<not_null<Trajectory<Frame1> const*>, std::int64_t>
+        number_of_lookups_;
+    std::map<not_null<Trajectory<Frame1> const*>, std::int64_t> number_of_hits_;
+  };
+
   // A cache for the result of the |first_| transform.  This cache assumes that
   // the iterator is never called with the same time but different degrees of
   // freedom.
-  std::map<std::pair<not_null<Trajectory<FromFrame> const*>, Instant const>,
-           DegreesOfFreedom<ThroughFrame>> first_cache_;
+  Cache<FromFrame, ThroughFrame> first_cache_;
 };
 
 }  // namespace physics

--- a/physics/transforms_body.hpp
+++ b/physics/transforms_body.hpp
@@ -84,9 +84,10 @@ Transforms<FromFrame, ThroughFrame, ToFrame>::BodyCentredNonRotating(
           not_null<Trajectory<FromFrame> const*> const trajectory) ->
       DegreesOfFreedom<ThroughFrame> {
     // First check if the result is cached.
-    auto cache_it = that->first_cache_.find(std::make_pair(trajectory, t));
-    if (cache_it != that->first_cache_.end()) {
-      return cache_it->second;
+    DegreesOfFreedom<ThroughFrame>* cached_through_degrees_of_freedom = nullptr;
+    if (that->first_cache_.Lookup(trajectory, t,
+                                  &cached_through_degrees_of_freedom)) {
+      return *cached_through_degrees_of_freedom;
     }
 
     // on_or_after() is Ln(N), but it doesn't matter unless the map gets very
@@ -110,9 +111,8 @@ Transforms<FromFrame, ThroughFrame, ToFrame>::BodyCentredNonRotating(
                       centre_degrees_of_freedom.velocity())};
 
     // Cache the result before returning it.
-    that->first_cache_.emplace(std::make_pair(trajectory, t),
-                               through_degrees_of_freedom);
-    return std::move(through_degrees_of_freedom);
+    that->first_cache_.Insert(trajectory, t, through_degrees_of_freedom);
+    return through_degrees_of_freedom;
   };
 
   transforms->second_ =
@@ -156,12 +156,13 @@ Transforms<FromFrame, ThroughFrame, ToFrame>::BarycentricRotating(
           not_null<Trajectory<FromFrame> const*> const trajectory) ->
       DegreesOfFreedom<ThroughFrame> {
     // First check if the result is cached.
-    auto cache_it = that->first_cache_.find(std::make_pair(trajectory, t));
-    if (cache_it != that->first_cache_.end()) {
-      return cache_it->second;
+    DegreesOfFreedom<ThroughFrame>* cached_through_degrees_of_freedom = nullptr;
+    if (that->first_cache_.Lookup(trajectory, t,
+                                  &cached_through_degrees_of_freedom)) {
+      return *cached_through_degrees_of_freedom;
     }
 
-    // on_or_after() is Ln(N).
+    // |on_or_after()| is Ln(N).
     TYPENAME Trajectory<FromFrame>::NativeIterator const primary_it =
         from_primary_trajectory().on_or_after(t);
     CHECK_EQ(primary_it.time(), t)
@@ -211,9 +212,8 @@ Transforms<FromFrame, ThroughFrame, ToFrame>::BarycentricRotating(
                            barycentre_degrees_of_freedom.position()) / Radian)};
 
     // Cache the result before returning it.
-    that->first_cache_.emplace(std::make_pair(trajectory, t),
-                               through_degrees_of_freedom);
-    return std::move(through_degrees_of_freedom);
+    that->first_cache_.Insert(trajectory, t, through_degrees_of_freedom);
+    return through_degrees_of_freedom;
   };
 
   transforms->second_ =
@@ -287,6 +287,38 @@ typename Trajectory<ThroughFrame>::template TransformingIterator<ToFrame>
 Transforms<FromFrame, ThroughFrame, ToFrame>::second(
     Trajectory<ThroughFrame> const& through_trajectory) {
   return through_trajectory.first_with_transform(second_);
+}
+
+
+template<typename FromFrame, typename ThroughFrame, typename ToFrame>
+template<typename Frame1, typename Frame2>
+bool
+Transforms<FromFrame, ThroughFrame, ToFrame>::Cache<Frame1, Frame2>::Lookup(
+    not_null<Trajectory<Frame1> const*> const trajectory,
+    Instant const& time,
+    not_null<DegreesOfFreedom<Frame2>**> degrees_of_freedom) {
+  bool found = false;
+  ++number_of_lookups_[trajectory];
+  auto const it = map_.find(std::make_pair(trajectory, time));
+  if (it != map_.end()) {
+    ++number_of_hits_[trajectory];
+    *degrees_of_freedom = &it->second;
+    found = true;
+  }
+  VLOG_EVERY_N(1, 1000) << "Hit ratio for trajectory " << trajectory << " is "
+                        << static_cast<double>(number_of_hits_[trajectory]) /
+                           number_of_lookups_[trajectory];
+  return found;
+}
+
+template<typename FromFrame, typename ThroughFrame, typename ToFrame>
+template<typename Frame1, typename Frame2>
+void
+Transforms<FromFrame, ThroughFrame, ToFrame>::Cache<Frame1, Frame2>::Insert(
+    not_null<Trajectory<Frame1> const*> const trajectory,
+    Instant const& time,
+    DegreesOfFreedom<Frame2> const& degrees_of_freedom) {
+  map_.emplace(std::make_pair(trajectory, time), degrees_of_freedom);
 }
 
 }  // namespace physics


### PR DESCRIPTION
As part of investigating #451, adding traces shows good cache hit ratio for the histories and none for the predictions, which is as expected given the state of things:

```
I0419 13:45:37.631872  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999347
I0419 13:45:37.690878  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999347
I0419 13:45:37.723881  4444 transforms_body.hpp:308] Hit ratio for trajectory 4A897E60 is 0.975899
I0419 13:45:37.780887  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999349
I0419 13:45:37.838893  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999347
I0419 13:45:37.865896  4444 transforms_body.hpp:308] Hit ratio for trajectory 4A898060 is 0
I0419 13:45:37.928902  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999349
I0419 13:45:37.963906  4444 transforms_body.hpp:308] Hit ratio for trajectory 4A898060 is 0
I0419 13:45:38.026912  4444 transforms_body.hpp:308] Hit ratio for trajectory 4A898060 is 0
I0419 13:45:38.086918  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.999351
I0419 13:45:38.115921  4444 transforms_body.hpp:308] Hit ratio for trajectory 4A898060 is 0
I0419 13:45:38.176928  4444 transforms_body.hpp:308] Hit ratio for trajectory 62126AE8 is 0.99935
```

It would be good to have a way to disable caching for the predictions, because we burn memory for no good reason.