### PR TITLE
fix aclocal issues

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -40,6 +40,8 @@ popd
 
 git clone "https://github.com/mockingbirdnest/glog"
 pushd glog
+aclocal
+automake
 ./configure CC=clang CXX=clang++ CFLAGS="$C_FLAGS" CXXFLAGS="$CXX_FLAGS" LDFLAGS="$LD_FLAGS" LIBS="-lc++ -lc++abi"
 make -j8
 popd


### PR DESCRIPTION
make sure aclocal.m4 api version matches up with local version of autotools (there may be a better way to do this)