### PR TITLE
More Confusing C++

### DIFF
--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -181,7 +181,16 @@ class not_null {
 
   // Returns |pointer_|, by const reference to avoid a copy if |pointer| is
   // |unique_ptr|.
-  operator pointer const&() const&;
+  // If this were to return by |const&|, ambiguities would arise where an rvalue
+  // of type |not_null<pointer>| is given as an argument to a function that has
+  // overloads for both |pointer const&| and |pointer&&|.
+  // Note that the preference for |T&&| over |T const&| for overload resolution
+  // is not relevant here since both go through a user-defined conversion,
+  // see 13.3.3.2.
+  // GCC nevertheless incorrectly prefers |T&&| in that case, while clang and
+  // MSVC recognize the ambiguity.
+  // The |RValue| test gives two examples of this.
+  operator pointer const&&() const&;
 
   // Used to convert a |not_null<unique_ptr<>>| to |unique_ptr<>|.
   operator pointer&&() &&;

--- a/base/not_null_body.hpp
+++ b/base/not_null_body.hpp
@@ -59,8 +59,10 @@ not_null<Pointer>& not_null<Pointer>::operator=(
 }
 
 template<typename Pointer>
-not_null<Pointer>::operator pointer const&() const& {
-  return pointer_;
+not_null<Pointer>::operator pointer const&&() const& {
+  // This |move| is deceptive: we are not actually moving anything (|*this| is
+  // |const&|), we are simply casting to an rvalue reference.
+  return std::move(pointer_);
 }
 
 template<typename Pointer>


### PR DESCRIPTION
I had to look at the standard for this one.
See also this example with a dummy `not_null` http://goo.gl/PJoIfa.
Once again, clang is the closest we have to the standard.
See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3797.pdf 13.3.3.2 (this document should really be in the bibliograhpy...).