### PR TITLE
Rotating body angular frequency accessor

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -297,7 +297,7 @@ Angle Plugin::CelestialInitialRotation(Index const celestial_index) const {
 Time Plugin::CelestialRotationPeriod(Index const celestial_index) const {
   auto const& body = dynamic_cast<RotatingBody<Barycentric> const&>(
       *FindOrDie(celestials_, celestial_index)->body());
-  return 2 * π * Radian / body.angular_velocity().Norm();
+  return 2 * π * Radian / body.angular_frequency();
 }
 
 bool Plugin::InsertOrKeepVessel(GUID const& vessel_guid,

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -297,6 +297,8 @@ Angle Plugin::CelestialInitialRotation(Index const celestial_index) const {
 Time Plugin::CelestialRotationPeriod(Index const celestial_index) const {
   auto const& body = dynamic_cast<RotatingBody<Barycentric> const&>(
       *FindOrDie(celestials_, celestial_index)->body());
+  // The result will be negative if the pole is the negative pole
+  // (e.g. for Venus).  This is the convention KSP uses for retrograde rotation.
   return 2 * π * Radian / body.angular_frequency();
 }
 

--- a/physics/rotating_body.hpp
+++ b/physics/rotating_body.hpp
@@ -76,7 +76,11 @@ class RotatingBody : public MassiveBody {
   // Returns the declination at construction.
   Angle const& declination_of_pole() const;
 
-  // Returns the angular velocity passed at construction.
+  // Returns the angular frequency passed at construction.
+  AngularFrequency const& angular_frequency() const;
+
+  // Returns the angular velocity defined by the right ascension, declination,
+  // and angular frequency passed at construction.
   AngularVelocity<Frame> const& angular_velocity() const;
 
   // Returns the position at time |t|.

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -71,6 +71,11 @@ Angle const& RotatingBody<Frame>::declination_of_pole() const {
 }
 
 template<typename Frame>
+AngularFrequency const& RotatingBody<Frame>::angular_frequency() const {
+  return parameters_.angular_frequency_;
+}
+
+template<typename Frame>
 AngularVelocity<Frame> const& RotatingBody<Frame>::angular_velocity() const {
   return angular_velocity_;
 }


### PR DESCRIPTION
This addresses #1111, and it also fixes a where bodies whose reference pole was the negative pole would rotate opposite to their scaled body.