### PR TITLE
Change the properties files so that _test is only appended to the exe name if googletest is imported

### DIFF
--- a/astronomy/astronomy.vcxproj
+++ b/astronomy/astronomy.vcxproj
@@ -42,9 +42,6 @@
     <Import Project="..\include_solution.props" />
     <Import Project="..\..\Google\protobuf\vsprojects\portability_macros.props" />
     <Import Project="..\google_protobuf.props" />
-    <Import Project="..\..\Google\googletest\msvc\portability_macros.props" />
-    <Import Project="..\google_googletest.props" />
-    <Import Project="..\google_googlemock_main.props" />
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
@@ -57,20 +54,13 @@
     <Import Project="..\include_solution.props" />
     <Import Project="..\..\Google\protobuf\vsprojects\portability_macros.props" />
     <Import Project="..\google_protobuf.props" />
-    <Import Project="..\..\Google\googletest\msvc\portability_macros.props" />
-    <Import Project="..\google_googletest.props" />
-    <Import Project="..\google_googlemock_main.props" />
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <TargetName>$(ProjectName)</TargetName>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>$(ProjectName)</TargetName>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/geometry/permutation.hpp
+++ b/geometry/permutation.hpp
@@ -5,7 +5,6 @@
 #include "geometry/linear_map.hpp"
 #include "geometry/r3_element.hpp"
 #include "geometry/sign.hpp"
-#include "gtest/gtest_prod.h"
 #include "serialization/geometry.pb.h"
 
 namespace principia {
@@ -83,16 +82,6 @@ class Permutation : public LinearMap<FromFrame, ToFrame> {
   friend Permutation<From, To> operator*(
       Permutation<Through, To> const& left,
       Permutation<From, Through> const& right);
-
-  // As much as I dislike FRIEND_TEST(), it seems like the most convenient way
-  // to access the above operator.
-  FRIEND_TEST(PermutationTest, Identity);
-  FRIEND_TEST(PermutationTest, XYZ);
-  FRIEND_TEST(PermutationTest, YZX);
-  FRIEND_TEST(PermutationTest, ZXY);
-  FRIEND_TEST(PermutationTest, XZY);
-  FRIEND_TEST(PermutationTest, ZYX);
-  FRIEND_TEST(PermutationTest, YXZ);
 };
 
 template<typename FromFrame, typename ThroughFrame, typename ToFrame>

--- a/geometry/permutation_test.cpp
+++ b/geometry/permutation_test.cpp
@@ -48,37 +48,37 @@ class PermutationTest : public testing::Test {
 using PermutationDeathTest = PermutationTest;
 
 TEST_F(PermutationTest, Identity) {
-  EXPECT_THAT(Perm::Identity()(vector_.coordinates()),
+  EXPECT_THAT(Perm::Identity()(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(PermutationTest, XYZ) {
-  EXPECT_THAT(Perm(Perm::XYZ)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::XYZ)(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(PermutationTest, YZX) {
-  EXPECT_THAT(Perm(Perm::YZX)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::YZX)(vector_).coordinates(),
               Eq<R3>({2.0 * Metre, 3.0 * Metre, 1.0 * Metre}));
 }
 
 TEST_F(PermutationTest, ZXY) {
-  EXPECT_THAT(Perm(Perm::ZXY)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::ZXY)(vector_).coordinates(),
               Eq<R3>({3.0 * Metre, 1.0 * Metre, 2.0 * Metre}));
 }
 
 TEST_F(PermutationTest, XZY) {
-  EXPECT_THAT(Perm(Perm::XZY)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::XZY)(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 3.0 * Metre, 2.0 * Metre}));
 }
 
 TEST_F(PermutationTest, ZYX) {
-  EXPECT_THAT(Perm(Perm::ZYX)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::ZYX)(vector_).coordinates(),
               Eq<R3>({3.0 * Metre, 2.0 * Metre, 1.0 * Metre}));
 }
 
 TEST_F(PermutationTest, YXZ) {
-  EXPECT_THAT(Perm(Perm::YXZ)(vector_.coordinates()),
+  EXPECT_THAT(Perm(Perm::YXZ)(vector_).coordinates(),
               Eq<R3>({2.0 * Metre, 1.0 * Metre, 3.0 * Metre}));
 }
 

--- a/google_glog.props
+++ b/google_glog.props
@@ -2,9 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <TargetName>$(ProjectName)_tests</TargetName>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\Google\glog\src\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/google_googlemock_main.props
+++ b/google_googlemock_main.props
@@ -2,9 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <TargetName>$(ProjectName)_tests</TargetName>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\Google\googlemock\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
This requires to remove an include of `gtest_prod.h`.