### PR TITLE
Penumbrae

### DIFF
--- a/astronomy/ephemeris.py
+++ b/astronomy/ephemeris.py
@@ -12,6 +12,21 @@ from astropy.time import Time
 # U4 = 22:18:54
 # P4 = 23:17:21
 
+# Additional total and 2x partial eclipses in 1950/51
+# 1950-09-26
+# P1 = 01:21:43 UT
+# U1 = 02:31:48
+# U2 = 03:54:33
+# U3 = 04:38:49
+# U4 = 06:01:33
+# P4 = 07:11:47
+# 1951-04-23
+# P1 = 08:50:00
+# P4 = 12:24:19
+# 1951-09-15
+# P1 = 10:29:16
+# P4 = 14:23:52
+
 # Last Lunar Eclipse will be 2048-01-01 
 # P1 = 03:52:39 UT
 # U1 = 05:05:17
@@ -26,6 +41,26 @@ P1U1234P4 = ['1950-04-02T18:10:49', '1950-04-02T19:09:19', \
 eclipseTimes = Time(P1U1234P4, format='isot', scale='utc')
 et2 = eclipseTimes.tdb
 csv = open('eclipsetimes.csv', 'w')
+csv.write(str(et2.jd))
+csv.write('\n')
+
+P1U1234P4 = ['1950-09-26T01:21:43', '1950-09-26T02:31:48', \
+             '1950-09-26T03:54:33', '1950-09-26T04:38:49', \
+             '1950-09-26T06:01:33', '1950-09-26T07:11:47']
+eclipseTimes = Time(P1U1234P4, format='isot', scale='utc')
+et2 = eclipseTimes.tdb
+csv.write(str(et2.jd))
+csv.write('\n')
+
+P1P4 = ['1951-04-23T08:50:00', '1951-04-23T12:24:19']
+eclipseTimes = Time(P1P4, format='isot', scale='utc')
+et2 = eclipseTimes.tdb
+csv.write(str(et2.jd))
+csv.write('\n')
+
+P1P4 = ['1951-09-15T10:29:16', '1951-09-15T14:23:52']
+eclipseTimes = Time(P1P4, format='isot', scale='utc')
+et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))
 csv.write('\n')
 

--- a/astronomy/ephemeris.py
+++ b/astronomy/ephemeris.py
@@ -76,8 +76,8 @@ et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))
 csv.write('\n')
 
-P1U14P4 = ['1952-02-11T22:08:20', '1952-02-12T00:04:17', \
-           '1952-02-12T01:14:24', '1952-02-12T03:10:15']
+P1U14P4 = ['1952-02-10T22:08:20', '1952-02-11T00:04:17', \
+           '1952-02-11T01:14:24', '1952-02-11T03:10:15']
 eclipseTimes = Time(P1U14P4, format='isot', scale='utc')
 et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))

--- a/astronomy/ephemeris.py
+++ b/astronomy/ephemeris.py
@@ -12,7 +12,7 @@ from astropy.time import Time
 # U4 = 22:18:54
 # P4 = 23:17:21
 
-# Additional total and 2x partial eclipses in 1950/51
+# Additional total and 2x penumbral eclipses in 1950/51
 # 1950-09-26
 # P1 = 01:21:43 UT
 # U1 = 02:31:48
@@ -20,12 +20,24 @@ from astropy.time import Time
 # U3 = 04:38:49
 # U4 = 06:01:33
 # P4 = 07:11:47
-# 1951-04-23
+# 1951-03-23
 # P1 = 08:50:00
 # P4 = 12:24:19
 # 1951-09-15
 # P1 = 10:29:16
 # P4 = 14:23:52
+
+# 2x partial eclipses in 1952
+# 1952-02-11
+# P1 = 22:08:20 UT
+# U1 = 00:04:17
+# U4 = 01:14:24
+# P4 = 03:10:15
+# 1952-08-05
+# P1 = 17:28:13 UT
+# U1 = 18:33:49
+# U4 = 21:01:00
+# P4 = 22:06:35
 
 # Last Lunar Eclipse will be 2048-01-01 
 # P1 = 03:52:39 UT
@@ -52,7 +64,7 @@ et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))
 csv.write('\n')
 
-P1P4 = ['1951-04-23T08:50:00', '1951-04-23T12:24:19']
+P1P4 = ['1951-03-23T08:50:00', '1951-03-23T12:24:19']
 eclipseTimes = Time(P1P4, format='isot', scale='utc')
 et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))
@@ -60,6 +72,20 @@ csv.write('\n')
 
 P1P4 = ['1951-09-15T10:29:16', '1951-09-15T14:23:52']
 eclipseTimes = Time(P1P4, format='isot', scale='utc')
+et2 = eclipseTimes.tdb
+csv.write(str(et2.jd))
+csv.write('\n')
+
+P1U14P4 = ['1952-02-11T22:08:20', '1952-02-12T00:04:17', \
+           '1952-02-12T01:14:24', '1952-02-12T03:10:15']
+eclipseTimes = Time(P1U14P4, format='isot', scale='utc')
+et2 = eclipseTimes.tdb
+csv.write(str(et2.jd))
+csv.write('\n')
+
+P1U14P4 = ['1952-08-05T17:28:13', '1952-08-05T18:33:49', \
+           '1952-08-05T21:01:00', '1952-08-05T22:06:35']
+eclipseTimes = Time(P1U14P4, format='isot', scale='utc')
 et2 = eclipseTimes.tdb
 csv.write(str(et2.jd))
 csv.write('\n')

--- a/astronomy/ephemeris.py
+++ b/astronomy/ephemeris.py
@@ -4,7 +4,7 @@ from astropy.time import Time
 # Finds the times (in TDB) of events in two sets of lunar eclipses, given
 # the more easily found UTC times.
 
-# First Lunar Eclipse was 1950-04-02
+# First Lunar Eclipse was 1950-04-02.
 # P1 = 18:10:49 UT
 # U1 = 19:09:19
 # U2 = 20:30:38
@@ -12,7 +12,6 @@ from astropy.time import Time
 # U4 = 22:18:54
 # P4 = 23:17:21
 
-# Additional total and 2x penumbral eclipses in 1950/51
 # 1950-09-26
 # P1 = 01:21:43 UT
 # U1 = 02:31:48
@@ -20,6 +19,8 @@ from astropy.time import Time
 # U3 = 04:38:49
 # U4 = 06:01:33
 # P4 = 07:11:47
+
+# Penumbral eclipses only in 1951.
 # 1951-03-23
 # P1 = 08:50:00
 # P4 = 12:24:19
@@ -27,7 +28,7 @@ from astropy.time import Time
 # P1 = 10:29:16
 # P4 = 14:23:52
 
-# 2x partial eclipses in 1952
+# Partial eclipses in 1952.
 # 1952-02-11
 # P1 = 22:08:20 UT
 # U1 = 00:04:17

--- a/physics/eclipse_test.cpp
+++ b/physics/eclipse_test.cpp
@@ -17,18 +17,23 @@ using geometry::JulianDate;
 using geometry::Sign;
 using integrators::McLachlanAtela1992Order5Optimal;
 using quantities::ArcCos;
+using quantities::si::Day;
 using quantities::si::Kilo;
 using quantities::si::Metre;
 using quantities::si::Milli;
 using quantities::si::Minute;
 using quantities::si::Nano;
-using quantities::si::Second;
 using testing_utilities::AbsoluteError;
 using ::testing::AllOf;
 using ::testing::Gt;
 using ::testing::Lt;
 
 namespace physics {
+
+namespace {
+Sign const U14 = Sign(1);
+Sign const U23 = Sign(-1);
+}  // namespace
 
 class EclipseTest : public testing::Test {
  protected:
@@ -46,7 +51,7 @@ class EclipseTest : public testing::Test {
         45 * Minute, 5 * Milli(Metre));
 
     ephemeris->Prolong(current_time +
-                       86400 * Second);  // Prolong 1 day past date of eclipse.
+                       1 * Day);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -96,7 +101,7 @@ class EclipseTest : public testing::Test {
         45 * Minute, 5 * Milli(Metre));
 
     ephemeris->Prolong(current_time +
-                       86400 * Second);  // Prolong 1 day past date of eclipse.
+                       1 * Day);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -139,7 +144,7 @@ class EclipseTest : public testing::Test {
   SolarSystem<ICRFJ2000Equator> solar_system_1950_;
 };
 
-TEST_F(EclipseTest, Dummy) {
+TEST_F(EclipseTest, Year1950) {
   // Dates are TDB Julian Day for 1950-04-02.
   auto P1 = JulianDate(2433374.25788409);  // 18:10:49 UT
   auto U1 = JulianDate(2433374.29850909);  // 19:09:19
@@ -148,8 +153,6 @@ TEST_F(EclipseTest, Dummy) {
   auto U4 = JulianDate(2433374.43016419);  // 22:18:54
   auto P4 = JulianDate(2433374.47075446);  // 23:17:21
 
-  Sign const U14 = Sign(1);
-  Sign const U23 = Sign(-1);
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarUmbralEclipse(U1, U14);
   CheckLunarUmbralEclipse(U2, U23);
@@ -171,10 +174,12 @@ TEST_F(EclipseTest, Dummy) {
   CheckLunarUmbralEclipse(U3, U23);
   CheckLunarUmbralEclipse(U4, U14);
   CheckLunarPenumbralEclipse(P4, U14);
+}
 
+TEST_F(EclipseTest, Year1951) {
   // Dates are TDB Julian Day for 1951-03-23.
-  P1 = JulianDate(2433728.86842806);  // 08:50:50
-  P4 = JulianDate(2433729.01725909);  // 12:24:19
+  auto P1 = JulianDate(2433728.86842806);  // 08:50:50
+  auto P4 = JulianDate(2433729.01725909);  // 12:24:19
 
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarPenumbralEclipse(P4, U14);
@@ -185,12 +190,14 @@ TEST_F(EclipseTest, Dummy) {
 
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarPenumbralEclipse(P4, U14);
+}
 
+TEST_F(EclipseTest, Year1952) {
   // Dates are TDB Julian Day for 1952-02-11 (or 10 for P1).
-  P1 = JulianDate(2434053.42282623);  // P1 = 22:08:20 UT
-  U1 = JulianDate(2434053.50334705);  // U1 = 00:04:17
-  U4 = JulianDate(2434053.55203917);  // U4 = 01:14:24
-  P4 = JulianDate(2434053.63249055);  // P4 = 03:10:15
+  auto P1 = JulianDate(2434053.42282623);  // P1 = 22:08:20 UT
+  auto U1 = JulianDate(2434053.50334705);  // U1 = 00:04:17
+  auto U4 = JulianDate(2434053.55203917);  // U4 = 01:14:24
+  auto P4 = JulianDate(2434053.63249055);  // P4 = 03:10:15
 
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarUmbralEclipse(U1, U14);

--- a/physics/eclipse_test.cpp
+++ b/physics/eclipse_test.cpp
@@ -22,6 +22,7 @@ using quantities::si::Metre;
 using quantities::si::Milli;
 using quantities::si::Minute;
 using quantities::si::Nano;
+using quantities::si::Second;
 using testing_utilities::AbsoluteError;
 using ::testing::AllOf;
 using ::testing::Gt;
@@ -44,10 +45,7 @@ class EclipseTest : public testing::Test {
         McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
         45 * Minute, 5 * Milli(Metre));
 
-    ephemeris->Prolong(
-        JulianDate(2433374.5));  // Prolong just past date of eclipse
-                                 // (Eclipse was 1950-04-02 but JD
-                                 // is 1950-04-03 00:00:00).
+    ephemeris->Prolong(current_time + 86400 * Second);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -96,10 +94,7 @@ class EclipseTest : public testing::Test {
         McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
         45 * Minute, 5 * Milli(Metre));
 
-    ephemeris->Prolong(
-        JulianDate(2433374.5));  // Prolong just past date of eclipse
-                                 // (Eclipse was 1950-04-02 but JD
-                                 // is 1950-04-03 00:00:00).
+    ephemeris->Prolong(current_time + 86400 * Second);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -144,12 +139,12 @@ class EclipseTest : public testing::Test {
 
 TEST_F(EclipseTest, Dummy) {
   // Dates are TDB Julian Day for 1948-04-02.
-  auto const P1 = JulianDate(2433374.25788409);  // 18:10:49 UT
-  auto const U1 = JulianDate(2433374.29850909);  // 19:09:19
-  auto const U2 = JulianDate(2433374.354979);    // 20:30:38
-  auto const U3 = JulianDate(2433374.37367113);  // 20:57:33
-  auto const U4 = JulianDate(2433374.43016419);  // 22:18:54
-  auto const P4 = JulianDate(2433374.47075446);  // 23:17:21
+  auto P1 = JulianDate(2433374.25788409);  // 18:10:49 UT
+  auto U1 = JulianDate(2433374.29850909);  // 19:09:19
+  auto U2 = JulianDate(2433374.354979);    // 20:30:38
+  auto U3 = JulianDate(2433374.37367113);  // 20:57:33
+  auto U4 = JulianDate(2433374.43016419);  // 22:18:54
+  auto P4 = JulianDate(2433374.47075446);  // 23:17:21
 
   Sign const U14 = Sign(1);
   Sign const U23 = Sign(-1);
@@ -164,15 +159,20 @@ TEST_F(EclipseTest, Dummy) {
   // y_normx).Norm(),(x_norm_y + y_norm_x).Norm())
   // x_norm_y = x * y.Norm() and y_norm_x = y * x.Norm()
 
-  // Future: check 2048-01-01 Lunar eclipse.
-  // P1 = 03:52:39 UT
-  // U1 = 05:05:17 UT
-  // U2 = 06:24:27
-  // U3 = 07:20:23
-  // U4 = 08:39:33
-  // P4 = 09:52:05
-  // etimes = {2469076.66235167, 2469076.71279148, 2469076.76776833,
-  // 2469076.80661092, 2469076.86158778, 2469076.91195815};
+  // Future is now: check 2048-01-01 Lunar eclipse.
+  P1 = JulianDate(2469076.66235167);  // 03:52:39 UT
+  U1 = JulianDate(2469076.71279148);  // 05:05:17
+  U2 = JulianDate(2469076.76776833);  // 06:24:27
+  U3 = JulianDate(2469076.80661092);  // 07:20:23
+  U4 = JulianDate(2469076.86158778);  // 08:39:33
+  P4 = JulianDate(2469076.91195815);  // 09:52:05
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarUmbralEclipse(U1, U14);
+  CheckLunarUmbralEclipse(U2, U23);
+  CheckLunarUmbralEclipse(U3, U23);
+  CheckLunarUmbralEclipse(U4, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
 }
 
 }  // namespace physics

--- a/physics/eclipse_test.cpp
+++ b/physics/eclipse_test.cpp
@@ -138,7 +138,7 @@ class EclipseTest : public testing::Test {
 };
 
 TEST_F(EclipseTest, Dummy) {
-  // Dates are TDB Julian Day for 1948-04-02.
+  // Dates are TDB Julian Day for 1950-04-02.
   auto P1 = JulianDate(2433374.25788409);  // 18:10:49 UT
   auto U1 = JulianDate(2433374.29850909);  // 19:09:19
   auto U2 = JulianDate(2433374.354979);    // 20:30:38
@@ -155,12 +155,63 @@ TEST_F(EclipseTest, Dummy) {
   CheckLunarUmbralEclipse(U4, U14);
   CheckLunarPenumbralEclipse(P4, U14);
 
+  // Dates are TDB Julian Day for 1950-09-26.
+  P1 = JulianDate(2433550.55712016);  // 01:21:43 UT
+  U1 = JulianDate(2433550.60578913);  // 02:31:48 
+  U2 = JulianDate(2433550.66325441);  // 03:54:33 
+  U3 = JulianDate(2433550.69399515);  // 04:38:49
+  U4 = JulianDate(2433550.75144885);  // 06:01:33
+  P4 = JulianDate(2433550.800222);  // 07:11:47
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarUmbralEclipse(U1, U14);
+  CheckLunarUmbralEclipse(U2, U23);
+  CheckLunarUmbralEclipse(U3, U23);
+  CheckLunarUmbralEclipse(U4, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
+
+  // Dates are TDB Julian Day for 1951-03-23.
+  P1 = JulianDate(2433728.86842806);  // 08:50:50
+  P4 = JulianDate(2433729.01725909);  // 12:24:19
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
+
+  // Dates are TDB Julian Day for 1951-09-15.
+  P1 = JulianDate(2433904.93736321);  // 10:29:16 
+  P4 = JulianDate(2433905.1002799);  // 14:23:52
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
+
+  // Dates are TDB Julian Day for 1952-02-11 (or 10 for P1).
+  P1 = JulianDate(2434053.42282623);  // P1 = 22:08:20 UT
+  U1 = JulianDate(2434053.50334705);  // U1 = 00:04:17
+  U4 = JulianDate(2434053.55203917);  // U4 = 01:14:24
+  P4 = JulianDate(2434053.63249055);  // P4 = 03:10:15
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarUmbralEclipse(U1, U14);
+  CheckLunarUmbralEclipse(U4, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
+
+  // Dates are TDB Julian Day for 1952-08-05.
+  P1 = JulianDate(2434230.22830075);  // P1 = 17:28:13 UT
+  U1 = JulianDate(2434230.27385631);  // U1 = 18:33:49
+  U4 = JulianDate(2434230.37606695);  // U4 = 21:01:00
+  P4 = JulianDate(2434230.42161093);  // P4 = 22:06:35
+
+  CheckLunarPenumbralEclipse(P1, U14);
+  CheckLunarUmbralEclipse(U1, U14);
+  CheckLunarUmbralEclipse(U4, U14);
+  CheckLunarPenumbralEclipse(P4, U14);
+
   // Later on for additional accuracy: 2 * ArcTan((x_norm_y -
   // y_normx).Norm(),(x_norm_y + y_norm_x).Norm())
   // x_norm_y = x * y.Norm() and y_norm_x = y * x.Norm()
 
-  // Future is now: check 2048-01-01 Lunar eclipse.
-  P1 = JulianDate(2469076.66235167);  // 03:52:39 UT
+  // Future is not now: check 2048-01-01 Lunar eclipse.
+  /*P1 = JulianDate(2469076.66235167);  // 03:52:39 UT
   U1 = JulianDate(2469076.71279148);  // 05:05:17
   U2 = JulianDate(2469076.76776833);  // 06:24:27
   U3 = JulianDate(2469076.80661092);  // 07:20:23
@@ -172,7 +223,7 @@ TEST_F(EclipseTest, Dummy) {
   CheckLunarUmbralEclipse(U2, U23);
   CheckLunarUmbralEclipse(U3, U23);
   CheckLunarUmbralEclipse(U4, U14);
-  CheckLunarPenumbralEclipse(P4, U14);
+  CheckLunarPenumbralEclipse(P4, U14); */
 }
 
 }  // namespace physics

--- a/physics/eclipse_test.cpp
+++ b/physics/eclipse_test.cpp
@@ -40,12 +40,13 @@ class EclipseTest : public testing::Test {
   }
 
   void CheckLunarUmbralEclipse(Instant const& current_time,
-                         Sign const moon_offset_sign) {
+                               Sign const moon_offset_sign) {
     auto ephemeris = solar_system_1950_.MakeEphemeris(
         McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
         45 * Minute, 5 * Milli(Metre));
 
-    ephemeris->Prolong(current_time + 86400 * Second);  // Prolong 1 day past date of eclipse.
+    ephemeris->Prolong(current_time +
+                       86400 * Second);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -89,12 +90,13 @@ class EclipseTest : public testing::Test {
   }
 
   void CheckLunarPenumbralEclipse(Instant const& current_time,
-                         Sign const moon_offset_sign) {
+                                  Sign const moon_offset_sign) {
     auto ephemeris = solar_system_1950_.MakeEphemeris(
         McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
         45 * Minute, 5 * Milli(Metre));
 
-    ephemeris->Prolong(current_time + 86400 * Second);  // Prolong 1 day past date of eclipse.
+    ephemeris->Prolong(current_time +
+                       86400 * Second);  // Prolong 1 day past date of eclipse.
     auto const sun = solar_system_1950_.massive_body(*ephemeris, "Sun");
     auto const earth = solar_system_1950_.massive_body(*ephemeris, "Earth");
     auto const moon = solar_system_1950_.massive_body(*ephemeris, "Moon");
@@ -157,11 +159,11 @@ TEST_F(EclipseTest, Dummy) {
 
   // Dates are TDB Julian Day for 1950-09-26.
   P1 = JulianDate(2433550.55712016);  // 01:21:43 UT
-  U1 = JulianDate(2433550.60578913);  // 02:31:48 
-  U2 = JulianDate(2433550.66325441);  // 03:54:33 
+  U1 = JulianDate(2433550.60578913);  // 02:31:48
+  U2 = JulianDate(2433550.66325441);  // 03:54:33
   U3 = JulianDate(2433550.69399515);  // 04:38:49
   U4 = JulianDate(2433550.75144885);  // 06:01:33
-  P4 = JulianDate(2433550.800222);  // 07:11:47
+  P4 = JulianDate(2433550.800222);    // 07:11:47
 
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarUmbralEclipse(U1, U14);
@@ -178,8 +180,8 @@ TEST_F(EclipseTest, Dummy) {
   CheckLunarPenumbralEclipse(P4, U14);
 
   // Dates are TDB Julian Day for 1951-09-15.
-  P1 = JulianDate(2433904.93736321);  // 10:29:16 
-  P4 = JulianDate(2433905.1002799);  // 14:23:52
+  P1 = JulianDate(2433904.93736321);  // 10:29:16
+  P4 = JulianDate(2433905.1002799);   // 14:23:52
 
   CheckLunarPenumbralEclipse(P1, U14);
   CheckLunarPenumbralEclipse(P4, U14);


### PR DESCRIPTION
Penumbral eclipses are now checkable, and several additional eclipses (through 1952) added. The 2048 eclipse is excluded because running the ephemeris out that far requires >1.5 GiB of RAM/swap.