### PR TITLE
Change the player test to be a test/benchmark mix

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -62,9 +62,9 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
-    <Import Project="..\google_benchmark.props" />
-    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
     <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
+    <Import Project="..\google_benchmark.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -82,9 +82,9 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
-    <Import Project="..\google_benchmark.props" />
     <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
     <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\google_benchmark.props" />
     <Import Project="..\define_ndebug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|Win32'" Label="PropertySheets">
@@ -102,9 +102,9 @@
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
     <Import Project="..\generate_version_header.props" />
-    <Import Project="..\google_benchmark.props" />
-    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
     <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
+    <Import Project="..\google_benchmark.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />

--- a/journal/journal.vcxproj
+++ b/journal/journal.vcxproj
@@ -60,6 +60,9 @@
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
+    <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
+    <Import Project="..\google_benchmark.props" />
     <Import Project="..\generate_version_header.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -77,6 +80,9 @@
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
+    <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
+    <Import Project="..\google_benchmark.props" />
     <Import Project="..\generate_version_header.props" />
     <Import Project="..\define_ndebug.props" />
   </ImportGroup>
@@ -95,6 +101,9 @@
     <Import Project="..\..\Google\glog\vsprojects\static_linking.props" />
     <Import Project="..\..\Google\glog\vsprojects\portability_macros.props" />
     <Import Project="..\google_glog.props" />
+    <Import Project="..\..\Google\benchmark\msvc\windows_libraries.props" />
+    <Import Project="..\..\Google\benchmark\msvc\portability_macros.props" />
+    <Import Project="..\google_benchmark.props" />
     <Import Project="..\generate_version_header.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "journal/method.hpp"
 #include "journal/profiles.hpp"
@@ -14,8 +15,28 @@
 namespace principia {
 namespace journal {
 
+void BM_PlayForReal(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    Player player("P:\\Public Mockingbird\\Principia\\JOURNAL.20151206-170008");
+    int count = 0;
+    while (player.Play()) {
+      ++count;
+      LOG_IF(INFO, (count % 10'000) == 0)
+        << count << " journal entries replayed";
+    }
+  }
+}
+
+#if 0
+BENCHMARK(BM_PlayForReal);
+#endif
+
 class PlayerTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    benchmark::RunSpecifiedBenchmarks();
+  }
+
   PlayerTest()
       : test_name_(
             testing::UnitTest::GetInstance()->current_test_info()->name()),
@@ -55,18 +76,6 @@ TEST_F(PlayerTest, PlayTiny) {
   }
   EXPECT_EQ(2, count);
 }
-
-#if 0
-TEST_F(PlayerTest, PlayForReal) {
-  Player player("P:\\Public Mockingbird\\Principia\\JOURNAL.20151206-170008");
-  int count = 0;
-  while (player.Play()) {
-    ++count;
-    LOG_IF(ERROR, (count % 10'000) == 0)
-        << count << " journal entries replayed";
-  }
-}
-#endif
 
 }  // namespace journal
 }  // namespace principia

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -27,7 +27,7 @@ void BM_PlayForReal(benchmark::State& state) {  // NOLINT(runtime/references)
   }
 }
 
-#if 1
+#if 0
 BENCHMARK(BM_PlayForReal);
 #endif
 

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -21,13 +21,13 @@ void BM_PlayForReal(benchmark::State& state) {
     int count = 0;
     while (player.Play()) {
       ++count;
-      LOG_IF(INFO, (count % 10'000) == 0)
-        << count << " journal entries replayed";
+      LOG_IF(ERROR, (count % 100'000) == 0)
+          << count << " journal entries replayed";
     }
   }
 }
 
-#if 0
+#if 1
 BENCHMARK(BM_PlayForReal);
 #endif
 

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -15,7 +15,7 @@
 namespace principia {
 namespace journal {
 
-void BM_PlayForReal(benchmark::State& state) {
+void BM_PlayForReal(benchmark::State& state) {  // NOLINT(runtime/references)
   while (state.KeepRunning()) {
     Player player("P:\\Public Mockingbird\\Principia\\JOURNAL.20151206-170008");
     int count = 0;


### PR DESCRIPTION
This makes it possible to measure the CPU time semi-accurately and it solves the odd coverage in Jenkins.

For instance, timing pre-PGO:
```
Run on (1 X 3310 MHz CPU )
2015-12-12 12:43:04
Benchmark        Time(ns)    CPU(ns) Iterations
-----------------------------------------------
BM_PlayForReal 36580656528 30030192500          1
```
and timing post-PGO:
```
Run on (1 X 3310 MHz CPU )
2015-12-12 12:43:04
Benchmark        Time(ns)    CPU(ns) Iterations
-----------------------------------------------
BM_PlayForReal 34107412577 27003773100          1
```
Considering that profiling shows 41.8% spent parsing the journal (code that's not affected by PGO) this means that PGO buys us a 19% speedup on the code that we care about.