### PR TITLE
Various usability fixes

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -233,7 +233,7 @@ class FlightPlanner : WindowRenderer {
         show_guidance_ =
             UnityEngine.GUILayout.Toggle(show_guidance_, "Show on navball");
         if (UnityEngine.GUILayout.Button("Warp to manœuvre")) {
-          TimeWarp.fetch.WarpTo(manoeuvre.burn.initial_time - 30);
+          TimeWarp.fetch.WarpTo(manoeuvre.burn.initial_time - 60);
         }
         UnityEngine.GUILayout.EndHorizontal();
         if (show_guidance_ &&

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -229,8 +229,13 @@ class FlightPlanner : WindowRenderer {
               "Cutoff " + FormatTimeSpan(TimeSpan.FromSeconds(
                               current_time - manoeuvre.final_time)));
         }
+        UnityEngine.GUILayout.BeginHorizontal();
         show_guidance_ =
             UnityEngine.GUILayout.Toggle(show_guidance_, "Show on navball");
+        if (UnityEngine.GUILayout.Button("Warp to manœuvre")) {
+          TimeWarp.fetch.WarpTo(manoeuvre.burn.initial_time - 30);
+        }
+        UnityEngine.GUILayout.EndHorizontal();
         if (show_guidance_ &&
             !double.IsNaN(manoeuvre.inertial_direction.x +
                           manoeuvre.inertial_direction.y +

--- a/ksp_plugin_adapter/gl_lines.cs
+++ b/ksp_plugin_adapter/gl_lines.cs
@@ -113,7 +113,7 @@ internal static class GLLines {
             colour.a = (float)(4 * i + size) / (float)(5 * size);
             UnityEngine.GL.Color(colour);
           }
-          if (style != Style.DASHED || i % 2 == 0) {
+          if (style != Style.DASHED || i % 2 == 1) {
             AddSegment(previous_point.Value,
                        current_point,
                        hide_behind_bodies : true);

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -780,6 +780,7 @@ public partial class PrincipiaPluginAdapter
                                              sun_world_position),
             XKCDColors.AcidGreen,
             GLLines.Style.FADED);
+        RenderPredictionApsides(active_vessel_guid, sun_world_position);
         GLLines.RenderAndDeleteTrajectory(
             plugin_.RenderedPrediction(active_vessel_guid, sun_world_position),
             XKCDColors.Fuchsia,
@@ -796,7 +797,7 @@ public partial class PrincipiaPluginAdapter
                                                   sun_world_position,
                                                   i),
                 is_burn ? XKCDColors.OrangeRed : XKCDColors.BabyBlue,
-                GLLines.Style.DASHED);
+                is_burn ? GLLines.Style.SOLID : GLLines.Style.DASHED);
             if (is_burn) {
               Vector3d position_at_ignition =
                   (Vector3d)plugin_.FlightPlanRenderedSegmentEndpoints(
@@ -831,6 +832,28 @@ public partial class PrincipiaPluginAdapter
     }
   }
 
+  private void RenderPredictionApsides(String vessel_guid,
+                                       XYZ sun_world_position) {
+    foreach (CelestialBody celestial in
+             plotting_frame_selector_.get().FixedBodies()) {
+      IntPtr apoapsis_iterator;
+      IntPtr periapsis_iterator;
+      plugin_.RenderedPredictionApsides(vessel_guid,
+                                        celestial.flightGlobalsIndex,
+                                        sun_world_position,
+                                        out apoapsis_iterator,
+                                        out periapsis_iterator);
+      map_node_pool_.RenderAndDeleteApsides(apoapsis_iterator,
+                                            celestial,
+                                            MapObject.ObjectType.Apoapsis,
+                                            MapNodePool.NodeSource.PREDICTION);
+      map_node_pool_.RenderAndDeleteApsides(periapsis_iterator,
+                                            celestial,
+                                            MapObject.ObjectType.Periapsis,
+                                            MapNodePool.NodeSource.PREDICTION);
+    }
+  }
+
   private void RenderFlightPlanApsides(String vessel_guid,
                                        XYZ sun_world_position) {
     foreach (CelestialBody celestial in
@@ -844,10 +867,12 @@ public partial class PrincipiaPluginAdapter
                                         out periapsis_iterator);
       map_node_pool_.RenderAndDeleteApsides(apoapsis_iterator,
                                             celestial,
-                                            MapObject.ObjectType.Apoapsis);
+                                            MapObject.ObjectType.Apoapsis,
+                                            MapNodePool.NodeSource.FLIGHT_PLAN);
       map_node_pool_.RenderAndDeleteApsides(periapsis_iterator,
                                             celestial,
-                                            MapObject.ObjectType.Periapsis);
+                                            MapObject.ObjectType.Periapsis,
+                                            MapNodePool.NodeSource.FLIGHT_PLAN);
     }
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -589,26 +589,12 @@ public partial class PrincipiaPluginAdapter
           Vector3d normal =
               (Vector3d)plugin_.VesselBinormal(active_vessel.id.ToString());
 
-          double ball_radius =
-              navball_.progradeVector.transform.localPosition.magnitude;
-
-          // TODO(egg): deal with the transparency and disappearance of the
-          // markers too, not just their position.
-          navball_.progradeVector.transform.localPosition =
-              (UnityEngine.QuaternionD)navball_.attitudeGymbal *
-                  prograde * ball_radius;
-          navball_.radialInVector.transform.localPosition =
-              (UnityEngine.QuaternionD)navball_.attitudeGymbal *
-                  radial * ball_radius;
-          navball_.normalVector.transform.localPosition =
-              (UnityEngine.QuaternionD)navball_.attitudeGymbal *
-                  normal * ball_radius;
-          navball_.retrogradeVector.transform.localPosition =
-              -navball_.progradeVector.transform.localPosition;
-          navball_.radialOutVector.transform.localPosition =
-              -navball_.radialInVector.transform.localPosition;
-          navball_.antiNormalVector.transform.localPosition =
-              -navball_.normalVector.transform.localPosition;
+          SetNavballVector(navball_.progradeVector, prograde);
+          SetNavballVector(navball_.radialInVector, radial);
+          SetNavballVector(navball_.normalVector, normal);
+          SetNavballVector(navball_.retrogradeVector, -prograde);
+          SetNavballVector(navball_.radialOutVector, -radial);
+          SetNavballVector(navball_.antiNormalVector, -normal);
           // Make the autopilot target our Frenet trihedron.
           if (active_vessel.OnAutopilotUpdate.GetInvocationList()[0] !=
               (Delegate)(FlightInputCallback)OverrideRSASTarget) {
@@ -720,6 +706,19 @@ public partial class PrincipiaPluginAdapter
   }
 
   #endregion
+
+  private void SetNavballVector(UnityEngine.Transform vector,
+                                Vector3d direction) {
+     vector.localPosition = (UnityEngine.QuaternionD)navball_.attitudeGymbal *
+                            direction * navball_.VectorUnitScale;
+     vector.gameObject.SetActive(vector.localPosition.z >
+                                 navball_.VectorUnitCutoff);
+     vector.GetComponent<UnityEngine.MeshRenderer>().materials[0].SetFloat(
+         "_Opacity",
+         UnityEngine.Mathf.Clamp01(UnityEngine.Vector3.Dot(
+             vector.localPosition.normalized,
+             UnityEngine.Vector3.forward)));
+  }
 
   private void RemoveStockTrajectoriesIfNeeded(Vessel vessel) {
     vessel.patchedConicRenderer.relativityMode =

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -8,6 +8,11 @@ namespace ksp_plugin_adapter {
 
 internal class MapNodePool {
 
+  public enum NodeSource {
+    PREDICTION,
+    FLIGHT_PLAN,
+  }
+
   public MapNodePool() {
     nodes_ = new List<KSP.UI.Screens.Mapview.MapNode>();
     properties_ =
@@ -38,7 +43,8 @@ internal class MapNodePool {
 
   public void RenderAndDeleteApsides(IntPtr apsis_iterator,
                                      CelestialBody celestial,
-                                     MapObject.ObjectType type) {
+                                     MapObject.ObjectType type,
+                                     NodeSource source) {
     for (; !apsis_iterator.IteratorAtEnd();
          apsis_iterator.IteratorIncrement()) {
       Vector3d apsis = (Vector3d)apsis_iterator.IteratorGetXYZ();
@@ -46,6 +52,7 @@ internal class MapNodePool {
       node_properties.object_type = type;
       node_properties.celestial = celestial;
       node_properties.world_position = apsis;
+      node_properties.source = source;
 
       if (pool_index_ == nodes_.Count) {
         UnityEngine.Debug.LogWarning("Adding node to pool");
@@ -114,6 +121,17 @@ internal class MapNodePool {
               properties_[node].celestial.name + " Impact<color=" +
               XKCDColors.HexFormat.Chartreuse + "></color>";
           }
+          switch (properties_[node].source) {
+            case NodeSource.FLIGHT_PLAN:
+              caption.Header = "Planned " + caption.Header;
+              break;
+            case NodeSource.PREDICTION:
+              caption.Header = "Predicted " + caption.Header;
+              break;
+            default:
+              throw Log.Fatal("Unexpected node source " +
+                              properties_[node].source);
+          }
         };
     new_node.OnUpdatePosition +=
         (KSP.UI.Screens.Mapview.MapNode node) =>
@@ -126,6 +144,7 @@ internal class MapNodePool {
     public MapObject.ObjectType object_type;
     public Vector3d world_position;
     public CelestialBody celestial;
+    public NodeSource source;
   }
 
   private List<KSP.UI.Screens.Mapview.MapNode> nodes_;


### PR DESCRIPTION
* Apsides for the prediction (I'm not sure whether we want to keep using the colour of the celestial, we'll see how things turn out in practice).
* "Warp to manœuvre" button, warps with 1 min overhead.
* Solid line for the planned burns (they're quite short, the dashing is a bit silly there).
* Change the parity of the dashing so that burns start at the marker and end at a colour change.
* Qualify the apsides so one can tell whether they're from the prediction or the flight plan.
* Prevent the navball markers from disappearing or fading when they're right in the middle.