### PR TITLE
Change the parameterization of MassiveBody and OblateBody

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -355,13 +355,14 @@ void principia__DirectlyInsertOblateCelestial(
                               ParseSpeed(vz)})},
       std::make_unique<OblateBody<Barycentric>>(
           ParseGravitationalParameter(gravitational_parameter),
-          ParseDimensionless(j2),
-          ParseLength(reference_radius),
-          Vector<double, Barycentric>(
-              RadiusLatitudeLongitude(
-                  1.0,
-                  ParseAngle(axis_declination),
-                  ParseAngle(axis_right_ascension)).ToCartesian())));
+          OblateBody<Barycentric>::Parameters(
+              ParseDimensionless(j2),
+              ParseLength(reference_radius),
+              Vector<double, Barycentric>(
+                  RadiusLatitudeLongitude(
+                      1.0,
+                      ParseAngle(axis_declination),
+                      ParseAngle(axis_right_ascension)).ToCartesian()))));
 }
 
 // NOTE(egg): The |* (Metre / Second)| might be slower than |* SIUnit<Speed>()|,

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -28,8 +28,9 @@ class BodyTest : public testing::Test {
     auto const axis = Normalize(Vector<double, F>({-1, 2, 5}));
     auto const oblate_body =
         OblateBody<F>(17 * SIUnit<GravitationalParameter>(),
-                      163 * SIUnit<Order2ZonalCoefficient>(),
-                      axis);
+                      OblateBody<F>::Parameters(
+                          163 * SIUnit<Order2ZonalCoefficient>(),
+                          axis));
 
     serialization::Body message;
     OblateBody<F> const* cast_oblate_body;
@@ -53,8 +54,9 @@ class BodyTest : public testing::Test {
       MassiveBody(42 * SIUnit<GravitationalParameter>());
   OblateBody<World> oblate_body_ =
       OblateBody<World>(17 * SIUnit<GravitationalParameter>(),
-                        163 * SIUnit<Order2ZonalCoefficient>(),
-                        axis_);
+                        OblateBody<World>::Parameters(
+                            163 * SIUnit<Order2ZonalCoefficient>(),
+                            axis_));
 };
 
 using BodyDeathTest = BodyTest;

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -788,9 +788,10 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
 
   auto* earth = new OblateBody<EarthMoonOrbitPlane>(
                         5.9721986E24 * Kilogram,
-                        kEarthJ2,
-                        kEarthPolarRadius,
-                        Vector<double, EarthMoonOrbitPlane>({0, 0, 1}));
+                        OblateBody<EarthMoonOrbitPlane>::Parameters(
+                            kEarthJ2,
+                            kEarthPolarRadius,
+                            Vector<double, EarthMoonOrbitPlane>({0, 0, 1})));
   Velocity<EarthMoonOrbitPlane> const v({0 * SIUnit<Speed>(),
                                          0 * SIUnit<Speed>(),
                                          0 * SIUnit<Speed>()});
@@ -868,9 +869,10 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
   Mass const m3 = 4 * SolarMass;
 
   auto const b0 = new OblateBody<World>(m0,
-                                        kJ2,
-                                        kRadius,
-                                        Vector<double, World>({0, 0, 1}));
+                                        OblateBody<World>::Parameters(
+                                            kJ2,
+                                            kRadius,
+                                            Vector<double, World>({0, 0, 1})));
   auto const b1 = new MassiveBody(m1);
   auto const b2 = new MassiveBody(m2);
   auto const b3 = new MassiveBody(m3);
@@ -928,7 +930,7 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
            (-3 * m3 + (3 / Sqrt(512)) * m2) * GravitationalConstant *
                Pow<2>(kRadius) * kJ2 / Pow<4>((q0 - q1).Norm())});
   EXPECT_THAT(actual_acceleration0,
-              AlmostEquals(expected_acceleration0, 0, 3));
+              AlmostEquals(expected_acceleration0, 0, 5));
 
   Vector<Acceleration, World> actual_acceleration1 =
       ephemeris.ComputeGravitationalAcceleration(b1, t0_);
@@ -971,7 +973,7 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
            3 * GravitationalConstant * m0 * Pow<2>(kRadius) * kJ2 /
                Pow<4>((q0 - q1).Norm())});
   EXPECT_THAT(actual_acceleration3,
-              AlmostEquals(expected_acceleration3, 0, 2));
+              AlmostEquals(expected_acceleration3, 0, 4));
 }
 
 }  // namespace physics

--- a/physics/massive_body.hpp
+++ b/physics/massive_body.hpp
@@ -23,8 +23,19 @@ class MassiveBody : public Body {
   // We use the gravitational parameter μ = G M in order not to accumulate
   // unit roundoffs from repeated multiplications by G.  The parameter must not
   // be zero.
-  explicit MassiveBody(GravitationalParameter const& gravitational_parameter);
-  explicit MassiveBody(Mass const& mass);
+  class Parameters {
+   public:
+    // The constructors are implicit on purpose.
+    Parameters(GravitationalParameter const& gravitational_parameter);
+    Parameters(Mass const& mass);
+
+   private:
+    GravitationalParameter const gravitational_parameter_;
+    Mass const mass_;
+    friend class MassiveBody;
+  };
+
+  explicit MassiveBody(Parameters const& parameters);
   ~MassiveBody() = default;
 
   // Returns the construction parameter.
@@ -54,8 +65,7 @@ class MassiveBody : public Body {
       serialization::MassiveBody const& message);
 
  private:
-  GravitationalParameter const gravitational_parameter_;
-  Mass const mass_;
+  Parameters const parameters_;
 };
 
 }  // namespace physics

--- a/physics/massive_body.hpp
+++ b/physics/massive_body.hpp
@@ -26,8 +26,9 @@ class MassiveBody : public Body {
   class Parameters {
    public:
     // The constructors are implicit on purpose.
-    Parameters(GravitationalParameter const& gravitational_parameter);
-    Parameters(Mass const& mass);
+    Parameters(
+        GravitationalParameter const& gravitational_parameter);  // NOLINT
+    Parameters(Mass const& mass);  // NOLINT(runtime/explicit)
 
    private:
     GravitationalParameter const gravitational_parameter_;

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -20,7 +20,7 @@ using geometry::ReadFrameFromMessage;
 
 namespace physics {
 
-inline MassiveBody::MassiveBody(
+inline MassiveBody::Parameters::Parameters(
     GravitationalParameter const& gravitational_parameter)
     : gravitational_parameter_(gravitational_parameter),
       mass_(gravitational_parameter / GravitationalConstant) {
@@ -28,20 +28,22 @@ inline MassiveBody::MassiveBody(
       << "Massive body cannot have zero gravitational parameter";
 }
 
-inline MassiveBody::MassiveBody(Mass const& mass)
+inline MassiveBody::Parameters::Parameters(Mass const& mass)
     : gravitational_parameter_(mass * GravitationalConstant),
       mass_(mass) {
-  CHECK_NE(mass, Mass())
-      << "Massive body cannot have zero mass";
+  CHECK_NE(mass, Mass()) << "Massive body cannot have zero mass";
 }
+
+inline MassiveBody::MassiveBody(Parameters const& parameters)
+    : parameters_(parameters) {}
 
 inline GravitationalParameter const&
 MassiveBody::gravitational_parameter() const {
-  return gravitational_parameter_;
+  return parameters_.gravitational_parameter_;
 }
 
 inline Mass const& MassiveBody::mass() const {
-  return mass_;
+  return parameters_.mass_;
 }
 
 inline bool MassiveBody::is_massless() const {
@@ -59,7 +61,7 @@ inline void MassiveBody::WriteToMessage(
 
 inline void MassiveBody::WriteToMessage(
     not_null<serialization::MassiveBody*> const message) const {
-  gravitational_parameter_.WriteToMessage(
+  parameters_.gravitational_parameter_.WriteToMessage(
       message->mutable_gravitational_parameter());
 }
 

--- a/physics/oblate_body.hpp
+++ b/physics/oblate_body.hpp
@@ -8,6 +8,8 @@
 #ifndef PRINCIPIA_PHYSICS_OBLATE_BODY_HPP_
 #define PRINCIPIA_PHYSICS_OBLATE_BODY_HPP_
 
+#include <optional.hpp>
+
 #include <vector>
 
 #include "geometry/grassmann.hpp"
@@ -30,20 +32,24 @@ class OblateBody : public MassiveBody {
   static_assert(Frame::is_inertial, "Frame must be inertial");
 
  public:
-  OblateBody(GravitationalParameter const& gravitational_parameter,
-             double const j2,
-             Length const& radius,
-             Vector<double, Frame> const& axis);
-  OblateBody(Mass const& mass,
-             double const j2,
-             Length const& radius,
-             Vector<double, Frame> const& axis);
-  OblateBody(GravitationalParameter const& gravitational_parameter,
-             Order2ZonalCoefficient const& j2,
-             Vector<double, Frame> const& axis);
-  OblateBody(Mass const& mass,
-             Order2ZonalCoefficient const& j2,
-             Vector<double, Frame> const& axis);
+  class Parameters {
+   public:
+    Parameters(double const j2,
+               Length const& radius,
+               Vector<double, Frame> const& axis);
+    Parameters(Order2ZonalCoefficient const& j2,
+               Vector<double, Frame> const& axis);
+
+   private:
+    std::experimental::optional<Order2ZonalCoefficient> j2_;
+    std::experimental::optional<
+        Quotient<Order2ZonalCoefficient, GravitationalParameter>> j2_over_μ_;
+    Vector<double, Frame> const axis_;
+    friend class OblateBody;
+  };
+
+  OblateBody(MassiveBody::Parameters const& massive_body_parameters,
+             Parameters const& parameters);
   ~OblateBody() = default;
 
   // Returns the j2 coefficient.
@@ -76,9 +82,7 @@ class OblateBody : public MassiveBody {
       serialization::MassiveBody const& message);
 
  private:
-  Order2ZonalCoefficient const j2_;
-  Quotient<Order2ZonalCoefficient, GravitationalParameter> const j2_over_μ_;
-  Vector<double, Frame> const axis_;
+  Parameters parameters_;
 };
 
 }  // namespace physics

--- a/testing_utilities/solar_system_body.hpp
+++ b/testing_utilities/solar_system_body.hpp
@@ -61,7 +61,8 @@ not_null<std::unique_ptr<MassiveBody>> NewBody(
       return make_not_null_unique<MassiveBody>(gravitational_parameter);
     case SolarSystem::Accuracy::kAllBodiesAndOblateness:
       return make_not_null_unique<OblateBody<ICRFJ2000Ecliptic>>(
-          gravitational_parameter, j2, radius, axis);
+          gravitational_parameter,
+          OblateBody<ICRFJ2000Ecliptic>::Parameters(j2, radius, axis));
     default:
       LOG(FATAL) << FUNCTION_SIGNATURE << "Unexpected accuracy "
                  << static_cast<int>(accuracy);


### PR DESCRIPTION
Introduce Parameters classes to reduce the combinatorial explosion of parameters in constructors.  This is preliminary work for rotating bodies.