### PR TITLE
Prevent Makefile cleaning up valid .o files on build errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ LDFLAGS := $(SHARED_ARGS)
 
 
 .PHONY: all adapter lib tests check plugin run_tests clean
+.PRECIOUS: %.o
 .DEFAULT_GOAL := plugin
 
 ##### CONVENIENCE TARGETS #####

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/a
 apt-get update
 apt-get install -y clang git unzip wget libc++-dev libc++abi-dev binutils make automake libtool curl cmake monodevelop
 git clone https://github.com/mockingbirdnest/Principia.git principia
+chown -R vagrant:vagrant principia KSP
 cd principia
 if [ -d deps ]; then echo "Dependencies already installed, remove deps/ to reinstall."; else ./install_deps.sh; fi
 SCRIPT


### PR DESCRIPTION
Just a minor tweak to the Makefile since it was previously ending up doing a lot of unnecessary recompiling while trying to fix errors.