### PR TITLE
C# should not own things

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -447,6 +447,12 @@ NavigationFrame* principia__NewBarycentricRotatingNavigationFrame(
                                            secondary_index).release());
 }
 
+// TODO(phl): Journalling.
+void principia__SetPlottingFrame(Plugin* const plugin,
+                                 NavigationFrame** const navigation_frame) {
+  CHECK_NOTNULL(plugin)->SetPlottingFrame(TakeOwnership(navigation_frame));
+}
+
 void principia__DeleteNavigationFrame(
     NavigationFrame** const navigation_frame) {
   Journal::Method<DeleteNavigationFrame> m({navigation_frame},

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -491,7 +491,6 @@ LineAndIterator* principia__RenderedVesselTrajectory(
   RenderedTrajectory<World> rendered_trajectory = CHECK_NOTNULL(plugin)->
       RenderedVesselTrajectory(
           vessel_guid,
-          navigation_frame,
           World::origin + Displacement<World>(
                               ToR3Element(sun_world_position) * Metre));
   not_null<std::unique_ptr<LineAndIterator>> result =
@@ -518,7 +517,6 @@ LineAndIterator* principia__RenderedPrediction(
   RenderedTrajectory<World> rendered_trajectory = CHECK_NOTNULL(plugin)->
       RenderedPrediction(
           vessel_guid,
-          navigation_frame,
           World::origin + Displacement<World>(
                               ToR3Element(sun_world_position) * Metre));
   not_null<std::unique_ptr<LineAndIterator>> result =
@@ -548,7 +546,6 @@ LineAndIterator* principia__RenderedFlightPlan(
       CHECK_NOTNULL(plugin)->RenderedFlightPlan(
           vessel_guid,
           plan_phase,
-          navigation_frame,
           World::origin + Displacement<World>(
                               ToR3Element(sun_world_position) * Metre));
   not_null<std::unique_ptr<LineAndIterator>> result =
@@ -682,7 +679,6 @@ WXYZ principia__NavballOrientation(
                                          sun_world_position,
                                          ship_world_position});
   FrameField<World> const frame_field = CHECK_NOTNULL(plugin)->Navball(
-      navigation_frame,
       World::origin +
           Displacement<World>(ToR3Element(sun_world_position) * Metre));
   return m.Return(ToWXYZ(
@@ -696,24 +692,24 @@ XYZ principia__VesselTangent(Plugin const* const plugin,
                              char const* const vessel_guid,
                              NavigationFrame* const navigation_frame) {
   Journal::Method<VesselTangent> m({plugin, vessel_guid, navigation_frame});
-  return m.Return(ToXYZ(CHECK_NOTNULL(plugin)->
-             VesselTangent(vessel_guid, navigation_frame).coordinates()));
+  return m.Return(
+      ToXYZ(CHECK_NOTNULL(plugin)->VesselTangent(vessel_guid).coordinates()));
 }
 
 XYZ principia__VesselNormal(Plugin const* const plugin,
                             char const* const vessel_guid,
                             NavigationFrame* const navigation_frame) {
   Journal::Method<VesselNormal> m({plugin, vessel_guid, navigation_frame});
-  return m.Return(ToXYZ(CHECK_NOTNULL(plugin)->
-             VesselNormal(vessel_guid, navigation_frame).coordinates()));
+  return m.Return(
+      ToXYZ(CHECK_NOTNULL(plugin)->VesselNormal(vessel_guid).coordinates()));
 }
 
 XYZ principia__VesselBinormal(Plugin const* const plugin,
                               char const* const vessel_guid,
                               NavigationFrame* const navigation_frame) {
   Journal::Method<VesselBinormal> m({plugin, vessel_guid, navigation_frame});
-  return m.Return(ToXYZ(CHECK_NOTNULL(plugin)->
-             VesselBinormal(vessel_guid, navigation_frame).coordinates()));
+  return m.Return(
+      ToXYZ(CHECK_NOTNULL(plugin)->VesselBinormal(vessel_guid).coordinates()));
 }
 
 double principia__CurrentTime(Plugin const* const plugin) {

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -239,9 +239,16 @@ NavigationFrame* CDECL principia__NewBarycentricRotatingNavigationFrame(
     int const primary_index,
     int const secondary_index);
 
-// Deletes and nulls |*navigation_frame|.
 // |navigation_frame| must not be null.  No transfer of ownership of
-// |*navigation_frame|, takes ownership of |**navigation_frame|.
+// |*navigation_frame|, takes ownership of |**navigation_frame|, nulls
+// |*navigation_frame|.
+// TODO(phl): test.
+extern "C" PRINCIPIA_DLL
+void CDECL principia__SetPlottingFrame(
+    Plugin* const plugin,
+    NavigationFrame** const navigation_frame);
+
+// TODO(phl): remove.
 extern "C" PRINCIPIA_DLL
 void CDECL principia__DeleteNavigationFrame(
     NavigationFrame** const navigation_frame);

--- a/ksp_plugin/mock_plugin.hpp
+++ b/ksp_plugin/mock_plugin.hpp
@@ -68,19 +68,15 @@ class MockPlugin : public Plugin {
                      RelativeDegreesOfFreedom<AliceSun>(
                          Index const celestial_index));
 
-  MOCK_CONST_METHOD3(
+  MOCK_CONST_METHOD2(
       RenderedVesselTrajectory,
-      RenderedTrajectory<World>(
-          GUID const& vessel_guid,
-          not_null<NavigationFrame*> const navigation_frame,
-          Position<World> const& sun_world_position));
+      RenderedTrajectory<World>(GUID const& vessel_guid,
+                                Position<World> const& sun_world_position));
 
-  MOCK_CONST_METHOD3(
+  MOCK_CONST_METHOD2(
       RenderedPrediction,
-      RenderedTrajectory<World>(
-          GUID const& vessel_guid,
-          not_null<NavigationFrame*> const navigation_frame,
-          Position<World> const& sun_world_position));
+      RenderedTrajectory<World>(GUID const& vessel_guid,
+                                Position<World> const& sun_world_position));
 
   MOCK_METHOD1(SetPredictionLength, void(Time const& t));
 
@@ -132,25 +128,18 @@ class MockPlugin : public Plugin {
                      Velocity<World>(
                          Index const reference_body_index));
 
-  MOCK_CONST_METHOD2(Navball,
+  MOCK_CONST_METHOD1(Navball,
                      FrameField<World>(
-                         not_null<NavigationFrame*> const navigation_frame,
                          Position<World> const& sun_world_position));
 
-  MOCK_CONST_METHOD2(VesselTangent,
-                     Vector<double, World>(
-                         GUID const& vessel_guid,
-                         not_null<NavigationFrame*> const navigation_frame));
+  MOCK_CONST_METHOD1(VesselTangent,
+                     Vector<double, World>(GUID const& vessel_guid));
 
-  MOCK_CONST_METHOD2(VesselNormal,
-                     Vector<double, World>(
-                         GUID const& vessel_guid,
-                         not_null<NavigationFrame*> const navigation_frame));
+  MOCK_CONST_METHOD1(VesselNormal,
+                     Vector<double, World>(GUID const& vessel_guid));
 
-  MOCK_CONST_METHOD2(VesselBinormal,
-                     Vector<double, World>(
-                         GUID const& vessel_guid,
-                         not_null<NavigationFrame*> const navigation_frame));
+  MOCK_CONST_METHOD1(VesselBinormal,
+                     Vector<double, World>(GUID const& vessel_guid));
 
   MOCK_CONST_METHOD0(CurrentTime, Instant());
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -156,6 +156,16 @@ void Plugin::EndInitialization() {
     auto& celestial = *pair.second;
     celestial.set_trajectory(ephemeris_->trajectory(celestial.body()));
   }
+
+  // This would use NewBodyCentredNonRotatingNavigationFrame, but we don't have
+  // the sun's index at hand.
+  // TODO(egg): maybe these functions should take |Celestial*|s, and we should
+  // then export |FindOrDie(celestials_, _)|.
+  SetPlottingFrame(
+      make_not_null_unique<
+          BodyCentredNonRotatingDynamicFrame<Barycentric, Navigation>>(
+          ephemeris_.get(),
+          sun_->body()));
 }
 
 void Plugin::UpdateCelestialHierarchy(Index const celestial_index,
@@ -420,6 +430,11 @@ Plugin::NewBarycentricRotatingNavigationFrame(
           ephemeris_.get(),
           primary.body(),
           secondary.body());
+}
+
+void Plugin::SetPlottingFrame(
+    not_null<std::unique_ptr<NavigationFrame>> plotting_frame) {
+  plotting_frame_ = std::move(plotting_frame);
 }
 
 void Plugin::AddVesselToNextPhysicsBubble(

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -323,7 +323,6 @@ void Plugin::UpdateFlightPlan(GUID const& vessel_guid,
 
 RenderedTrajectory<World> Plugin::RenderedVesselTrajectory(
     GUID const& vessel_guid,
-    not_null<NavigationFrame*> const navigation_frame,
     Position<World> const& sun_world_position) const {
   CHECK(!initializing_);
   not_null<std::unique_ptr<Vessel>> const& vessel =
@@ -355,7 +354,6 @@ bool Plugin::HasPrediction(GUID const& vessel_guid) const {
 
 RenderedTrajectory<World> Plugin::RenderedPrediction(
     GUID const& vessel_guid,
-    not_null<NavigationFrame*> const navigation_frame,
     Position<World> const& sun_world_position) const {
   CHECK(!initializing_);
   Vessel const& vessel = *find_vessel_by_guid_or_die(vessel_guid);
@@ -370,7 +368,6 @@ RenderedTrajectory<World> Plugin::RenderedPrediction(
 RenderedTrajectory<World> Plugin::RenderedFlightPlan(
     GUID const& vessel_guid,
     int const plan_phase,
-    not_null<NavigationFrame*> const navigation_frame,
     Position<World> const& sun_world_position) {
   CHECK(!initializing_);
   Vessel const& vessel = *find_vessel_by_guid_or_die(vessel_guid);
@@ -463,7 +460,6 @@ Velocity<World> Plugin::BubbleVelocityCorrection(
 }
 
 FrameField<World> Plugin::Navball(
-    not_null<NavigationFrame*> const navigation_frame,
     Position<World> const& sun_world_position) const {
   auto const to_world =
       OrthogonalMap<WorldSun, World>::Identity() * BarycentricToWorldSun();
@@ -488,25 +484,19 @@ FrameField<World> Plugin::Navball(
   };
 }
 
-Vector<double, World> Plugin::VesselTangent(
-    GUID const& vessel_guid,
-    not_null<NavigationFrame*> const navigation_frame) const {
+Vector<double, World> Plugin::VesselTangent(GUID const& vessel_guid) const {
   return FromVesselFrenetFrame(*find_vessel_by_guid_or_die(vessel_guid),
                                navigation_frame,
                                Vector<double, Frenet<Navigation>>({1, 0, 0}));
 }
 
-Vector<double, World> Plugin::VesselNormal(
-    GUID const& vessel_guid,
-    not_null<NavigationFrame*> const navigation_frame) const {
+Vector<double, World> Plugin::VesselNormal(GUID const& vessel_guid) const {
   return FromVesselFrenetFrame(*find_vessel_by_guid_or_die(vessel_guid),
                                navigation_frame,
                                Vector<double, Frenet<Navigation>>({0, 1, 0}));
 }
 
-Vector<double, World> Plugin::VesselBinormal(
-    GUID const& vessel_guid,
-    not_null<NavigationFrame*> const navigation_frame) const {
+Vector<double, World> Plugin::VesselBinormal(GUID const& vessel_guid) const {
   return FromVesselFrenetFrame(*find_vessel_by_guid_or_die(vessel_guid),
                                navigation_frame,
                                Vector<double, Frenet<Navigation>>({0, 0, 1}));
@@ -936,7 +926,6 @@ void Plugin::EvolveProlongationsAndBubble(Instant const& t) {
 RenderedTrajectory<World> Plugin::RenderTrajectory(
     DiscreteTrajectory<Barycentric>::Iterator const& begin,
     DiscreteTrajectory<Barycentric>::Iterator const& end,
-    not_null<NavigationFrame*> const navigation_frame,
     Position<World> const& sun_world_position) const {
   RenderedTrajectory<World> result;
   auto const to_world =

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -386,7 +386,6 @@ class Plugin {
 
   Vector<double, World> FromVesselFrenetFrame(
       Vessel const& vessel,
-      not_null<NavigationFrame*> const navigation_frame,
       Vector<double, Frenet<Navigation>> const& vector) const;
 
   // Fill |celestials| using the |index| and |parent_index| fields found in

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -247,6 +247,9 @@ class Plugin {
   NewBarycentricRotatingNavigationFrame(Index const primary_index,
                                         Index const secondary_index) const;
 
+  virtual void SetPlottingFrame(
+      not_null<std::unique_ptr<NavigationFrame>> plotting_frame);
+
   // Creates |next_physics_bubble_| if it is null.  Adds the vessel with GUID
   // |vessel_guid| to |next_physics_bubble_->vessels| with a list of pointers to
   // the |Part|s in |parts|.  Merges |parts| into |next_physics_bubble_->parts|.
@@ -452,8 +455,8 @@ class Plugin {
 
   Celestial* sun_ = nullptr;  // Not owning, not null after InsertSun is called.
 
-  // Not null after InsertSun is called; set to the heliocentric frame by
-  // InsertSun.
+  // Not null after initialization. |EndInitialization| sets it to the
+  // heliocentric frame.
   std::unique_ptr<NavigationFrame> plotting_frame_;
 
   friend class TestablePlugin;

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -202,13 +202,13 @@ class Plugin {
                         Instant const& last_time) const;
 
   // Returns a polygon in |World| space depicting the trajectory of the vessel
-  // with the given |GUID| in the frame defined by |navigation_frame|.
+  // with the given |GUID| in the frame defined by the current
+  // |plotting_frame_|.
   // |sun_world_position| is the current position of the sun in |World| space as
   // returned by |Planetarium.fetch.Sun.position|.  It is used to define the
   // relation between |WorldSun| and |World|.  No transfer of ownership.
   virtual RenderedTrajectory<World> RenderedVesselTrajectory(
       GUID const& vessel_guid,
-      not_null<NavigationFrame*> const navigation_frame,
       Position<World> const& sun_world_position) const;
 
   int FlightPlanSize(GUID const& vessel_guid) const;
@@ -216,22 +216,20 @@ class Plugin {
 
   // Returns a polygon in |World| space depicting the trajectory of
   // |predicted_vessel_| from |CurrentTime()| to
-  // |CurrentTime() + prediction_length_| in the frame defined by
-  // |navigation_frame|.  |sun_world_position| is the current position of the
-  // sun in |World| space as returned by |Planetarium.fetch.Sun.position|.  It
-  // is used to define the relation between |WorldSun| and |World|.
+  // |CurrentTime() + prediction_length_| in the current |plotting_frame_|.
+  // |sun_world_position| is the current position of the sun in |World| space as
+  // returned by |Planetarium.fetch.Sun.position|.  It is used to define the
+  // relation between |WorldSun| and |World|.
   // No transfer of ownership.
   // |predicted_vessel_| must have been set, and |AdvanceTime()| must have been
   // called after |predicted_vessel_| was set.
   virtual RenderedTrajectory<World> RenderedPrediction(
       GUID const& vessel_guid,
-      not_null<NavigationFrame*> const navigation_frame,
       Position<World> const& sun_world_position) const;
 
   virtual RenderedTrajectory<World> RenderedFlightPlan(
       GUID const& vessel_guid,
       int const plan_phase,
-      not_null<NavigationFrame*> const navigation_frame,
       Position<World> const& sun_world_position);
 
   virtual void SetPredictionLength(Time const& t);
@@ -274,22 +272,15 @@ class Plugin {
   virtual Velocity<World> BubbleVelocityCorrection(
       Index const reference_body_index) const;
 
-  // The navball field at |current_time| for the given |navigation_frame|.
+  // The navball field at |current_time| for the current |plotting_frame_|.
   virtual FrameField<World> Navball(
-      not_null<NavigationFrame*> const navigation_frame,
       Position<World> const& sun_world_position) const;
 
-  // The unit tangent vector to the trajectory of the vessel with the given GUID
-  // in the frame given by |navigation_frame|.
-  virtual Vector<double, World> VesselTangent(
-      GUID const& vessel_guid,
-      not_null<NavigationFrame*> const navigation_frame) const;
-  virtual Vector<double, World> VesselNormal(
-      GUID const& vessel_guid,
-      not_null<NavigationFrame*> const navigation_frame) const;
-  virtual Vector<double, World> VesselBinormal(
-      GUID const& vessel_guid,
-      not_null<NavigationFrame*> const navigation_frame) const;
+  // The unit tangent, normal, or binormal vector to the trajectory of the
+  // vessel with the given GUID in the current |plotting_frame_|.
+  virtual Vector<double, World> VesselTangent(GUID const& vessel_guid) const;
+  virtual Vector<double, World> VesselNormal(GUID const& vessel_guid) const;
+  virtual Vector<double, World> VesselBinormal(GUID const& vessel_guid) const;
 
   virtual Instant CurrentTime() const;
 
@@ -386,12 +377,11 @@ class Plugin {
   void EvolveProlongationsAndBubble(Instant const& t);
 
   // A utility for |RenderedPrediction| and |RenderedVesselTrajectory|,
-  // returns a |RenderedTrajectory| as computed by the given |navigation_frame|
-  // from the trajectory defined by |begin| and |end|.
+  // returns a |RenderedTrajectory| corresponding to the trajectory defined by
+  // |begin| and |end|, as seen in the current |plotting_frame_|.
   RenderedTrajectory<World> RenderTrajectory(
       DiscreteTrajectory<Barycentric>::Iterator const& begin,
       DiscreteTrajectory<Barycentric>::Iterator const& end,
-      not_null<NavigationFrame*>const navigation_frame,
       Position<World> const& sun_world_position) const;
 
   Vector<double, World> FromVesselFrenetFrame(
@@ -462,6 +452,10 @@ class Plugin {
   Instant history_time_;
 
   Celestial* sun_ = nullptr;  // Not owning, not null after InsertSun is called.
+
+  // Not null after InsertSun is called; set to the heliocentric frame by
+  // InsertSun.
+  std::unique_ptr<NavigationFrame> plotting_frame_;
 
   friend class TestablePlugin;
 };

--- a/ksp_plugin_adapter/interface.cs
+++ b/ksp_plugin_adapter/interface.cs
@@ -365,9 +365,10 @@ internal static class Interface {
       int secondary_index);
 
   [DllImport(dllName           : kDllPath,
-             EntryPoint        = "principia__DeleteNavigationFrame",
+             EntryPoint        = "principia__SetPlottingFrame",
              CallingConvention = CallingConvention.Cdecl)]
-  internal static extern void DeleteNavigationFrame(ref IntPtr navigation_frame);
+  internal static extern void SetPlottingFrame(this IntPtr plugin,
+                                               ref IntPtr navigation_frame);
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -531,7 +531,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
         navball_.navBall.rotation =
             (UnityEngine.QuaternionD)navball_.attitudeGymbal *  // sic.
                 (UnityEngine.QuaternionD)plugin_.NavballOrientation(
-                    rendering_frame_selector_.frame,
+                    IntPtr.Zero /*TODO(phl)*/,
                     (XYZ)Planetarium.fetch.Sun.position,
                     (XYZ)(Vector3d)active_vessel.ReferenceTransform.position);
         // TODO(egg): the navball should be independent from the frame of the
@@ -546,15 +546,15 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
           // Orient the Frenet trihedron.
           Vector3d prograde =
               (Vector3d)plugin_.VesselTangent(active_vessel.id.ToString(),
-                                              rendering_frame_selector_.frame);
+                                              IntPtr.Zero /*TODO(phl)*/);
           Vector3d radial =
               (Vector3d)plugin_.VesselNormal(active_vessel.id.ToString(),
-                                             rendering_frame_selector_.frame);
+                                             IntPtr.Zero /*TODO(phl)*/);
           // Yes, the astrodynamicist's normal is the mathematician's binormal.
           // Don't ask.
           Vector3d normal =
               (Vector3d)plugin_.VesselBinormal(active_vessel.id.ToString(),
-                                               rendering_frame_selector_.frame);
+                                               IntPtr.Zero /*TODO(phl)*/);
 
           navball_.progradeVector.transform.localPosition =
               (UnityEngine.QuaternionD)navball_.attitudeGymbal *
@@ -731,14 +731,14 @@ public partial class PrincipiaPluginAdapter : ScenarioModule {
       IntPtr trajectory_iterator = IntPtr.Zero;
       trajectory_iterator = plugin_.RenderedVesselTrajectory(
                                 active_vessel.id.ToString(),
-                                rendering_frame_selector_.frame,
+                                IntPtr.Zero /*TODO(phl)*/,
                                 (XYZ)Planetarium.fetch.Sun.position);
       RenderAndDeleteTrajectory(ref trajectory_iterator,
                                 rendered_trajectory_);
       if (plugin_.HasPrediction(active_vessel.id.ToString())) {
         trajectory_iterator = plugin_.RenderedPrediction(
                                   active_vessel.id.ToString(),
-                                  rendering_frame_selector_.frame,
+                                  IntPtr.Zero /*TODO(phl)*/,
                                   (XYZ)Planetarium.fetch.Sun.position);
         RenderAndDeleteTrajectory(ref trajectory_iterator,
                                   rendered_prediction_);

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -60,11 +60,6 @@ class ReferenceFrameSelector {
     ResetFrame();
   }
 
-  ~ReferenceFrameSelector() {
-    Interface.DeleteNavigationFrame(ref frame_);
-  }
-
-  public IntPtr frame { get { return frame_; } }
   public FrameType frame_type { get; private set; }
 
   public void RenderButton() {
@@ -194,18 +189,18 @@ class ReferenceFrameSelector {
 
   private void ResetFrame() {
     on_change_();
-    Interface.DeleteNavigationFrame(ref frame_);
+    IntPtr navigation_frame = IntPtr.Zero;
     switch (frame_type) {
       case FrameType.BODY_CENTRED_NON_ROTATING:
-        frame_ = plugin_.NewBodyCentredNonRotatingNavigationFrame(
-                     selected_celestial_.flightGlobalsIndex);
+        navigation_frame = plugin_.NewBodyCentredNonRotatingNavigationFrame(
+                               selected_celestial_.flightGlobalsIndex);
       break;
 #if HAS_SURFACE
       case FrameType.SURFACE:
       break;
 #endif
       case FrameType.BARYCENTRIC_ROTATING:
-        frame_ =
+        navigation_frame =
             plugin_.NewBarycentricRotatingNavigationFrame(
                 primary_index   :
                     selected_celestial_.referenceBody.flightGlobalsIndex,
@@ -217,11 +212,12 @@ class ReferenceFrameSelector {
       break;
 #endif
     }
+    plugin_.SetPlottingFrame(ref navigation_frame);
   }
 
   private Callback on_change_;
+  // Not owned.
   private IntPtr plugin_;
-  private IntPtr frame_;
   private bool show_selector_;
   private UnityEngine.Rect window_rectangle_;
   private Dictionary<CelestialBody, bool> expanded_;

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -476,7 +476,6 @@ TEST_F(InterfaceTest, RenderedPrediction) {
   EXPECT_CALL(*plugin_,
               RenderedPrediction(
                   kVesselGUID,
-                  check_not_null(navigation_frame),
                   World::origin + Displacement<World>(
                                       {kParentPosition.x * SIUnit<Length>(),
                                        kParentPosition.y * SIUnit<Length>(),
@@ -547,7 +546,6 @@ TEST_F(InterfaceTest, LineAndIterator) {
   EXPECT_CALL(*plugin_,
               RenderedVesselTrajectory(
                   kVesselGUID,
-                  check_not_null(navigation_frame),
                   World::origin + Displacement<World>(
                                       {kParentPosition.x * SIUnit<Length>(),
                                        kParentPosition.y * SIUnit<Length>(),
@@ -658,7 +656,7 @@ TEST_F(InterfaceTest, NavballOrientation) {
   auto const rotation =
       Rotation<World, World>(π / 2 * Radian,
                              Bivector<double, World>({4, 5, 6}));
-  EXPECT_CALL(*plugin_, Navball(check_not_null(navigation_frame), sun_position))
+  EXPECT_CALL(*plugin_, Navball(sun_position))
       .WillOnce(
           Return([rotation](Position<World> const& q) { return rotation; }));
   WXYZ q = principia__NavballOrientation(plugin_.get(),
@@ -690,9 +688,7 @@ TEST_F(InterfaceTest, Frenet) {
                                                        kParentIndex);
   {
     auto const tangent = Vector<double, World>({4, 5, 6});
-    EXPECT_CALL(*plugin_,
-                VesselTangent(kVesselGUID, check_not_null(navigation_frame)))
-        .WillOnce(Return(tangent));
+    EXPECT_CALL(*plugin_, VesselTangent(kVesselGUID)).WillOnce(Return(tangent));
     XYZ t =
         principia__VesselTangent(plugin_.get(), kVesselGUID, navigation_frame);
     EXPECT_EQ(t.x, tangent.coordinates().x);
@@ -701,9 +697,7 @@ TEST_F(InterfaceTest, Frenet) {
   }
   {
     auto const normal = Vector<double, World>({-13, 7, 5});
-    EXPECT_CALL(*plugin_,
-                VesselNormal(kVesselGUID, check_not_null(navigation_frame)))
-        .WillOnce(Return(normal));
+    EXPECT_CALL(*plugin_, VesselNormal(kVesselGUID)).WillOnce(Return(normal));
     XYZ n =
         principia__VesselNormal(plugin_.get(), kVesselGUID, navigation_frame);
     EXPECT_EQ(n.x, normal.coordinates().x);
@@ -712,8 +706,7 @@ TEST_F(InterfaceTest, Frenet) {
   }
   {
     auto const binormal = Vector<double, World>({43, 67, 163});
-    EXPECT_CALL(*plugin_,
-                VesselBinormal(kVesselGUID, check_not_null(navigation_frame)))
+    EXPECT_CALL(*plugin_, VesselBinormal(kVesselGUID))
         .WillOnce(Return(binormal));
     XYZ b =
         principia__VesselBinormal(plugin_.get(), kVesselGUID, navigation_frame);

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -167,9 +167,9 @@ TEST_F(PluginIntegrationTest, BodyCentredNonrotatingNavigationIntegration) {
                                 RelativeDegreesOfFreedom<AliceSun>(
                                     satellite_initial_displacement_,
                                     satellite_initial_velocity_));
-  not_null<std::unique_ptr<NavigationFrame>> const geocentric =
+  plugin_->SetPlottingFrame(
       plugin_->NewBodyCentredNonRotatingNavigationFrame(
-          SolarSystemFactory::kEarth);
+          SolarSystemFactory::kEarth));
   // We'll check that our orbit is rendered as circular (actually, we only check
   // that it is rendered within a thin spherical shell around the Earth).
   Length perigee = std::numeric_limits<double>::infinity() * Metre;
@@ -204,7 +204,6 @@ TEST_F(PluginIntegrationTest, BodyCentredNonrotatingNavigationIntegration) {
               0.0 * AstronomicalUnit / Hour}) * (t - initial_time_);
     RenderedTrajectory<World> const rendered_trajectory =
         plugin_->RenderedVesselTrajectory(satellite,
-                                          geocentric.get(),
                                           sun_world_position);
     Position<World> const earth_world_position =
         sun_world_position + alice_sun_to_world(plugin_->CelestialFromParent(
@@ -248,9 +247,10 @@ TEST_F(PluginIntegrationTest, BarycentricRotatingNavigationIntegration) {
               from_the_earth_to_the_moon.velocity());
   plugin_->SetVesselStateOffset(satellite,
                                 {from_the_earth_to_l5, initial_velocity});
-  not_null<std::unique_ptr<NavigationFrame>> const earth_moon_barycentric =
-      plugin_->NewBarycentricRotatingNavigationFrame(SolarSystemFactory::kEarth,
-                                                    SolarSystemFactory::kMoon);
+  plugin_->SetPlottingFrame(
+      plugin_->NewBarycentricRotatingNavigationFrame(
+          SolarSystemFactory::kEarth,
+          SolarSystemFactory::kMoon));
   Permutation<AliceSun, World> const alice_sun_to_world =
       Permutation<AliceSun, World>(Permutation<AliceSun, World>::XZY);
   Time const δt_long = 1 * Hour;
@@ -287,7 +287,6 @@ TEST_F(PluginIntegrationTest, BarycentricRotatingNavigationIntegration) {
             0.0 * AstronomicalUnit / Hour}) * (t - initial_time_);
   RenderedTrajectory<World> const rendered_trajectory =
       plugin_->RenderedVesselTrajectory(satellite,
-                                        earth_moon_barycentric.get(),
                                         sun_world_position);
   Position<World> const earth_world_position =
       sun_world_position + alice_sun_to_world(plugin_->CelestialFromParent(
@@ -594,8 +593,8 @@ TEST_F(PluginIntegrationTest, Prediction) {
   plugin.InsertSun(celestial, SIUnit<GravitationalParameter>());
   plugin.EndInitialization();
   EXPECT_TRUE(plugin.InsertOrKeepVessel(satellite, celestial));
-  auto const navigation_frame =
-      plugin.NewBodyCentredNonRotatingNavigationFrame(celestial);
+  plugin.SetPlottingFrame(
+      plugin.NewBodyCentredNonRotatingNavigationFrame(celestial));
   plugin.SetVesselStateOffset(
       satellite,
       {Displacement<AliceSun>({1 * Metre, 0 * Metre, 0 * Metre}),
@@ -608,7 +607,6 @@ TEST_F(PluginIntegrationTest, Prediction) {
   plugin.UpdatePrediction(satellite);
   RenderedTrajectory<World> rendered_prediction =
       plugin.RenderedPrediction(satellite,
-                                navigation_frame.get(),
                                 World::origin);
   EXPECT_EQ(14, rendered_prediction.size());
   for (int i = 0; i < rendered_prediction.size(); ++i) {

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -564,12 +564,13 @@ TEST_F(PluginTest, Navball) {
                 0 * Radian);
   plugin.InsertSun(SolarSystemFactory::kSun, sun_gravitational_parameter_);
   plugin.EndInitialization();
-  not_null<std::unique_ptr<NavigationFrame>> const heliocentric =
-      plugin.NewBodyCentredNonRotatingNavigationFrame(SolarSystemFactory::kSun);
+  plugin.SetPlottingFrame(
+      plugin.NewBodyCentredNonRotatingNavigationFrame(
+          SolarSystemFactory::kSun));
   Vector<double, World> x({1, 0, 0});
   Vector<double, World> y({0, 1, 0});
   Vector<double, World> z({0, 0, 1});
-  auto navball = plugin.Navball(heliocentric.get(), World::origin);
+  auto navball = plugin.Navball(World::origin);
   EXPECT_THAT(AbsoluteError(-z, navball(World::origin)(x)),
               Lt(2 * std::numeric_limits<double>::epsilon()));
   EXPECT_THAT(AbsoluteError(y, navball(World::origin)(y)),
@@ -603,12 +604,9 @@ TEST_F(PluginTest, Frenet) {
   not_null<std::unique_ptr<NavigationFrame>> const geocentric =
       plugin.NewBodyCentredNonRotatingNavigationFrame(
           SolarSystemFactory::kEarth);
-  EXPECT_THAT(plugin.VesselTangent(satellite, geocentric.get()),
-              AlmostEquals(t, 2));
-  EXPECT_THAT(plugin.VesselNormal(satellite, geocentric.get()),
-              AlmostEquals(n, 3));
-  EXPECT_THAT(plugin.VesselBinormal(satellite, geocentric.get()),
-              AlmostEquals(b, 4));
+  EXPECT_THAT(plugin.VesselTangent(satellite), AlmostEquals(t, 2));
+  EXPECT_THAT(plugin.VesselNormal(satellite), AlmostEquals(n, 3));
+  EXPECT_THAT(plugin.VesselBinormal(satellite), AlmostEquals(b, 4));
 }
 
 }  // namespace ksp_plugin


### PR DESCRIPTION
The selector no longer owns its navigation frame, it is (explicitly, safely) owned by the plugin instead.
Two transfers of ownership occur at creation, but locally in the C#.