### PR TITLE
Out with the old, in with the new

### DIFF
--- a/generate_version_header.ps1
+++ b/generate_version_header.ps1
@@ -20,14 +20,28 @@ $versionheadertext = [string]::format(
     $newdate.ToUniversalTime(),
     $newversion)
 
-if ((test-path -path $headerpath) -and
-    [system.io.file]::readalltext($headerpath).equals($versionheadertext)) {
-  echo "No change to git describe, leaving base/version.generated.h untouched"
-  return
+for(;;) {
+  try {
+    if ((test-path -path $headerpath) -and
+        [system.io.file]::readalltext($headerpath).equals($versionheadertext)) {
+      echo "No change to git describe, leaving base/version.generated.h untouched"
+      return
+    }
+    break
+  } catch {
+    start-sleep -m 10
+  }
 }
 
-echo "Updating base/version.generated.h, version is $newversion"
-[system.io.file]::writealltext(
-      $headerpath,
-      $versionheadertext,
-      [system.text.encoding]::utf8)
+for(;;) {
+  try {
+    echo "Updating base/version.generated.h, version is $newversion"
+    [system.io.file]::writealltext(
+          $headerpath,
+          $versionheadertext,
+          [system.text.encoding]::utf8)
+    break
+  } catch {
+      start-sleep -m 10
+  }
+}

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -347,6 +347,13 @@ void principia__ForgetAllHistoriesBefore(Plugin* const plugin,
   return m.Return();
 }
 
+void principia__FreeVesselsAndCollectPileUps(Plugin* const plugin) {
+  journal::Method<journal::FreeVesselsAndCollectPileUps> m({plugin});
+  CHECK_NOTNULL(plugin);
+  plugin->FreeVesselsAndCollectPileUps();
+  return m.Return();
+}
+
 int principia__GetBufferDuration() {
   journal::Method<journal::GetBufferDuration> m;
   return m.Return(FLAGS_logbufsecs);

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -72,7 +72,7 @@ void PileUp::SetVesselApparentDegreesOfFreedom(
                   << degrees_of_freedom;
 }
 
-void PileUp::UpdateVesselsInPileUp() {
+void PileUp::UpdateVesselsInPileUpIfUpdated() {
   // A consistency check that |SetVesselApparentDegreesOfFreedom| was called for
   // all the vessels.
   CHECK_EQ(vessels_.size(), apparent_vessel_degrees_of_freedom_.size());

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -73,6 +73,9 @@ void PileUp::SetVesselApparentDegreesOfFreedom(
 }
 
 void PileUp::UpdateVesselsInPileUpIfUpdated() {
+  if (apparent_vessel_degrees_of_freedom_.empty()) {
+    return;
+  }
   // A consistency check that |SetVesselApparentDegreesOfFreedom| was called for
   // all the vessels.
   CHECK_EQ(vessels_.size(), apparent_vessel_degrees_of_freedom_.size());

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -52,8 +52,8 @@ class PileUp final {
   // Update the degrees of freedom of all the vessels by comparing the centre of
   // mass of the *apparent* degrees of freedom to the centre of mass computed by
   // integration.  |SetVesselApparentDegreesOfFreedom| must have been called for
-  // each vessel in the pile-up.
-  void UpdateVesselsInPileUp();
+  // each vessel in the pile-up, or for none.
+  void UpdateVesselsInPileUpIfUpdated();
 
   // Obtains the *actual* degrees of freedom for the given |vessel|.  The vessel
   // in the game should be nudged to match the value returned by this function.

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -406,16 +406,20 @@ void Plugin::SetVesselStateOffset(
       vessel->parent()->current_degrees_of_freedom(current_time_) + relative);
 }
 
-void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
-  VLOG(1) << __FUNCTION__ << '\n'
-          << NAMED(t) << '\n' << NAMED(planetarium_rotation);
+void Plugin::FreeVesselsAndCollectPileUps() {
   CHECK(!initializing_);
-  CHECK_GT(t, current_time_);
   FreeVessels();
   for (auto const& pair : vessels_) {
     Vessel& vessel = *pair.second;
     Subset<Vessel>::Find(vessel).mutable_properties().Collect(&pile_ups_);
   }
+}
+
+void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
+  VLOG(1) << __FUNCTION__ << '\n'
+          << NAMED(t) << '\n' << NAMED(planetarium_rotation);
+  CHECK(!initializing_);
+  CHECK_GT(t, current_time_);
   ephemeris_->Prolong(t);
   bubble_->Prepare(BarycentricToWorldSun(), current_time_, t);
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -801,7 +801,7 @@ Velocity<World> Plugin::VesselVelocity(GUID const& vessel_guid) const {
 
 void Plugin::UpdateAllVesselsInPileUps() {
   for (auto& pile_up : pile_ups_) {
-    pile_up.UpdateVesselsInPileUp();
+    pile_up.UpdateVesselsInPileUpIfUpdated();
   }
 }
 

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -166,6 +166,11 @@ class Plugin {
       GUID const& vessel_guid,
       RelativeDegreesOfFreedom<AliceSun> const& from_parent);
 
+  // Destroys the vessels for which |InsertOrKeepVessel| has not been called
+  // since the last call to |FreeVesselsAndCollectPileUps|, and updates the list
+  // of |pile_ups_| according to the reported collisions.
+  virtual void FreeVesselsAndCollectPileUps();
+
   // Simulates the system until instant |t|. All vessels that have not been
   // refreshed by calling |InsertOrKeepVessel| since the last call to
   // |AdvanceTime| will be removed.  Sets |current_time_| to |t|.

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -320,7 +320,7 @@ class Plugin {
 
   virtual Velocity<World> VesselVelocity(GUID const& vessel_guid) const;
 
-  // Calls |UpdateVesselsInPileUp| on all the pile-ups.
+  // Calls |UpdateVesselsInPileUpIfUpdated| on all the pile-ups.
   virtual void UpdateAllVesselsInPileUps();
 
   // Coordinate transforms.

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -851,8 +851,8 @@ public partial class PrincipiaPluginAdapter
        // all parts.  |ChangeWorldVelocity| is an increment, so that works.
        // Again when we start dealing with rotation we'll have to set the
        // velocities of the parts individually.
-       //vessel.ChangeWorldVelocity(vessel_actual_world_velocity -
-         //                         apparent_world_velocities[vessel]);
+       vessel.ChangeWorldVelocity(vessel_actual_world_velocity -
+                                  apparent_world_velocities[vessel]);
      }
    }
 
@@ -1473,8 +1473,8 @@ public partial class PrincipiaPluginAdapter
         Log.Fatal("Cartesian config without gravity models");
       }
       try {
-        ConfigNode initial_states =
-            GameDatabase.Instance.GetConfigs(principia_initial_state_config_name)[0].config;
+        ConfigNode initial_states = GameDatabase.Instance.GetConfigs(
+            principia_initial_state_config_name)[0].config;
         plugin_ =
             Interface.NewPlugin(initial_states.GetValue("game_epoch"),
                                 initial_states.GetValue("solar_system_epoch"),

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -100,7 +100,6 @@ public partial class PrincipiaPluginAdapter
   }
   private PluginSource plugin_source_;
 
-  private Krakensbane krakensbane_;
   private KSP.UI.Screens.Flight.NavBall navball_;
   private UnityEngine.Texture compass_navball_texture_;
   private UnityEngine.Texture inertial_navball_texture_;
@@ -122,6 +121,14 @@ public partial class PrincipiaPluginAdapter
   private static Dictionary<CelestialBody, Orbit> unmodified_orbits_;
 
   private String bad_installation_popup_;
+  
+  private Krakensbane krakensbane_;
+  private Krakensbane krakensbane {
+    get {
+     return krakensbane_.GetValueOrDefault(
+         krakensbane_ = (Krakensbane)FindObjectOfType(typeof(Krakensbane)));
+    }
+  }
 
   // The first apocalyptic error message.
   [KSPField(isPersistant = true)]
@@ -844,8 +851,8 @@ public partial class PrincipiaPluginAdapter
        // all parts.  |ChangeWorldVelocity| is an increment, so that works.
        // Again when we start dealing with rotation we'll have to set the
        // velocities of the parts individually.
-       vessel.ChangeWorldVelocity(vessel_actual_world_velocity -
-                                  apparent_world_velocities[vessel]);
+       //vessel.ChangeWorldVelocity(vessel_actual_world_velocity -
+         //                         apparent_world_velocities[vessel]);
      }
    }
 

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -87,7 +87,7 @@ TEST_F(PileUpTest, ApparentDegreesOfFreedom) {
                                  50 * Metre / Second,
                                  40 * Metre / Second})));
 
-  pile_up.UpdateVesselsInPileUp();
+  pile_up.UpdateVesselsInPileUpIfUpdated();
 
   EXPECT_THAT(
       pile_up.GetVesselActualDegreesOfFreedom(&v1_),

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -149,8 +149,8 @@ class ParallelTestRunner {
       var process = processes[i];
       // We cannot use i in the lambdas, it would be captured by reference.
       int index = i;
-      tasks[i] = new Task(async () => {
-        process.Start();
+      process.Start();
+      tasks[i] = Task.Run(async () => {
         while (!process.StandardOutput.EndOfStream) {
           Console.WriteLine("O" + index.ToString().PadLeft(4) + " " +
                             await process.StandardOutput.ReadLineAsync());
@@ -163,19 +163,12 @@ class ParallelTestRunner {
           Environment.Exit(process.ExitCode);
         }
       });
-      tasks[i].Start();
-    }
-    // For some reason if I create those tasks in the loop above, they throw
-    // exceptions complaining that stderr isn't redirected.  Here it works...
-    for (int i = 0; i < processes.Count; ++i) {
-      var process = processes[i];
-      int index = i;
-      new Task(async () => {
+      Task.Run(async () => {
         while (!process.StandardError.EndOfStream) {
           Console.WriteLine("E" + index.ToString().PadLeft(4) + " " +
                             await process.StandardError.ReadLineAsync());
         }
-      }).Start();
+      });
     }
 
     Task.WaitAll(tasks);

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -94,7 +94,7 @@ message WXYZ {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5110.
+  extensions 5000 to 5999;  // Last used: 5111.
 }
 
 message AddVesselToNextPhysicsBubble {
@@ -559,6 +559,16 @@ message ForgetAllHistoriesBefore {
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
     required double t = 2;
+  }
+  optional In in = 1;
+}
+
+message FreeVesselsAndCollectPileUps {
+  extend Method {
+    optional FreeVesselsAndCollectPileUps extension = 5111;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
   }
   optional In in = 1;
 }


### PR DESCRIPTION
Stop using `PhysicsBubble` in the adapter, start using the `PileUp`-related functions. This is hilariously broken at the moment because we get a correction from the velocity relative to the barycentre of the solar system (we shouldn't try to convert anyway, we don't have anything to refer to right after AdvanceTime).