### PR TITLE
Draw the Frenet trihedron

### DIFF
--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -94,6 +94,9 @@ NavigationManoeuvre ToNavigationManoeuvre(Plugin const* const plugin,
       manœuvre.FrenetFrame();
   Instant const current_time = plugin->CurrentTime();
   Instant const initial_time = manœuvre.initial_time();
+  // TODO(egg): a separate |Frame| for plotted geometry (for now plotting goes
+  // from |Barycentric| to itself, so it's easily forgotten), an utility for
+  // plotting |Vector|s like the one for |Position|s.
   auto const plotting_frame = plugin->GetPlottingFrame();
   OrthogonalMap<Frenet<Navigation>, World> frenet_to_plotted_world =
       barycentric_to_world *

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -816,6 +816,8 @@ public partial class PrincipiaPluginAdapter
             }
           }
         }
+      } else {
+        DestroyRenderedFlightPlan();
       }
     } else {
       DestroyRenderedTrajectory();

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -892,9 +892,9 @@ public partial class PrincipiaPluginAdapter
       rendered_frenet_trihedra_[3 * i] =
           NewRenderedTrajectory(new UnityEngine.Color(0.84f, 1, 0), 2);
       rendered_frenet_trihedra_[3 * i + 1] =
-          NewRenderedTrajectory(new UnityEngine.Color(0.84f, 0, 0.84f), 2);
-      rendered_frenet_trihedra_[3 * i + 2] =
           NewRenderedTrajectory(new UnityEngine.Color(0, 0.84f, 0.84f), 2);
+      rendered_frenet_trihedra_[3 * i + 2] =
+          NewRenderedTrajectory(new UnityEngine.Color(0.84f, 0, 0.84f), 2);
     }
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -826,7 +826,7 @@ public partial class PrincipiaPluginAdapter
   }
 
   private void RenderAndDeleteTrajectory(ref IntPtr trajectory_iterator,
-                                              VectorLine vector_line) {
+                                         VectorLine vector_line) {
     int new_min_draw_index = 0;
     try {
       XYZSegment segment;
@@ -869,10 +869,8 @@ public partial class PrincipiaPluginAdapter
 
   private void ResetRenderedTrajectory() {
     DestroyRenderedTrajectory();
-    rendered_trajectory_ =
-        NewRenderedTrajectory(XKCDColors.AcidGreen);
-    rendered_prediction_ =
-        NewRenderedTrajectory(XKCDColors.Fuchsia);
+    rendered_trajectory_ = NewRenderedTrajectory(XKCDColors.AcidGreen);
+    rendered_prediction_ = NewRenderedTrajectory(XKCDColors.Fuchsia);
   }
 
   private void ResetRenderedFlightPlan(int segments) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -386,6 +386,7 @@ public partial class PrincipiaPluginAdapter
                      "navball_barycentric.png");
 
     rendered_flight_plan_ = new VectorLine[0];
+    rendered_frenet_trihedra_ = new VectorLine[0];
 
     if (unmodified_orbits_ == null) {
       unmodified_orbits_ = new Dictionary<CelestialBody, Orbit>();
@@ -927,6 +928,10 @@ public partial class PrincipiaPluginAdapter
     for (int i = 0; i < rendered_flight_plan_.Length; ++i) {
       Vector.DestroyLine(ref rendered_flight_plan_[i]);
     }
+    for (int i = 0; i < rendered_frenet_trihedra_.Length; ++i) {
+      Vector.DestroyLine(ref rendered_frenet_trihedra_[i]);
+    }
+    rendered_frenet_trihedra_ = new VectorLine[0];
     rendered_flight_plan_ = new VectorLine[0];
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -799,7 +799,7 @@ public partial class PrincipiaPluginAdapter
             Func<Vector3d, UnityEngine.Vector2> world_to_screen =
                 (world_position) =>
                     MapView.MapCamera.camera.WorldToScreenPoint(
-                          ScaledSpace.LocalToScaledSpace(world_position));
+                        ScaledSpace.LocalToScaledSpace(world_position));
             Action<int, XYZ> set_vector = (arrow_index, world_direction) => {
               VectorLine line =
                   rendered_frenet_trihedra_[3 * manoeuvre_index + arrow_index];
@@ -882,12 +882,9 @@ public partial class PrincipiaPluginAdapter
     }
     rendered_frenet_trihedra_ = new VectorLine[3 * (segments / 2)];
     for (int i = 0; i < segments / 2; ++i) {
-      rendered_frenet_trihedra_[3 * i] =
-          NewUILine(new UnityEngine.Color(0.84f, 1, 0));
-      rendered_frenet_trihedra_[3 * i + 1] =
-          NewUILine(new UnityEngine.Color(0, 0.84f, 0.84f));
-      rendered_frenet_trihedra_[3 * i + 2] =
-          NewUILine(new UnityEngine.Color(0.84f, 0, 0.84f));
+      rendered_frenet_trihedra_[3 * i] = NewUILine(XKCDColors.NeonYellow);
+      rendered_frenet_trihedra_[3 * i + 1] = NewUILine(XKCDColors.AquaBlue);
+      rendered_frenet_trihedra_[3 * i + 2] = NewUILine(XKCDColors.PurplePink);
     }
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -797,19 +797,25 @@ public partial class PrincipiaPluginAdapter
                 (world_position) =>
                     MapView.MapCamera.camera.WorldToScreenPoint(
                           ScaledSpace.LocalToScaledSpace(world_position));
-            for (int j = 0; j < 3; ++j) {
-              rendered_frenet_trihedra_[3 * manoeuvre_index + j].points2[0] =
-                  world_to_screen(first_point_of_segment);
-            }
-            rendered_frenet_trihedra_[3 * manoeuvre_index].points2[1] =
-                world_to_screen(first_point_of_segment +
-                                scale * (Vector3d)manoeuvre.tangent);
-            rendered_frenet_trihedra_[3 * manoeuvre_index + 1].points2[1] =
-                world_to_screen(first_point_of_segment +
-                                scale * (Vector3d)manoeuvre.normal);
-            rendered_frenet_trihedra_[3 * manoeuvre_index + 2].points2[1] =
-                world_to_screen(first_point_of_segment +
-                                scale * (Vector3d)manoeuvre.binormal);
+            Action<int, XYZ> set_arrow = (arrow_index, world_direction) => {
+              VectorLine line =
+                  rendered_frenet_trihedra_[3 * manoeuvre_index + arrow_index];
+              line.points2[0] = world_to_screen(first_point_of_segment);
+              line.points2[1] =
+                  world_to_screen(first_point_of_segment +
+                                  0.9 * scale * (Vector3d)world_direction);
+              line.points2[2] =
+                  world_to_screen(first_point_of_segment +
+                                  0.7 * scale * (Vector3d)world_direction);
+              line.points2[3] =
+                  world_to_screen(first_point_of_segment +
+                                  0.85 * scale * (Vector3d)world_direction);
+              line.points2[4] = world_to_screen(
+                  first_point_of_segment + scale * (Vector3d)world_direction);
+            };
+            set_arrow(0, manoeuvre.tangent);
+            set_arrow(1, manoeuvre.normal);
+            set_arrow(2, manoeuvre.binormal);
             for (int j = 0; j < 3; ++j) {
               Vector.DrawLine(
                   rendered_frenet_trihedra_[3 * manoeuvre_index + j]);
@@ -890,11 +896,11 @@ public partial class PrincipiaPluginAdapter
     rendered_frenet_trihedra_ = new VectorLine[3 * (segments / 2)];
     for (int i = 0; i < segments / 2; ++i) {
       rendered_frenet_trihedra_[3 * i] =
-          NewUILine(new UnityEngine.Color(0.84f, 1, 0));
+          NewUIArrow(new UnityEngine.Color(0.84f, 1, 0));
       rendered_frenet_trihedra_[3 * i + 1] =
-          NewUILine(new UnityEngine.Color(0, 0.84f, 0.84f));
+          NewUIArrow(new UnityEngine.Color(0, 0.84f, 0.84f));
       rendered_frenet_trihedra_[3 * i + 2] =
-          NewUILine(new UnityEngine.Color(0.84f, 0, 0.84f));
+          NewUIArrow(new UnityEngine.Color(0.84f, 0, 0.84f));
     }
   }
 
@@ -913,15 +919,17 @@ public partial class PrincipiaPluginAdapter
     return result;
   }
 
-  private VectorLine NewUILine(UnityEngine.Color colour) {
-    UnityEngine.Vector2[] line_points = new UnityEngine.Vector2[2];
+  private VectorLine NewUIArrow(UnityEngine.Color colour) {
+    UnityEngine.Vector2[] line_points = new UnityEngine.Vector2[5];
     var result = new VectorLine(
-        lineName     : "UILine",
+        lineName     : "UIArrow",
         linePoints   : line_points,
         lineMaterial : MapView.OrbitLinesMaterial,
         color        : colour,
         width        : 5,
-        lineType     : LineType.Discrete);
+        lineType     : LineType.Continuous);
+    Vector.SetWidths(result, new float[]{5, 5, 10, 0});
+    result.smoothWidth = true;
     return result;
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -792,7 +792,7 @@ public partial class PrincipiaPluginAdapter
                                                 manoeuvre_index);
             double scale = (ScaledSpace.ScaledToLocalSpace(
                                 MapView.MapCamera.transform.position) -
-                            first_point_of_segment).magnitude * 0.03;
+                            first_point_of_segment).magnitude * 0.015;
             Func<Vector3d, UnityEngine.Vector2> world_to_screen =
                 (world_position) =>
                     MapView.MapCamera.camera.WorldToScreenPoint(

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -797,25 +797,16 @@ public partial class PrincipiaPluginAdapter
                 (world_position) =>
                     MapView.MapCamera.camera.WorldToScreenPoint(
                           ScaledSpace.LocalToScaledSpace(world_position));
-            Action<int, XYZ> set_arrow = (arrow_index, world_direction) => {
+            Action<int, XYZ> set_vector = (arrow_index, world_direction) => {
               VectorLine line =
                   rendered_frenet_trihedra_[3 * manoeuvre_index + arrow_index];
               line.points2[0] = world_to_screen(first_point_of_segment);
-              line.points2[1] =
-                  world_to_screen(first_point_of_segment +
-                                  0.9 * scale * (Vector3d)world_direction);
-              line.points2[2] =
-                  world_to_screen(first_point_of_segment +
-                                  0.7 * scale * (Vector3d)world_direction);
-              line.points2[3] =
-                  world_to_screen(first_point_of_segment +
-                                  0.85 * scale * (Vector3d)world_direction);
-              line.points2[4] = world_to_screen(
+              line.points2[1] = world_to_screen(
                   first_point_of_segment + scale * (Vector3d)world_direction);
             };
-            set_arrow(0, manoeuvre.tangent);
-            set_arrow(1, manoeuvre.normal);
-            set_arrow(2, manoeuvre.binormal);
+            set_vector(0, manoeuvre.tangent);
+            set_vector(1, manoeuvre.normal);
+            set_vector(2, manoeuvre.binormal);
             for (int j = 0; j < 3; ++j) {
               Vector.DrawLine(
                   rendered_frenet_trihedra_[3 * manoeuvre_index + j]);
@@ -896,11 +887,11 @@ public partial class PrincipiaPluginAdapter
     rendered_frenet_trihedra_ = new VectorLine[3 * (segments / 2)];
     for (int i = 0; i < segments / 2; ++i) {
       rendered_frenet_trihedra_[3 * i] =
-          NewUIArrow(new UnityEngine.Color(0.84f, 1, 0));
+          NewUILine(new UnityEngine.Color(0.84f, 1, 0));
       rendered_frenet_trihedra_[3 * i + 1] =
-          NewUIArrow(new UnityEngine.Color(0, 0.84f, 0.84f));
+          NewUILine(new UnityEngine.Color(0, 0.84f, 0.84f));
       rendered_frenet_trihedra_[3 * i + 2] =
-          NewUIArrow(new UnityEngine.Color(0.84f, 0, 0.84f));
+          NewUILine(new UnityEngine.Color(0.84f, 0, 0.84f));
     }
   }
 
@@ -919,17 +910,15 @@ public partial class PrincipiaPluginAdapter
     return result;
   }
 
-  private VectorLine NewUIArrow(UnityEngine.Color colour) {
-    UnityEngine.Vector2[] line_points = new UnityEngine.Vector2[5];
+  private VectorLine NewUILine(UnityEngine.Color colour) {
+    UnityEngine.Vector2[] line_points = new UnityEngine.Vector2[2];
     var result = new VectorLine(
-        lineName     : "UIArrow",
+        lineName     : "UILine",
         linePoints   : line_points,
         lineMaterial : MapView.OrbitLinesMaterial,
         color        : colour,
         width        : 5,
-        lineType     : LineType.Continuous);
-    Vector.SetWidths(result, new float[]{5, 5, 10, 0});
-    result.smoothWidth = true;
+        lineType     : LineType.Discrete);
     return result;
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -790,27 +790,26 @@ public partial class PrincipiaPluginAdapter
             NavigationManoeuvre manoeuvre = plugin_.FlightPlanGetManoeuvre(
                                                 active_vessel_guid,
                                                 manoeuvre_index);
-            Vector3d scaled_point =
-                ScaledSpace.LocalToScaledSpace(first_point_of_segment);
             double scale = (ScaledSpace.ScaledToLocalSpace(
                                 MapView.MapCamera.transform.position) -
-                            first_point_of_segment).magnitude * 0.1;
+                            first_point_of_segment).magnitude * 0.03;
+            Func<Vector3d, UnityEngine.Vector2> world_to_screen =
+                (world_position) =>
+                    MapView.MapCamera.camera.WorldToScreenPoint(
+                          ScaledSpace.LocalToScaledSpace(world_position));
             for (int j = 0; j < 3; ++j) {
-              rendered_frenet_trihedra_[3 * manoeuvre_index + j].points3[0] =
-                  scaled_point;
+              rendered_frenet_trihedra_[3 * manoeuvre_index + j].points2[0] =
+                  world_to_screen(first_point_of_segment);
             }
-            rendered_frenet_trihedra_[3 * manoeuvre_index].points3[1] =
-                ScaledSpace.LocalToScaledSpace(
-                    first_point_of_segment +
-                    scale * (Vector3d)manoeuvre.tangent);
-            rendered_frenet_trihedra_[3 * manoeuvre_index + 1].points3[1] =
-                ScaledSpace.LocalToScaledSpace(
-                    first_point_of_segment +
-                    scale * (Vector3d)manoeuvre.normal);
-            rendered_frenet_trihedra_[3 * manoeuvre_index + 2].points3[1] =
-                ScaledSpace.LocalToScaledSpace(
-                    first_point_of_segment +
-                    scale * (Vector3d)manoeuvre.binormal);
+            rendered_frenet_trihedra_[3 * manoeuvre_index].points2[1] =
+                world_to_screen(first_point_of_segment +
+                                scale * (Vector3d)manoeuvre.tangent);
+            rendered_frenet_trihedra_[3 * manoeuvre_index + 1].points2[1] =
+                world_to_screen(first_point_of_segment +
+                                scale * (Vector3d)manoeuvre.normal);
+            rendered_frenet_trihedra_[3 * manoeuvre_index + 2].points2[1] =
+                world_to_screen(first_point_of_segment +
+                                scale * (Vector3d)manoeuvre.binormal);
             for (int j = 0; j < 3; ++j) {
               Vector.DrawLine(
                   rendered_frenet_trihedra_[3 * manoeuvre_index + j]);
@@ -874,9 +873,9 @@ public partial class PrincipiaPluginAdapter
   private void ResetRenderedTrajectory() {
     DestroyRenderedTrajectory();
     rendered_trajectory_ =
-        NewRenderedTrajectory(XKCDColors.AcidGreen, kMaxVectorLinePoints);
+        NewRenderedTrajectory(XKCDColors.AcidGreen);
     rendered_prediction_ =
-        NewRenderedTrajectory(XKCDColors.Fuchsia, kMaxVectorLinePoints);
+        NewRenderedTrajectory(XKCDColors.Fuchsia);
   }
 
   private void ResetRenderedFlightPlan(int segments) {
@@ -884,26 +883,23 @@ public partial class PrincipiaPluginAdapter
     rendered_flight_plan_ = new VectorLine[segments];
     for (int i = 0; i < segments; ++i) {
       rendered_flight_plan_[i] = NewRenderedTrajectory(
-          (i % 2 == 0) ? XKCDColors.RoyalBlue : XKCDColors.OrangeRed,
-          kMaxVectorLinePoints);
+          (i % 2 == 0) ? XKCDColors.RoyalBlue : XKCDColors.OrangeRed);
     }
     rendered_frenet_trihedra_ = new VectorLine[3 * (segments / 2)];
     for (int i = 0; i < segments / 2; ++i) {
       rendered_frenet_trihedra_[3 * i] =
-          NewRenderedTrajectory(new UnityEngine.Color(0.84f, 1, 0), 2);
+          NewUILine(new UnityEngine.Color(0.84f, 1, 0));
       rendered_frenet_trihedra_[3 * i + 1] =
-          NewRenderedTrajectory(new UnityEngine.Color(0, 0.84f, 0.84f), 2);
+          NewUILine(new UnityEngine.Color(0, 0.84f, 0.84f));
       rendered_frenet_trihedra_[3 * i + 2] =
-          NewRenderedTrajectory(new UnityEngine.Color(0.84f, 0, 0.84f), 2);
+          NewUILine(new UnityEngine.Color(0.84f, 0, 0.84f));
     }
   }
 
-  private VectorLine NewRenderedTrajectory(UnityEngine.Color colour,
-                                           int points) {
-    UnityEngine.Vector3[] line_points = new UnityEngine.Vector3[points];
+  private VectorLine NewRenderedTrajectory(UnityEngine.Color colour) {
     var result = new VectorLine(
-        lineName     : "rendered_prediction_",
-        linePoints   : line_points,
+        lineName     : "RenderedTrajectory",
+        linePoints   : new UnityEngine.Vector3[kMaxVectorLinePoints],
         lineMaterial : MapView.OrbitLinesMaterial,
         color        : colour,
         width        : 5,
@@ -912,6 +908,18 @@ public partial class PrincipiaPluginAdapter
     result.vectorObject.renderer.castShadows = false;
     result.vectorObject.renderer.receiveShadows = false;
     result.layer = 31;
+    return result;
+  }
+
+  private VectorLine NewUILine(UnityEngine.Color colour) {
+    UnityEngine.Vector2[] line_points = new UnityEngine.Vector2[2];
+    var result = new VectorLine(
+        lineName     : "UILine",
+        linePoints   : line_points,
+        lineMaterial : MapView.OrbitLinesMaterial,
+        color        : colour,
+        width        : 5,
+        lineType     : LineType.Discrete);
     return result;
   }
 


### PR DESCRIPTION
There was a bug in the plotting of the Frenet trihedron in a rotating frame that suggests we may want to distinguish `World` and `PlottedWorld` somehow, since the plotting operation, namely from `Barycentric` to `Navigation` (`plotting_frame`) at actual time and then from `Navigation` (`plotting_frame`) to `Barycentric` at current time, does not change the type.