### PR TITLE
Poles

### DIFF
--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -65,7 +65,7 @@ FORCE_INLINE Vector<Quotient<Acceleration,
     Displacement<Frame> const& r,
     Exponentiation<Length, -2> const& one_over_r_squared,
     Exponentiation<Length, -3> const& one_over_r_cubed) {
-  Vector<double, Frame> const& axis = body.axis();
+  Vector<double, Frame> const& axis = body.polar_axis();
   Length const r_axis_projection = InnerProduct(axis, r);
   auto const j2_over_r_fifth =
       body.j2_over_μ() * one_over_r_cubed * one_over_r_squared;

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -816,10 +816,9 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
                                             1 * Metre,
                                             1 * Radian,
                                             t0_,
-                                            AngularVelocity<World>({
-                                                0 * Radian / Second,
-                                                0 * Radian / Second,
-                                                4 * Radian / Second})),
+                                            4 * Radian / Second,
+                                            0 * Radian,
+                                            π / 2 * Radian),
                                         OblateBody<World>::Parameters(
                                             j2, radius));
   auto const b1 = new MassiveBody(m1);
@@ -895,7 +894,7 @@ TEST_F(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
            0 * SIUnit<Acceleration>(),
            0 * SIUnit<Acceleration>()});
   EXPECT_THAT(actual_acceleration1,
-              AlmostEquals(expected_acceleration1, 0, 2));
+              AlmostEquals(expected_acceleration1, 0, 4));
 
   Vector<Acceleration, World> actual_acceleration2 =
       ephemeris.ComputeGravitationalAccelerationOnMassiveBody(b2, t0_);

--- a/physics/oblate_body.hpp
+++ b/physics/oblate_body.hpp
@@ -57,9 +57,6 @@ class OblateBody : public RotatingBody<Frame> {
   Quotient<Order2ZonalCoefficient,
            GravitationalParameter> const& j2_over_μ() const;
 
-  // Returns the axis passed at construction.
-  Vector<double, Frame> const& axis() const;
-
   // Returns false.
   bool is_massless() const override;
 
@@ -82,7 +79,6 @@ class OblateBody : public RotatingBody<Frame> {
 
  private:
   Parameters parameters_;
-  Vector<double, Frame> const axis_;
 };
 
 }  // namespace internal_oblate_body

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -108,7 +108,7 @@ not_null<std::unique_ptr<OblateBody<Frame>>> OblateBody<Frame>::ReadFromMessage(
       rotating_body_parameters(Length(),
                                Angle(),
                                J2000,
-                               Radian / Second,
+                               1 * Radian / Second,
                                axis_spherical_coordinates.longitude,
                                axis_spherical_coordinates.latitude);
   Parameters parameters(Order2ZonalCoefficient::ReadFromMessage(message.j2()));

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -62,11 +62,6 @@ Quotient<Order2ZonalCoefficient,
 }
 
 template<typename Frame>
-Vector<double, Frame> const& OblateBody<Frame>::axis() const {
-  return axis_;
-}
-
-template<typename Frame>
 bool OblateBody<Frame>::is_massless() const {
   return false;
 }
@@ -110,12 +105,14 @@ not_null<std::unique_ptr<OblateBody<Frame>>> OblateBody<Frame>::ReadFromMessage(
     serialization::PreBrouwerOblateBody const& message,
     MassiveBody::Parameters const& massive_body_parameters) {
   auto const axis = Vector<double, Frame>::ReadFromMessage(message.axis());
+  auto const axis_spherical_coordinates = axis.coordinates().ToSpherical();
   typename RotatingBody<Frame>::Parameters
       rotating_body_parameters(Length(),
                                Angle(),
                                J2000,
-                               AngularVelocity<Frame>(
-                                   axis.coordinates() * Radian / Second));
+                               Radian / Second,
+                               axis_spherical_coordinates.longitude,
+                               axis_spherical_coordinates.latitude);
   Parameters parameters(Order2ZonalCoefficient::ReadFromMessage(message.j2()));
 
   return std::make_unique<OblateBody<Frame>>(massive_body_parameters,

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -39,9 +39,7 @@ OblateBody<Frame>::OblateBody(
     typename RotatingBody<Frame>::Parameters const& rotating_body_parameters,
     Parameters const& parameters)
     : RotatingBody<Frame>(massive_body_parameters, rotating_body_parameters),
-      parameters_(parameters),
-      axis_(Vector<double, Frame>(
-                Normalize(this->angular_velocity()).coordinates())) {
+      parameters_(parameters) {
   if (parameters_.j2_) {
     parameters_.j2_over_μ_ = *parameters_.j2_ / this->gravitational_parameter();
   }

--- a/physics/rotating_body.hpp
+++ b/physics/rotating_body.hpp
@@ -36,18 +36,25 @@ class RotatingBody : public MassiveBody {
   class Parameters {
    public:
     // |reference_angle| is the angle of the prime meridian at
-    // |reference_instant|.  |angular_velocity| gives the direction and speed of
-    // the rotation of the body.
+    // |reference_instant|.  |angular_frequency| gives the rate of rotation of
+    // the body around the pole (it may be negative, as is the convention for
+    // planets and satellites whose rotation is retrograde).  The direction of
+    // the pole is specified in |Frame| using |right_ascension_of_pole| and
+    // |declination_of_pole|.
     Parameters(Length const& mean_radius,
                Angle const& reference_angle,
                Instant const& reference_instant,
-               AngularVelocity<Frame> const& angular_velocity);
+               AngularFrequency const& angular_frequency,
+               Angle const& right_ascension_of_pole,
+               Angle const& declination_of_pole);
 
    private:
     Length const mean_radius_;
     Angle const reference_angle_;
     Instant const reference_instant_;
-    AngularVelocity<Frame> const angular_velocity_;
+    AngularFrequency const angular_frequency_;
+    Angle const right_ascension_of_pole_;
+    Angle const declination_of_pole_;
     template<typename F>
     friend class RotatingBody;
   };
@@ -58,6 +65,11 @@ class RotatingBody : public MassiveBody {
 
   // Returns the radius passed at construction.
   Length mean_radius() const override;
+
+  // Returns the axis passed at construction.
+  Vector<double, Frame> const& polar_axis() const;
+  Angle const& right_ascension_of_pole() const;
+  Angle const& declination_of_pole() const;
 
   // Returns the angular velocity passed at construction.
   AngularVelocity<Frame> const& angular_velocity() const;
@@ -86,6 +98,8 @@ class RotatingBody : public MassiveBody {
 
  private:
   Parameters const parameters_;
+  Vector<double, Frame> const polar_axis_;
+  AngularVelocity<Frame> const angular_velocity_;
 };
 
 }  // namespace internal_rotating_body

--- a/physics/rotating_body.hpp
+++ b/physics/rotating_body.hpp
@@ -66,9 +66,14 @@ class RotatingBody : public MassiveBody {
   // Returns the radius passed at construction.
   Length mean_radius() const override;
 
-  // Returns the axis passed at construction.
+  // Returns the direction defined by the right ascension and declination passed
+  // at construction.
   Vector<double, Frame> const& polar_axis() const;
+
+  // Returns the right ascension passed at construction.
   Angle const& right_ascension_of_pole() const;
+
+  // Returns the declination at construction.
   Angle const& declination_of_pole() const;
 
   // Returns the angular velocity passed at construction.

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -30,19 +30,20 @@ RotatingBody<Frame>::Parameters::Parameters(
       angular_frequency_(angular_frequency),
       right_ascension_of_pole_(right_ascension_of_pole),
       declination_of_pole_(declination_of_pole) {
-  CHECK_NE(angular_velocity_, 0.0 * SIUnit<AngularFrequency>())
+  CHECK_NE(angular_frequency_, 0.0 * SIUnit<AngularFrequency>())
       << "Rotating body cannot have zero angular velocity";
 }
 
-template<typename Frame>
+template <typename Frame>
 RotatingBody<Frame>::RotatingBody(
     MassiveBody::Parameters const& massive_body_parameters,
     Parameters const& parameters)
     : MassiveBody(massive_body_parameters),
       parameters_(parameters),
-      polar_axis_(RadiusLatitudeLongitude(1.0,
-                                          parameters.declination_of_pole_,
-                                          parameters.right_ascension_of_pole_)),
+      polar_axis_(RadiusLatitudeLongitude(
+                      1.0,
+                      parameters.declination_of_pole_,
+                      parameters.right_ascension_of_pole_).ToCartesian()),
       angular_velocity_(polar_axis_.coordinates() *
                         parameters.angular_frequency_) {}
 
@@ -76,7 +77,7 @@ template<typename Frame>
 Angle RotatingBody<Frame>::AngleAt(Instant const& t) const {
   return parameters_.reference_angle_ +
          (t - parameters_.reference_instant_) *
-             parameters_.angular_velocity_.Norm();
+             angular_velocity_.Norm();
 }
 
 template<typename Frame>

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -34,7 +34,7 @@ RotatingBody<Frame>::Parameters::Parameters(
       << "Rotating body cannot have zero angular velocity";
 }
 
-template <typename Frame>
+template<typename Frame>
 RotatingBody<Frame>::RotatingBody(
     MassiveBody::Parameters const& massive_body_parameters,
     Parameters const& parameters)

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -220,13 +220,9 @@ std::unique_ptr<MassiveBody> SolarSystem<Frame>::MakeMassiveBody(
             ParseQuantity<Length>(body.mean_radius()),
             ParseQuantity<Angle>(body.reference_angle()),
             JulianDate(body.reference_instant()),
-            Bivector<double, Frame>(
-                RadiusLatitudeLongitude(
-                    1.0,
-                    ParseQuantity<Angle>(body.axis_declination()),
-                    ParseQuantity<Angle>(body.axis_right_ascension()))
-                    .ToCartesian()) *
-                ParseQuantity<AngularFrequency>(body.angular_frequency()));
+            ParseQuantity<AngularFrequency>(body.angular_frequency()),
+            ParseQuantity<Angle>(body.axis_right_ascension()),
+            ParseQuantity<Angle>(body.axis_declination()));
     if (body.has_j2()) {
       typename OblateBody<Frame>::Parameters oblate_body_parameters(
           ParseQuantity<double>(body.j2()),

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -137,6 +137,13 @@ message RotatingBody {
   optional Quantity mean_radius = 5;
   required Quantity reference_angle = 2;
   required Point reference_instant = 3;
-  required Multivector angular_velocity = 4;
+  // angular_velocity is deprecated, and does not contain the angular velocity
+  // in any released version; its norm is 1 rad/s.
+  optional Multivector angular_velocity = 4;
+  // The following three should probably be made optional for pre-Cardano
+  // compatibility.
+  required Quantity angular_frequency = 6;
+  required Quantity right_ascension_of_pole = 7;
+  required Quantity declination_of_pole = 8;
   extensions 4000 to 4999;  // Last used: 4000.
 }


### PR DESCRIPTION
Store polar α and δ for rotating bodies, this allows for non-positive poles (which is the convention for retrograde planets and satellites), and removes singularities that would occur when defining the rotation of bodies.