### PR TITLE
Add a hook to control cacheability of lazy trajectories

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -312,7 +312,8 @@ Plugin::NewBarycentricRotatingTransforms(Index const primary_index,
       FindOrDie(celestials_, primary_index).get();
   not_null<Celestial*> secondary =
       FindOrDie(celestials_, secondary_index).get();
-  auto transforms = RenderingTransforms::BarycentricRotating(*primary,
+  auto transforms = RenderingTransforms::BarycentricRotating(
+                        *primary,
                         *secondary,
                         &MobileInterface::prolongation);
   transforms->set_cacheable(&MobileInterface::history);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -261,6 +261,7 @@ RenderedTrajectory<World> Plugin::RenderedPrediction(
   RenderedTrajectory<World> result =
       RenderTrajectory(predicted_vessel_->body(),
                        transforms->first_on_or_after(
+                           false,
                            *predicted_vessel_,
                            &MobileInterface::prediction,
                            *predicted_vessel_->prediction().fork_time()),
@@ -377,7 +378,8 @@ Vector<double, World> Plugin::VesselTangent(
     not_null<RenderingTransforms*> const transforms) const {
   Vessel const& vessel = *find_vessel_by_guid_or_die(vessel_guid);
   auto const actual_it =
-      transforms->first_on_or_after(vessel,
+      transforms->first_on_or_after(true,
+                                    vessel,
                                     &MobileInterface::prolongation,
                                     vessel.prolongation().last().time());
   Trajectory<Rendering> intermediate_trajectory(vessel.body());

--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "base/not_null.hpp"
 #include "physics/frame_field.hpp"

--- a/physics/transforms.hpp
+++ b/physics/transforms.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <utility>
 
 #include "base/not_null.hpp"
@@ -64,7 +65,8 @@ class Transforms {
         LazyTrajectory<FromFrame> const& from_trajectory);
 
   typename Trajectory<FromFrame>::template TransformingIterator<ThroughFrame>
-  first_on_or_after(Mobile const& mobile,
+  first_on_or_after(bool const cache,
+                    Mobile const& mobile,
                     LazyTrajectory<FromFrame> const& from_trajectory,
                     Instant const& time);
 
@@ -99,6 +101,8 @@ class Transforms {
     void Insert(not_null<Trajectory<Frame1> const*> const trajectory,
                 Instant const& time,
                 DegreesOfFreedom<Frame2> const& degrees_of_freedom);
+
+    std::set<not_null<Trajectory<Frame1> const*>> forgotten_;
 
    private:
     std::map<std::pair<not_null<Trajectory<Frame1> const*>, Instant const>,

--- a/physics/transforms_body.hpp
+++ b/physics/transforms_body.hpp
@@ -125,8 +125,13 @@ Transforms<Mobile, FromFrame, ThroughFrame, ToFrame>::BodyCentredNonRotating(
           not_null<Trajectory<FromFrame> const*> const trajectory) ->
       DegreesOfFreedom<ThroughFrame> {
     // First check if the result is cached.
+    bool const cacheable =
+        std::find(that->cacheable_.begin(),
+                  that->cacheable_.end(),
+                  from_trajectory) !=  that->cacheable_.end();
     DegreesOfFreedom<ThroughFrame>* cached_through_degrees_of_freedom = nullptr;
-    if (that->first_cache_.Lookup(trajectory, t,
+    if (cacheable &&
+        that->first_cache_.Lookup(trajectory, t,
                                   &cached_through_degrees_of_freedom)) {
       return *cached_through_degrees_of_freedom;
     }
@@ -152,9 +157,7 @@ Transforms<Mobile, FromFrame, ThroughFrame, ToFrame>::BodyCentredNonRotating(
                       centre_degrees_of_freedom.velocity())};
 
     // Cache the result before returning it.
-    if (std::find(that->cacheable_.begin(),
-                  that->cacheable_.end(),
-                  from_trajectory) !=  that->cacheable_.end()) {
+    if (cacheable) {
       that->first_cache_.Insert(trajectory, t, through_degrees_of_freedom);
     }
     return through_degrees_of_freedom;
@@ -219,8 +222,13 @@ Transforms<Mobile, FromFrame, ThroughFrame, ToFrame>::BarycentricRotating(
           not_null<Trajectory<FromFrame> const*> const trajectory) ->
       DegreesOfFreedom<ThroughFrame> {
     // First check if the result is cached.
+    bool const cacheable =
+        std::find(that->cacheable_.begin(),
+                  that->cacheable_.end(),
+                  from_trajectory) !=  that->cacheable_.end();
     DegreesOfFreedom<ThroughFrame>* cached_through_degrees_of_freedom = nullptr;
-    if (that->first_cache_.Lookup(trajectory, t,
+    if (cacheable &&
+        that->first_cache_.Lookup(trajectory, t,
                                   &cached_through_degrees_of_freedom)) {
       return *cached_through_degrees_of_freedom;
     }
@@ -275,9 +283,7 @@ Transforms<Mobile, FromFrame, ThroughFrame, ToFrame>::BarycentricRotating(
                            barycentre_degrees_of_freedom.position()) / Radian)};
 
     // Cache the result before returning it.
-    if (std::find(that->cacheable_.begin(),
-                  that->cacheable_.end(),
-                  from_trajectory) !=  that->cacheable_.end()) {
+    if (cacheable) {
       that->first_cache_.Insert(trajectory, t, through_degrees_of_freedom);
     }
     return through_degrees_of_freedom;


### PR DESCRIPTION
This fixes a bug where the graph of predictions was oscillating between two trajectories because of deallocated/reallocated pointers left in the cache.