### PR TITLE
Unity assembly `UnityEngine.UI.dll`

### DIFF
--- a/documentation/Setup.md
+++ b/documentation/Setup.md
@@ -18,7 +18,7 @@ This directory should not contain any of the following subfolders:
 This project depends upon:
 - the KSP assemblies `Assembly-CSharp.dll` and `Assembly-CSharp-firstpass.dll`,
   found in `<KSP directory>\KSP_Data\Managed`;
-- the Unity assembly `UnityEngine.dll`, found in
+- the Unity assemblies `UnityEngine.dll` and `UnityEngine.UI.dll`, found in
   `<KSP directory>\KSP_Data\Managed`;
 - our [fork](https://github.com/mockingbirdnest/glog) of the Google glog
   library;


### PR DESCRIPTION
Unity assembly `UnityEngine.UI.dll` is also required from `<KSP directory>\KSP_Data\Managed`
See Principia/ksp_plugin_adapter/ksp_plugin_adapter.csproj lines 55 thru 58:
https://github.com/mockingbirdnest/Principia/blob/3b6af2d12fe43e905346381b4593c294952fe89c/ksp_plugin_adapter/ksp_plugin_adapter.csproj#L56