### PR TITLE
Rename all extensions to be named `extension`.

### DIFF
--- a/geometry/affine_map_test.cpp
+++ b/geometry/affine_map_test.cpp
@@ -128,7 +128,7 @@ TEST_F(AffineMapTest, Serialization) {
   EXPECT_TRUE(message.from_origin().has_multivector());
   EXPECT_TRUE(message.to_origin().has_multivector());
   EXPECT_TRUE(message.linear_map().HasExtension(
-      serialization::Rotation::rotation));
+      serialization::Rotation::extension));
   RigidTransformation const map2 =
       RigidTransformation::ReadFromMessage(message);
   EXPECT_EQ(map1(back_right_bottom_) - origin_,

--- a/geometry/identity_body.hpp
+++ b/geometry/identity_body.hpp
@@ -61,16 +61,16 @@ template<typename FromFrame, typename ToFrame>
 void Identity<FromFrame, ToFrame>::WriteToMessage(
     not_null<serialization::LinearMap*> const message) const {
   LinearMap<FromFrame, ToFrame>::WriteToMessage(message);
-  WriteToMessage(message->MutableExtension(serialization::Identity::identity));
+  WriteToMessage(message->MutableExtension(serialization::Identity::extension));
 }
 
 template<typename FromFrame, typename ToFrame>
 Identity<FromFrame, ToFrame> Identity<FromFrame, ToFrame>::ReadFromMessage(
     serialization::LinearMap const& message) {
   LinearMap<FromFrame, ToFrame>::ReadFromMessage(message);
-  CHECK(message.HasExtension(serialization::Identity::identity));
+  CHECK(message.HasExtension(serialization::Identity::extension));
   return ReadFromMessage(
-      message.GetExtension(serialization::Identity::identity));
+      message.GetExtension(serialization::Identity::extension));
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -65,7 +65,7 @@ void OrthogonalMap<FromFrame, ToFrame>::WriteToMessage(
       not_null<serialization::LinearMap*> const message) const {
   LinearMap<FromFrame, ToFrame>::WriteToMessage(message);
   WriteToMessage(
-      message->MutableExtension(serialization::OrthogonalMap::orthogonal_map));
+      message->MutableExtension(serialization::OrthogonalMap::extension));
 }
 
 template<typename FromFrame, typename ToFrame>
@@ -73,9 +73,9 @@ OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::ReadFromMessage(
     serialization::LinearMap const& message) {
   LinearMap<FromFrame, ToFrame>::ReadFromMessage(message);
-  CHECK(message.HasExtension(serialization::OrthogonalMap::orthogonal_map));
+  CHECK(message.HasExtension(serialization::OrthogonalMap::extension));
   return ReadFromMessage(
-      message.GetExtension(serialization::OrthogonalMap::orthogonal_map));
+      message.GetExtension(serialization::OrthogonalMap::extension));
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/orthogonal_map_test.cpp
+++ b/geometry/orthogonal_map_test.cpp
@@ -148,9 +148,9 @@ TEST_F(OrthogonalMapTest, SerializationSuccess) {
   EXPECT_EQ(message.from_frame().is_inertial(),
             message.to_frame().is_inertial());
   EXPECT_TRUE(message.HasExtension(
-      serialization::OrthogonalMap::orthogonal_map));
+      serialization::OrthogonalMap::extension));
   serialization::OrthogonalMap const& extension =
-      message.GetExtension(serialization::OrthogonalMap::orthogonal_map);
+      message.GetExtension(serialization::OrthogonalMap::extension);
   EXPECT_TRUE(extension.determinant().negative());
   EXPECT_THAT(extension.rotation().quaternion().real_part(),
               AlmostEquals(0.5, 1));

--- a/geometry/permutation_body.hpp
+++ b/geometry/permutation_body.hpp
@@ -94,7 +94,7 @@ void Permutation<FromFrame, ToFrame>::WriteToMessage(
       not_null<serialization::LinearMap*> const message) const {
   LinearMap<FromFrame, ToFrame>::WriteToMessage(message);
   WriteToMessage(
-      message->MutableExtension(serialization::Permutation::permutation));
+      message->MutableExtension(serialization::Permutation::extension));
 }
 
 template<typename FromFrame, typename ToFrame>
@@ -102,9 +102,9 @@ Permutation<FromFrame, ToFrame>
 Permutation<FromFrame, ToFrame>::ReadFromMessage(
     serialization::LinearMap const& message) {
   LinearMap<FromFrame, ToFrame>::ReadFromMessage(message);
-  CHECK(message.HasExtension(serialization::Permutation::permutation));
+  CHECK(message.HasExtension(serialization::Permutation::extension));
   return ReadFromMessage(
-      message.GetExtension(serialization::Permutation::permutation));
+      message.GetExtension(serialization::Permutation::extension));
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/permutation_test.cpp
+++ b/geometry/permutation_test.cpp
@@ -209,9 +209,9 @@ TEST_F(PermutationTest, SerializationSuccess) {
               message.to_frame().tag());
     EXPECT_EQ(message.from_frame().is_inertial(),
               message.to_frame().is_inertial());
-    EXPECT_TRUE(message.HasExtension(serialization::Permutation::permutation));
+    EXPECT_TRUE(message.HasExtension(serialization::Permutation::extension));
     serialization::Permutation const& extension =
-        message.GetExtension(serialization::Permutation::permutation);
+        message.GetExtension(serialization::Permutation::extension);
     EXPECT_EQ(cp, extension.coordinate_permutation());
     Perm const perm_b = Perm::ReadFromMessage(message);
     EXPECT_EQ(perm_a(vector_), perm_b(vector_));

--- a/geometry/rotation_body.hpp
+++ b/geometry/rotation_body.hpp
@@ -139,16 +139,16 @@ template<typename FromFrame, typename ToFrame>
 void Rotation<FromFrame, ToFrame>::WriteToMessage(
     not_null<serialization::LinearMap*> const message) const {
   LinearMap<FromFrame, ToFrame>::WriteToMessage(message);
-  WriteToMessage(message->MutableExtension(serialization::Rotation::rotation));
+  WriteToMessage(message->MutableExtension(serialization::Rotation::extension));
 }
 
 template<typename FromFrame, typename ToFrame>
 Rotation<FromFrame, ToFrame> Rotation<FromFrame, ToFrame>::ReadFromMessage(
     serialization::LinearMap const& message) {
   LinearMap<FromFrame, ToFrame>::ReadFromMessage(message);
-  CHECK(message.HasExtension(serialization::Rotation::rotation));
+  CHECK(message.HasExtension(serialization::Rotation::extension));
   return ReadFromMessage(
-      message.GetExtension(serialization::Rotation::rotation));
+      message.GetExtension(serialization::Rotation::extension));
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/rotation_test.cpp
+++ b/geometry/rotation_test.cpp
@@ -235,9 +235,9 @@ TEST_F(RotationTest, SerializationSuccess) {
             message.to_frame().tag());
   EXPECT_EQ(message.from_frame().is_inertial(),
             message.to_frame().is_inertial());
-  EXPECT_TRUE(message.HasExtension(serialization::Rotation::rotation));
+  EXPECT_TRUE(message.HasExtension(serialization::Rotation::extension));
   serialization::Rotation const& extension =
-      message.GetExtension(serialization::Rotation::rotation);
+      message.GetExtension(serialization::Rotation::extension);
   EXPECT_THAT(extension.quaternion().real_part(), AlmostEquals(0.5, 1));
   EXPECT_EQ(0.5, extension.quaternion().imaginary_part().x().double_());
   EXPECT_EQ(0.5, extension.quaternion().imaginary_part().y().double_());

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -51,7 +51,7 @@ class BodyTest : public testing::Test {
     EXPECT_TRUE(message.has_massive_body());
     EXPECT_FALSE(message.has_massless_body());
     EXPECT_TRUE(message.massive_body().HasExtension(
-                    serialization::RotatingBody::rotating_body));
+                    serialization::RotatingBody::extension));
 
     not_null<std::unique_ptr<MassiveBody const>> const massive_body =
         MassiveBody::ReadFromMessage(message);
@@ -143,11 +143,11 @@ TEST_F(BodyTest, RotatingSerializationSuccess) {
   EXPECT_TRUE(message.has_massive_body());
   EXPECT_FALSE(message.has_massless_body());
   EXPECT_TRUE(message.massive_body().HasExtension(
-                  serialization::RotatingBody::rotating_body));
+                  serialization::RotatingBody::extension));
   EXPECT_EQ(17, message.massive_body().gravitational_parameter().magnitude());
   serialization::RotatingBody const rotating_body_extension =
       message.massive_body().GetExtension(
-          serialization::RotatingBody::rotating_body);
+          serialization::RotatingBody::extension);
   EXPECT_EQ(3, rotating_body_extension.reference_angle().magnitude());
   EXPECT_EQ(4,
             rotating_body_extension.reference_instant().scalar().magnitude());
@@ -192,13 +192,13 @@ TEST_F(BodyTest, OblateSerializationSuccess) {
   EXPECT_TRUE(message.has_massive_body());
   EXPECT_FALSE(message.has_massless_body());
   EXPECT_TRUE(message.massive_body().GetExtension(
-                  serialization::RotatingBody::rotating_body).
-                      HasExtension(serialization::OblateBody::oblate_body));
+                  serialization::RotatingBody::extension).
+                      HasExtension(serialization::OblateBody::extension));
   EXPECT_EQ(17, message.massive_body().gravitational_parameter().magnitude());
   serialization::OblateBody const oblate_body_extension =
       message.massive_body().GetExtension(
-                  serialization::RotatingBody::rotating_body).
-                      GetExtension(serialization::OblateBody::oblate_body);
+                  serialization::RotatingBody::extension).
+                      GetExtension(serialization::OblateBody::extension);
   EXPECT_EQ(163, oblate_body_extension.j2().magnitude());
 
   // Dispatching from |MassiveBody|.
@@ -235,10 +235,10 @@ TEST_F(BodyTest, PreBrouwerOblateDeserializationSuccess) {
      post_brouwer_body.massive_body();
   serialization::RotatingBody const& post_brouwer_rotating_body =
      post_brouwer_massive_body.GetExtension(
-        serialization::RotatingBody::rotating_body);
+        serialization::RotatingBody::extension);
   serialization::OblateBody const& post_brouwer_oblate_body =
      post_brouwer_rotating_body.GetExtension(
-        serialization::OblateBody::oblate_body);
+        serialization::OblateBody::extension);
 
   // Construct explicitly an equivalent pre-Brouwer message.
   serialization::Body pre_brouwer_body;
@@ -248,7 +248,7 @@ TEST_F(BodyTest, PreBrouwerOblateDeserializationSuccess) {
       post_brouwer_massive_body.gravitational_parameter());
   serialization::PreBrouwerOblateBody* pre_brouwer_oblate_body =
       pre_brouwer_massive_body->MutableExtension(
-          serialization::PreBrouwerOblateBody::pre_brouwer_oblate_body);
+          serialization::PreBrouwerOblateBody::extension);
   pre_brouwer_oblate_body->mutable_frame()->CopyFrom(
       post_brouwer_rotating_body.frame());
   pre_brouwer_oblate_body->mutable_j2()->CopyFrom(

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -98,19 +98,17 @@ inline not_null<std::unique_ptr<MassiveBody>> MassiveBody::ReadFromMessage(
   serialization::RotatingBody const* rotating_body_extension = nullptr;
   serialization::PreBrouwerOblateBody const* pre_brouwer_oblate_body_extension =
       nullptr;
-  if (message.HasExtension(serialization::RotatingBody::rotating_body)) {
+  if (message.HasExtension(serialization::RotatingBody::extension)) {
     rotating_body_extension =
-        &message.GetExtension(serialization::RotatingBody::rotating_body);
+        &message.GetExtension(serialization::RotatingBody::extension);
     ReadFrameFromMessage(rotating_body_extension->frame(),
                          &enum_value_descriptor,
                          &is_inertial);
     CHECK(is_inertial);
   }
-  if (message.HasExtension(
-          serialization::PreBrouwerOblateBody::pre_brouwer_oblate_body)) {
+  if (message.HasExtension(serialization::PreBrouwerOblateBody::extension)) {
     pre_brouwer_oblate_body_extension =
-        &message.GetExtension(
-            serialization::PreBrouwerOblateBody::pre_brouwer_oblate_body);
+        &message.GetExtension(serialization::PreBrouwerOblateBody::extension);
     ReadFrameFromMessage(pre_brouwer_oblate_body_extension->frame(),
                          &enum_value_descriptor,
                          &is_inertial);

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -83,8 +83,8 @@ void OblateBody<Frame>::WriteToMessage(
     not_null<serialization::MassiveBody*> const message) const {
   RotatingBody<Frame>::WriteToMessage(message);
   not_null<serialization::OblateBody*> const oblate_body =
-      message->MutableExtension(serialization::RotatingBody::rotating_body)->
-               MutableExtension(serialization::OblateBody::oblate_body);
+      message->MutableExtension(serialization::RotatingBody::extension)->
+               MutableExtension(serialization::OblateBody::extension);
   parameters_.j2_->WriteToMessage(oblate_body->mutable_j2());
 }
 

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -73,7 +73,7 @@ void RotatingBody<Frame>::WriteToMessage(
     not_null<serialization::MassiveBody*> const message) const {
   MassiveBody::WriteToMessage(message);
   not_null<serialization::RotatingBody*> const rotating_body =
-      message->MutableExtension(serialization::RotatingBody::rotating_body);
+      message->MutableExtension(serialization::RotatingBody::extension);
   Frame::WriteToMessage(rotating_body->mutable_frame());
   parameters_.reference_angle_.WriteToMessage(
       rotating_body->mutable_reference_angle());
@@ -94,9 +94,9 @@ RotatingBody<Frame>::ReadFromMessage(
                  AngularVelocity<Frame>::ReadFromMessage(
                      message.angular_velocity()));
 
-  if (message.HasExtension(serialization::OblateBody::oblate_body)) {
+  if (message.HasExtension(serialization::OblateBody::extension)) {
     serialization::OblateBody const& extension =
-        message.GetExtension(serialization::OblateBody::oblate_body);
+        message.GetExtension(serialization::OblateBody::extension);
 
     return OblateBody<Frame>::ReadFromMessage(extension,
                                               massive_body_parameters,

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -76,13 +76,13 @@ message LinearMap {
 
 message Identity {
   extend LinearMap {
-    optional Identity identity = 1000;
+    optional Identity extension = 1000;
   }
 }
 
 message OrthogonalMap {
   extend LinearMap {
-    optional OrthogonalMap orthogonal_map = 1001;
+    optional OrthogonalMap extension = 1001;
   }
   required Sign determinant = 1;
   required Rotation rotation = 2;
@@ -90,7 +90,7 @@ message OrthogonalMap {
 
 message Permutation {
   extend LinearMap {
-    optional Permutation permutation = 1002;
+    optional Permutation extension = 1002;
   }
 
   // These enums are used in the definition of the field
@@ -120,7 +120,7 @@ message Permutation {
 
 message Rotation {
   extend LinearMap {
-    optional Rotation rotation = 1003;
+    optional Rotation extension = 1003;
   }
   required Quaternion quaternion = 1;
 }

--- a/serialization/integrators.proto
+++ b/serialization/integrators.proto
@@ -6,7 +6,7 @@ package principia.serialization;
 
 message AdaptiveStepSizeIntegrator {
   extend Integrator {
-    optional AdaptiveStepSizeIntegrator adaptive_step_size_integrator = 3000;
+    optional AdaptiveStepSizeIntegrator extension = 3000;
   }
   enum Kind {
     DORMAND_ELMIKKAWY_PRINCE_1986_RKN_434FM = 1;
@@ -16,7 +16,7 @@ message AdaptiveStepSizeIntegrator {
 
 message FixedStepSizeIntegrator {
   extend Integrator {
-    optional FixedStepSizeIntegrator fixed_step_size_integrator = 3001;
+    optional FixedStepSizeIntegrator extension = 3001;
   }
   enum Kind {
     DUMMY = 0;  // For testing.

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -69,14 +69,14 @@ message MasslessBody {}
 
 message OblateBody {
   extend RotatingBody {
-    optional OblateBody oblate_body = 4000;
+    optional OblateBody extension = 4000;
   }
   required Quantity j2 = 1;
 }
 
 message PreBrouwerOblateBody {
   extend MassiveBody {
-    optional PreBrouwerOblateBody pre_brouwer_oblate_body = 2001;
+    optional PreBrouwerOblateBody extension = 2001;
   }
   required Frame frame = 3;
   required Quantity j2 = 1;
@@ -85,7 +85,7 @@ message PreBrouwerOblateBody {
 
 message RotatingBody {
   extend MassiveBody {
-    optional RotatingBody rotating_body = 2002;
+    optional RotatingBody extension = 2002;
   }
   required Frame frame = 1;
   required Quantity reference_angle = 2;


### PR DESCRIPTION
Fix #779.