### PR TITLE
Do not ignore engines

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -169,9 +169,9 @@ void principia__AdvanceTime(Plugin* const plugin,
   return m.Return();
 }
 
-void principia__BeginReportingCollisions(Plugin* const plugin) {
-  journal::Method<journal::BeginReportingCollisions> m({plugin});
-  CHECK_NOTNULL(plugin)->BeginReportingCollisions();
+void principia__PrepareToReportCollisions(Plugin* const plugin) {
+  journal::Method<journal::PrepareToReportCollisions> m({plugin});
+  CHECK_NOTNULL(plugin)->PrepareToReportCollisions();
   return m.Return();
 }
 

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -169,6 +169,12 @@ void principia__AdvanceTime(Plugin* const plugin,
   return m.Return();
 }
 
+void principia__BeginReportingCollisions(Plugin* const plugin) {
+  journal::Method<journal::BeginReportingCollisions> m({plugin});
+  CHECK_NOTNULL(plugin)->BeginReportingCollisions();
+  return m.Return();
+}
+
 // Calls |plugin->CelestialFromParent| with the arguments given.
 // |plugin| must not be null.  No transfer of ownership.
 QP principia__CelestialFromParent(Plugin const* const plugin,

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -169,7 +169,9 @@ void PileUp::AdvanceTime(
                       /*authoritative=*/it != psychohistory_->last() ||
                                         last_point_is_authoritative);
   }
-  psychohistory_->ForgetBefore(last_authoritative().time());
+  psychohistory_->ForgetBefore(last_point_is_authoritative
+                                   ? psychohistory_->last().time()
+                                   : (--psychohistory_->last()).time());
   CHECK(last_point_is_authoritative ? psychohistory_->Size() == 1
                                     : psychohistory_->Size() == 2)
       << NAMED(last_point_is_authoritative) << ", "

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -487,8 +487,8 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
   vessel->part(part_id)->increment_intrinsic_force(WorldToBarycentric()(force));
 }
 
-void Plugin::BeginReportingCollisions() {
-  for (not_null<Vessel*>vessel:loaded_vessels_) {
+void Plugin::PrepareToReportCollisions() {
+  for (not_null<Vessel*> vessel : loaded_vessels_) {
     // TODO(egg): we're taking the address of a parameter passed by reference
     // here; but then I don't think I want to pass this by pointer, it's quite
     // convenient everywhere else...

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -477,11 +477,6 @@ void Plugin::InsertOrKeepLoadedPart(
   // NOTE(egg): we do not call |MakeSingleton| here, as that copies the current
   // intrinsic force of the part, so we must wait for
   // |IncrementPartIntrinsicForce| to be called.
-  // TODO(egg): we need a new function called after all calls to
-  // |IncrementPartIntrinsicForce| and before the calls to |ReportCollision| to
-  // make the singletons.  For now we make the singletons here and the forces
-  // get ignored.
-  Subset<Part>::MakeSingleton(*part, part);
 }
 
 void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
@@ -490,6 +485,22 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
   vessel->part(part_id)->increment_intrinsic_force(WorldToBarycentric()(force));
+}
+
+void Plugin::BeginReportingCollisions() {
+  for (not_null<Vessel*>vessel:loaded_vessels_) {
+    // TODO(egg): we're taking the address of a parameter passed by reference
+    // here; but then I don't think I want to pass this by pointer, it's quite
+    // convenient everywhere else...
+    vessel->ForAllParts(
+        [](Part& part) { Subset<Part>::MakeSingleton(part, &part); });
+  }
+}
+
+void Plugin::ReportCollision(PartId const part1, PartId const part2) const {
+  Part& p1 = *FindOrDie(part_id_to_vessel_, part1)->part(part1);
+  Part& p2 = *FindOrDie(part_id_to_vessel_, part2)->part(part2);
+  Subset<Part>::Unite(Subset<Part>::Find(p1), Subset<Part>::Find(p2));
 }
 
 void Plugin::FreeVesselsAndPartsAndCollectPileUps() {
@@ -872,12 +883,6 @@ void Plugin::SetPlottingFrame(
 
 not_null<NavigationFrame const*> Plugin::GetPlottingFrame() const {
   return plotting_frame_.get();
-}
-
-void Plugin::ReportCollision(PartId const part1, PartId const part2) const {
-  Part& p1 = *FindOrDie(part_id_to_vessel_, part1)->part(part1);
-  Part& p2 = *FindOrDie(part_id_to_vessel_, part2)->part(part2);
-  Subset<Part>::Unite(Subset<Part>::Find(p1), Subset<Part>::Find(p2));
 }
 
 std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -187,6 +187,16 @@ class Plugin {
   virtual void IncrementPartIntrinsicForce(PartId part_id,
                                            Vector<Force, World> const& force);
 
+  // Calls |MakeSingleton| for all parts in loaded vessels, enabling the use of
+  // union-find for pile up construction.  This must be called after the calls
+  // to |IncrementPartIntrinsicForce|, and before the calls to
+  // |ReportCollision|.
+  virtual void BeginReportingCollisions();
+
+  // Notifies |this| that the given vessels are touching, and should gravitate
+  // as part of a single rigid body.
+  virtual void ReportCollision(PartId part1, PartId part2) const;
+
   // Destroys the vessels for which |InsertOrKeepVessel| has not been called
   // since the last call to |FreeVesselsAndCollectPileUps|, as well as the parts
   // in loaded vessels for which |InsertOrKeepLoadedPart| has not been called,
@@ -319,10 +329,6 @@ class Plugin {
   virtual void SetPlottingFrame(
       not_null<std::unique_ptr<NavigationFrame>> plotting_frame);
   virtual not_null<NavigationFrame const*> GetPlottingFrame() const;
-
-  // Notifies |this| that the given vessels are touching, and should gravitate
-  // as part of a single rigid body.
-  virtual void ReportCollision(PartId part1, PartId part2) const;
 
   // The navball field at |current_time| for the current |plotting_frame_|.
   virtual std::unique_ptr<FrameField<World, Navball>> NavballFrameField(

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -191,7 +191,7 @@ class Plugin {
   // union-find for pile up construction.  This must be called after the calls
   // to |IncrementPartIntrinsicForce|, and before the calls to
   // |ReportCollision|.
-  virtual void BeginReportingCollisions();
+  virtual void PrepareToReportCollisions();
 
   // Notifies |this| that the given vessels are touching, and should gravitate
   // as part of a single rigid body.

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -722,6 +722,8 @@ public partial class PrincipiaPluginAdapter
      // step, the Planetarium hasn't run yet, and still has its old time.
      universal_time += Planetarium.TimeScale * Planetarium.fetch.fixedDeltaTime;
 
+     plugin_.BeginReportingCollisions();
+
      // The collisions are reported and stored into |currentCollisions| in
      // OnCollisionEnter|Stay|Exit, which occurred while we yielded.
      // Here, the |currentCollisions| are the collisions that occurred in the

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -722,7 +722,7 @@ public partial class PrincipiaPluginAdapter
      // step, the Planetarium hasn't run yet, and still has its old time.
      universal_time += Planetarium.TimeScale * Planetarium.fetch.fixedDeltaTime;
 
-     plugin_.BeginReportingCollisions();
+     plugin_.PrepareToReportCollisions();
 
      // The collisions are reported and stored into |currentCollisions| in
      // OnCollisionEnter|Stay|Exit, which occurred while we yielded.

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -85,7 +85,7 @@ message WXYZ {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5117.
+  extensions 5000 to 5999;  // Last used: 5118.
 }
 
 message AdvanceTime {
@@ -96,6 +96,16 @@ message AdvanceTime {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
     required double t = 2;
     required double planetarium_rotation = 3;
+  }
+  optional In in = 1;
+}
+
+message BeginReportingCollisions {
+  extend Method {
+    optional BeginReportingCollisions extension = 5118;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
   }
   optional In in = 1;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -100,9 +100,9 @@ message AdvanceTime {
   optional In in = 1;
 }
 
-message BeginReportingCollisions {
+message PrepareToReportCollisions {
   extend Method {
-    optional BeginReportingCollisions extension = 5118;
+    optional PrepareToReportCollisions extension = 5118;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];


### PR DESCRIPTION
Engines are now taken into account correctly, and conservation of momentum is otherwise enforced. Stage separation appears to work, however it also seems to jettison the camera for a while. This needs to be looked into.