### PR TITLE
Simplify the API of DiscreteTrajectory by removing functions and types that we don't need anymore

### DIFF
--- a/astronomy/astronomy.vcxproj
+++ b/astronomy/astronomy.vcxproj
@@ -57,6 +57,7 @@
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />

--- a/base/base.vcxproj
+++ b/base/base.vcxproj
@@ -73,6 +73,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -85,6 +85,7 @@
     <Import Project="..\google_benchmark.props" />
     <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
     <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -96,7 +96,7 @@ std::vector<std::pair<Position<ICRFJ2000Equator>,
                       Position<ICRFJ2000Equator>>> ApplyDynamicFrame(
     not_null<Body const*> const body,
     not_null<DynamicFrame<ICRFJ2000Equator, Rendering>*> const dynamic_frame,
-    DiscreteTrajectory<ICRFJ2000Equator>::NativeIterator const& actual_it) {
+    DiscreteTrajectory<ICRFJ2000Equator>::Iterator const& actual_it) {
   std::vector<std::pair<Position<ICRFJ2000Equator>,
                         Position<ICRFJ2000Equator>>> result;
 

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -96,13 +96,14 @@ std::vector<std::pair<Position<ICRFJ2000Equator>,
                       Position<ICRFJ2000Equator>>> ApplyDynamicFrame(
     not_null<Body const*> const body,
     not_null<DynamicFrame<ICRFJ2000Equator, Rendering>*> const dynamic_frame,
-    DiscreteTrajectory<ICRFJ2000Equator>::Iterator const& actual_it) {
+    DiscreteTrajectory<ICRFJ2000Equator>::Iterator const& begin,
+    DiscreteTrajectory<ICRFJ2000Equator>::Iterator const& end) {
   std::vector<std::pair<Position<ICRFJ2000Equator>,
                         Position<ICRFJ2000Equator>>> result;
 
   // Compute the trajectory in the rendering frame.
   DiscreteTrajectory<Rendering> intermediate_trajectory;
-  for (auto it = actual_it; !it.at_end(); ++it) {
+  for (auto it = begin; it != end; ++it) {
     intermediate_trajectory.Append(
         it.time(),
         dynamic_frame->ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
@@ -110,17 +111,19 @@ std::vector<std::pair<Position<ICRFJ2000Equator>,
 
   // Render the trajectory at current time in |Rendering|.
   Instant const& current_time = intermediate_trajectory.last().time();
-  auto initial_it = intermediate_trajectory.first();
-  auto from_rendering_frame_to_Rendering_at_current_time =
-          dynamic_frame->
-              FromThisFrameAtTime(current_time).rigid_transformation();
-  if (!initial_it.at_end()) {
+  DiscreteTrajectory<Rendering>::Iterator initial_it =
+      intermediate_trajectory.Begin();
+  DiscreteTrajectory<Rendering>::Iterator const intermediate_end =
+      intermediate_trajectory.End();
+  auto to_rendering_frame_at_current_time =
+      dynamic_frame->FromThisFrameAtTime(current_time).rigid_transformation();
+  if (initial_it != intermediate_end) {
     for (auto final_it = initial_it;
-         ++final_it, !final_it.at_end();
+         ++final_it, final_it != intermediate_end;
          initial_it = final_it) {
-      result.emplace_back(from_rendering_frame_to_Rendering_at_current_time(
+      result.emplace_back(to_rendering_frame_at_current_time(
                               initial_it.degrees_of_freedom().position()),
-                          from_rendering_frame_to_Rendering_at_current_time(
+                          to_rendering_frame_at_current_time(
                               final_it.degrees_of_freedom().position()));
     }
   }
@@ -170,7 +173,8 @@ void BM_BodyCentredNonRotatingDynamicFrame(
   while (state.KeepRunning()) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
-                               probe_trajectory.first());
+                               probe_trajectory.Begin(),
+                               probe_trajectory.End());
   }
 }
 
@@ -219,7 +223,8 @@ void BM_BarycentricRotatingDynamicFrame(
   while (state.KeepRunning()) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
-                               probe_trajectory.first());
+                               probe_trajectory.Begin(),
+                               probe_trajectory.End());
   }
 }
 

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -209,7 +209,7 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
                            EvaluatePosition(final_time, nullptr) -
                    trajectory.last().degrees_of_freedom().position()).
                        Norm();
-    steps = trajectory.Times().size();
+    steps = trajectory.Size();
     state->ResumeTiming();
   }
   std::stringstream ss;
@@ -282,7 +282,7 @@ void EphemerisLEOProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
                            EvaluatePosition(final_time, nullptr) -
                    trajectory.last().degrees_of_freedom().position()).
                        Norm();
-    steps = trajectory.Times().size();
+    steps = trajectory.Size();
     state->ResumeTiming();
   }
   std::stringstream ss;

--- a/define_ndebug.props
+++ b/define_ndebug.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/geometry/geometry.vcxproj
+++ b/geometry/geometry.vcxproj
@@ -74,6 +74,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/integrators/integrators.vcxproj
+++ b/integrators/integrators.vcxproj
@@ -76,6 +76,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -76,6 +76,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -936,7 +936,7 @@ void Plugin::EvolveProlongationsAndBubble(Instant const& t) {
 
 RenderedTrajectory<World> Plugin::RenderTrajectory(
     not_null<Body const*> const body,
-    DiscreteTrajectory<Barycentric>::NativeIterator const& actual_it,
+    DiscreteTrajectory<Barycentric>::Iterator const& actual_it,
     not_null<RenderingFrame*> const rendering_frame,
     Position<World> const& sun_world_position) const {
   RenderedTrajectory<World> result;

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -954,14 +954,17 @@ RenderedTrajectory<World> Plugin::RenderTrajectory(
   }
 
   // Render the trajectory at current time in |World|.
-  auto initial_it = intermediate_trajectory.first();
+  DiscreteTrajectory<Rendering>::Iterator initial_it =
+      intermediate_trajectory.Begin();
+  DiscreteTrajectory<Rendering>::Iterator const intermediate_end =
+      intermediate_trajectory.End();
   auto from_rendering_frame_to_world_at_current_time =
       to_world *
           rendering_frame->
               FromThisFrameAtTime(current_time_).rigid_transformation();
-  if (!initial_it.at_end()) {
+  if (initial_it != intermediate_end) {
     for (auto final_it = initial_it;
-         ++final_it, !final_it.at_end();
+         ++final_it, final_it != intermediate_end;
          initial_it = final_it) {
       result.emplace_back(from_rendering_frame_to_world_at_current_time(
                               initial_it.degrees_of_freedom().position()),

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -384,11 +384,10 @@ class Plugin {
 
   // A utility for |RenderedPrediction| and |RenderedVesselTrajectory|,
   // returns a |RenderedTrajectory| as computed by the given |rendering_frame|
-  // from the trajectory of |body| starting at |actual_it|.
+  // from the trajectory defined by |begin| and |end|.
   RenderedTrajectory<World> RenderTrajectory(
-      not_null<Body const*> const body,
-      DiscreteTrajectory<Barycentric>::Iterator const&
-          actual_it,
+      DiscreteTrajectory<Barycentric>::Iterator const& begin,
+      DiscreteTrajectory<Barycentric>::Iterator const& end,
       not_null<RenderingFrame*>const rendering_frame,
       Position<World> const& sun_world_position) const;
 

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -387,7 +387,7 @@ class Plugin {
   // from the trajectory of |body| starting at |actual_it|.
   RenderedTrajectory<World> RenderTrajectory(
       not_null<Body const*> const body,
-      DiscreteTrajectory<Barycentric>::NativeIterator const&
+      DiscreteTrajectory<Barycentric>::Iterator const&
           actual_it,
       not_null<RenderingFrame*>const rendering_frame,
       Position<World> const& sun_world_position) const;

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj
@@ -99,6 +99,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/ksp_plugin_test/physics_bubble_test.cpp
+++ b/ksp_plugin_test/physics_bubble_test.cpp
@@ -282,6 +282,17 @@ class PhysicsBubbleTest : public testing::Test {
                      16568.0 / 89.0 * SIUnit<Speed>()}) - cdm_velocity, 32));
   }
 
+  std::list<Instant> Times(
+      DiscreteTrajectory<Barycentric> const& trajectory) const {
+    std::list<Instant> result;
+    for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
+      auto const timeline_it = it.current();
+      Instant const& time = timeline_it->first;
+      result.push_back(time);
+    }
+    return result;
+  }
+
   PhysicsBubble bubble_;
   PhysicsBubble::BarycentricToWorldSun rotation_;
   DegreesOfFreedom<Barycentric> celestial_dof_;
@@ -355,10 +366,10 @@ TEST_F(PhysicsBubbleTest, OneVesselOneStep) {
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
   EXPECT_FALSE(bubble_.centre_of_mass_intrinsic_acceleration());
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t1_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t1_));
   DiscreteTrajectory<Barycentric>* mutable_trajectory =
       bubble_.mutable_centre_of_mass_trajectory();
-  EXPECT_THAT(mutable_trajectory->Times(), ElementsAre(t1_));
+  EXPECT_THAT(Times(*mutable_trajectory), ElementsAre(t1_));
 
   // Check the positions and velocities.
   CheckOneVesselDegreesOfFreedom(bubble_);
@@ -391,7 +402,7 @@ TEST_F(PhysicsBubbleTest, OneVesselTwoSteps) {
   // The trajectory now has an intrinsic acceleration.
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t1_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t1_));
   EXPECT_TRUE(bubble_.centre_of_mass_intrinsic_acceleration());
   EXPECT_THAT(bubble_.centre_of_mass_intrinsic_acceleration()(t2_),
               AlmostEquals(Vector<Acceleration, Barycentric>(
@@ -435,7 +446,7 @@ TEST_F(PhysicsBubbleTest, OneVesselPartRemoved) {
   // change of parts.
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t2_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t2_));
   EXPECT_EQ(dof1_.position(),
             trajectory.last().degrees_of_freedom().position());
   EXPECT_EQ(dof1_.velocity() +
@@ -496,7 +507,7 @@ TEST_F(PhysicsBubbleTest, OneVesselPartAdded) {
   // |OneVesselPartRemoved|.
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t2_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t2_));
   EXPECT_EQ(dof1_.position(),
             trajectory.last().degrees_of_freedom().position());
   EXPECT_EQ(dof1_.velocity() +
@@ -549,7 +560,7 @@ TEST_F(PhysicsBubbleTest, OneVesselNoCommonParts) {
   // The bubble was restarted.
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t2_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t2_));
   EXPECT_FALSE(bubble_.centre_of_mass_intrinsic_acceleration());
 
   // All the other assertions remain as in |OneVesselOneStep| since we restarted
@@ -580,7 +591,7 @@ TEST_F(PhysicsBubbleTest, TwoVessels) {
   // The trajectory of the centre of mass has only one point.
   DiscreteTrajectory<Barycentric> const& trajectory =
       bubble_.centre_of_mass_trajectory();
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t1_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t1_));
   EXPECT_FALSE(bubble_.centre_of_mass_intrinsic_acceleration());
 
   // Check the positions and velocities.
@@ -605,7 +616,7 @@ TEST_F(PhysicsBubbleTest, TwoVessels) {
   EXPECT_THAT(bubble_.vessels(), ElementsAre(&vessel1_, &vessel2_));
 
   // Not much has changed, except that the trajectory now has an acceleration.
-  EXPECT_THAT(trajectory.Times(), ElementsAre(t1_));
+  EXPECT_THAT(Times(trajectory), ElementsAre(t1_));
   Vector<Acceleration, World> const acceleration_correction =
       bubble_.VelocityCorrection(rotation_, celestial_) / (t3_ - t2_);
   EXPECT_TRUE(bubble_.centre_of_mass_intrinsic_acceleration());

--- a/ksp_plugin_test/physics_bubble_test.cpp
+++ b/ksp_plugin_test/physics_bubble_test.cpp
@@ -1,5 +1,6 @@
 ﻿#include "ksp_plugin/physics_bubble.hpp"
 
+#include <list>
 #include <map>
 #include <string>
 #include <vector>

--- a/mathematica/mathematica.vcxproj
+++ b/mathematica/mathematica.vcxproj
@@ -76,6 +76,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/numerics/numerics.vcxproj
+++ b/numerics/numerics.vcxproj
@@ -73,6 +73,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -64,11 +64,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // O(|depth|).  The result may be at end if the trajectory is empty.
   Iterator first() const;
 
-  // Returns at the first point of the trajectory which is on or after |time|.
-  // Complexity is O(|depth| + Ln(|length|)).  The result may be at end if the
-  // |time| is after the end of the trajectory.
-  Iterator on_or_after(Instant const& time) const;
-
   // Returns an iterator at the last point of the trajectory.  Complexity is
   // O(1).  The trajectory must not be empty.
   Iterator last() const;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -42,7 +42,19 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
       typename Forkable<DiscreteTrajectory<Frame>>::TimelineConstIterator;
 
  public:
-  class Iterator;
+  // An iterator over the points of a trajectory.
+  class Iterator : public Forkable<DiscreteTrajectory<Frame>>::Iterator {
+   public:
+    // Not explicit because we want the factory functions in |Forkable| to be
+    // easily usable for |Iterator|.
+    Iterator(typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
+
+    Instant const& time() const;
+    DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
+
+   private:
+    friend class DiscreteTrajectory;
+  };
 
   DiscreteTrajectory() = default;
   ~DiscreteTrajectory() override;
@@ -57,17 +69,15 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
       std::function<void(not_null<DiscreteTrajectory<Frame>const*> const)>
           on_destroy);
 
-  // TODO(phl): Many/most of the iterator functions are obsolete.  Remove them
-  // and use the ones from Forkable.
-
   // Returns an iterator at the last point of the trajectory.  Complexity is
   // O(1).  The trajectory must not be empty.
+  // TODO(phl): This is really RBegin, but Forkable doesn't have reverse
+  // iterators.
   Iterator last() const;
 
-  // These functions return the series of positions/velocities/times for the
-  // trajectory.  All three containers are guaranteed to have the same size.
-  // These functions are O(|depth| + |length|).
-  std::list<Instant> Times() const;
+  // Returns the number of points in the trajectory.  Complexity is O(|length| +
+  // |depth|).
+  int Size() const;
 
   // Creates a new child trajectory forked at time |time|, and returns it.  The
   // child trajectory shares its data with the current trajectory for times less
@@ -101,17 +111,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // that requires a VS 2015 feature (rvalue references for |*this|).
   static std::unique_ptr<DiscreteTrajectory> ReadFromMessage(
       serialization::Trajectory const& message);
-
-  class Iterator : public Forkable<DiscreteTrajectory<Frame>>::Iterator {
-   public:
-    Iterator(typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
-
-    Instant const& time() const;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
-
-   private:
-    friend class DiscreteTrajectory;
-  };
 
  protected:
   // The API inherited from Forkable.

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -44,15 +44,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
 
  public:
   class NativeIterator;
-  template<typename ToFrame>
-  class TransformingIterator;
-
-  // A function that transforms the coordinates to a different frame.
-  template<typename ToFrame>
-  using Transform = std::function<DegreesOfFreedom<ToFrame>(
-                        Instant const&,
-                        DegreesOfFreedom<Frame> const&,
-                        not_null<DiscreteTrajectory<Frame> const*> const)>;
 
   DiscreteTrajectory() = default;
   ~DiscreteTrajectory() override;
@@ -82,26 +73,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // Returns an iterator at the last point of the trajectory.  Complexity is
   // O(1).  The trajectory must not be empty.
   NativeIterator last() const;
-
-  // Same as |first| above, but returns an iterator that performs a coordinate
-  // tranformation to ToFrame.
-  template<typename ToFrame>
-  TransformingIterator<ToFrame> first_with_transform(
-      Transform<ToFrame> const& transform) const;
-
-  // Returns at the first point of the trajectory which is on or after |time|.
-  // Complexity is O(|depth| + Ln(|length|)).  The result may be at end if the
-  // |time| is after the end of the trajectory.
-  template<typename ToFrame>
-  TransformingIterator<ToFrame> on_or_after_with_transform(
-      Instant const& time,
-      Transform<ToFrame> const& transform) const;
-
-  // Same as |last| above, but returns an iterator that performs a coordinate
-  // tranformation to ToFrame.
-  template<typename ToFrame>
-  TransformingIterator<ToFrame> last_with_transform(
-      Transform<ToFrame> const& transform) const;
 
   // These functions return the series of positions/velocities/times for the
   // trajectory.  All three containers are guaranteed to have the same size.
@@ -153,20 +124,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
 
    private:
     explicit NativeIterator(Iterator it);
-    friend class DiscreteTrajectory;
-  };
-
-  // An iterator which returns the coordinates in another frame, |ToFrame|.
-  template<typename ToFrame>
-  class TransformingIterator : public Iterator {
-   public:
-    bool at_end() const;
-    Instant const& time() const;
-    DegreesOfFreedom<ToFrame> degrees_of_freedom() const;
-
-   private:
-    TransformingIterator(Iterator it, Transform<ToFrame> transform);
-    Transform<ToFrame> transform_;
     friend class DiscreteTrajectory;
   };
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -112,7 +112,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
    public:
     Iterator(typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
 
-    bool at_end() const;
     Instant const& time() const;
     DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -67,8 +67,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // These functions return the series of positions/velocities/times for the
   // trajectory.  All three containers are guaranteed to have the same size.
   // These functions are O(|depth| + |length|).
-  std::map<Instant, Position<Frame>> Positions() const;
-  std::map<Instant, Velocity<Frame>> Velocities() const;
   std::list<Instant> Times() const;
 
   // Creates a new child trajectory forked at time |time|, and returns it.  The

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -115,13 +115,13 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
 
   class Iterator : public Forkable<DiscreteTrajectory<Frame>>::Iterator {
    public:
+    Iterator(typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
+
     bool at_end() const;
     Instant const& time() const;
     DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
 
    private:
-    explicit Iterator(
-        typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
     friend class DiscreteTrajectory;
   };
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -60,10 +60,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // TODO(phl): Many/most of the iterator functions are obsolete.  Remove them
   // and use the ones from Forkable.
 
-  // Returns an iterator at the first point of the trajectory.  Complexity is
-  // O(|depth|).  The result may be at end if the trajectory is empty.
-  Iterator first() const;
-
   // Returns an iterator at the last point of the trajectory.  Complexity is
   // O(1).  The trajectory must not be empty.
   Iterator last() const;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -47,7 +47,8 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
    public:
     // Not explicit because we want the factory functions in |Forkable| to be
     // easily usable for |Iterator|.
-    Iterator(typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
+    Iterator(
+        typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);  // NOLINT
 
     Instant const& time() const;
     DegreesOfFreedom<Frame> const& degrees_of_freedom() const;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -37,13 +37,12 @@ struct ForkableTraits<DiscreteTrajectory<Frame>> {
 
 template<typename Frame>
 class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
-  using Iterator = typename Forkable<DiscreteTrajectory<Frame>>::Iterator;
   using Timeline = std::map<Instant, DegreesOfFreedom<Frame>>;
   using TimelineConstIterator =
       typename Forkable<DiscreteTrajectory<Frame>>::TimelineConstIterator;
 
  public:
-  class NativeIterator;
+  class Iterator;
 
   DiscreteTrajectory() = default;
   ~DiscreteTrajectory() override;
@@ -63,16 +62,16 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
 
   // Returns an iterator at the first point of the trajectory.  Complexity is
   // O(|depth|).  The result may be at end if the trajectory is empty.
-  NativeIterator first() const;
+  Iterator first() const;
 
   // Returns at the first point of the trajectory which is on or after |time|.
   // Complexity is O(|depth| + Ln(|length|)).  The result may be at end if the
   // |time| is after the end of the trajectory.
-  NativeIterator on_or_after(Instant const& time) const;
+  Iterator on_or_after(Instant const& time) const;
 
   // Returns an iterator at the last point of the trajectory.  Complexity is
   // O(1).  The trajectory must not be empty.
-  NativeIterator last() const;
+  Iterator last() const;
 
   // These functions return the series of positions/velocities/times for the
   // trajectory.  All three containers are guaranteed to have the same size.
@@ -114,16 +113,15 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   static std::unique_ptr<DiscreteTrajectory> ReadFromMessage(
       serialization::Trajectory const& message);
 
-  // An iterator which returns the coordinates in the native frame of the
-  // trajectory, i.e., |Frame|.
-  class NativeIterator : public Iterator {
+  class Iterator : public Forkable<DiscreteTrajectory<Frame>>::Iterator {
    public:
     bool at_end() const;
     Instant const& time() const;
     DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
 
    private:
-    explicit NativeIterator(Iterator it);
+    explicit Iterator(
+        typename Forkable<DiscreteTrajectory<Frame>>::Iterator it);
     friend class DiscreteTrajectory;
   };
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -75,10 +75,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>> {
   // iterators.
   Iterator last() const;
 
-  // Returns the number of points in the trajectory.  Complexity is O(|length| +
-  // |depth|).
-  int Size() const;
-
   // Creates a new child trajectory forked at time |time|, and returns it.  The
   // child trajectory shares its data with the current trajectory for times less
   // than or equal to |time|, and is an exact copy of the current trajectory for

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -57,32 +57,6 @@ DiscreteTrajectory<Frame>::last() const {
 }
 
 template<typename Frame>
-template<typename ToFrame>
-typename DiscreteTrajectory<Frame>::TEMPLATE TransformingIterator<ToFrame>
-DiscreteTrajectory<Frame>::first_with_transform(
-    Transform<ToFrame> const& transform) const {
-  return TransformingIterator<ToFrame>(this->Begin(), transform);
-}
-
-template<typename Frame>
-template<typename ToFrame>
-typename DiscreteTrajectory<Frame>::TEMPLATE TransformingIterator<ToFrame>
-DiscreteTrajectory<Frame>::on_or_after_with_transform(
-    Instant const& time,
-    Transform<ToFrame> const& transform) const {
-  return TransformingIterator<ToFrame>(this->LowerBound(time), transform);
-}
-
-template<typename Frame>
-template<typename ToFrame>
-typename DiscreteTrajectory<Frame>::TEMPLATE TransformingIterator<ToFrame>
-DiscreteTrajectory<Frame>::last_with_transform(
-    Transform<ToFrame> const& transform) const {
-  auto it = this->End();
-  return TransformingIterator<ToFrame>(--it, transform);
-}
-
-template<typename Frame>
 std::map<Instant, Position<Frame>>
 DiscreteTrajectory<Frame>::Positions() const {
   std::map<Instant, Position<Frame>> result;
@@ -219,34 +193,6 @@ DiscreteTrajectory<Frame>::NativeIterator::degrees_of_freedom() const {
 template<typename Frame>
 DiscreteTrajectory<Frame>::NativeIterator::NativeIterator(Iterator it)
     : Iterator(std::move(it)) {}
-
-template<typename Frame>
-template<typename ToFrame>
-bool DiscreteTrajectory<Frame>::TransformingIterator<ToFrame>::at_end() const {
-  return *this == this->trajectory()->End();
-}
-
-template<typename Frame>
-template<typename ToFrame>
-Instant const&
-DiscreteTrajectory<Frame>::TransformingIterator<ToFrame>::time() const {
-  return this->current()->first;
-}
-template<typename Frame>
-template<typename ToFrame>
-DegreesOfFreedom<ToFrame>
-DiscreteTrajectory<Frame>::
-TransformingIterator<ToFrame>::degrees_of_freedom() const {
-  auto it = this->current();
-  return transform_(it->first, it->second, this->trajectory());
-}
-
-template<typename Frame>
-template<typename ToFrame>
-DiscreteTrajectory<Frame>::TransformingIterator<ToFrame>::TransformingIterator(
-    Iterator it, Transform<ToFrame> transform)
-    : Iterator(std::move(it)),
-      transform_(std::move(transform)) {}
 
 template<typename Frame>
 not_null<DiscreteTrajectory<Frame>*> DiscreteTrajectory<Frame>::that() {

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -173,11 +173,6 @@ DiscreteTrajectory<Frame>::Iterator::Iterator(
     : Forkable<DiscreteTrajectory<Frame>>::Iterator(std::move(it)) {}
 
 template<typename Frame>
-bool DiscreteTrajectory<Frame>::Iterator::at_end() const {
-  return *this == this->trajectory()->End();
-}
-
-template<typename Frame>
 Instant const& DiscreteTrajectory<Frame>::Iterator::time() const {
   return this->current()->first;
 }

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -44,13 +44,6 @@ DiscreteTrajectory<Frame>::first() const {
 
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::Iterator
-DiscreteTrajectory<Frame>::on_or_after(
-    Instant const& time) const {
-  return Iterator(this->LowerBound(time));
-}
-
-template<typename Frame>
-typename DiscreteTrajectory<Frame>::Iterator
 DiscreteTrajectory<Frame>::last() const {
   auto it = this->End();
   return Iterator(--it);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -44,12 +44,10 @@ DiscreteTrajectory<Frame>::last() const {
 }
 
 template<typename Frame>
-std::list<Instant> DiscreteTrajectory<Frame>::Times() const {
-  std::list<Instant> result;
+int DiscreteTrajectory<Frame>::Size() const {
+  int result = 0;
   for (auto it = this->Begin(); it != this->End(); ++it) {
-    auto const timeline_it = it.current();
-    Instant const& time = timeline_it->first;
-    result.push_back(time);
+    ++result;
   }
   return result;
 }
@@ -73,19 +71,19 @@ template<typename Frame>
 void DiscreteTrajectory<Frame>::Append(
     Instant const& time,
     DegreesOfFreedom<Frame> const& degrees_of_freedom) {
-  auto const fork_time = this->ForkTime();
-  if (fork_time && time <= fork_time) {
+  Iterator const fork_it = this->Fork();
+  if (fork_it != this->End() && time <= fork_it.time()) {
     // TODO(egg): This is a logic error and it should CHECK.  Unfortunately, the
     // plugin integration test fails this check.
     LOG(ERROR) << "Append at " << time
-               << " which is before fork time " << *fork_time;
+               << " which is before fork time " << fork_it.time();
     return;
   }
 
   if (!timeline_.empty() && timeline_.cbegin()->first == time) {
     LOG(WARNING) << "Append at existing time " << time
-                 << ", time range = [" << Times().front() << ", "
-                 << Times().back() << "]";
+                 << ", time range = [" << Iterator(this->Begin()).time() << ", "
+                 << last().time() << "]";
     return;
   }
   auto it = timeline_.emplace_hint(timeline_.end(),

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -175,6 +175,11 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
 }
 
 template<typename Frame>
+DiscreteTrajectory<Frame>::Iterator::Iterator(
+    typename Forkable<DiscreteTrajectory<Frame>>::Iterator it)
+    : Forkable<DiscreteTrajectory<Frame>>::Iterator(std::move(it)) {}
+
+template<typename Frame>
 bool DiscreteTrajectory<Frame>::Iterator::at_end() const {
   return *this == this->trajectory()->End();
 }
@@ -189,11 +194,6 @@ DegreesOfFreedom<Frame> const&
 DiscreteTrajectory<Frame>::Iterator::degrees_of_freedom() const {
   return this->current()->second;
 }
-
-template<typename Frame>
-DiscreteTrajectory<Frame>::Iterator::Iterator(
-    typename Forkable<DiscreteTrajectory<Frame>>::Iterator it)
-    : Forkable<DiscreteTrajectory<Frame>>::Iterator(std::move(it)) {}
 
 template<typename Frame>
 not_null<DiscreteTrajectory<Frame>*> DiscreteTrajectory<Frame>::that() {

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -44,32 +44,6 @@ DiscreteTrajectory<Frame>::last() const {
 }
 
 template<typename Frame>
-std::map<Instant, Position<Frame>>
-DiscreteTrajectory<Frame>::Positions() const {
-  std::map<Instant, Position<Frame>> result;
-  for (auto it = this->Begin(); it != this->End(); ++it) {
-    auto timeline_it = it.current();
-    Instant const& time = timeline_it->first;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = timeline_it->second;
-    result.emplace_hint(result.end(), time, degrees_of_freedom.position());
-  }
-  return result;
-}
-
-template<typename Frame>
-std::map<Instant, Velocity<Frame>>
-DiscreteTrajectory<Frame>::Velocities() const {
-  std::map<Instant, Velocity<Frame>> result;
-  for (auto it = this->Begin(); it != this->End(); ++it) {
-    auto const timeline_it = it.current();
-    Instant const& time = timeline_it->first;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = timeline_it->second;
-    result.emplace_hint(result.end(), time, degrees_of_freedom.velocity());
-  }
-  return result;
-}
-
-template<typename Frame>
 std::list<Instant> DiscreteTrajectory<Frame>::Times() const {
   std::list<Instant> result;
   for (auto it = this->Begin(); it != this->End(); ++it) {

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -44,15 +44,6 @@ DiscreteTrajectory<Frame>::last() const {
 }
 
 template<typename Frame>
-int DiscreteTrajectory<Frame>::Size() const {
-  int result = 0;
-  for (auto it = this->Begin(); it != this->End(); ++it) {
-    ++result;
-  }
-  return result;
-}
-
-template<typename Frame>
 not_null<DiscreteTrajectory<Frame>*>
 DiscreteTrajectory<Frame>::NewForkWithCopy(Instant const& time) {
   auto const fork = this->NewFork(time);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -38,12 +38,6 @@ void DiscreteTrajectory<Frame>::set_on_destroy(
 
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::Iterator
-DiscreteTrajectory<Frame>::first() const {
-  return Iterator(this->Begin());
-}
-
-template<typename Frame>
-typename DiscreteTrajectory<Frame>::Iterator
 DiscreteTrajectory<Frame>::last() const {
   auto it = this->End();
   return Iterator(--it);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -37,23 +37,23 @@ void DiscreteTrajectory<Frame>::set_on_destroy(
 }
 
 template<typename Frame>
-typename DiscreteTrajectory<Frame>::NativeIterator
+typename DiscreteTrajectory<Frame>::Iterator
 DiscreteTrajectory<Frame>::first() const {
-  return NativeIterator(this->Begin());
+  return Iterator(this->Begin());
 }
 
 template<typename Frame>
-typename DiscreteTrajectory<Frame>::NativeIterator
+typename DiscreteTrajectory<Frame>::Iterator
 DiscreteTrajectory<Frame>::on_or_after(
     Instant const& time) const {
-  return NativeIterator(this->LowerBound(time));
+  return Iterator(this->LowerBound(time));
 }
 
 template<typename Frame>
-typename DiscreteTrajectory<Frame>::NativeIterator
+typename DiscreteTrajectory<Frame>::Iterator
 DiscreteTrajectory<Frame>::last() const {
   auto it = this->End();
-  return NativeIterator(--it);
+  return Iterator(--it);
 }
 
 template<typename Frame>
@@ -175,24 +175,25 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
 }
 
 template<typename Frame>
-bool DiscreteTrajectory<Frame>::NativeIterator::at_end() const {
+bool DiscreteTrajectory<Frame>::Iterator::at_end() const {
   return *this == this->trajectory()->End();
 }
 
 template<typename Frame>
-Instant const& DiscreteTrajectory<Frame>::NativeIterator::time() const {
+Instant const& DiscreteTrajectory<Frame>::Iterator::time() const {
   return this->current()->first;
 }
 
 template<typename Frame>
 DegreesOfFreedom<Frame> const&
-DiscreteTrajectory<Frame>::NativeIterator::degrees_of_freedom() const {
+DiscreteTrajectory<Frame>::Iterator::degrees_of_freedom() const {
   return this->current()->second;
 }
 
 template<typename Frame>
-DiscreteTrajectory<Frame>::NativeIterator::NativeIterator(Iterator it)
-    : Iterator(std::move(it)) {}
+DiscreteTrajectory<Frame>::Iterator::Iterator(
+    typename Forkable<DiscreteTrajectory<Frame>>::Iterator it)
+    : Forkable<DiscreteTrajectory<Frame>>::Iterator(std::move(it)) {}
 
 template<typename Frame>
 not_null<DiscreteTrajectory<Frame>*> DiscreteTrajectory<Frame>::that() {

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -103,6 +103,16 @@ class DiscreteTrajectoryTest : public testing::Test {
     return result;
   }
 
+  std::list<Instant> Times(DiscreteTrajectory<World> const& trajectory) const {
+    std::list<Instant> result;
+    for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
+      auto const timeline_it = it.current();
+      Instant const& time = timeline_it->first;
+      result.push_back(time);
+    }
+    return result;
+  }
+
   Position<World> q1_, q2_, q3_, q4_;
   Velocity<World> p1_, p2_, p3_, p4_;
   DegreesOfFreedom<World> d1_, d2_, d3_, d4_;
@@ -139,7 +149,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopySuccess) {
       Positions(*massive_trajectory_);
   std::map<Instant, Velocity<World>> velocities =
       Velocities(*massive_trajectory_);
-  std::list<Instant> times = massive_trajectory_->Times();
+  std::list<Instant> times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -149,7 +159,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopySuccess) {
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
   positions = Positions(*fork);
   velocities = Velocities(*fork);
-  times = fork->Times();
+  times = Times(*fork);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_),
@@ -176,7 +186,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
 
   std::map<Instant, Position<World>> positions = Positions(*fork2);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork2);
-  std::list<Instant> times = fork2->Times();
+  std::list<Instant> times = Times(*fork2);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -199,7 +209,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   fork2->ForgetAfter(t3_);
   positions = Positions(*fork2);
   velocities = Velocities(*fork2);
-  times = fork2->Times();
+  times = Times(*fork2);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -222,7 +232,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   fork1->Append(t4_, d4_);
   positions = Positions(*fork2);
   velocities = Velocities(*fork2);
-  times = fork2->Times();
+  times = Times(*fork2);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -244,7 +254,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
 
   positions = Positions(*fork3);
   velocities = Velocities(*fork3);
-  times = fork3->Times();
+  times = Times(*fork3);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -303,7 +313,7 @@ TEST_F(DiscreteTrajectoryTest, AppendSuccess) {
       Positions(*massive_trajectory_);
   std::map<Instant, Velocity<World>> const velocities =
       Velocities(*massive_trajectory_);
-  std::list<Instant> const times = massive_trajectory_->Times();
+  std::list<Instant> const times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -324,7 +334,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   fork->ForgetAfter(t3_ + (t4_ - t3_) / 2);
   std::map<Instant, Position<World>> positions = Positions(*fork);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork);
-  std::list<Instant> times = fork->Times();
+  std::list<Instant> times = Times(*fork);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -336,7 +346,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   fork->ForgetAfter(t2_);
   positions = Positions(*fork);
   velocities = Velocities(*fork);
-  times = fork->Times();
+  times = Times(*fork);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_)));
   EXPECT_THAT(velocities, ElementsAre(testing::Pair(t1_, p1_),
@@ -348,7 +358,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
 
   positions = Positions(*massive_trajectory_);
   velocities = Velocities(*massive_trajectory_);
-  times = massive_trajectory_->Times();
+  times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_),
                                      testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
@@ -360,7 +370,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   massive_trajectory_->ForgetAfter(t1_);
   positions = Positions(*massive_trajectory_);
   velocities = Velocities(*massive_trajectory_);
-  times = massive_trajectory_->Times();
+  times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t1_, q1_)));
   EXPECT_THAT(velocities, ElementsAre(testing::Pair(t1_, p1_)));
   EXPECT_THAT(times, ElementsAre(t1_));
@@ -380,7 +390,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetBefore) {
       Positions(*massive_trajectory_);
   std::map<Instant, Velocity<World>> velocities =
       Velocities(*massive_trajectory_);
-  std::list<Instant> times = massive_trajectory_->Times();
+  std::list<Instant> times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_)));
   EXPECT_THAT(velocities, ElementsAre(testing::Pair(t2_, p2_),
@@ -388,7 +398,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetBefore) {
   EXPECT_THAT(times, ElementsAre(t2_, t3_));
   positions = Positions(*fork);
   velocities = Velocities(*fork);
-  times = fork->Times();
+  times = Times(*fork);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t2_, q2_),
                                      testing::Pair(t3_, q3_),
                                      testing::Pair(t4_, q4_)));
@@ -400,7 +410,7 @@ TEST_F(DiscreteTrajectoryTest, ForgetBefore) {
   massive_trajectory_->ForgetBefore(t2_);
   positions = Positions(*massive_trajectory_);
   velocities = Velocities(*massive_trajectory_);
-  times = massive_trajectory_->Times();
+  times = Times(*massive_trajectory_);
   EXPECT_THAT(positions, ElementsAre(testing::Pair(t3_, q3_)));
   EXPECT_THAT(velocities, ElementsAre(testing::Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t3_));

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -503,14 +503,14 @@ TEST_F(DiscreteTrajectoryTest, LastSuccess) {
   EXPECT_EQ(t3_, massive_trajectory_->last().time());
 }
 
-TEST_F(DiscreteTrajectoryDeathTest, NativeIteratorError) {
+TEST_F(DiscreteTrajectoryDeathTest, IteratorError) {
   EXPECT_DEATH({
-    DiscreteTrajectory<World>::NativeIterator it = massive_trajectory_->last();
+    DiscreteTrajectory<World>::Iterator it = massive_trajectory_->last();
   }, "parent_.*non NULL");
 }
 
-TEST_F(DiscreteTrajectoryTest, NativeIteratorSuccess) {
-  DiscreteTrajectory<World>::NativeIterator it = massive_trajectory_->first();
+TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
+  DiscreteTrajectory<World>::Iterator it = massive_trajectory_->first();
   EXPECT_TRUE(it.at_end());
 
   massless_trajectory_->Append(t1_, d1_);
@@ -551,8 +551,8 @@ TEST_F(DiscreteTrajectoryTest, NativeIteratorSuccess) {
   EXPECT_TRUE(it.at_end());
 }
 
-TEST_F(DiscreteTrajectoryTest, NativeIteratorOnOrAfterSuccess) {
-  DiscreteTrajectory<World>::NativeIterator it =
+TEST_F(DiscreteTrajectoryTest, IteratorOnOrAfterSuccess) {
+  DiscreteTrajectory<World>::Iterator it =
       massive_trajectory_->on_or_after(t0_);
   EXPECT_TRUE(it.at_end());
 

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -522,15 +522,15 @@ TEST_F(DiscreteTrajectoryDeathTest, IteratorError) {
 }
 
 TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
-  DiscreteTrajectory<World>::Iterator it = massive_trajectory_->first();
-  EXPECT_TRUE(it.at_end());
+  DiscreteTrajectory<World>::Iterator it = massive_trajectory_->Begin();
+  EXPECT_TRUE(it == massive_trajectory_->End());
 
   massless_trajectory_->Append(t1_, d1_);
   massless_trajectory_->Append(t2_, d2_);
   massless_trajectory_->Append(t3_, d3_);
 
-  it = massless_trajectory_->first();
-  EXPECT_FALSE(it.at_end());
+  it = massless_trajectory_->Begin();
+  EXPECT_FALSE(it == massless_trajectory_->End());
   EXPECT_EQ(t1_, it.time());
   EXPECT_EQ(d1_, it.degrees_of_freedom());
   ++it;
@@ -540,14 +540,14 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(t3_, it.time());
   EXPECT_EQ(d3_, it.degrees_of_freedom());
   ++it;
-  EXPECT_TRUE(it.at_end());
+  EXPECT_TRUE(it == massless_trajectory_->End());
 
   not_null<DiscreteTrajectory<World>*> const fork =
       massless_trajectory_->NewForkWithCopy(t2_);
   fork->Append(t4_, d4_);
 
-  it = fork->first();
-  EXPECT_FALSE(it.at_end());
+  it = fork->Begin();
+  EXPECT_FALSE(it == fork->End());
   EXPECT_EQ(t1_, it.time());
   EXPECT_EQ(d1_, it.degrees_of_freedom());
   ++it;
@@ -560,7 +560,7 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(t4_, it.time());
   EXPECT_EQ(d4_, it.degrees_of_freedom());
   ++it;
-  EXPECT_TRUE(it.at_end());
+  EXPECT_TRUE(it == fork->End());
 }
 
 }  // namespace physics

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -165,7 +165,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_EQ(t3_, fork2->last().time());
 
   std::vector<Instant> after;
-  for (auto it = fork3->on_or_after(t3_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
+       it != fork3->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t3_));
@@ -186,7 +188,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_EQ(t3_, fork2->last().time());
 
   after.clear();
-  for (auto it = fork2->on_or_after(t3_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
+       it != fork2->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t3_));
@@ -207,7 +211,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_EQ(t3_, fork2->last().time());
 
   after.clear();
-  for (auto it = fork1->on_or_after(t3_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
+       it != fork1->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
@@ -228,20 +234,26 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
 
   fork2->Append(t4_, d4_);
   after.clear();
-  for (auto it = fork2->on_or_after(t3_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
+       it != fork2->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
   fork3->Append(t4_, d4_);
   after.clear();
-  for (auto it = fork3->on_or_after(t3_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
+       it != fork3->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
   after.clear();
-  for (auto it = fork3->on_or_after(t2_); !it.at_end(); ++it) {
+  for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t2_);
+       it != fork3->End();
+       ++it) {
     after.push_back(it.time());
   }
   EXPECT_THAT(after, ElementsAre(t2_, t3_, t4_));
@@ -548,43 +560,6 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(t4_, it.time());
   EXPECT_EQ(d4_, it.degrees_of_freedom());
   ++it;
-  EXPECT_TRUE(it.at_end());
-}
-
-TEST_F(DiscreteTrajectoryTest, IteratorOnOrAfterSuccess) {
-  DiscreteTrajectory<World>::Iterator it =
-      massive_trajectory_->on_or_after(t0_);
-  EXPECT_TRUE(it.at_end());
-
-  massless_trajectory_->Append(t1_, d1_);
-  massless_trajectory_->Append(t2_, d2_);
-  massless_trajectory_->Append(t3_, d3_);
-
-  it = massless_trajectory_->on_or_after(t0_);
-  EXPECT_FALSE(it.at_end());
-  EXPECT_EQ(t1_, it.time());
-  EXPECT_EQ(d1_, it.degrees_of_freedom());
-  it = massless_trajectory_->on_or_after(t2_);
-  EXPECT_EQ(t2_, it.time());
-  EXPECT_EQ(d2_, it.degrees_of_freedom());
-  it = massless_trajectory_->on_or_after(t4_);
-  EXPECT_TRUE(it.at_end());
-
-  not_null<DiscreteTrajectory<World>*> const fork =
-      massless_trajectory_->NewForkWithCopy(t2_);
-  fork->Append(t4_, d4_);
-
-  it = fork->on_or_after(t0_);
-  EXPECT_FALSE(it.at_end());
-  EXPECT_EQ(t1_, it.time());
-  EXPECT_EQ(d1_, it.degrees_of_freedom());
-  it = fork->on_or_after(t2_);
-  EXPECT_EQ(t2_, it.time());
-  EXPECT_EQ(d2_, it.degrees_of_freedom());
-  it = fork->on_or_after(t4_);
-  EXPECT_EQ(t4_, it.time());
-  EXPECT_EQ(d4_, it.degrees_of_freedom());
-  it = fork->on_or_after(t4_ + 1 * Second);
   EXPECT_TRUE(it.at_end());
 }
 

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -595,10 +595,10 @@ std::unique_ptr<Ephemeris<Frame>> Ephemeris<Frame>::ReadFromPreBourbakiMessages(
     }
     auto continuous_trajectory = ephemeris->trajectories_[j];
 
-    auto it = history->first();
+    DiscreteTrajectory<Frame>::Iterator it = history->Begin();
     Instant last_time = it.time();
     DegreesOfFreedom<Frame> last_degrees_of_freedom = it.degrees_of_freedom();
-    for (; !it.at_end(); ++it) {
+    for (; it != history->End(); ++it) {
       Time const duration_since_last_time = it.time() - last_time;
       if (duration_since_last_time == step) {
         // A time in the discrete trajectory that is aligned on the continuous

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -559,8 +559,10 @@ std::unique_ptr<Ephemeris<Frame>> Ephemeris<Frame>::ReadFromPreBourbakiMessages(
         DiscreteTrajectory<Frame>::ReadPointerFromMessage(
             celestial.history_and_prolongation().prolongation(),
             histories.back().get());
-    initial_state.push_back(histories.back()->first().degrees_of_freedom());
-    initial_time.insert(histories.back()->first().time());
+    DiscreteTrajectory<Frame>::Iterator const history_begin =
+        histories.back()->Begin();
+    initial_state.push_back(history_begin.degrees_of_freedom());
+    initial_time.insert(history_begin.time());
     final_time.insert(prolongation->last().time());
   }
   CHECK_EQ(1, initial_time.size());

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -559,7 +559,7 @@ std::unique_ptr<Ephemeris<Frame>> Ephemeris<Frame>::ReadFromPreBourbakiMessages(
         DiscreteTrajectory<Frame>::ReadPointerFromMessage(
             celestial.history_and_prolongation().prolongation(),
             histories.back().get());
-    DiscreteTrajectory<Frame>::Iterator const history_begin =
+    typename DiscreteTrajectory<Frame>::Iterator const history_begin =
         histories.back()->Begin();
     initial_state.push_back(history_begin.degrees_of_freedom());
     initial_time.insert(history_begin.time());
@@ -597,7 +597,7 @@ std::unique_ptr<Ephemeris<Frame>> Ephemeris<Frame>::ReadFromPreBourbakiMessages(
     }
     auto continuous_trajectory = ephemeris->trajectories_[j];
 
-    DiscreteTrajectory<Frame>::Iterator it = history->Begin();
+    typename DiscreteTrajectory<Frame>::Iterator it = history->Begin();
     Instant last_time = it.time();
     DegreesOfFreedom<Frame> last_degrees_of_freedom = it.degrees_of_freedom();
     for (; it != history->End(); ++it) {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -269,7 +269,6 @@ TEST_F(EphemerisTest, Forget) {
 
 // The Moon alone.  It moves in straight line.
 TEST_F(EphemerisTest, Moon) {
-  Position<EarthMoonOrbitPlane> const reference_position;
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<EarthMoonOrbitPlane>> initial_state;
   Position<EarthMoonOrbitPlane> centre_of_mass;
@@ -299,13 +298,13 @@ TEST_F(EphemerisTest, Moon) {
   DegreesOfFreedom<EarthMoonOrbitPlane> const moon_degrees_of_freedom =
       moon_trajectory.EvaluateDegreesOfFreedom(t0_ + period, &hint);
   Length const q = (moon_degrees_of_freedom.position() -
-                    reference_position).coordinates().y;
+                    EarthMoonOrbitPlane::origin).coordinates().y;
   Speed const v = moon_degrees_of_freedom.velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> moon_positions;
   for (int i = 0; i <= 100; ++i) {
     moon_positions.push_back(
         moon_trajectory.EvaluatePosition(t0_ + i * period / 100, &hint) -
-            reference_position);
+            EarthMoonOrbitPlane::origin);
   }
 
   EXPECT_THAT(moon_positions.size(), Eq(101));
@@ -327,7 +326,6 @@ TEST_F(EphemerisTest, Moon) {
 // and an acceleration which exactly compensates gravitational attraction.  Both
 // bodies move in straight lines.
 TEST_F(EphemerisTest, EarthProbe) {
-  Position<EarthMoonOrbitPlane> const reference_position;
   Length const kDistance = 1E9 * Metre;
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<EarthMoonOrbitPlane>> initial_state;
@@ -383,13 +381,13 @@ TEST_F(EphemerisTest, EarthProbe) {
   DegreesOfFreedom<EarthMoonOrbitPlane> const earth_degrees_of_freedom =
       earth_trajectory.EvaluateDegreesOfFreedom(t0_ + period, &hint);
   Length const q_earth = (earth_degrees_of_freedom.position() -
-                          reference_position).coordinates().y;
+                          EarthMoonOrbitPlane::origin).coordinates().y;
   Speed const v_earth = earth_degrees_of_freedom.velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> earth_positions;
   for (int i = 0; i <= 100; ++i) {
     earth_positions.push_back(
         earth_trajectory.EvaluatePosition(t0_ + i * period / 100, &hint) -
-            reference_position);
+            EarthMoonOrbitPlane::origin);
   }
 
   EXPECT_THAT(earth_positions.size(), Eq(101));
@@ -407,12 +405,16 @@ TEST_F(EphemerisTest, EarthProbe) {
   EXPECT_THAT(earth_positions[100].coordinates().y, Eq(q_earth));
 
   Length const q_probe = (trajectory.last().degrees_of_freedom().position() -
-                         reference_position).coordinates().y;
+                         EarthMoonOrbitPlane::origin).coordinates().y;
   Speed const v_probe =
       trajectory.last().degrees_of_freedom().velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> probe_positions;
-  for (auto const it : trajectory.Positions()) {
-    probe_positions.push_back(it.second - reference_position);
+  for (DiscreteTrajectory<EarthMoonOrbitPlane>::Iterator it =
+           trajectory.Begin();
+       it != trajectory.End();
+       ++it) {
+    probe_positions.push_back(it.degrees_of_freedom().position() -
+                              EarthMoonOrbitPlane::origin);
   }
   EXPECT_THAT(probe_positions.size(), Eq(11));
   EXPECT_THAT(probe_positions.back().coordinates().x,
@@ -424,7 +426,6 @@ TEST_F(EphemerisTest, EarthProbe) {
 // The Earth and two massless probes, similar to the previous test but flowing
 // with a fixed step.
 TEST_F(EphemerisTest, EarthTwoProbes) {
-  Position<EarthMoonOrbitPlane> const reference_position;
   Length const kDistance1 = 1E9 * Metre;
   Length const kDistance2 = 3E9 * Metre;
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
@@ -494,13 +495,13 @@ TEST_F(EphemerisTest, EarthTwoProbes) {
   DegreesOfFreedom<EarthMoonOrbitPlane> const earth_degrees_of_freedom =
       earth_trajectory.EvaluateDegreesOfFreedom(t0_ + period, &hint);
   Length const q_earth = (earth_degrees_of_freedom.position() -
-                          reference_position).coordinates().y;
+                          EarthMoonOrbitPlane::origin).coordinates().y;
   Speed const v_earth = earth_degrees_of_freedom.velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> earth_positions;
   for (int i = 0; i <= 100; ++i) {
     earth_positions.push_back(
         earth_trajectory.EvaluatePosition(t0_ + i * period / 100, &hint) -
-            reference_position);
+            EarthMoonOrbitPlane::origin);
   }
 
   EXPECT_THAT(earth_positions.size(), Eq(101));
@@ -518,20 +519,28 @@ TEST_F(EphemerisTest, EarthTwoProbes) {
   EXPECT_THAT(earth_positions[100].coordinates().y, Eq(q_earth));
 
   Length const q_probe1 = (trajectory1.last().degrees_of_freedom().position() -
-                     reference_position).coordinates().y;
+                     EarthMoonOrbitPlane::origin).coordinates().y;
   Length const q_probe2 = (trajectory2.last().degrees_of_freedom().position() -
-                     reference_position).coordinates().y;
+                     EarthMoonOrbitPlane::origin).coordinates().y;
   Speed const v_probe1 =
       trajectory1.last().degrees_of_freedom().velocity().coordinates().x;
   Speed const v_probe2 =
       trajectory2.last().degrees_of_freedom().velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> probe1_positions;
   std::vector<Displacement<EarthMoonOrbitPlane>> probe2_positions;
-  for (auto const it : trajectory1.Positions()) {
-    probe1_positions.push_back(it.second - reference_position);
+  for (DiscreteTrajectory<EarthMoonOrbitPlane>::Iterator it =
+           trajectory1.Begin();
+       it != trajectory1.End();
+       ++it) {
+    probe1_positions.push_back(it.degrees_of_freedom().position() -
+                               EarthMoonOrbitPlane::origin);
   }
-  for (auto const it : trajectory2.Positions()) {
-    probe2_positions.push_back(it.second - reference_position);
+  for (DiscreteTrajectory<EarthMoonOrbitPlane>::Iterator it =
+           trajectory2.Begin();
+       it != trajectory2.End();
+       ++it) {
+    probe2_positions.push_back(it.degrees_of_freedom().position() -
+                               EarthMoonOrbitPlane::origin);
   }
 #if defined(WE_LOVE_228)
   EXPECT_THAT(probe1_positions.size(), Eq(2));
@@ -785,7 +794,6 @@ TEST_F(EphemerisTest, Serialization) {
 
 // The gravitational acceleration on at elephant located at the pole.
 TEST_F(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
-  Position<EarthMoonOrbitPlane> const reference_position;
   Time const kDuration = 1 * Second;
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<EarthMoonOrbitPlane>> initial_state;
@@ -847,8 +855,15 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
   Speed const v_elephant =
       trajectory.last().degrees_of_freedom().velocity().coordinates().x;
   std::vector<Displacement<EarthMoonOrbitPlane>> elephant_positions;
-  for (auto const pair : trajectory.Positions()) {
-    elephant_positions.push_back(pair.second - reference_position);
+  std::vector<Vector<Acceleration, EarthMoonOrbitPlane>> elephant_accelerations;
+  for (DiscreteTrajectory<EarthMoonOrbitPlane>::Iterator it =
+           trajectory.Begin();
+       it != trajectory.End();
+       ++it) {
+    elephant_positions.push_back(it.degrees_of_freedom().position() -
+                                 EarthMoonOrbitPlane::origin);
+    elephant_accelerations.push_back(
+        ephemeris.ComputeGravitationalAcceleration(&trajectory, it.time()));
   }
   EXPECT_THAT(elephant_positions.size(), Eq(8));
   EXPECT_THAT(elephant_positions.back().coordinates().x,
@@ -856,11 +871,6 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
   EXPECT_LT(RelativeError(elephant_positions.back().coordinates().z,
                           kEarthPolarRadius), 8E-7);
 
-  std::vector<Vector<Acceleration, EarthMoonOrbitPlane>> elephant_accelerations;
-  for (auto const& t : trajectory.Times()) {
-    elephant_accelerations.push_back(
-        ephemeris.ComputeGravitationalAcceleration(&trajectory, t));
-  }
   EXPECT_THAT(elephant_accelerations.size(), Eq(8));
   EXPECT_THAT(elephant_accelerations.back().coordinates().x,
               AlmostEquals(0 * SIUnit<Acceleration>(), 0));

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -55,6 +55,7 @@ class Forkable {
 
   // Returns the fork time for a nonroot trajectory and null for a root
   // trajectory.
+  //TODO(phl):Unneeded?
   std::experimental::optional<Instant> ForkTime() const;
 
   // A base class for iterating over the timeline of a trajectory, taking forks

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -103,6 +103,10 @@ class Forkable {
   // this object is a root.
   Iterator Fork() const;
 
+  // Returns the number of points in this object.  Complexity is O(|length| +
+  // |depth|).
+  int Size() const;
+
   // Constructs an Iterator by wrapping the timeline iterator
   // |position_in_ancestor_timeline| which must be an iterator in the timeline
   // of |ancestor|.  |ancestor| must be an ancestor of this trajectory

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -53,11 +53,6 @@ class Forkable {
   not_null<Tr4jectory const*> root() const;
   not_null<Tr4jectory*> root();
 
-  // Returns the fork time for a nonroot trajectory and null for a root
-  // trajectory.
-  //TODO(phl):Unneeded?
-  std::experimental::optional<Instant> ForkTime() const;
-
   // A base class for iterating over the timeline of a trajectory, taking forks
   // into account.
   class Iterator {

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -70,6 +70,7 @@ class Forkable {
     // Returns the point in the timeline that is denoted by this iterator.
     TimelineConstIterator current() const;
 
+   protected:
     // Returns the (most forked) trajectory to which this iterator applies.
     not_null<Tr4jectory const*> trajectory() const;
 
@@ -102,11 +103,15 @@ class Forkable {
   Iterator Find(Instant const& time) const;
   Iterator LowerBound(Instant const& time) const;
 
+  // Returns an iterator denoting the fork point of this object, or |End()| if
+  // this object is a root.
+  Iterator Fork() const;
+
   // Constructs an Iterator by wrapping the timeline iterator
   // |position_in_ancestor_timeline| which must be an iterator in the timeline
   // of |ancestor|.  |ancestor| must be an ancestor of this trajectory
   // (it may be this object).  |position_in_ancestor_timeline| may only be at
-  // end if it is an iterator in this object (and ancestor is this object).
+  // end if it is an iterator in this object (and |ancestor| is this object).
   // TODO(phl): This is only used for |Begin|.  Unclear if it needs to be a
   // separate method.
   Iterator Wrap(
@@ -123,8 +128,6 @@ class Forkable {
 
  protected:
   // The API that must be implemented by subclasses.
-  // TODO(phl): Try to reduce this API.  Forkable should probably not modify the
-  // timeline.
 
   // Must return |this| of the proper type
   virtual not_null<Tr4jectory*> that() = 0;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -59,6 +59,7 @@ std::experimental::optional<Instant> Forkable<Tr4jectory>::ForkTime() const {
 
 template<typename Tr4jectory>
 bool Forkable<Tr4jectory>::Iterator::operator==(Iterator const& right) const {
+  DCHECK_EQ(trajectory(), right.trajectory());
   return ancestry_ == right.ancestry_ && current_ == right.current_;
 }
 

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -53,7 +53,7 @@ std::experimental::optional<Instant> Forkable<Tr4jectory>::ForkTime() const {
   if (is_root()) {
     return std::experimental::nullopt;
   } else {
-    return (*position_in_parent_children_)->first;
+    return ForkableTraits<Tr4jectory>::time(Fork().current_);
   }
 }
 
@@ -224,6 +224,23 @@ Forkable<Tr4jectory>::LowerBound(Instant const& time) const {
 
   iterator.NormalizeIfEnd();
   return iterator;
+}
+
+template<typename Tr4jectory>
+typename Forkable<Tr4jectory>::Iterator
+Forkable<Tr4jectory>::Fork() const {
+  if (parent_ == nullptr) {
+    return End();
+  } else {
+    not_null<Tr4jectory const*> ancestor = that();
+    TimelineConstIterator position_in_ancestor_timeline;
+    do {
+      position_in_ancestor_timeline = *ancestor->position_in_parent_timeline_;
+      ancestor = ancestor->parent_;
+    } while (position_in_ancestor_timeline == ancestor->timeline_end() &&
+             ancestor->parent_ != nullptr);
+    return Wrap(ancestor, position_in_ancestor_timeline);
+  }
 }
 
 template<typename Tr4jectory>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -236,6 +236,15 @@ Forkable<Tr4jectory>::Fork() const {
 }
 
 template<typename Tr4jectory>
+int Forkable<Tr4jectory>::Size() const {
+  int result = 0;
+  for (auto it = Begin(); it != End(); ++it) {
+    ++result;
+  }
+  return result;
+}
+
+template<typename Tr4jectory>
 typename Forkable<Tr4jectory>::Iterator
 Forkable<Tr4jectory>::Wrap(
     not_null<const Tr4jectory*> const ancestor,

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -182,7 +182,7 @@ TEST_F(ForkableTest, ForkAtLast) {
   auto times = Times(fork2);
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
   EXPECT_EQ(t3_, LastTime(fork2));
-  EXPECT_EQ(t3_, *fork2->ForkTime());
+  EXPECT_EQ(t3_, *fork2->Fork().current());
 
   auto after = After(fork3, t3_);
   EXPECT_THAT(after, ElementsAre(t3_));
@@ -217,7 +217,7 @@ TEST_F(ForkableDeathTest, DeleteForkError) {
     trajectory_.push_back(t1_);
     FakeTrajectory* root = &trajectory_;
     trajectory_.DeleteFork(&root);
-  }, "fork_time");
+  }, "fork.*End");
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     FakeTrajectory* fork1 = trajectory_.NewFork(t1_);
@@ -429,8 +429,8 @@ TEST_F(ForkableTest, Root) {
   EXPECT_FALSE(fork->is_root());
   EXPECT_EQ(&trajectory_, trajectory_.root());
   EXPECT_EQ(&trajectory_, fork->root());
-  EXPECT_FALSE(trajectory_.ForkTime());
-  EXPECT_EQ(t2_, *fork->ForkTime());
+  EXPECT_TRUE(trajectory_.Fork() == trajectory_.End());
+  EXPECT_EQ(t2_, *fork->Fork().current());
 }
 
 TEST_F(ForkableTest, IteratorBeginSuccess) {

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -408,6 +408,7 @@ TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
   EXPECT_EQ(it, fork3->End());
 }
 
+#if !defined(_DEBUG)
 TEST_F(ForkableTest, IteratorEndEquality) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
@@ -417,6 +418,7 @@ TEST_F(ForkableTest, IteratorEndEquality) {
   auto it2 = fork2->End();
   EXPECT_NE(it1, it2);
 }
+#endif
 
 TEST_F(ForkableTest, Root) {
   trajectory_.push_back(t1_);

--- a/physics/physics.vcxproj
+++ b/physics/physics.vcxproj
@@ -76,6 +76,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/quantities/quantities.vcxproj
+++ b/quantities/quantities.vcxproj
@@ -75,6 +75,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/serialization/serialization.vcxproj
+++ b/serialization/serialization.vcxproj
@@ -63,6 +63,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/testing_utilities/testing_utilities.vcxproj
+++ b/testing_utilities/testing_utilities.vcxproj
@@ -108,6 +108,7 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
+    <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />


### PR DESCRIPTION
* Remove `TransformingIterator` and related types and functions.
* Rename `NativeIterator` into `Iterator`.
* Remove most of the old iterator API: `first`, `on_or_after`, `Positions`, `Velocities`, `Times`, `at_end`.
* Add methods `Size` and  `Fork` to `Forkable`.
* Remove `ForkTime`.  Clients should use `Fork` instead.