### PR TITLE
Optimize the benchmarks for SymplecticYadaYada

### DIFF
--- a/benchmarks/sprk_integrator.cpp
+++ b/benchmarks/sprk_integrator.cpp
@@ -157,6 +157,7 @@ void SolveHarmonicOscillatorAndComputeError(
     not_null<Length*> const q_error,
     not_null<Speed*> const v_error,
     SRKNIntegrator const& integrator) {
+  state->PauseTiming();
   SRKNIntegrator::Solution<Length, Speed> solution;
   SRKNIntegrator::Parameters<Length, Speed> parameters;
 
@@ -172,6 +173,8 @@ void SolveHarmonicOscillatorAndComputeError(
   // in the new benchmarks.  Reducing to 3.0E-4 to permit comparisons.
   parameters.Δt = 3.0E-4 * SIUnit<Time>();
   parameters.sampling_period = 1;
+  state->ResumeTiming();
+
   integrator.SolveTrivialKineticEnergyIncrement<Length>(
       &ComputeHarmonicOscillatorAcceleration,
       parameters,

--- a/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
@@ -5,11 +5,13 @@
 #include <vector>
 
 #include "geometry/sign.hpp"
+#include "quantities/quantities.hpp"
 #include "testing_utilities/numerics.hpp"
 
 namespace principia {
 
 using geometry::Sign;
+using quantities::Abs;
 using testing_utilities::ULPDistance;
 
 namespace integrators {
@@ -91,7 +93,8 @@ void SymplecticRungeKuttaNyströmIntegrator<Position, order, time_reversible,
   typename ODE::SystemState current_state = *problem.initial_state;
 
   // Time step.
-  Time h = step;
+  Time const& h = step;
+  Time const abs_h = integration_direction * h;
   // Current time.  This is a non-const reference whose purpose is to make the
   // equations more readable.
   DoublePrecision<Instant>& t = current_state.time;
@@ -120,8 +123,7 @@ void SymplecticRungeKuttaNyströmIntegrator<Position, order, time_reversible,
   // exp(bᵢ h B).
   int first_stage = composition == kABA ? 1 : 0;
 
-  while (integration_direction * h <=
-         integration_direction * ((problem.t_final - t.value) - t.error)) {
+  while (abs_h <= Abs((problem.t_final - t.value) - t.error)) {
     std::fill(Δq.begin(), Δq.end(), Displacement{});
     std::fill(Δv.begin(), Δv.end(), Velocity{});
 

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -192,7 +192,8 @@ class Quantity {
   friend constexpr Exponentiation<Quantity<BaseDimensions>, exponent> Pow(
       Quantity<BaseDimensions> const& x);
 
-  friend Quantity<D> Abs<>(Quantity<D> const&);
+  template<typename E>
+  friend Quantity<E> Abs(Quantity<E> const&);
 
   template<typename ArgumentDimensions>
   friend SquareRoot<Quantity<ArgumentDimensions>> Sqrt(

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -293,7 +293,8 @@ constexpr Quantity<D> Quantity<D>::operator*(double const right) const {
 }
 
 template<typename LDimensions, typename RDimensions>
-constexpr internal::Product<Quantity<LDimensions>, Quantity<RDimensions>>
+FORCE_INLINE constexpr internal::Product<Quantity<LDimensions>,
+                                         Quantity<RDimensions>>
 operator*(Quantity<LDimensions> const& left,
           Quantity<RDimensions> const& right) {
   return Product<Quantity<LDimensions>,
@@ -376,7 +377,7 @@ inline double Abs(double const x) {
 }
 
 template<typename D>
-Quantity<D> Abs(Quantity<D> const& quantity) {
+FORCE_INLINE Quantity<D> Abs(Quantity<D> const& quantity) {
   return Quantity<D>(std::abs(quantity.magnitude_));
 }
 


### PR DESCRIPTION
Changes to the benchmark speed up by roughly 20% and are for fairness with legacy benchmarks.  Changes to the integrator speed up by roughly 12%.