### PR TITLE
Factor fictitious accelerations

### DIFF
--- a/physics/barycentric_rotating_dynamic_frame.hpp
+++ b/physics/barycentric_rotating_dynamic_frame.hpp
@@ -54,10 +54,10 @@ class BarycentricRotatingDynamicFrame
           serialization::BarycentricRotatingDynamicFrame const& message);
 
  private:
-  virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
+  Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,
       Position<InertialFrame> const& q) const override;
-  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+  SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
       Instant const& t) const override;
 
   // Fills |*rotation| with the rotation that maps the basis of |InertialFrame|

--- a/physics/barycentric_rotating_dynamic_frame.hpp
+++ b/physics/barycentric_rotating_dynamic_frame.hpp
@@ -28,6 +28,7 @@ namespace internal_barycentric_rotating_dynamic_frame {
 using base::not_null;
 using geometry::AngularVelocity;
 using geometry::Instant;
+using geometry::Position;
 using geometry::Rotation;
 using geometry::Vector;
 using quantities::Acceleration;
@@ -43,11 +44,6 @@ class BarycentricRotatingDynamicFrame
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
-  RigidMotion<ThisFrame, InertialFrame> FromThisFrameAtTime(
-      Instant const& t) const override;
-  Vector<Acceleration, ThisFrame> GeometricAcceleration(
-      Instant const& t,
-      DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const override;
 
   void WriteToMessage(
       not_null<serialization::DynamicFrame*> const message) const override;
@@ -58,6 +54,12 @@ class BarycentricRotatingDynamicFrame
           serialization::BarycentricRotatingDynamicFrame const& message);
 
  private:
+  virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
+      Instant const& t,
+      Position<InertialFrame> const& q) const override;
+  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+      Instant const& t) const override;
+
   // Fills |*rotation| with the rotation that maps the basis of |InertialFrame|
   // to the basis of |ThisFrame|.  Fills |*angular_frequency| with the
   // corresponding angular velocity.

--- a/physics/barycentric_rotating_dynamic_frame.hpp
+++ b/physics/barycentric_rotating_dynamic_frame.hpp
@@ -57,7 +57,7 @@ class BarycentricRotatingDynamicFrame
   Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,
       Position<InertialFrame> const& q) const override;
-  SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+  AcceleratedRigidMotion<InertialFrame, ThisFrame> MotionOfThisFrame(
       Instant const& t) const override;
 
   // Fills |*rotation| with the rotation that maps the basis of |InertialFrame|

--- a/physics/body_centered_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centered_non_rotating_dynamic_frame.hpp
@@ -50,10 +50,10 @@ class BodyCentredNonRotatingDynamicFrame
           serialization::BodyCentredNonRotatingDynamicFrame const& message);
 
  private:
-  virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
+  Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,
       Position<InertialFrame> const& q) const override;
-  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+  SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
       Instant const& t) const override;
 
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;

--- a/physics/body_centered_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centered_non_rotating_dynamic_frame.hpp
@@ -53,7 +53,7 @@ class BodyCentredNonRotatingDynamicFrame
   Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,
       Position<InertialFrame> const& q) const override;
-  SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+  AcceleratedRigidMotion<InertialFrame, ThisFrame> MotionOfThisFrame(
       Instant const& t) const override;
 
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;

--- a/physics/body_centered_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centered_non_rotating_dynamic_frame.hpp
@@ -26,6 +26,7 @@ namespace internal_body_centred_non_rotating_dynamic_frame {
 
 using base::not_null;
 using geometry::Instant;
+using geometry::Position;
 using geometry::Vector;
 using quantities::Acceleration;
 
@@ -39,11 +40,6 @@ class BodyCentredNonRotatingDynamicFrame
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
-  RigidMotion<ThisFrame, InertialFrame> FromThisFrameAtTime(
-      Instant const& t) const override;
-  Vector<Acceleration, ThisFrame> GeometricAcceleration(
-      Instant const& t,
-      DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const override;
 
   void WriteToMessage(
       not_null<serialization::DynamicFrame*> const message) const override;
@@ -54,6 +50,12 @@ class BodyCentredNonRotatingDynamicFrame
           serialization::BodyCentredNonRotatingDynamicFrame const& message);
 
  private:
+  virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
+      Instant const& t,
+      Position<InertialFrame> const& q) const override;
+  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+      Instant const& t) const override;
+
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;
   not_null<MassiveBody const*> const centre_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const centre_trajectory_;

--- a/physics/body_centered_non_rotating_dynamic_frame_body.hpp
+++ b/physics/body_centered_non_rotating_dynamic_frame_body.hpp
@@ -38,37 +38,6 @@ BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
 }
 
 template<typename InertialFrame, typename ThisFrame>
-RigidMotion<ThisFrame, InertialFrame>
-BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
-FromThisFrameAtTime(Instant const& t) const {
-  return ToThisFrameAtTime(t).Inverse();
-}
-
-template<typename InertialFrame, typename ThisFrame>
-Vector<Acceleration, ThisFrame>
-BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
-GeometricAcceleration(
-    Instant const& t,
-    DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const {
-  auto const to_this_frame = ToThisFrameAtTime(t);
-  auto const from_this_frame = to_this_frame.Inverse();
-
-  Vector<Acceleration, ThisFrame> const gravitational_acceleration_at_point =
-      to_this_frame.orthogonal_map()(
-          ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(
-              from_this_frame.rigid_transformation()(
-                  degrees_of_freedom.position()), t));
-  Vector<Acceleration, ThisFrame> const linear_acceleration =
-      to_this_frame.orthogonal_map()(
-          -ephemeris_->ComputeGravitationalAccelerationOnMassiveBody(
-              centre_, t));
-
-  Vector<Acceleration, ThisFrame> const& fictitious_acceleration =
-      linear_acceleration;
-  return gravitational_acceleration_at_point + fictitious_acceleration;
-}
-
-template<typename InertialFrame, typename ThisFrame>
 void BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
 WriteToMessage(not_null<serialization::DynamicFrame*> const message) const {
   message->MutableExtension(
@@ -86,6 +55,25 @@ BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::ReadFromMessage(
   return std::make_unique<BodyCentredNonRotatingDynamicFrame>(
              ephemeris,
              ephemeris->body_for_serialization_index(message.centre()));
+}
+
+template<typename InertialFrame, typename ThisFrame>
+Vector<Acceleration, InertialFrame>
+BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
+    GravitationalAcceleration(Instant const& t,
+                              Position<InertialFrame> const& q) const {
+  return ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(q, t);
+}
+
+template<typename InertialFrame, typename ThisFrame>
+SecondOrderRigidMotion<InertialFrame, ThisFrame>
+BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::Motion(
+    Instant const& t) const {
+  return SecondOrderRigidMotion<InertialFrame, ThisFrame>(
+             ToThisFrameAtTime(t),
+             /*angular_acceleration_of_to_frame=*/{},
+             /*acceleration_of_to_frame_origin=*/ephemeris_->
+                 ComputeGravitationalAccelerationOnMassiveBody(centre_, t));
 }
 
 }  // namespace internal_body_centred_non_rotating_dynamic_frame

--- a/physics/body_centered_non_rotating_dynamic_frame_body.hpp
+++ b/physics/body_centered_non_rotating_dynamic_frame_body.hpp
@@ -66,10 +66,10 @@ BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
 }
 
 template<typename InertialFrame, typename ThisFrame>
-SecondOrderRigidMotion<InertialFrame, ThisFrame>
-BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::Motion(
+AcceleratedRigidMotion<InertialFrame, ThisFrame>
+BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::MotionOfThisFrame(
     Instant const& t) const {
-  return SecondOrderRigidMotion<InertialFrame, ThisFrame>(
+  return AcceleratedRigidMotion<InertialFrame, ThisFrame>(
              ToThisFrameAtTime(t),
              /*angular_acceleration_of_to_frame=*/{},
              /*acceleration_of_to_frame_origin=*/ephemeris_->

--- a/physics/dynamic_frame.hpp
+++ b/physics/dynamic_frame.hpp
@@ -33,8 +33,12 @@ class DynamicFrame {
 
  public:
   virtual ~DynamicFrame() = default;
+
+  // At least one of |ToThisFrameAtTime| and |FromThisFrameAtTime| must be
+  // overriden in derived classes; the default implementation inverts the other
+  // one.
   virtual RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
-      Instant const& t) const = 0;
+      Instant const& t) const;
   virtual RigidMotion<ThisFrame, InertialFrame> FromThisFrameAtTime(
       Instant const& t) const;
 
@@ -64,7 +68,7 @@ class DynamicFrame {
   virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,
       Position<InertialFrame> const& q) const = 0;
-  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+  virtual AcceleratedRigidMotion<InertialFrame, ThisFrame> MotionOfThisFrame(
       Instant const& t) const = 0;
 };
 

--- a/physics/dynamic_frame.hpp
+++ b/physics/dynamic_frame.hpp
@@ -13,6 +13,7 @@ namespace principia {
 namespace physics {
 namespace internal_dynamic_frame {
 
+using geometry::Position;
 using geometry::Rotation;
 using geometry::Vector;
 using quantities::Acceleration;
@@ -35,14 +36,14 @@ class DynamicFrame {
   virtual RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const = 0;
   virtual RigidMotion<ThisFrame, InertialFrame> FromThisFrameAtTime(
-      Instant const& t) const = 0;
+      Instant const& t) const;
 
   // The acceleration due to the non-inertial motion of |ThisFrame| and gravity.
   // A particle in free fall follows a trajectory whose second derivative
   // is |GeometricAcceleration|.
   virtual Vector<Acceleration, ThisFrame> GeometricAcceleration(
       Instant const& t,
-      DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const = 0;
+      DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const;
 
   // The definition of the Frenet frame of a free fall trajectory in |ThisFrame|
   // with the given |degrees_of_freedom| at instant |t|.
@@ -58,6 +59,13 @@ class DynamicFrame {
   static std::unique_ptr<DynamicFrame>
       ReadFromMessage(not_null<Ephemeris<InertialFrame> const*> const ephemeris,
                       serialization::DynamicFrame const& message);
+
+ private:
+  virtual Vector<Acceleration, InertialFrame> GravitationalAcceleration(
+      Instant const& t,
+      Position<InertialFrame> const& q) const = 0;
+  virtual SecondOrderRigidMotion<InertialFrame, ThisFrame> Motion(
+      Instant const& t) const = 0;
 };
 
 }  // namespace internal_dynamic_frame

--- a/physics/dynamic_frame_body.hpp
+++ b/physics/dynamic_frame_body.hpp
@@ -42,8 +42,9 @@ Vector<Acceleration, ThisFrame>
 DynamicFrame<InertialFrame, ThisFrame>::GeometricAcceleration(
     Instant const& t,
     DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const {
-  AcceleratedRigidMotion<InertialFrame, ThisFrame> const motion = MotionOfThisFrame(t);
-  RigidMotion<InertialFrame, ThisFrame> const to_this_frame =
+  AcceleratedRigidMotion<InertialFrame, ThisFrame> const motion =
+      MotionOfThisFrame(t);
+  RigidMotion<InertialFrame, ThisFrame> const& to_this_frame =
       motion.rigid_motion();
   RigidMotion<ThisFrame, InertialFrame> const from_this_frame =
       to_this_frame.Inverse();

--- a/physics/dynamic_frame_body.hpp
+++ b/physics/dynamic_frame_body.hpp
@@ -41,27 +41,20 @@ DynamicFrame<InertialFrame, ThisFrame>::GeometricAcceleration(
 
   // Beware, we want the angular velocity of ThisFrame as seen in the
   // InertialFrame, but pushed to ThisFrame.  Otherwise the sign is wrong.
-  AngularVelocity<InertialFrame> const Ω_inertial =
-      to_this_frame.angular_velocity_of_to_frame();
-  AngularVelocity<ThisFrame> const Ω =
-      to_this_frame.orthogonal_map()(Ω_inertial);
-
-  Variation<AngularVelocity<InertialFrame>> const dΩ_over_dt_inertial =
-      motion.angular_acceleration_of_to_frame();
+  AngularVelocity<ThisFrame> const Ω = to_this_frame.orthogonal_map()(
+      to_this_frame.angular_velocity_of_to_frame());
   Variation<AngularVelocity<ThisFrame>> const dΩ_over_dt =
-      to_this_frame.orthogonal_map()(dΩ_over_dt_inertial);
+      to_this_frame.orthogonal_map()(motion.angular_acceleration_of_to_frame());
+  Displacement<ThisFrame> const r =
+      degrees_of_freedom.position() - ThisFrame::origin;
 
   Vector<Acceleration, ThisFrame> const gravitational_acceleration_at_point =
       to_this_frame.orthogonal_map()(
           GravitationalAcceleration(t,
                                     from_this_frame.rigid_transformation()(
                                         degrees_of_freedom.position())));
-
   Vector<Acceleration, ThisFrame> const linear_acceleration =
       -to_this_frame.orthogonal_map()(motion.acceleration_of_to_frame_origin());
-
-  Displacement<ThisFrame> const r =
-      degrees_of_freedom.position() - ThisFrame::origin;
   Vector<Acceleration, ThisFrame> const coriolis_acceleration_at_point =
       -2 * Ω * degrees_of_freedom.velocity() / Radian;
   Vector<Acceleration, ThisFrame> const centrifugal_acceleration_at_point =

--- a/physics/dynamic_frame_body.hpp
+++ b/physics/dynamic_frame_body.hpp
@@ -11,13 +11,71 @@ namespace principia {
 namespace physics {
 namespace internal_dynamic_frame {
 
+using geometry::AngularVelocity;
 using geometry::Bivector;
+using geometry::Displacement;
 using geometry::InnerProduct;
 using geometry::Normalize;
 using geometry::R3x3Matrix;
 using geometry::Velocity;
 using geometry::Wedge;
+using quantities::Pow;
 using quantities::Sqrt;
+using quantities::si::Radian;
+
+template<typename InertialFrame, typename ThisFrame>
+RigidMotion<ThisFrame, InertialFrame>
+DynamicFrame<InertialFrame, ThisFrame>::FromThisFrameAtTime(
+    Instant const& t) const {
+  return ToThisFrameAtTime(t).Inverse();
+}
+
+template<typename InertialFrame, typename ThisFrame>
+Vector<Acceleration, ThisFrame>
+DynamicFrame<InertialFrame, ThisFrame>::GeometricAcceleration(
+    Instant const& t,
+    DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const {
+  auto const motion = Motion(t);
+  auto const to_this_frame = motion.first_order_motion();
+  auto const from_this_frame = to_this_frame.Inverse();
+
+  // Beware, we want the angular velocity of ThisFrame as seen in the
+  // InertialFrame, but pushed to ThisFrame.  Otherwise the sign is wrong.
+  AngularVelocity<InertialFrame> const Ω_inertial =
+      to_this_frame.angular_velocity_of_to_frame();
+  AngularVelocity<ThisFrame> const Ω =
+      to_this_frame.orthogonal_map()(Ω_inertial);
+
+  Variation<AngularVelocity<InertialFrame>> const dΩ_over_dt_inertial =
+      motion.angular_acceleration_of_to_frame();
+  Variation<AngularVelocity<ThisFrame>> const dΩ_over_dt =
+      to_this_frame.orthogonal_map()(dΩ_over_dt_inertial);
+
+  Vector<Acceleration, ThisFrame> const gravitational_acceleration_at_point =
+      to_this_frame.orthogonal_map()(
+          GravitationalAcceleration(t,
+                                    from_this_frame.rigid_transformation()(
+                                        degrees_of_freedom.position())));
+
+  Vector<Acceleration, ThisFrame> const linear_acceleration =
+      -to_this_frame.orthogonal_map()(motion.acceleration_of_to_frame_origin());
+
+  Displacement<ThisFrame> const r =
+      degrees_of_freedom.position() - ThisFrame::origin;
+  Vector<Acceleration, ThisFrame> const coriolis_acceleration_at_point =
+      -2 * Ω * degrees_of_freedom.velocity() / Radian;
+  Vector<Acceleration, ThisFrame> const centrifugal_acceleration_at_point =
+      -Ω * (Ω * r) / Pow<2>(Radian);
+  Vector<Acceleration, ThisFrame> const euler_acceleration_at_point =
+      -dΩ_over_dt * r / Radian;
+
+  Vector<Acceleration, ThisFrame> const fictitious_acceleration =
+      linear_acceleration +
+      coriolis_acceleration_at_point +
+      centrifugal_acceleration_at_point +
+      euler_acceleration_at_point;
+  return gravitational_acceleration_at_point + fictitious_acceleration;
+}
 
 template<typename InertialFrame, typename ThisFrame>
 Rotation<Frenet<ThisFrame>, ThisFrame>

--- a/physics/dynamic_frame_body.hpp
+++ b/physics/dynamic_frame_body.hpp
@@ -24,6 +24,13 @@ using quantities::Sqrt;
 using quantities::si::Radian;
 
 template<typename InertialFrame, typename ThisFrame>
+RigidMotion<InertialFrame, ThisFrame>
+DynamicFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
+    Instant const& t) const {
+  return FromThisFrameAtTime(t).Inverse();
+}
+
+template<typename InertialFrame, typename ThisFrame>
 RigidMotion<ThisFrame, InertialFrame>
 DynamicFrame<InertialFrame, ThisFrame>::FromThisFrameAtTime(
     Instant const& t) const {
@@ -35,9 +42,11 @@ Vector<Acceleration, ThisFrame>
 DynamicFrame<InertialFrame, ThisFrame>::GeometricAcceleration(
     Instant const& t,
     DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const {
-  auto const motion = Motion(t);
-  auto const to_this_frame = motion.first_order_motion();
-  auto const from_this_frame = to_this_frame.Inverse();
+  AcceleratedRigidMotion<InertialFrame, ThisFrame> const motion = MotionOfThisFrame(t);
+  RigidMotion<InertialFrame, ThisFrame> const to_this_frame =
+      motion.rigid_motion();
+  RigidMotion<ThisFrame, InertialFrame> const from_this_frame =
+      to_this_frame.Inverse();
 
   // Beware, we want the angular velocity of ThisFrame as seen in the
   // InertialFrame, but pushed to ThisFrame.  Otherwise the sign is wrong.

--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -59,10 +59,10 @@ class InertialFrame : public DynamicFrame<OtherFrame, ThisFrame> {
       not_null<serialization::DynamicFrame*> message) const override;
 
  private:
-  virtual Vector<Acceleration, OtherFrame> GravitationalAcceleration(
+  Vector<Acceleration, OtherFrame> GravitationalAcceleration(
       Instant const& t,
       Position<OtherFrame> const& q) const override;
-  virtual SecondOrderRigidMotion<OtherFrame, ThisFrame> Motion(
+  SecondOrderRigidMotion<OtherFrame, ThisFrame> Motion(
       Instant const& t) const override;
 
   DegreesOfFreedom<OtherFrame> const origin_degrees_of_freedom_at_epoch_;

--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -115,7 +115,8 @@ InertialFrame<OtherFrame, ThisFrame>::GravitationalAcceleration(
 
 template<typename OtherFrame, typename ThisFrame>
 AcceleratedRigidMotion<OtherFrame, ThisFrame>
-InertialFrame<OtherFrame, ThisFrame>::MotionOfThisFrame(Instant const& t) const {
+InertialFrame<OtherFrame, ThisFrame>::MotionOfThisFrame(
+    Instant const& t) const {
   return AcceleratedRigidMotion<OtherFrame, ThisFrame>(
       ToThisFrameAtTime(t),
       /*angular_acceleration_of_to_frame=*/{},

--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -62,7 +62,7 @@ class InertialFrame : public DynamicFrame<OtherFrame, ThisFrame> {
   Vector<Acceleration, OtherFrame> GravitationalAcceleration(
       Instant const& t,
       Position<OtherFrame> const& q) const override;
-  SecondOrderRigidMotion<OtherFrame, ThisFrame> Motion(
+  AcceleratedRigidMotion<OtherFrame, ThisFrame> MotionOfThisFrame(
       Instant const& t) const override;
 
   DegreesOfFreedom<OtherFrame> const origin_degrees_of_freedom_at_epoch_;
@@ -114,9 +114,9 @@ InertialFrame<OtherFrame, ThisFrame>::GravitationalAcceleration(
 }
 
 template<typename OtherFrame, typename ThisFrame>
-SecondOrderRigidMotion<OtherFrame, ThisFrame>
-InertialFrame<OtherFrame, ThisFrame>::Motion(Instant const& t) const {
-  return SecondOrderRigidMotion<OtherFrame, ThisFrame>(
+AcceleratedRigidMotion<OtherFrame, ThisFrame>
+InertialFrame<OtherFrame, ThisFrame>::MotionOfThisFrame(Instant const& t) const {
+  return AcceleratedRigidMotion<OtherFrame, ThisFrame>(
       ToThisFrameAtTime(t),
       /*angular_acceleration_of_to_frame=*/{},
       /*acceleration_of_to_frame_origin=*/{});

--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -54,20 +54,17 @@ class InertialFrame : public DynamicFrame<OtherFrame, ThisFrame> {
 
   RigidMotion<OtherFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
-  RigidMotion<ThisFrame, OtherFrame> FromThisFrameAtTime(
-      Instant const& t) const override;
-
-  // The acceleration due to gravity.
-  // A particle in free fall follows a trajectory whose second derivative
-  // is |GeometricAcceleration|.
-  Vector<Acceleration, ThisFrame> GeometricAcceleration(
-      Instant const& t,
-      DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const override;
 
   void WriteToMessage(
       not_null<serialization::DynamicFrame*> message) const override;
 
  private:
+  virtual Vector<Acceleration, OtherFrame> GravitationalAcceleration(
+      Instant const& t,
+      Position<OtherFrame> const& q) const override;
+  virtual SecondOrderRigidMotion<OtherFrame, ThisFrame> Motion(
+      Instant const& t) const override;
+
   DegreesOfFreedom<OtherFrame> const origin_degrees_of_freedom_at_epoch_;
   Instant const epoch_;
   OrthogonalMap<OtherFrame, ThisFrame> const orthogonal_map_;
@@ -105,24 +102,25 @@ InertialFrame<OtherFrame, ThisFrame>::ToThisFrameAtTime(
 }
 
 template<typename OtherFrame, typename ThisFrame>
-RigidMotion<ThisFrame, OtherFrame>
-InertialFrame<OtherFrame, ThisFrame>::FromThisFrameAtTime(
-    Instant const& t) const {
-  return ToThisFrameAtTime(t).Inverse();
-}
-
-template<typename OtherFrame, typename ThisFrame>
-Vector<Acceleration, ThisFrame>
-InertialFrame<OtherFrame, ThisFrame>::GeometricAcceleration(
-    Instant const& t,
-    DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const {
-  return orthogonal_map_(
-      gravity_(t, FromThisFrameAtTime(t)(degrees_of_freedom).position()));
-}
-
-template<typename OtherFrame, typename ThisFrame>
 void InertialFrame<OtherFrame, ThisFrame>::WriteToMessage(
     not_null<serialization::DynamicFrame*> message) const {}
+
+template<typename OtherFrame, typename ThisFrame>
+Vector<Acceleration, OtherFrame>
+InertialFrame<OtherFrame, ThisFrame>::GravitationalAcceleration(
+    Instant const& t,
+    Position<OtherFrame> const& q) const {
+  return gravity_(t, q);
+}
+
+template<typename OtherFrame, typename ThisFrame>
+SecondOrderRigidMotion<OtherFrame, ThisFrame>
+InertialFrame<OtherFrame, ThisFrame>::Motion(Instant const& t) const {
+  return SecondOrderRigidMotion<OtherFrame, ThisFrame>(
+      ToThisFrameAtTime(t),
+      /*angular_acceleration_of_to_frame=*/{},
+      /*acceleration_of_to_frame_origin=*/{});
+}
 
 }  // namespace
 

--- a/physics/mock_dynamic_frame.hpp
+++ b/physics/mock_dynamic_frame.hpp
@@ -35,6 +35,15 @@ class MockDynamicFrame : public DynamicFrame<InertialFrame, ThisFrame> {
   MOCK_CONST_METHOD1_T(
       WriteToMessage,
       void(not_null<serialization::DynamicFrame*> const message));
+
+ private:
+  MOCK_CONST_METHOD2_T(
+      GravitationalAcceleration,
+      Vector<Acceleration, InertialFrame>(Instant const& t,
+                                          Position<InertialFrame> const& q));
+  MOCK_CONST_METHOD1_T(
+      Motion,
+      SecondOrderRigidMotion<InertialFrame, ThisFrame>(Instant const& t));
 };
 
 }  // namespace internal_dynamic_frame

--- a/physics/mock_dynamic_frame.hpp
+++ b/physics/mock_dynamic_frame.hpp
@@ -42,8 +42,8 @@ class MockDynamicFrame : public DynamicFrame<InertialFrame, ThisFrame> {
       Vector<Acceleration, InertialFrame>(Instant const& t,
                                           Position<InertialFrame> const& q));
   MOCK_CONST_METHOD1_T(
-      Motion,
-      SecondOrderRigidMotion<InertialFrame, ThisFrame>(Instant const& t));
+      MotionOfThisFrame,
+      AcceleratedRigidMotion<InertialFrame, ThisFrame>(Instant const& t));
 };
 
 }  // namespace internal_dynamic_frame

--- a/physics/rigid_motion.hpp
+++ b/physics/rigid_motion.hpp
@@ -89,10 +89,11 @@ class AcceleratedRigidMotion {
           angular_acceleration_of_to_frame,
       Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin);
 
-  RigidMotion<FromFrame, ToFrame> rigid_motion() const;
-  Variation<AngularVelocity<FromFrame>> angular_acceleration_of_to_frame()
+  RigidMotion<FromFrame, ToFrame> const& rigid_motion() const;
+  Variation<AngularVelocity<FromFrame>> const&
+  angular_acceleration_of_to_frame() const;
+  Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin()
       const;
-  Vector<Acceleration, FromFrame> acceleration_of_to_frame_origin() const;
 
  private:
   RigidMotion<FromFrame, ToFrame> const rigid_motion_;
@@ -104,9 +105,9 @@ class AcceleratedRigidMotion {
 
 }  // namespace internal_rigid_motion
 
+using internal_rigid_motion::AcceleratedRigidMotion;
 using internal_rigid_motion::RigidMotion;
 using internal_rigid_motion::RigidTransformation;
-using internal_rigid_motion::AcceleratedRigidMotion;
 
 }  // namespace physics
 }  // namespace principia

--- a/physics/rigid_motion.hpp
+++ b/physics/rigid_motion.hpp
@@ -16,6 +16,7 @@ namespace internal_rigid_motion {
 
 using geometry::AffineMap;
 using geometry::AngularVelocity;
+using geometry::Bivector;
 using geometry::Instant;
 using geometry::OrthogonalMap;
 using geometry::Position;
@@ -23,6 +24,7 @@ using geometry::Vector;
 using geometry::Velocity;
 using quantities::Acceleration;
 using quantities::Length;
+using quantities::Variation;
 using quantities::si::Radian;
 
 // An arbitrary rigid transformation.  Simultaneous positions between two frames
@@ -76,10 +78,35 @@ RigidMotion<FromFrame, ToFrame> operator*(
     RigidMotion<ThroughFrame, ToFrame> const& left,
     RigidMotion<FromFrame, ThroughFrame> const& right);
 
+// A |RigidTransformation|, its first derivative (a |RigidMotion|), and its
+// second derivative (angular and linear accelerations).
+template<typename FromFrame, typename ToFrame>
+class SecondOrderRigidMotion {
+ public:
+  SecondOrderRigidMotion(
+      RigidMotion<FromFrame, ToFrame> const& first_order_motion,
+      Variation<AngularVelocity<FromFrame>> const&
+          angular_acceleration_of_to_frame,
+      Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin);
+
+  RigidMotion<FromFrame, ToFrame> first_order_motion() const;
+  Variation<AngularVelocity<FromFrame>> angular_acceleration_of_to_frame()
+      const;
+  Vector<Acceleration, FromFrame> acceleration_of_to_frame_origin() const;
+
+ private:
+  RigidMotion<FromFrame, ToFrame> first_order_motion_;
+  // d/dt first_order_motion_.angular_velocity_of_to_frame().
+  Variation<AngularVelocity<FromFrame>> angular_acceleration_of_to_frame_;
+  // d/dt first_order_motion_.velocity_of_to_frame_origin().
+  Vector<Acceleration, FromFrame> acceleration_of_to_frame_origin_;
+};
+
 }  // namespace internal_rigid_motion
 
 using internal_rigid_motion::RigidMotion;
 using internal_rigid_motion::RigidTransformation;
+using internal_rigid_motion::SecondOrderRigidMotion;
 
 }  // namespace physics
 }  // namespace principia

--- a/physics/rigid_motion.hpp
+++ b/physics/rigid_motion.hpp
@@ -81,32 +81,32 @@ RigidMotion<FromFrame, ToFrame> operator*(
 // A |RigidTransformation|, its first derivative (a |RigidMotion|), and its
 // second derivative (angular and linear accelerations).
 template<typename FromFrame, typename ToFrame>
-class SecondOrderRigidMotion {
+class AcceleratedRigidMotion {
  public:
-  SecondOrderRigidMotion(
-      RigidMotion<FromFrame, ToFrame> const& first_order_motion,
+  AcceleratedRigidMotion(
+      RigidMotion<FromFrame, ToFrame> const& rigid_motion,
       Variation<AngularVelocity<FromFrame>> const&
           angular_acceleration_of_to_frame,
       Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin);
 
-  RigidMotion<FromFrame, ToFrame> first_order_motion() const;
+  RigidMotion<FromFrame, ToFrame> rigid_motion() const;
   Variation<AngularVelocity<FromFrame>> angular_acceleration_of_to_frame()
       const;
   Vector<Acceleration, FromFrame> acceleration_of_to_frame_origin() const;
 
  private:
-  RigidMotion<FromFrame, ToFrame> first_order_motion_;
-  // d/dt first_order_motion_.angular_velocity_of_to_frame().
-  Variation<AngularVelocity<FromFrame>> angular_acceleration_of_to_frame_;
-  // d/dt first_order_motion_.velocity_of_to_frame_origin().
-  Vector<Acceleration, FromFrame> acceleration_of_to_frame_origin_;
+  RigidMotion<FromFrame, ToFrame> const rigid_motion_;
+  // d/dt rigid_motion_.angular_velocity_of_to_frame().
+  Variation<AngularVelocity<FromFrame>> const angular_acceleration_of_to_frame_;
+  // d/dt rigid_motion_.velocity_of_to_frame_origin().
+  Vector<Acceleration, FromFrame> const acceleration_of_to_frame_origin_;
 };
 
 }  // namespace internal_rigid_motion
 
 using internal_rigid_motion::RigidMotion;
 using internal_rigid_motion::RigidTransformation;
-using internal_rigid_motion::SecondOrderRigidMotion;
+using internal_rigid_motion::AcceleratedRigidMotion;
 
 }  // namespace physics
 }  // namespace principia

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -88,18 +88,18 @@ AcceleratedRigidMotion<FromFrame, ToFrame>::AcceleratedRigidMotion(
       acceleration_of_to_frame_origin_(acceleration_of_to_frame_origin) {}
 
 template<typename FromFrame, typename ToFrame>
-RigidMotion<FromFrame, ToFrame>
+RigidMotion<FromFrame, ToFrame> const&
 AcceleratedRigidMotion<FromFrame, ToFrame>::rigid_motion() const {
   return rigid_motion_;
 }
 template<typename FromFrame, typename ToFrame>
-Variation<AngularVelocity<FromFrame>>
+Variation<AngularVelocity<FromFrame>> const&
 AcceleratedRigidMotion<FromFrame, ToFrame>::angular_acceleration_of_to_frame()
     const {
   return angular_acceleration_of_to_frame_;
 }
 template<typename FromFrame, typename ToFrame>
-Vector<Acceleration, FromFrame>
+Vector<Acceleration, FromFrame> const&
 AcceleratedRigidMotion<FromFrame, ToFrame>::acceleration_of_to_frame_origin()
     const {
   return acceleration_of_to_frame_origin_;

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -78,29 +78,29 @@ RigidMotion<FromFrame, ToFrame> operator*(
 }
 
 template<typename FromFrame, typename ToFrame>
-SecondOrderRigidMotion<FromFrame, ToFrame>::SecondOrderRigidMotion(
-    RigidMotion<FromFrame, ToFrame> const& first_order_motion,
+AcceleratedRigidMotion<FromFrame, ToFrame>::AcceleratedRigidMotion(
+    RigidMotion<FromFrame, ToFrame> const& rigid_motion,
     Variation<AngularVelocity<FromFrame>> const&
         angular_acceleration_of_to_frame,
     Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin)
-    : first_order_motion_(first_order_motion),
+    : rigid_motion_(rigid_motion),
       angular_acceleration_of_to_frame_(angular_acceleration_of_to_frame),
       acceleration_of_to_frame_origin_(acceleration_of_to_frame_origin) {}
 
 template<typename FromFrame, typename ToFrame>
 RigidMotion<FromFrame, ToFrame>
-SecondOrderRigidMotion<FromFrame, ToFrame>::first_order_motion() const {
-  return first_order_motion_;
+AcceleratedRigidMotion<FromFrame, ToFrame>::rigid_motion() const {
+  return rigid_motion_;
 }
 template<typename FromFrame, typename ToFrame>
 Variation<AngularVelocity<FromFrame>>
-SecondOrderRigidMotion<FromFrame, ToFrame>::angular_acceleration_of_to_frame()
+AcceleratedRigidMotion<FromFrame, ToFrame>::angular_acceleration_of_to_frame()
     const {
   return angular_acceleration_of_to_frame_;
 }
 template<typename FromFrame, typename ToFrame>
 Vector<Acceleration, FromFrame>
-SecondOrderRigidMotion<FromFrame, ToFrame>::acceleration_of_to_frame_origin()
+AcceleratedRigidMotion<FromFrame, ToFrame>::acceleration_of_to_frame_origin()
     const {
   return acceleration_of_to_frame_origin_;
 }

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -77,6 +77,34 @@ RigidMotion<FromFrame, ToFrame> operator*(
           {ToFrame::origin, Velocity<ToFrame>()})).velocity());
 }
 
+template<typename FromFrame, typename ToFrame>
+SecondOrderRigidMotion<FromFrame, ToFrame>::SecondOrderRigidMotion(
+    RigidMotion<FromFrame, ToFrame> const& first_order_motion,
+    Variation<AngularVelocity<FromFrame>> const&
+        angular_acceleration_of_to_frame,
+    Vector<Acceleration, FromFrame> const& acceleration_of_to_frame_origin)
+    : first_order_motion_(first_order_motion),
+      angular_acceleration_of_to_frame_(angular_acceleration_of_to_frame),
+      acceleration_of_to_frame_origin_(acceleration_of_to_frame_origin) {}
+
+template<typename FromFrame, typename ToFrame>
+RigidMotion<FromFrame, ToFrame>
+SecondOrderRigidMotion<FromFrame, ToFrame>::first_order_motion() const {
+  return first_order_motion_;
+}
+template<typename FromFrame, typename ToFrame>
+Variation<AngularVelocity<FromFrame>>
+SecondOrderRigidMotion<FromFrame, ToFrame>::angular_acceleration_of_to_frame()
+    const {
+  return angular_acceleration_of_to_frame_;
+}
+template<typename FromFrame, typename ToFrame>
+Vector<Acceleration, FromFrame>
+SecondOrderRigidMotion<FromFrame, ToFrame>::acceleration_of_to_frame_origin()
+    const {
+  return acceleration_of_to_frame_origin_;
+}
+
 }  // namespace internal_rigid_motion
 }  // namespace physics
 }  // namespace principia


### PR DESCRIPTION
This should also enable cleaner unit testing of the linear, Coriolis, centrifugal, and Euler accelerations (for now the [tests](https://github.com/mockingbirdnest/Principia/blob/f54bcf9589d79b38a651d8af8fbc441db3b48fb6/physics/barycentric_rotating_dynamic_frame_test.cpp#L216-L482) from BarycentricRotatingDynamicFrame take care of that).