### PR TITLE
Two bugs

### DIFF
--- a/astronomy/gravity_models.cfg
+++ b/astronomy/gravity_models.cfg
@@ -69,7 +69,7 @@ principia_gravity_models {
     name                    = Earth
     gravitational_parameter = 3.9860043543609598E+05 km^3/s^2
     axis_right_ascension    = 0.0 deg
-    axis_declination        = 0.0 deg
+    axis_declination        = 90.0 deg
     j2                      = 0.00108262545
     reference_radius        = 6378.1363 km
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1269,6 +1269,10 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
           }
         };
         ApplyToBodyTree(insert_body);
+        EndInitialization(plugin_);
+        AdvanceTime(plugin_,
+                    Planetarium.GetUniversalTime(),
+                    Planetarium.InverseRotAngle);
       } catch (Exception e) {
         Log.Fatal("Exception while reading initial state: " + e.ToString());
       }
@@ -1289,8 +1293,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
                                p = (XYZ)body.orbit.vel});
       };
       ApplyToBodyTree(insert_body);
+      EndInitialization(plugin_);
     }
-    EndInitialization(plugin_);
     UpdateRenderingFrame();
     VesselProcessor insert_vessel = vessel => {
       Log.Info("Inserting " + vessel.name + "...");


### PR DESCRIPTION
The axis of the Earth was on the equator, and we inserted existing vessels at the epoch of the initial state when resetting the plugin.