### PR TITLE
Handle the FSAL property in the embedded ERKN

### DIFF
--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -35,8 +35,12 @@ namespace integrators {
 // Since we are interested in physical applications, we call the solution q and
 // its derivative v, rather than the more common y and y′ found in the
 // literature on Runge-Kutta-Nyström methods.
+// The order of the template parameters follow the notation of Dormand and
+// Prince, whose RKNq(p)sF has higher order q, lower order p, comprises
+// s stages, and has the first-same-as-last property.
 
-template<typename Position, int higher_order, int lower_order, int stages>
+template<typename Position, int higher_order, int lower_order, int stages,
+         bool first_same_as_last>
 class EmbeddedExplicitRungeKuttaNyströmIntegrator
     : public AdaptiveSizeIntegrator<
                  SpecialSecondOrderDifferentialEquation<Position>> {
@@ -73,14 +77,15 @@ class EmbeddedExplicitRungeKuttaNyströmIntegrator
   FixedVector<double, stages> const b_prime_;
 };
 
-// Coefficients form Dormand, El-Mikkawy and Prince (1986),
+// Coefficients from Dormand, El-Mikkawy and Prince (1986),
 // Families of Runge-Kutta-Nyström formulae, table 3 (the RK4(3)4FM).
-// first-same-as-last, minimizes the 4th order truncation error.
+// Minimizes the 4th order truncation error.
 template<typename Position>
 EmbeddedExplicitRungeKuttaNyströmIntegrator<Position,
                                             4 /*higher_order*/,
                                             3 /*lower_order*/,
-                                            4  /*stages*/> const&
+                                            4 /*stages*/,
+                                            true /*first_same_as_last*/> const&
 DormandElMikkawyPrince1986RKN434FM();
 
 }  // namespace integrators

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -181,7 +181,6 @@ void EmbeddedExplicitRungeKuttaNyströmIntegrator<Position,
         }
         problem.equation.compute_acceleration(t_stage, q_stage, &g[i]);
       }
-      // TODO(egg): handle the FSAL case.
 
       // Increment computation and step size control.
       for (int k = 0; k < dimension; ++k) {

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -210,6 +210,7 @@ void EmbeddedExplicitRungeKuttaNyströmIntegrator<Position,
     } while (tolerance_to_error_ratio < 1.0);
 
     if (first_same_as_last) {
+      using std::swap;
       std::swap(g.front(), g.back());
       i0 = 1;
     }

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -210,7 +210,7 @@ void EmbeddedExplicitRungeKuttaNyströmIntegrator<Position,
           adaptive_step_size.tolerance_to_error_ratio(h, error_estimate);
     } while (tolerance_to_error_ratio < 1.0);
 
-    if (first_same_as_last && false) {
+    if (first_same_as_last) {
       std::swap(g.front(), g.back());
       i0 = 1;
     }

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -210,7 +210,7 @@ void EmbeddedExplicitRungeKuttaNyströmIntegrator<Position,
           adaptive_step_size.tolerance_to_error_ratio(h, error_estimate);
     } while (tolerance_to_error_ratio < 1.0);
 
-    if (first_same_as_last) {
+    if (first_same_as_last && false) {
       std::swap(g.front(), g.back());
       i0 = 1;
     }

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
@@ -122,12 +122,14 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
   EXPECT_EQ(t_final, solution.back().time.value);
   EXPECT_EQ(steps_forward, solution.size());
   EXPECT_EQ(
-      (steps_forward + initial_rejections + subsequent_rejections) * 4,
+      (1 + initial_rejections) * 4 +
+          (steps_forward - 1 + subsequent_rejections) * 3,
       evaluations);
 
   evaluations = 0;
   subsequent_rejections = 0;
   initial_rejections = 0;
+  first_step = true;
   problem.initial_state = &solution.back();
   problem.t_final = t_initial;
   adaptive_step_size.first_time_step = t_initial - t_final;
@@ -144,7 +146,8 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
   EXPECT_EQ(t_initial, solution.back().time.value);
   EXPECT_EQ(steps_backward, solution.size() - steps_forward);
   EXPECT_EQ(
-      (steps_backward + initial_rejections + subsequent_rejections) * 4,
+      (1 + initial_rejections) * 4 +
+          (steps_backward - 1 + subsequent_rejections) * 3,
       evaluations);
 }
 

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
@@ -39,17 +39,23 @@ namespace {
 void ComputeHarmonicOscillatorAcceleration(
     Instant const& t,
     std::vector<Length> const& q,
-    std::vector<Acceleration>* const result) {
+    std::vector<Acceleration>* const result,
+    not_null<int*> evaluation_count) {
   (*result)[0] = -q[0] * (SIUnit<Stiffness>() / SIUnit<Mass>());
+  ++*evaluation_count;
 }
 
 double HarmonicOscillatorToleranceRatio(
     Time const& h,
     ODE::SystemStateError const& error,
     Length const& q_tolerance,
-    Speed const& v_tolerance) {
+    Speed const& v_tolerance,
+    not_null<int*> rejection_count) {
   double const r = std::min(q_tolerance / Abs(error.position_error[0]),
                             v_tolerance / Abs(error.velocity_error[0]));
+  if (r < 1.0) {
+    ++*rejection_count;
+  }
   return r;
 }
 
@@ -73,10 +79,14 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
   // We integrate backward with double the tolerance.
   int const steps_backward = 112;
 
+  int evaluation_count = 0;
+  int rejection_count = 0;
+
   std::vector<ODE::SystemState> solution;
   ODE harmonic_oscillator;
   harmonic_oscillator.compute_acceleration =
-      ComputeHarmonicOscillatorAcceleration;
+      std::bind(ComputeHarmonicOscillatorAcceleration,
+                _1, _2, _3, &evaluation_count);
   IntegrationProblem<ODE> problem;
   problem.equation = harmonic_oscillator;
   ODE::SystemState const initial_state = {{x_initial}, {v_initial}, t_initial};
@@ -90,7 +100,7 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
   adaptive_step_size.safety_factor = 0.9;
   adaptive_step_size.tolerance_to_error_ratio =
       std::bind(HarmonicOscillatorToleranceRatio,
-                _1, _2, length_tolerance, speed_tolerance);
+                _1, _2, length_tolerance, speed_tolerance, &rejection_count);
 
   integrator.Solve(problem, adaptive_step_size);
   EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
@@ -99,13 +109,17 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
               AllOf(Ge(2E-3 * Metre / Second), Le(3E-3 * Metre / Second)));
   EXPECT_EQ(t_final, solution.back().time.value);
   EXPECT_EQ(steps_forward, solution.size());
+  EXPECT_EQ((steps_forward + rejection_count) * 4, evaluation_count);
 
+  evaluation_count = 0;
+  rejection_count = 0;
   problem.initial_state = &solution.back();
   problem.t_final = t_initial;
   adaptive_step_size.first_time_step = t_initial - t_final;
   adaptive_step_size.tolerance_to_error_ratio =
       std::bind(HarmonicOscillatorToleranceRatio,
-                _1, _2, 2 * length_tolerance, 2 * speed_tolerance);
+                _1, _2, 2 * length_tolerance, 2 * speed_tolerance,
+                &rejection_count);
 
   integrator.Solve(problem, adaptive_step_size);
   EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
@@ -114,6 +128,7 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
               AllOf(Ge(2E-3 * Metre / Second), Le(3E-3 * Metre / Second)));
   EXPECT_EQ(t_initial, solution.back().time.value);
   EXPECT_EQ(steps_backward, solution.size() - steps_forward);
+  EXPECT_EQ((steps_backward + rejection_count) * 4, evaluation_count);
 }
 
 }  // namespace integrators

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
@@ -125,6 +125,8 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
       (1 + initial_rejections) * 4 +
           (steps_forward - 1 + subsequent_rejections) * 3,
       evaluations);
+  EXPECT_EQ(1, initial_rejections);
+  EXPECT_EQ(3, subsequent_rejections);
 
   evaluations = 0;
   subsequent_rejections = 0;
@@ -149,6 +151,8 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
       (1 + initial_rejections) * 4 +
           (steps_backward - 1 + subsequent_rejections) * 3,
       evaluations);
+  EXPECT_EQ(1, initial_rejections);
+  EXPECT_EQ(11, subsequent_rejections);
 }
 
 }  // namespace integrators

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
@@ -121,10 +121,9 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
               AllOf(Ge(2E-3 * Metre / Second), Le(3E-3 * Metre / Second)));
   EXPECT_EQ(t_final, solution.back().time.value);
   EXPECT_EQ(steps_forward, solution.size());
-  EXPECT_EQ(
-      (1 + initial_rejections) * 4 +
-          (steps_forward - 1 + subsequent_rejections) * 3,
-      evaluations);
+  EXPECT_EQ((1 + initial_rejections) * 4 +
+                (steps_forward - 1 + subsequent_rejections) * 3,
+            evaluations);
   EXPECT_EQ(1, initial_rejections);
   EXPECT_EQ(3, subsequent_rejections);
 
@@ -147,10 +146,9 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest,
               AllOf(Ge(2E-3 * Metre / Second), Le(3E-3 * Metre / Second)));
   EXPECT_EQ(t_initial, solution.back().time.value);
   EXPECT_EQ(steps_backward, solution.size() - steps_forward);
-  EXPECT_EQ(
-      (1 + initial_rejections) * 4 +
-          (steps_backward - 1 + subsequent_rejections) * 3,
-      evaluations);
+  EXPECT_EQ((1 + initial_rejections) * 4 +
+                (steps_backward - 1 + subsequent_rejections) * 3,
+            evaluations);
   EXPECT_EQ(1, initial_rejections);
   EXPECT_EQ(11, subsequent_rejections);
 }


### PR DESCRIPTION
This looks far more elegant than it did in the SPRK/SRKN.