### PR TITLE
Cleanup and restructuring of barycentre computations

### DIFF
--- a/geometry/barycentre_calculator.hpp
+++ b/geometry/barycentre_calculator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #include <utility>
 
 namespace principia {
@@ -20,6 +21,10 @@ class BarycentreCalculator {
   decltype(std::declval<Vector>() * std::declval<Scalar>()) weighted_sum_;
   Scalar weight_;
 };
+
+// |T| is anything for which a specialization of BarycentreCalculator exists.
+template<typename T, typename Scalar>
+T Barycentre(std::vector<T> const& ts, std::vector<Scalar> const& weights);
 
 }  // namespace geometry
 }  // namespace principia

--- a/geometry/barycentre_calculator_body.hpp
+++ b/geometry/barycentre_calculator_body.hpp
@@ -28,5 +28,16 @@ Vector BarycentreCalculator<Vector, Scalar>::Get() const {
   return Vector(weighted_sum_ / weight_);
 }
 
+template<typename T, typename Scalar>
+T Barycentre(std::vector<T> const& ts, std::vector<Scalar> const& weights) {
+  CHECK_EQ(ts.size(), weights.size()) << "Ts and weights of unequal sizes";
+  CHECK(!ts.empty()) << "Empty input";
+  BarycentreCalculator<T, Scalar> calculator;
+  for (size_t i = 0; i < ts.size(); ++i) {
+    calculator.Add(ts[i], weights[i]);
+  }
+  return calculator.Get();
+}
+
 }  // namespace geometry
 }  // namespace principia

--- a/geometry/pair.hpp
+++ b/geometry/pair.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base/mappable.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/point.hpp"
 #include "serialization/geometry.pb.h"
 
@@ -96,30 +97,6 @@ class Pair {
   void WriteToMessage(not_null<serialization::Pair*> const message) const;
   static Pair ReadFromMessage(serialization::Pair const& message);
 
-  template<typename Weight>
-  class BarycentreCalculator {
-   public:
-    BarycentreCalculator() = default;
-    ~BarycentreCalculator() = default;
-
-    void Add(Pair const& pair, Weight const& weight);
-    Pair Get() const;
-
-   private:
-    bool empty_ = true;
-    decltype(std::declval<typename vector_of<T1>::type>() *
-             std::declval<Weight>()) t1_weighted_sum_;
-    decltype(std::declval<typename vector_of<T2>::type>() *
-             std::declval<Weight>()) t2_weighted_sum_;
-    Weight weight_;
-
-    // We need reference values to convert points into vectors, if needed.  We
-    // pick default-constructed objects as they don't introduce any inaccuracies
-    // in the computations.
-    static T1 const reference_t1_;
-    static T2 const reference_t2_;
-  };
-
  protected:
   // The subclasses can access the members directly to implement accessors.
   T1 t1_;
@@ -128,8 +105,12 @@ class Pair {
  private:
   // This is needed so that different instantiations of Pair can access the
   // members.
-  template<typename T3, typename T4>
+  template<typename U1, typename U2>
   friend class Pair;
+
+  // This is needed to specialize BarycentreCalculator.
+  template<typename V, typename S>
+  friend class BarycentreCalculator;
 
   // This is needed to make Pair mappable.
   template<typename Functor, typename T, typename>
@@ -139,52 +120,52 @@ class Pair {
   template<typename T1Matcher, typename T2Matcher>
   friend class testing_utilities::ComponentwiseMatcher2;
 
-  template<typename T3, typename T4>
-  friend typename vector_of<Pair<T3, T4>>::type operator-(
-      typename enable_if_affine<Pair<T3, T4>>::type const& left,
-      Pair<T3, T4> const& right);
+  template<typename U1, typename U2>
+  friend typename vector_of<Pair<U1, U2>>::type operator-(
+      typename enable_if_affine<Pair<U1, U2>>::type const& left,
+      Pair<U1, U2> const& right);
 
-  template<typename T3, typename T4>
-  friend typename enable_if_vector<Pair<T3, T4>>::type operator+(
-      Pair<T3, T4> const& right);
+  template<typename U1, typename U2>
+  friend typename enable_if_vector<Pair<U1, U2>>::type operator+(
+      Pair<U1, U2> const& right);
 
-  template<typename T3, typename T4>
-  friend typename enable_if_vector<Pair<T3, T4>>::type operator-(
-      Pair<T3, T4> const& right);
+  template<typename U1, typename U2>
+  friend typename enable_if_vector<Pair<U1, U2>>::type operator-(
+      Pair<U1, U2> const& right);
 
-  template<typename Scalar, typename T3, typename T4>
+  template<typename Scalar, typename U1, typename U2>
   friend typename enable_if_vector<
-      Pair<T3, T4>,
-      Pair<decltype(std::declval<Scalar>() * std::declval<T3>()),
-           decltype(std::declval<Scalar>() * std::declval<T4>())>>::type
-  operator*(Scalar const left, Pair<T3, T4> const& right);
+      Pair<U1, U2>,
+      Pair<decltype(std::declval<Scalar>() * std::declval<U1>()),
+           decltype(std::declval<Scalar>() * std::declval<U2>())>>::type
+  operator*(Scalar const left, Pair<U1, U2> const& right);
 
-  template<typename Scalar, typename T3, typename T4>
+  template<typename Scalar, typename U1, typename U2>
   friend typename enable_if_vector<
-      Pair<T3, T4>,
-      Pair<decltype(std::declval<T3>() * std::declval<Scalar>()),
-           decltype(std::declval<T4>() * std::declval<Scalar>())>>::type
-  operator*(Pair<T3, T4> const& left, Scalar const right);
+      Pair<U1, U2>,
+      Pair<decltype(std::declval<U1>() * std::declval<Scalar>()),
+           decltype(std::declval<U2>() * std::declval<Scalar>())>>::type
+  operator*(Pair<U1, U2> const& left, Scalar const right);
 
-  template<typename Scalar, typename T3, typename T4>
+  template<typename Scalar, typename U1, typename U2>
   friend typename enable_if_vector<
-      Pair<T3, T4>,
-      Pair<decltype(std::declval<T3>() / std::declval<Scalar>()),
-           decltype(std::declval<T4>() / std::declval<Scalar>())>>::type
-  operator/(Pair<T3, T4> const& left, Scalar const right);
+      Pair<U1, U2>,
+      Pair<decltype(std::declval<U1>() / std::declval<Scalar>()),
+           decltype(std::declval<U2>() / std::declval<Scalar>())>>::type
+  operator/(Pair<U1, U2> const& left, Scalar const right);
 
-  template<typename T3, typename T4>
-  friend typename enable_if_vector<Pair<T3, T4>>::type& operator*=(
-      Pair<T3, T4>& left,  // NOLINT(runtime/references)
+  template<typename U1, typename U2>
+  friend typename enable_if_vector<Pair<U1, U2>>::type& operator*=(
+      Pair<U1, U2>& left,  // NOLINT(runtime/references)
       double const right);
 
-  template<typename T3, typename T4>
-  friend typename enable_if_vector<Pair<T3, T4>>::type& operator/=(
-      Pair<T3, T4>& left,  // NOLINT(runtime/references)
+  template<typename U1, typename U2>
+  friend typename enable_if_vector<Pair<U1, U2>>::type& operator/=(
+      Pair<U1, U2>& left,  // NOLINT(runtime/references)
       double const right);
 
-  template<typename T3, typename T4>
-  friend std::ostream& operator<<(std::ostream& out, Pair<T3, T4> const& pair);
+  template<typename U1, typename U2>
+  friend std::ostream& operator<<(std::ostream& out, Pair<U1, U2> const& pair);
 };
 
 // NOTE(phl): Would like to put the enable_if_affine<> on the return type, but
@@ -235,6 +216,30 @@ typename enable_if_vector<Pair<T1, T2>>::type& operator/=(
 
 template<typename T1, typename T2>
 std::ostream& operator<<(std::ostream& out, Pair<T1, T2> const& pair);
+
+template<typename T1, typename T2, typename Weight>
+class BarycentreCalculator<Pair<T1, T2>, Weight> {
+  public:
+  BarycentreCalculator() = default;
+  ~BarycentreCalculator() = default;
+
+  void Add(Pair<T1, T2> const& pair, Weight const& weight);
+  Pair<T1, T2> Get() const;
+
+  private:
+  bool empty_ = true;
+  decltype(std::declval<typename vector_of<T1>::type>() *
+            std::declval<Weight>()) t1_weighted_sum_;
+  decltype(std::declval<typename vector_of<T2>::type>() *
+            std::declval<Weight>()) t2_weighted_sum_;
+  Weight weight_;
+
+  // We need reference values to convert points into vectors, if needed.  We
+  // pick default-constructed objects as they don't introduce any inaccuracies
+  // in the computations.
+  static T1 const reference_t1_;
+  static T2 const reference_t2_;
+};
 
 }  // namespace geometry
 

--- a/geometry/pair.hpp
+++ b/geometry/pair.hpp
@@ -217,16 +217,17 @@ typename enable_if_vector<Pair<T1, T2>>::type& operator/=(
 template<typename T1, typename T2>
 std::ostream& operator<<(std::ostream& out, Pair<T1, T2> const& pair);
 
+// Specialize BarycentreCalculator to make it applicable to Pairs.
 template<typename T1, typename T2, typename Weight>
 class BarycentreCalculator<Pair<T1, T2>, Weight> {
-  public:
+ public:
   BarycentreCalculator() = default;
   ~BarycentreCalculator() = default;
 
   void Add(Pair<T1, T2> const& pair, Weight const& weight);
   Pair<T1, T2> Get() const;
 
-  private:
+ private:
   bool empty_ = true;
   decltype(std::declval<typename vector_of<T1>::type>() *
             std::declval<Weight>()) t1_weighted_sum_;

--- a/geometry/pair_body.hpp
+++ b/geometry/pair_body.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "geometry/grassmann.hpp"
 #include "geometry/pair.hpp"
+
+#include "geometry/grassmann.hpp"
 #include "geometry/point.hpp"
 #include "geometry/serialization.hpp"
 
@@ -68,40 +69,6 @@ Pair<T1, T2> Pair<T1, T2>::ReadFromMessage(serialization::Pair const& message) {
                     ReadFromMessage(message.t2());
   return {t1, t2};
 }
-
-template<typename T1, typename T2>
-template<typename Weight>
-void Pair<T1, T2>::BarycentreCalculator<Weight>::Add(Pair const& pair,
-                                                     Weight const& weight) {
-  auto const t1_weighted_sum_diff = (pair.t1_ - reference_t1_) * weight;
-  auto const t2_weighted_sum_diff = (pair.t2_ - reference_t2_) * weight;
-  if (empty_) {
-    t1_weighted_sum_ = t1_weighted_sum_diff;
-    t2_weighted_sum_ = t2_weighted_sum_diff;
-    weight_ = weight;
-    empty_ = false;
-  } else {
-    t1_weighted_sum_ += t1_weighted_sum_diff;
-    t2_weighted_sum_ += t2_weighted_sum_diff;
-    weight_ += weight;
-  }
-}
-
-template<typename T1, typename T2>
-template<typename Weight>
-Pair<T1, T2> Pair<T1, T2>::BarycentreCalculator<Weight>::Get() const {
-  CHECK(!empty_) << "Empty BarycentreCalculator";
-  return Pair<T1, T2>(reference_t1_ + (t1_weighted_sum_ / weight_),
-                      reference_t2_ + (t2_weighted_sum_ / weight_));
-}
-
-template<typename T1, typename T2>
-template<typename Weight>
-T1 const Pair<T1, T2>::BarycentreCalculator<Weight>::reference_t1_;
-
-template<typename T1, typename T2>
-template<typename Weight>
-T2 const Pair<T1, T2>::BarycentreCalculator<Weight>::reference_t2_;
 
 template<typename T1, typename T2>
 typename vector_of<Pair<T1, T2>>::type operator-(
@@ -179,6 +146,36 @@ std::ostream& operator<<(std::ostream& out, Pair<T1, T2> const& pair) {
   out << "{" << pair.t1_ << ", " << pair.t2_ << "}";
   return out;
 }
+
+template<typename T1, typename T2, typename Weight>
+void BarycentreCalculator<Pair<T1, T2>, Weight>::Add(Pair<T1, T2> const& pair,
+                                                     Weight const& weight) {
+  auto const t1_weighted_sum_diff = (pair.t1_ - reference_t1_) * weight;
+  auto const t2_weighted_sum_diff = (pair.t2_ - reference_t2_) * weight;
+  if (empty_) {
+    t1_weighted_sum_ = t1_weighted_sum_diff;
+    t2_weighted_sum_ = t2_weighted_sum_diff;
+    weight_ = weight;
+    empty_ = false;
+  } else {
+    t1_weighted_sum_ += t1_weighted_sum_diff;
+    t2_weighted_sum_ += t2_weighted_sum_diff;
+    weight_ += weight;
+  }
+}
+
+template<typename T1, typename T2, typename Weight>
+Pair<T1, T2> BarycentreCalculator<Pair<T1, T2>, Weight>::Get() const {
+  CHECK(!empty_) << "Empty BarycentreCalculator";
+  return Pair<T1, T2>(reference_t1_ + (t1_weighted_sum_ / weight_),
+                      reference_t2_ + (t2_weighted_sum_ / weight_));
+}
+
+template<typename T1, typename T2, typename Weight>
+T1 const BarycentreCalculator<Pair<T1, T2>, Weight>::reference_t1_;
+
+template<typename T1, typename T2, typename Weight>
+T2 const BarycentreCalculator<Pair<T1, T2>, Weight>::reference_t2_;
 
 }  // namespace geometry
 

--- a/geometry/pair_test.cpp
+++ b/geometry/pair_test.cpp
@@ -486,20 +486,24 @@ TEST_F(PairTest, SerializationSuccess) {
 }
 
 TEST_F(PairDeathTest, BarycentreCalculatorError) {
+  using PPBarycentreCalculator = BarycentreCalculator<PP, Entropy>;
+  using PVBarycentreCalculator = BarycentreCalculator<PV, Entropy>;
+  using VPBarycentreCalculator = BarycentreCalculator<VP, Entropy>;
+  using VVBarycentreCalculator = BarycentreCalculator<VV, Entropy>;
   EXPECT_DEATH({
-    PP::BarycentreCalculator<Entropy> calculator;
+    PPBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
   EXPECT_DEATH({
-    PV::BarycentreCalculator<Entropy> calculator;
+    PVBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
   EXPECT_DEATH({
-    VP::BarycentreCalculator<Entropy> calculator;
+    VPBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
   EXPECT_DEATH({
-    VV::BarycentreCalculator<Entropy> calculator;
+    VVBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
 }
@@ -508,7 +512,7 @@ TEST_F(PairDeathTest, BarycentreCalculatorError) {
 // the computations, so we'll redo some testing for DegreesOfFreedom.
 TEST_F(PairTest, BarycentreCalculatorSuccess) {
   {
-    PP::BarycentreCalculator<double> calculator;
+    BarycentreCalculator<PP, double> calculator;
     calculator.Add(pp_, 3);
     PP barycentre = calculator.Get();
     EXPECT_EQ(pp_, barycentre);
@@ -520,7 +524,7 @@ TEST_F(PairTest, BarycentreCalculatorSuccess) {
     EXPECT_EQ(pp_ - 19.0 / 16.0 * vv_, barycentre);
   }
   {
-    PV::BarycentreCalculator<double> calculator;
+    BarycentreCalculator<PV, double> calculator;
     calculator.Add(pv_, 3);
     PV barycentre = calculator.Get();
     EXPECT_EQ(pv_, barycentre);
@@ -532,7 +536,7 @@ TEST_F(PairTest, BarycentreCalculatorSuccess) {
     EXPECT_EQ(pv_ - 19.0 / 16.0 * vv_, barycentre);
   }
   {
-    VP::BarycentreCalculator<double> calculator;
+    BarycentreCalculator<VP, double> calculator;
     calculator.Add(vp_, 3);
     VP barycentre = calculator.Get();
     EXPECT_EQ(vp_, barycentre);
@@ -544,7 +548,7 @@ TEST_F(PairTest, BarycentreCalculatorSuccess) {
     EXPECT_EQ(vp_ - 19.0 / 16.0 * vv_, barycentre);
   }
   {
-    VV::BarycentreCalculator<double> calculator;
+    BarycentreCalculator<VV, double> calculator;
     calculator.Add(vv_, 3);
     VV barycentre = calculator.Get();
     EXPECT_EQ(vv_, barycentre);

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "geometry/barycentre_calculator.hpp"
 #include "quantities/quantities.hpp"
 #include "serialization/geometry.pb.h"
 
@@ -38,21 +39,6 @@ class Point {
   void WriteToMessage(not_null<serialization::Point*> const message) const;
   static Point ReadFromMessage(serialization::Point const& message);
 
-  template<typename Weight>
-  class BarycentreCalculator {
-   public:
-    BarycentreCalculator() = default;
-    ~BarycentreCalculator() = default;
-
-    void Add(Point const& point, Weight const& weight);
-    Point Get() const;
-
-   private:
-    bool empty_ = true;
-    decltype(std::declval<Vector>() * std::declval<Weight>()) weighted_sum_;
-    Weight weight_;
-  };
-
  private:
   Vector coordinates_;
 
@@ -75,9 +61,8 @@ class Point {
   template<typename V>
   friend std::string DebugString(Point<V> const& point);
 
-  template<typename V, typename Weight>
-  friend Point<V> Barycentre(std::vector<Point<V>> const& points,
-                             std::vector<Weight> const& weights);
+  template<typename V, typename S>
+  friend class BarycentreCalculator;
 };
 
 template<typename Vector>
@@ -105,6 +90,22 @@ std::string DebugString(Point<Vector> const& point);
 
 template<typename Vector>
 std::ostream& operator<<(std::ostream& out, Point<Vector> const& point);
+
+// Specialize BarycentreCalculator to make it applicable to Points.
+template<typename Vector, typename Weight>
+class BarycentreCalculator<Point<Vector>, Weight> {
+ public:
+  BarycentreCalculator() = default;
+  ~BarycentreCalculator() = default;
+
+  void Add(Point<Vector> const& point, Weight const& weight);
+  Point<Vector> Get() const;
+
+ private:
+  bool empty_ = true;
+  decltype(std::declval<Vector>() * std::declval<Weight>()) weighted_sum_;
+  Weight weight_;
+};
 
 template<typename Vector, typename Weight>
 Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -107,10 +107,6 @@ class BarycentreCalculator<Point<Vector>, Weight> {
   Weight weight_;
 };
 
-template<typename Vector, typename Weight>
-Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,
-                         std::vector<Weight> const& weights);
-
 }  // namespace geometry
 }  // namespace principia
 

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -165,18 +165,5 @@ Point<Vector> BarycentreCalculator<Point<Vector>, Weight>::Get() const {
   return Point<Vector>(weighted_sum_ / weight_);
 }
 
-template<typename Vector, typename Weight>
-Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,
-                         std::vector<Weight> const& weights) {
-  CHECK_EQ(points.size(), weights.size())
-      << "Points and weights of unequal sizes";
-  CHECK(!points.empty()) << "Empty input";
-  BarycentreCalculator<Point<Vector>, Weight> calculator;
-  for (size_t i = 0; i < points.size(); ++i) {
-    calculator.Add(points[i], weights[i]);
-  }
-  return calculator.Get();
-}
-
 }  // namespace geometry
 }  // namespace principia

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -105,27 +105,6 @@ Point<Vector> Point<Vector>::ReadFromMessage(
 }
 
 template<typename Vector>
-template<typename Weight>
-void Point<Vector>::BarycentreCalculator<Weight>::Add(Point const& point,
-                                                      Weight const& weight) {
-  if (empty_) {
-    weighted_sum_ = point.coordinates_ * weight;
-    weight_ = weight;
-    empty_ = false;
-  } else {
-    weighted_sum_ += point.coordinates_ * weight;
-    weight_ += weight;
-  }
-}
-
-template<typename Vector>
-template<typename Weight>
-Point<Vector> Point<Vector>::BarycentreCalculator<Weight>::Get() const {
-  CHECK(!empty_) << "Empty BarycentreCalculator";
-  return Point<Vector>(weighted_sum_ / weight_);
-}
-
-template<typename Vector>
 Point<Vector> operator+(Vector const& translation,
                         Point<Vector> const& point) {
   return Point<Vector>(translation + point.coordinates_);
@@ -167,12 +146,32 @@ std::ostream& operator<<(std::ostream& out, Point<Vector> const& point) {
 }
 
 template<typename Vector, typename Weight>
+void BarycentreCalculator<Point<Vector>, Weight>::Add(
+    Point<Vector> const& point,
+    Weight const& weight) {
+  if (empty_) {
+    weighted_sum_ = point.coordinates_ * weight;
+    weight_ = weight;
+    empty_ = false;
+  } else {
+    weighted_sum_ += point.coordinates_ * weight;
+    weight_ += weight;
+  }
+}
+
+template<typename Vector, typename Weight>
+Point<Vector> BarycentreCalculator<Point<Vector>, Weight>::Get() const {
+  CHECK(!empty_) << "Empty BarycentreCalculator";
+  return Point<Vector>(weighted_sum_ / weight_);
+}
+
+template<typename Vector, typename Weight>
 Point<Vector> Barycentre(std::vector<Point<Vector>> const& points,
                          std::vector<Weight> const& weights) {
   CHECK_EQ(points.size(), weights.size())
       << "Points and weights of unequal sizes";
   CHECK(!points.empty()) << "Empty input";
-  typename Point<Vector>::template BarycentreCalculator<Weight> calculator;
+  BarycentreCalculator<Point<Vector>, Weight> calculator;
   for (size_t i = 0; i < points.size(); ++i) {
     calculator.Add(points[i], weights[i]);
   }

--- a/geometry/point_test.cpp
+++ b/geometry/point_test.cpp
@@ -115,7 +115,7 @@ TEST_F(PointDeathTest, BarycentreError) {
   auto barycentre =
       [](std::vector<Instant> const& instants,
          std::vector<Volume> const& weights) -> Instant {
-    return Barycentre<Time, Volume>(instants, weights);
+    return Barycentre<Instant, Volume>(instants, weights);
   };
   EXPECT_DEATH({
     Instant const t1 = kUnixEpoch + 1 * Day;
@@ -135,8 +135,9 @@ TEST_F(PointDeathTest, BarycentreError) {
 TEST_F(PointTest, Barycentres) {
   Instant const t1 = kUnixEpoch + 1 * Day;
   Instant const t2 = kUnixEpoch - 3 * Day;
-  Instant const b1 = Barycentre<Time, Volume>({t1, t2}, {3 * Litre, 1 * Litre});
-  Instant const b2 = Barycentre<Time, double>({t2, t1}, {1, 1});
+  Instant const b1 = Barycentre<Instant, Volume>({t1, t2},
+                                                 {3 * Litre, 1 * Litre});
+  Instant const b2 = Barycentre<Instant, double>({t2, t1}, {1, 1});
   EXPECT_THAT(b1, Eq(kUnixEpoch));
   EXPECT_THAT(b2, Eq(kUnixEpoch - 1 * Day));
 }

--- a/geometry/point_test.cpp
+++ b/geometry/point_test.cpp
@@ -125,8 +125,9 @@ TEST_F(PointDeathTest, BarycentreError) {
   EXPECT_DEATH({
     barycentre({}, {});
   }, "Empty input");
+  using InstantBarycentreCalculator = BarycentreCalculator<Instant, Volume>;
   EXPECT_DEATH({
-    Instant::BarycentreCalculator<Volume> calculator;
+    InstantBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
 }
@@ -141,7 +142,7 @@ TEST_F(PointTest, Barycentres) {
 }
 
 TEST_F(PointTest, InstantBarycentreCalculator) {
-  Instant::BarycentreCalculator<double> calculator;
+  BarycentreCalculator<Instant, double> calculator;
   Instant const t1 = kUnixEpoch + 2 * Day;
   Instant const t2 = kUnixEpoch - 3 * Day;
   Instant const t3 = kUnixEpoch + 5 * Day;
@@ -155,7 +156,7 @@ TEST_F(PointTest, InstantBarycentreCalculator) {
 }
 
 TEST_F(PointTest, DoubleBarycentreCalculator) {
-  Point<double>::BarycentreCalculator<double> calculator;
+  BarycentreCalculator<Point<double>, double> calculator;
   Point<double> const d1 = Point<double>(2);
   Point<double> const d2 = Point<double>(-3);
   Point<double> const d3 = Point<double>(5);

--- a/ksp_plugin/physics_bubble.cpp
+++ b/ksp_plugin/physics_bubble.cpp
@@ -335,7 +335,7 @@ PhysicsBubble::FullState::FullState(
 void PhysicsBubble::ComputeNextCentreOfMassWorldDegreesOfFreedom(
     not_null<FullState*> const next) {
   VLOG(1) << __FUNCTION__;
-  DegreesOfFreedom<World>::BarycentreCalculator<Mass> centre_of_mass_calculator;
+  BarycentreCalculator<DegreesOfFreedom<World>, Mass> centre_of_mass_calculator;
   for (auto const& id_part : next->parts) {
     not_null<std::unique_ptr<Part<World>>> const& part = id_part.second;
     centre_of_mass_calculator.Add(part->degrees_of_freedom(), part->mass());
@@ -356,7 +356,7 @@ void PhysicsBubble::ComputeNextVesselOffsets(
     std::vector<not_null<Part<World>*>> const& parts =
         vessel_parts.second;
     VLOG(1) << NAMED(vessel) << ", " << NAMED(parts.size());
-    DegreesOfFreedom<World>::BarycentreCalculator<Mass> vessel_calculator;
+    BarycentreCalculator<DegreesOfFreedom<World>, Mass> vessel_calculator;
     for (auto const part : parts) {
       vessel_calculator.Add(part->degrees_of_freedom(), part->mass());
     }
@@ -374,7 +374,7 @@ void PhysicsBubble::ComputeNextVesselOffsets(
 void PhysicsBubble::RestartNext(Instant const& current_time,
                                 not_null<FullState*> const next) {
   VLOG(1) << __FUNCTION__<< '\n' << NAMED(current_time);
-  DegreesOfFreedom<Barycentric>::BarycentreCalculator<Mass> bubble_calculator;
+  BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass> bubble_calculator;
   for (auto const& vessel_parts : next->vessels) {
     not_null<Vessel const*> vessel = vessel_parts.first;
     // NOTE(Norgg) TODO(Egg) Removed const from vector, custom allocator?
@@ -451,8 +451,8 @@ void PhysicsBubble::Shift(BarycentricToWorldSun const& barycentric_to_world_sun,
                           not_null<FullState*> const next) {
   VLOG(1) << __FUNCTION__ << '\n'
           << NAMED(current_time) << '\n' << NAMED(common_parts);
-  DegreesOfFreedom<World>::BarycentreCalculator<Mass> current_common_calculator;
-  DegreesOfFreedom<World>::BarycentreCalculator<Mass> next_common_calculator;
+  BarycentreCalculator<DegreesOfFreedom<World>, Mass> current_common_calculator;
+  BarycentreCalculator<DegreesOfFreedom<World>, Mass> next_common_calculator;
   for (auto const& current_next : common_parts) {
     not_null<Part<World>*> const current_part = current_next.first;
     not_null<Part<World>*> const next_part = current_next.second;

--- a/ksp_plugin_test/physics_bubble_test.cpp
+++ b/ksp_plugin_test/physics_bubble_test.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "base/not_null.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/grassmann.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -22,6 +23,7 @@
 namespace principia {
 
 using base::make_not_null_unique;
+using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::Rotation;
 using quantities::Acceleration;
@@ -263,7 +265,8 @@ class PhysicsBubbleTest : public testing::Test {
     DiscreteTrajectory<Barycentric> const& trajectory =
         bubble.centre_of_mass_trajectory();
     DegreesOfFreedom<Barycentric> const expected_dof =
-        physics::Barycentre<Barycentric, double>({dof1_, dof2_}, {23, 66});
+        Barycentre<DegreesOfFreedom<Barycentric>, double>({dof1_, dof2_},
+                                                          {23, 66});
     EXPECT_EQ(expected_dof, trajectory.last().degrees_of_freedom());
 
     EXPECT_THAT(bubble.DisplacementCorrection(

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -377,7 +377,7 @@ void GenerateSolarSystemPlanetsWorkErrorGraph() {
          b <= SolarSystemFactory::kLastMajorBody;
          ++b) {
       for (int i = 0; i < reference_size; ++i) {
-        Position<ICRFJ2000Equator>::BarycentreCalculator<double> reference_q;
+        BarycentreCalculator<Position<ICRFJ2000Equator>, double> reference_q;
         BarycentreCalculator<Velocity<ICRFJ2000Equator>, double> reference_v;
         for (auto const& solution : reference_solutions) {
           reference_q.Add(solution[i].positions[b].value, 1);

--- a/physics/barycentric_rotating_dynamic_frame_body.hpp
+++ b/physics/barycentric_rotating_dynamic_frame_body.hpp
@@ -2,6 +2,7 @@
 
 #include "physics/barycentric_rotating_dynamic_frame.hpp"
 
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/r3x3_matrix.hpp"
 #include "quantities/quantities.hpp"
@@ -9,6 +10,7 @@
 
 namespace principia {
 
+using geometry::Barycentre;
 using geometry::Displacement;
 using geometry::R3x3Matrix;
 using geometry::Velocity;
@@ -41,7 +43,7 @@ BarycentricRotatingDynamicFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
   DegreesOfFreedom<InertialFrame> const secondary_degrees_of_freedom =
       secondary_trajectory_->EvaluateDegreesOfFreedom(t, &secondary_hint_);
   DegreesOfFreedom<InertialFrame> const barycentre_degrees_of_freedom =
-      Barycentre<InertialFrame, GravitationalParameter>(
+      Barycentre<DegreesOfFreedom<InertialFrame>, GravitationalParameter>(
           {primary_degrees_of_freedom,
            secondary_degrees_of_freedom},
           {primary_->gravitational_parameter(),
@@ -86,7 +88,7 @@ GeometricAcceleration(
   DegreesOfFreedom<InertialFrame> const secondary_degrees_of_freedom =
       secondary_trajectory_->EvaluateDegreesOfFreedom(t, &secondary_hint_);
   DegreesOfFreedom<InertialFrame> const barycentre_degrees_of_freedom =
-      Barycentre<InertialFrame, GravitationalParameter>(
+      Barycentre<DegreesOfFreedom<InertialFrame>, GravitationalParameter>(
           {primary_degrees_of_freedom,
            secondary_degrees_of_freedom},
           {primary_->gravitational_parameter(),

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "astronomy/frames.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
@@ -22,6 +23,7 @@
 namespace principia {
 
 using astronomy::ICRFJ2000Equator;
+using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::Instant;
 using geometry::Rotation;
@@ -75,7 +77,7 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
     small_gravitational_parameter_ =
         solar_system_.gravitational_parameter(kSmall);
     centre_of_mass_initial_state_ =
-        Barycentre<ICRFJ2000Equator, GravitationalParameter>(
+        Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
             {big_initial_state_, small_initial_state_},
             {big_gravitational_parameter_, small_gravitational_parameter_});
     big_small_frame_ =

--- a/physics/body_centered_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centered_non_rotating_dynamic_frame_test.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "astronomy/frames.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
@@ -22,6 +23,7 @@
 namespace principia {
 
 using astronomy::ICRFJ2000Equator;
+using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::Instant;
 using geometry::Rotation;
@@ -86,7 +88,7 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
                          ephemeris_.get(),
                          solar_system_.massive_body(*ephemeris_, kSmall));
     centre_of_mass_initial_state_ =
-        Barycentre<ICRFJ2000Equator, GravitationalParameter>(
+        Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
             {big_initial_state_, small_initial_state_},
             {big_gravitational_parameter_, small_gravitational_parameter_});
   }

--- a/physics/degrees_of_freedom.hpp
+++ b/physics/degrees_of_freedom.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/pair.hpp"
@@ -100,6 +101,41 @@ class Mappable<Functor, physics::RelativeDegreesOfFreedom<Frame>> {
 };
 
 }  // namespace base
+
+namespace geometry {
+
+template<typename Frame, typename Weight>
+class BarycentreCalculator<physics::DegreesOfFreedom<Frame>, Weight> {
+ public:
+  BarycentreCalculator() = default;
+  ~BarycentreCalculator() = default;
+
+  void Add(physics::DegreesOfFreedom<Frame> const& degrees_of_freedom,
+           Weight const& weight);
+  physics::DegreesOfFreedom<Frame> Get() const;
+
+ private:
+  BarycentreCalculator<Pair<Position<Frame>, Velocity<Frame>>, Weight>
+      implementation_;
+};
+
+template<typename Frame, typename Weight>
+class BarycentreCalculator<physics::RelativeDegreesOfFreedom<Frame>, Weight> {
+ public:
+  BarycentreCalculator() = default;
+  ~BarycentreCalculator() = default;
+
+  void Add(physics::RelativeDegreesOfFreedom<Frame> const&
+               relative_degrees_of_freedom,
+           Weight const& weight);
+  physics::RelativeDegreesOfFreedom<Frame> Get() const;
+
+ private:
+  BarycentreCalculator<Pair<Displacement<Frame>, Velocity<Frame>>, Weight>
+      implementation_;
+};
+
+}  // namespace geometry
 }  // namespace principia
 
 #include "physics/degrees_of_freedom_body.hpp"

--- a/physics/degrees_of_freedom.hpp
+++ b/physics/degrees_of_freedom.hpp
@@ -61,11 +61,6 @@ class RelativeDegreesOfFreedom
   Velocity<Frame> const& velocity() const;
 };
 
-template<typename Frame, typename Weight>
-DegreesOfFreedom<Frame> Barycentre(
-    std::vector<DegreesOfFreedom<Frame>> const& degrees_of_freedom,
-    std::vector<Weight> const& weights);
-
 template<typename Frame>
 std::string DebugString(DegreesOfFreedom<Frame> const& degrees_of_freedom);
 
@@ -102,6 +97,8 @@ class Mappable<Functor, physics::RelativeDegreesOfFreedom<Frame>> {
 
 }  // namespace base
 
+// Reopen the geometry namespace to make BarycentreCalculator applicable to
+// degrees of freedom.
 namespace geometry {
 
 template<typename Frame, typename Weight>

--- a/physics/degrees_of_freedom_body.hpp
+++ b/physics/degrees_of_freedom_body.hpp
@@ -63,8 +63,7 @@ DegreesOfFreedom<Frame> Barycentre(
   CHECK_EQ(degrees_of_freedom.size(), weights.size())
       << "Degrees of freedom and weights of unequal sizes";
   CHECK(!degrees_of_freedom.empty()) << "Empty input";
-  typename DegreesOfFreedom<Frame>::
-      template BarycentreCalculator<Weight> calculator;
+  geometry::BarycentreCalculator<DegreesOfFreedom<Frame>, Weight> calculator;
   for (size_t i = 0; i < degrees_of_freedom.size(); ++i) {
     calculator.Add(degrees_of_freedom[i], weights[i]);
   }
@@ -114,4 +113,36 @@ Mappable<Functor, physics::RelativeDegreesOfFreedom<Frame>>::Do(
 }
 
 }  // namespace base
+
+namespace geometry {
+
+template<typename Frame, typename Weight>
+void BarycentreCalculator<physics::DegreesOfFreedom<Frame>, Weight>::Add(
+    physics::DegreesOfFreedom<Frame> const& degrees_of_freedom,
+    Weight const& weight) {
+  implementation_.Add(degrees_of_freedom, weight);
+}
+
+template<typename Frame, typename Weight>
+physics::DegreesOfFreedom<Frame>
+BarycentreCalculator<physics::DegreesOfFreedom<Frame>, Weight>::Get() const {
+  return implementation_.Get();
+}
+
+template<typename Frame, typename Weight>
+void
+BarycentreCalculator<physics::RelativeDegreesOfFreedom<Frame>, Weight>::Add(
+    physics::RelativeDegreesOfFreedom<Frame> const& relative_degrees_of_freedom,
+    Weight const& weight) {
+  implementation_.Add(relative_degrees_of_freedom, weight);
+}
+
+template<typename Frame, typename Weight>
+physics::RelativeDegreesOfFreedom<Frame>
+BarycentreCalculator<physics::RelativeDegreesOfFreedom<Frame>, Weight>::Get()
+    const {
+  return implementation_.Get();
+}
+
+}  // namespace geometry
 }  // namespace principia

--- a/physics/degrees_of_freedom_body.hpp
+++ b/physics/degrees_of_freedom_body.hpp
@@ -6,6 +6,9 @@
 #include "physics/degrees_of_freedom.hpp"
 
 namespace principia {
+
+using geometry::BarycentreCalculator;
+
 namespace physics {
 
 template<typename Frame>
@@ -54,22 +57,6 @@ RelativeDegreesOfFreedom<Frame>::displacement() const {
 template<typename Frame>
 Velocity<Frame> const& RelativeDegreesOfFreedom<Frame>::velocity() const {
   return this->t2_;
-}
-
-template<typename Frame, typename Weight>
-DegreesOfFreedom<Frame> Barycentre(
-    std::vector<DegreesOfFreedom<Frame>> const& degrees_of_freedom,
-    std::vector<Weight> const& weights) {
-  CHECK_EQ(degrees_of_freedom.size(), weights.size())
-      << "Degrees of freedom and weights of unequal sizes";
-  CHECK(!degrees_of_freedom.empty()) << "Empty input";
-  geometry::BarycentreCalculator<DegreesOfFreedom<Frame>, Weight> calculator;
-  for (size_t i = 0; i < degrees_of_freedom.size(); ++i) {
-    calculator.Add(degrees_of_freedom[i], weights[i]);
-  }
-  return calculator.Get();
-  CHECK_EQ(degrees_of_freedom.size(), weights.size());
-  CHECK(!degrees_of_freedom.empty());
 }
 
 template<typename Frame>

--- a/physics/degrees_of_freedom_test.cpp
+++ b/physics/degrees_of_freedom_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -11,6 +12,8 @@
 
 namespace principia {
 
+using geometry::Barycentre;
+using geometry::BarycentreCalculator;
 using geometry::Displacement;
 using geometry::Position;
 using geometry::Velocity;
@@ -61,7 +64,8 @@ TEST_F(DegreesOfFreedomDeathTest, BarycentreError) {
   auto barycentre =
       [](std::vector<DegreesOfFreedom<World>> const& degrees_of_freedom,
          std::vector<Entropy> const& weights) -> DegreesOfFreedom<World> {
-    return Barycentre<World, Entropy>(degrees_of_freedom, weights);
+    return Barycentre<DegreesOfFreedom<World>, Entropy>(
+               degrees_of_freedom, weights);
   };
   EXPECT_DEATH({
     barycentre({d1_, d2_, d3_}, {3 * SIUnit<Entropy>(), 4 * SIUnit<Entropy>()});
@@ -70,7 +74,7 @@ TEST_F(DegreesOfFreedomDeathTest, BarycentreError) {
     barycentre({}, {});
   }, "Empty input");
   using DegreesOfFreedomBarycentreCalculator =
-      geometry::BarycentreCalculator<DegreesOfFreedom<World>, Entropy>;
+      BarycentreCalculator<DegreesOfFreedom<World>, Entropy>;
   EXPECT_DEATH({
     DegreesOfFreedomBarycentreCalculator calculator;
     calculator.Get();
@@ -97,10 +101,10 @@ TEST_F(DegreesOfFreedomTest, Output) {\
 
 TEST_F(DegreesOfFreedomTest, Barycentre) {
   DegreesOfFreedom<World> const barycentre =
-      Barycentre<World, Entropy>({d1_, d2_, d3_},
-                                 {3 * SIUnit<Entropy>(),
-                                  4 * SIUnit<Entropy>(),
-                                  5 * SIUnit<Entropy>()});
+      Barycentre<DegreesOfFreedom<World>, Entropy>({d1_, d2_, d3_},
+                                                   {3 * SIUnit<Entropy>(),
+                                                    4 * SIUnit<Entropy>(),
+                                                    5 * SIUnit<Entropy>()});
   EXPECT_THAT(barycentre,
               Componentwise(
                   Eq(origin_ +
@@ -113,7 +117,7 @@ TEST_F(DegreesOfFreedomTest, Barycentre) {
 }
 
 TEST_F(DegreesOfFreedomTest, BarycentreCalculator) {
-  geometry::BarycentreCalculator<DegreesOfFreedom<World>, double> calculator;
+  BarycentreCalculator<DegreesOfFreedom<World>, double> calculator;
   calculator.Add(d1_, 3);
   DegreesOfFreedom<World> barycentre = calculator.Get();
   EXPECT_THAT(barycentre, Eq(d1_));

--- a/physics/degrees_of_freedom_test.cpp
+++ b/physics/degrees_of_freedom_test.cpp
@@ -69,8 +69,10 @@ TEST_F(DegreesOfFreedomDeathTest, BarycentreError) {
   EXPECT_DEATH({
     barycentre({}, {});
   }, "Empty input");
+  using DegreesOfFreedomBarycentreCalculator =
+      geometry::BarycentreCalculator<DegreesOfFreedom<World>, Entropy>;
   EXPECT_DEATH({
-    DegreesOfFreedom<World>::BarycentreCalculator<Entropy> calculator;
+    DegreesOfFreedomBarycentreCalculator calculator;
     calculator.Get();
   }, "Empty BarycentreCalculator");
 }
@@ -111,7 +113,7 @@ TEST_F(DegreesOfFreedomTest, Barycentre) {
 }
 
 TEST_F(DegreesOfFreedomTest, BarycentreCalculator) {
-  DegreesOfFreedom<World>::BarycentreCalculator<double> calculator;
+  geometry::BarycentreCalculator<DegreesOfFreedom<World>, double> calculator;
   calculator.Add(d1_, 3);
   DegreesOfFreedom<World> barycentre = calculator.Get();
   EXPECT_THAT(barycentre, Eq(d1_));

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -6,6 +6,7 @@
 
 #include "astronomy/frames.hpp"
 #include "base/macros.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -28,6 +29,7 @@ namespace principia {
 
 using astronomy::ICRFJ2000Equator;
 using astronomy::kSolarSystemBarycentreEquator;
+using geometry::Barycentre;
 using integrators::DormandElMikkawyPrince1986RKN434FM;
 using integrators::McLachlanAtela1992Order5Optimal;
 using quantities::Abs;
@@ -85,17 +87,17 @@ class EphemerisTest : public testing::Test {
     // The Earth-Moon system, roughly, with a circular orbit with velocities
     // in the centre-of-mass frame.
     Position<EarthMoonOrbitPlane> const q1(
-        Vector<Length, EarthMoonOrbitPlane>({0 * Metre, 0 * Metre, 0 * Metre}));
+        Displacement<EarthMoonOrbitPlane>({0 * Metre, 0 * Metre, 0 * Metre}));
     Position<EarthMoonOrbitPlane> const q2(
-        Vector<Length, EarthMoonOrbitPlane>({0 * Metre,
-                                             4E8 * Metre,
-                                             0 * Metre}));
+        Displacement<EarthMoonOrbitPlane>({0 * Metre,
+                                           4E8 * Metre,
+                                           0 * Metre}));
     Length const semi_major_axis = (q1 - q2).Norm();
     *period = 2 * π * Sqrt(Pow<3>(semi_major_axis) /
                                (earth->gravitational_parameter() +
                                 moon->gravitational_parameter()));
     *centre_of_mass =
-        geometry::Barycentre<Vector<Length, EarthMoonOrbitPlane>, Mass>(
+        Barycentre<Position<EarthMoonOrbitPlane>, Mass>(
             {q1, q2}, {earth->mass(), moon->mass()});
     Velocity<EarthMoonOrbitPlane> const v1(
         {-2 * π * (q1 - *centre_of_mass).Norm() / *period,
@@ -150,7 +152,7 @@ TEST_F(EphemerisTest, ProlongSpecialCases) {
   EXPECT_EQ(t_max, ephemeris.t_max());
 
   Instant const last_t =
-      geometry::Barycentre<Time, double>({t0_ + period, t_max}, {0.5, 0.5});
+      Barycentre<Instant, double>({t0_ + period, t_max}, {0.5, 0.5});
   ephemeris.Prolong(last_t);
   EXPECT_EQ(t_max, ephemeris.t_max());
 }

--- a/physics/transforms_body.hpp
+++ b/physics/transforms_body.hpp
@@ -7,6 +7,7 @@
 
 #include "base/not_null.hpp"
 #include "geometry/affine_map.hpp"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/identity.hpp"
 #include "geometry/named_quantities.hpp"
@@ -22,6 +23,7 @@ namespace principia {
 
 using base::make_not_null_unique;
 using geometry::AffineMap;
+using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::Displacement;
 using geometry::Identity;
@@ -92,7 +94,7 @@ void FromStandardBasisToBasisOfLastBarycentricFrame(
       to_secondary_trajectory.EvaluateDegreesOfFreedom(
           last, &*to_secondary_hint);
   *last_barycentre_degrees_of_freedom =
-      Barycentre<ToFrame, GravitationalParameter>(
+      Barycentre<DegreesOfFreedom<ToFrame>, GravitationalParameter>(
           {last_primary_degrees_of_freedom,
            last_secondary_degrees_of_freedom},
           {primary.gravitational_parameter(),
@@ -263,7 +265,7 @@ Transforms<FromFrame, ThroughFrame, ToFrame>::BarycentricRotating(
         from_secondary_trajectory.EvaluateDegreesOfFreedom(
             t, &*from_secondary_hint);
     DegreesOfFreedom<FromFrame> const barycentre_degrees_of_freedom =
-        Barycentre<FromFrame, GravitationalParameter>(
+        Barycentre<DegreesOfFreedom<FromFrame>, GravitationalParameter>(
             {primary_degrees_of_freedom,
              secondary_degrees_of_freedom},
             {primary.gravitational_parameter(),

--- a/physics/transforms_test.cpp
+++ b/physics/transforms_test.cpp
@@ -299,8 +299,9 @@ TEST_F(TransformsTest, BodiesBarycentricRotating) {
                               VanishesBefore(s, 0, 13)));
 
     DegreesOfFreedom<Through> const barycentre_degrees_of_freedom =
-        Barycentre<Through, Mass>({degrees_of_freedom1, degrees_of_freedom2},
-                                  {body1_.mass(), body2_.mass()});
+        Barycentre<DegreesOfFreedom<Through>, Mass>(
+            {degrees_of_freedom1, degrees_of_freedom2},
+            {body1_.mass(), body2_.mass()});
     EXPECT_THAT(barycentre_degrees_of_freedom.position() - Through::origin,
                 Componentwise(VanishesBefore(l, 0, 2),
                               VanishesBefore(l, 0, 4),


### PR DESCRIPTION
* `BarycentreCalculator` is now specialized for all the classes that need it, instead of being sometimes a nested template.
* `Barycentre` is implemented one and is available for all the classes that have a`BarycentreCalculator`.
* All of this is in `geometry`, not in random namespaces.