### PR TITLE
Linux test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ TEST_INCLUDES := -I$(DEP_DIR)/googlemock/include -I$(DEP_DIR)/googletest/include
 INCLUDES := -I. -I$(DEP_DIR)/glog/src -I$(DEP_DIR)/protobuf/src -I$(DEP_DIR)/benchmark/include -I$(DEP_DIR)/Optional $(TEST_INCLUDES)
 SHARED_ARGS := -std=c++14 -stdlib=libc++ -O3 -g -fPIC -fexceptions -ferror-limit=0 -fno-omit-frame-pointer -Wall -Wpedantic \
 	-DPROJECT_DIR='std::experimental::filesystem::path("$(PROJECT_DIR)")'\
-	-DSOLUTION_DIR='std::experimental::filesystem::path("$(SOLUTION_DIR)")'
+	-DSOLUTION_DIR='std::experimental::filesystem::path("$(SOLUTION_DIR)")' \
+	-DNDEBUG
 
 # detect OS
 UNAME_S := $(shell uname -s)
@@ -111,6 +112,7 @@ plugin: $(ADAPTER) $(LIB)
 ##### TESTS #####
 run_tests: tests
 	@echo "Cake, and grief counseling, will be available at the conclusion of the test."
+	-astronomy/test
 	-base/test
 	-geometry/test
 	-integrators/test

--- a/physics/hierarchical_system_test.cpp
+++ b/physics/hierarchical_system_test.cpp
@@ -123,9 +123,9 @@ TEST_F(HierarchicalSystemTest, FromMeanMotions) {
                    return (dof.position() - Frame::origin).coordinates().x;
                  });
   EXPECT_THAT(x_positions,
-              ElementsAre(-1 * Metre,
-                          VanishesBefore(1 * Metre, 1),
-                          1 * Metre));
+              ElementsAre(AlmostEquals(-1 * Metre, 0, 1),
+                          VanishesBefore(1 * Metre, 0, 1),
+                          AlmostEquals(1 * Metre, 0, 1)));
 }
 
 }  // namespace physics

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -97,7 +97,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
   elements.mean_motion = 1.511718576836574E-04 * (Degree / Second);
   KeplerOrbit<ICRFJ2000Equator> moon_orbit_n(*earth, *moon, elements, date);
   EXPECT_THAT(moon_orbit_n.StateVectors(date).displacement(),
-              AlmostEquals(expected_displacement, 15));
+              AlmostEquals(expected_displacement, 13, 15));
   EXPECT_THAT(moon_orbit_n.StateVectors(date).velocity(),
               AlmostEquals(expected_velocity, 12));
 


### PR DESCRIPTION
Fix #855.
In particular, define `NDEBUG`; this might improve performance.