### PR TITLE
Make the sun set in the west again.

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -578,7 +578,7 @@ Instant const& Plugin::HistoryTime() const {
 Rotation<Barycentric, AliceSun> Plugin::PlanetariumRotation() const {
   return Rotation<Barycentric, AliceSun>(
       planetarium_rotation_,
-      Bivector<double, Barycentric>({0, 0, 1}));
+      Bivector<double, Barycentric>({0, 0, -1}));
 }
 
 OrthogonalMap<Barycentric, WorldSun> Plugin::BarycentricToWorldSun() const {

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -474,7 +474,7 @@ TEST_F(PluginTest, VesselInsertionAtInitialization) {
                                     satellite_initial_velocity_));
   EXPECT_THAT(plugin_->VesselFromParent(guid),
               Componentwise(
-                  AlmostEquals(satellite_initial_displacement_, 13906),
+                  AlmostEquals(satellite_initial_displacement_, 7460),
                   AlmostEquals(satellite_initial_velocity_, 3)));
 }
 
@@ -891,9 +891,9 @@ TEST_F(PluginTest, UpdateCelestialHierarchy) {
         from_parent,
         Componentwise(
             AlmostEquals(looking_glass_.Inverse()(
-                plugin_->CelestialFromParent(index).displacement()), 1, 37824),
+                plugin_->CelestialFromParent(index).displacement()), 1, 5056),
             AlmostEquals(looking_glass_.Inverse()(
-                plugin_->CelestialFromParent(index).velocity()), 0, 936)));
+                plugin_->CelestialFromParent(index).velocity()), 1, 936)));
   }
 }
 


### PR DESCRIPTION
The rotation axis was stupidly tansformed as if it were a vector [during the flipping of `Barycentre`](https://github.com/mockingbirdnest/Principia/commit/ddeaba08527bcdc40f35283140fcf9bf925e1bd9#diff-5e7c3a9ac924e644e0a57506e5e1a2a3R582).
This made the planet on which the player is rotate backwards (with respects to the planets; the fixed stars rotated backwards too for some reason), yielding some pretty sunsets in the east.