### PR TITLE
Restore issue #228

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -171,5 +171,9 @@ inline void noreturn() { std::exit(0); }
 
 #define NAMED(expression) #expression << ": " << (expression)
 
+// We preserve issue #228 in Bourbaki because we don't have trajectory
+// decimation yet.
+#define WE_LOVE_228
+
 }  // namespace base
 }  // namespace principia

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/macros.hpp"
 #include "geometry/permutation.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -326,9 +327,15 @@ TEST_F(PluginTest, Serialization) {
   EXPECT_TRUE(message.vessel(0).vessel().has_history_and_prolongation());
   auto const& vessel_0_history =
       message.vessel(0).vessel().history_and_prolongation().history();
+#if defined(WE_LOVE_228)
+  EXPECT_EQ(1, vessel_0_history.timeline_size());
+  EXPECT_EQ((HistoryTime(sync_time, 6) - Instant()) / (1 * Second),
+            vessel_0_history.timeline(0).instant().scalar().magnitude());
+#else
   EXPECT_EQ(3, vessel_0_history.timeline_size());
   EXPECT_EQ((HistoryTime(sync_time, 4) - Instant()) / (1 * Second),
             vessel_0_history.timeline(0).instant().scalar().magnitude());
+#endif
   EXPECT_FALSE(message.bubble().has_current());
 }
 

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <vector>
 
+#include "base/macros.hpp"
 #include "geometry/frame.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -488,8 +489,13 @@ TEST_F(EphemerisTest, EarthTwoProbes) {
   for (auto const it : trajectory2.Positions()) {
     probe2_positions.push_back(it.second - reference_position);
   }
+#if defined(WE_LOVE_228)
+  EXPECT_THAT(probe1_positions.size(), Eq(2));
+  EXPECT_THAT(probe2_positions.size(), Eq(2));
+#else
   EXPECT_THAT(probe1_positions.size(), Eq(1001));
   EXPECT_THAT(probe2_positions.size(), Eq(1001));
+#endif
   EXPECT_THAT(probe1_positions.back().coordinates().x,
               AlmostEquals(1.00 * period * v_probe1, 2));
   EXPECT_THAT(probe2_positions.back().coordinates().x,


### PR DESCRIPTION
This issue was fixed in the new class Ephemeris, but it turns out that the resulting trajectories are very large and cause memory problems.  We'll properly address this mess by decimating trajectories post-Bourbaki, but for Bourbaki the best approach is to restore the bug.