### PR TITLE
ULP distance in numerics

### DIFF
--- a/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include "geometry/sign.hpp"
+#include "numerics/ulp_distance.hpp"
 #include "quantities/quantities.hpp"
-#include "testing_utilities/numerics.hpp"
 
 namespace principia {
 namespace integrators {
@@ -16,8 +16,8 @@ namespace internal_symplectic_runge_kutta_nyström_integrator {
 using base::make_not_null_unique;
 using geometry::Sign;
 using numerics::DoublePrecision;
+using numerics::ULPDistance;
 using quantities::Abs;
-using testing_utilities::ULPDistance;
 
 template<typename Position, int order, bool time_reversible, int evaluations,
          CompositionMethod composition>

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -10,6 +10,7 @@
 #include "geometry/permutation.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "testing_utilities/numerics.hpp"
 #include "testing_utilities/solar_system_factory.hpp"
 
 namespace principia {

--- a/numerics/numerics.vcxproj
+++ b/numerics/numerics.vcxproj
@@ -264,6 +264,8 @@
     <ClInclude Include="newhall.mathematica.h" />
     <ClInclude Include="root_finders.hpp" />
     <ClInclude Include="root_finders_body.hpp" />
+    <ClInclude Include="ulp_distance.hpp" />
+    <ClInclude Include="ulp_distance_body.hpp" />
     <ClInclude Include="чебышёв_series.hpp" />
     <ClInclude Include="чебышёв_series_body.hpp" />
   </ItemGroup>

--- a/numerics/numerics.vcxproj.filters
+++ b/numerics/numerics.vcxproj.filters
@@ -47,6 +47,12 @@
     <ClInclude Include="hermite3_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="ulp_distance.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ulp_distance_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="чебышёв_series_test.cpp">

--- a/numerics/ulp_distance.hpp
+++ b/numerics/ulp_distance.hpp
@@ -1,0 +1,12 @@
+
+#pragma once
+
+namespace principia {
+namespace numerics {
+
+std::int64_t ULPDistance(double const x, double const y);
+
+}  // namespace numerics
+}  // namespace principia
+
+#include "numerics/ulp_distance_body.hpp"

--- a/numerics/ulp_distance_body.hpp
+++ b/numerics/ulp_distance_body.hpp
@@ -31,10 +31,10 @@ inline std::int64_t ULPDistance(double const x, double const y) {
   std::int64_t x_bits;
   std::int64_t y_bits;
   static_assert(sizeof(x_bits) == sizeof(x),
-                "conversion between types of different sizes");
+                "Conversion between types of different sizes");
   std::memcpy(&x_bits, &x, sizeof(x));
   static_assert(sizeof(y_bits) == sizeof(y),
-                "conversion between types of different sizes");
+                "Conversion between types of different sizes");
   std::memcpy(&y_bits, &y, sizeof(y));
   return std::abs(x_bits - y_bits);
 }

--- a/numerics/ulp_distance_body.hpp
+++ b/numerics/ulp_distance_body.hpp
@@ -30,8 +30,11 @@ inline std::int64_t ULPDistance(double const x, double const y) {
   }
   std::int64_t x_bits;
   std::int64_t y_bits;
-  static_assert(sizeof(x_bits) == sizeof(x), "");
+  static_assert(sizeof(x_bits) == sizeof(x),
+                "conversion between types of different sizes");
   std::memcpy(&x_bits, &x, sizeof(x));
+  static_assert(sizeof(y_bits) == sizeof(y),
+                "conversion between types of different sizes");
   std::memcpy(&y_bits, &y, sizeof(y));
   return std::abs(x_bits - y_bits);
 }

--- a/numerics/ulp_distance_body.hpp
+++ b/numerics/ulp_distance_body.hpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 
 namespace principia {
 namespace numerics {

--- a/numerics/ulp_distance_body.hpp
+++ b/numerics/ulp_distance_body.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "numerics/ulp_distance.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+namespace principia {
+namespace numerics {
+
+inline std::int64_t ULPDistance(double const x, double const y) {
+  if (x == y) {
+    return 0;
+  }
+  double const x_sign = std::copysign(1, x);
+  double const y_sign = std::copysign(1, y);
+  if (x_sign != y_sign) {
+    double const positive = x_sign == 1 ? x : y;
+    double const negative = x_sign == 1 ? y : x;
+    std::int64_t const positive_distance = ULPDistance(positive, +0.0);
+    std::int64_t const negative_distance = ULPDistance(negative, -0.0);
+    if (positive_distance >
+            std::numeric_limits<std::int64_t>::max() - negative_distance) {
+      return std::numeric_limits<std::int64_t>::max();
+    } else {
+      return positive_distance + negative_distance;
+    }
+  }
+  std::int64_t x_bits;
+  std::int64_t y_bits;
+  static_assert(sizeof(x_bits) == sizeof(x), "");
+  std::memcpy(&x_bits, &x, sizeof(x));
+  std::memcpy(&y_bits, &y, sizeof(y));
+  return std::abs(x_bits - y_bits);
+}
+
+}  // namespace numerics
+}  // namespace principia

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -9,20 +9,20 @@
 
 #include "astronomy/epoch.hpp"
 #include "glog/stl_logging.h"
+#include "numerics/ulp_distance.hpp"
 #include "physics/continuous_trajectory.hpp"
 #include "quantities/si.hpp"
-#include "testing_utilities/numerics.hpp"
 
 namespace principia {
 namespace physics {
 namespace internal_continuous_trajectory {
 
 using base::Error;
+using numerics::ULPDistance;
 using quantities::DebugString;
 using quantities::SIUnit;
 using quantities::si::Metre;
 using quantities::si::Second;
-using testing_utilities::ULPDistance;
 
 int const max_degree = 17;
 int const min_degree = 3;

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -13,9 +13,13 @@
 #include "geometry/grassmann.hpp"
 #include "geometry/r3_element.hpp"
 #include "gmock/gmock.h"
+#include "numerics/ulp_distance.hpp"
 #include "testing_utilities/numerics.hpp"
 
 namespace principia {
+
+using numerics::ULPDistance;
+
 namespace testing_utilities {
 
 template<typename T>

--- a/testing_utilities/numerics.hpp
+++ b/testing_utilities/numerics.hpp
@@ -79,8 +79,6 @@ template<typename Scalar, typename Frame, int rank>
 double RelativeError(geometry::Multivector<Scalar, Frame, rank> const& expected,
                      geometry::Multivector<Scalar, Frame, rank> const& actual);
 
-std::int64_t ULPDistance(double const x, double const y);
-
 }  // namespace testing_utilities
 }  // namespace principia
 

--- a/testing_utilities/numerics_body.hpp
+++ b/testing_utilities/numerics_body.hpp
@@ -1,12 +1,12 @@
 ﻿
 #pragma once
 
+#include "testing_utilities/numerics.hpp"
+
 #include <cmath>
 #include <cstdint>
-
 #include <functional>
 #include <limits>
-#include "numerics.hpp"
 
 namespace principia {
 namespace testing_utilities {
@@ -106,36 +106,6 @@ double RelativeError(geometry::Multivector<Scalar, Frame, rank> const& expected,
                      geometry::Multivector<Scalar, Frame, rank> const& actual) {
   return RelativeError(expected, actual,
                        &geometry::Multivector<Scalar, Frame, rank>::Norm);
-}
-
-union Qword {
-  double double_value;
-  std::int64_t long_value;
-};
-
-inline std::int64_t ULPDistance(double const x, double const y) {
-  if (x == y) {
-    return 0;
-  }
-  double const x_sign = std::copysign(1, x);
-  double const y_sign = std::copysign(1, y);
-  if (x_sign != y_sign) {
-    double const positive = x_sign == 1 ? x : y;
-    double const negative = x_sign == 1 ? y : x;
-    std::int64_t const positive_distance = ULPDistance(positive, +0.0);
-    std::int64_t const negative_distance = ULPDistance(negative, -0.0);
-    if (positive_distance >
-            std::numeric_limits<std::int64_t>::max() - negative_distance) {
-      return std::numeric_limits<std::int64_t>::max();
-    } else {
-      return positive_distance + negative_distance;
-    }
-  }
-  Qword x_qword;
-  Qword y_qword;
-  x_qword.double_value = x;
-  y_qword.double_value = y;
-  return std::abs(x_qword.long_value - y_qword.long_value);
 }
 
 }  // namespace testing_utilities

--- a/testing_utilities/vanishes_before_body.hpp
+++ b/testing_utilities/vanishes_before_body.hpp
@@ -12,9 +12,13 @@
 #include <string>
 
 #include "gmock/gmock.h"
+#include "numerics/ulp_distance.hpp"
 #include "testing_utilities/numerics.hpp"
 
 namespace principia {
+
+using numerics::ULPDistance;
+
 namespace testing_utilities {
 
 template<typename T>


### PR DESCRIPTION
Following these changes, across all `*.hpp` files, `#include "testing_utilities` occurs only in `testing_utilities`.
This fixes #1165.