### PR TITLE
Fix the camera and selection bugs

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -217,10 +217,13 @@ WXYZ principia__CelestialSphereRotation(Plugin const* const plugin) {
 }
 
 QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
-                                             int const index) {
-  journal::Method<journal::CelestialWorldDegreesOfFreedom> m({plugin, index});
+                                             int const index,
+                                             PartId const part_at_origin) {
+  journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
+      {plugin, index, part_at_origin});
   CHECK_NOTNULL(plugin);
-  auto const result = plugin->CelestialWorldDegreesOfFreedom(index);
+  auto const result =
+      plugin->CelestialWorldDegreesOfFreedom(index, part_at_origin);
   return m.Return(
       {ToXYZ((result.position() - World::origin).coordinates() / Metre),
        ToXYZ(result.velocity().coordinates() / (Metre / Second))});
@@ -351,10 +354,13 @@ int principia__GetBufferedLogging() {
 }
 
 QP principia__GetPartActualDegreesOfFreedom(Plugin const* const plugin,
-                                            PartId const part_id) {
-  journal::Method<journal::GetPartActualDegreesOfFreedom> m({plugin, part_id});
+                                            PartId const part_id,
+                                            PartId const part_at_origin) {
+  journal::Method<journal::GetPartActualDegreesOfFreedom> m(
+      {plugin, part_id, part_at_origin});
   DegreesOfFreedom<World> const degrees_of_freedom =
-      CHECK_NOTNULL(plugin)->GetPartActualDegreesOfFreedom(part_id);
+      CHECK_NOTNULL(plugin)->GetPartActualDegreesOfFreedom(part_id,
+                                                           part_at_origin);
   return m.Return(QP{
       ToXYZ((degrees_of_freedom.position() - World::origin).coordinates() /
             Metre),

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -600,20 +600,6 @@ void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
     Vessel& vessel = *pair.second;
     vessel.AdvanceTime();
   }
-  if (loaded_vessels_.empty()) {
-    bubble_barycentre_ = std::experimental::nullopt;
-  } else {
-    BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass>
-        bubble_barycentre_calculator;
-    for (not_null<Vessel*> const vessel : loaded_vessels_) {
-      vessel->ForAllParts([&bubble_barycentre_calculator](Part& part) {
-        part.clear_intrinsic_force();
-        bubble_barycentre_calculator.Add(part.degrees_of_freedom(),
-                                         part.mass());
-      });
-    }
-    bubble_barycentre_ = bubble_barycentre_calculator.Get();
-  }
 
   VLOG(1) << "Time has been advanced" << '\n'
           << "from : " << current_time_ << '\n'
@@ -624,34 +610,36 @@ void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
 }
 
 DegreesOfFreedom<World> Plugin::GetPartActualDegreesOfFreedom(
-    PartId const part_id) const {
-  CHECK(bubble_barycentre_);
+    PartId const part_id,
+    PartId const part_at_origin) const {
+  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)
+                                ->part(part_at_origin)
+                                ->degrees_of_freedom();
   RigidMotion<Barycentric, World> barycentric_to_world{
       RigidTransformation<Barycentric, World>{
-          bubble_barycentre_->position(), World::origin, BarycentricToWorld()},
+          world_origin.position(), World::origin, BarycentricToWorld()},
       AngularVelocity<Barycentric>{},
-      bubble_barycentre_->velocity()};
+      world_origin.velocity()};
   return barycentric_to_world(FindOrDie(part_id_to_vessel_, part_id)
                                   ->part(part_id)
                                   ->degrees_of_freedom());
 }
 
-DegreesOfFreedom<Barycentric> Plugin::GetBubbleBarycentre() const {
-  CHECK(bubble_barycentre_);
-  return *bubble_barycentre_;
-}
-
 DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
-    Index const index) const {
+    Index const index,
+    PartId const part_at_origin) const {
+  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)
+                                ->part(part_at_origin)
+                                ->degrees_of_freedom();
   RigidMotion<Barycentric, World> barycentric_to_world{
-      RigidTransformation<Barycentric, World>{GetBubbleBarycentre().position(),
-                                              World::origin,
-                                              BarycentricToWorld()},
+      RigidTransformation<Barycentric, World>{
+          world_origin.position(), World::origin, BarycentricToWorld()},
       AngularVelocity<Barycentric>{},
-      GetBubbleBarycentre().velocity()};
+      world_origin.velocity()};
   return barycentric_to_world(
-      FindOrDie(celestials_, index)->trajectory().EvaluateDegreesOfFreedom(
-          current_time_, /*hint=*/nullptr));
+      FindOrDie(celestials_, index)
+          ->trajectory()
+          .EvaluateDegreesOfFreedom(current_time_, /*hint=*/nullptr));
 }
 
 void Plugin::ForgetAllHistoriesBefore(Instant const& t) const {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -600,6 +600,11 @@ void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
     Vessel& vessel = *pair.second;
     vessel.AdvanceTime();
   }
+  for (not_null<Vessel*> const vessel : loaded_vessels_) {
+    vessel->ForAllParts([&bubble_barycentre_calculator](Part& part) {
+      part.clear_intrinsic_force();
+    });
+  }
 
   VLOG(1) << "Time has been advanced" << '\n'
           << "from : " << current_time_ << '\n'

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -615,34 +615,34 @@ void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
 DegreesOfFreedom<World> Plugin::GetPartActualDegreesOfFreedom(
     PartId const part_id,
     PartId const part_at_origin) const {
-  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)
-                                ->part(part_at_origin)
-                                ->degrees_of_freedom();
+  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)->
+                                part(part_at_origin)->
+                                degrees_of_freedom();
   RigidMotion<Barycentric, World> barycentric_to_world{
       RigidTransformation<Barycentric, World>{
           world_origin.position(), World::origin, BarycentricToWorld()},
       AngularVelocity<Barycentric>{},
       world_origin.velocity()};
-  return barycentric_to_world(FindOrDie(part_id_to_vessel_, part_id)
-                                  ->part(part_id)
-                                  ->degrees_of_freedom());
+  return barycentric_to_world(FindOrDie(part_id_to_vessel_, part_id)->
+                                  part(part_id)->
+                                  degrees_of_freedom());
 }
 
 DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
     Index const index,
     PartId const part_at_origin) const {
-  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)
-                                ->part(part_at_origin)
-                                ->degrees_of_freedom();
+  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)->
+                                part(part_at_origin)->
+                                degrees_of_freedom();
   RigidMotion<Barycentric, World> barycentric_to_world{
       RigidTransformation<Barycentric, World>{
           world_origin.position(), World::origin, BarycentricToWorld()},
       AngularVelocity<Barycentric>{},
       world_origin.velocity()};
   return barycentric_to_world(
-      FindOrDie(celestials_, index)
-          ->trajectory()
-          .EvaluateDegreesOfFreedom(current_time_, /*hint=*/nullptr));
+      FindOrDie(celestials_, index)->
+          trajectory().EvaluateDegreesOfFreedom(current_time_,
+                                                /*hint=*/nullptr));
 }
 
 void Plugin::ForgetAllHistoriesBefore(Instant const& t) const {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -601,9 +601,7 @@ void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {
     vessel.AdvanceTime();
   }
   for (not_null<Vessel*> const vessel : loaded_vessels_) {
-    vessel->ForAllParts([&bubble_barycentre_calculator](Part& part) {
-      part.clear_intrinsic_force();
-    });
+    vessel->ForAllParts([](Part& part) { part.clear_intrinsic_force(); });
   }
 
   VLOG(1) << "Time has been advanced" << '\n'

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -221,17 +221,17 @@ class Plugin {
   virtual void AdvanceTime(Instant const& t, Angle const& planetarium_rotation);
 
   // Returns the degrees of freedom of the given part in |World|, assuming that
-  // the origin of |World| is fixed at |bubble_barycentre_|.  The part must be
-  // in a loaded vessel.
+  // the origin of |World| is fixed at the centre of mass of the
+  // |part_at_origin|.
   virtual DegreesOfFreedom<World> GetPartActualDegreesOfFreedom(
-      PartId part_id) const;
-
-  virtual DegreesOfFreedom<Barycentric> GetBubbleBarycentre() const;
+      PartId part_id,
+      PartId part_at_origin) const;
 
   // Returns the |World| degrees of freedom of the |Celestial| with the given
   // |Index|, identifying the origin of |World| with that of |Bubble|.
   virtual DegreesOfFreedom<World> CelestialWorldDegreesOfFreedom(
-      Index const index) const;
+      Index const index,
+      PartId part_at_origin) const;
 
   // Forgets the histories of the |celestials_| and of the vessels before |t|.
   virtual void ForgetAllHistoriesBefore(Instant const& t) const;
@@ -513,7 +513,6 @@ class Plugin {
   // The vessels that were inserted unloaded and have yet to be collected into a
   // pile-up.
   std::set<not_null<Vessel*>> new_unloaded_vessels_;
-  std::experimental::optional<DegreesOfFreedom<Barycentric>> bubble_barycentre_;
 
   // Compatibility.
   bool is_pre_cardano_ = false;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -796,41 +796,44 @@ public partial class PrincipiaPluginAdapter
      // We don't want to do too many things here, since all the KSP classes
      // still think they're in the preceding step.  We only nudge the Unity
      // transforms of loaded vessels & their parts.
-     // TODO(egg): get vessel nudged positions and call Vessel.SetPosition.
-     // Hopefully that will be enough.
-     foreach (Vessel vessel in FlightGlobals.VesselsLoaded) {
-       // TODO(egg): if I understand anything, there should probably be a
-       // special treatment for loaded packed vessels.  I don't understand
-       // anything though.
-       if (vessel.packed || !plugin_.HasVessel(vessel.id.ToString())) {
-         continue;
-       }
-       foreach (Part part in vessel.parts) {
-         if (part.rb == null) {
+     if (has_active_vessel_in_space() && !FlightGlobals.ActiveVessel.packed) {
+       // TODO(egg): move this to the C++, this is just to check that I
+       // understand the issue.
+       QP root_dof =
+           plugin_.GetPartActualDegreesOfFreedom(
+               FlightGlobals.ActiveVessel.rootPart.flightID);
+       foreach (Vessel vessel in FlightGlobals.VesselsLoaded) {
+         // TODO(egg): if I understand anything, there should probably be a
+         // special treatment for loaded packed vessels.  I don't understand
+         // anything though.
+         if (vessel.packed || !plugin_.HasVessel(vessel.id.ToString())) {
            continue;
          }
-         QP part_actual_degrees_of_freedom =
-             plugin_.GetPartActualDegreesOfFreedom(part.flightID);
-         // TODO(egg): use the centre of mass.  Here it's a bit tedious, some
-         // transform nonsense must probably be done.
-         Log.Error(
-             "q correction " +
-             ((Vector3d)part_actual_degrees_of_freedom.q - part.rb.position));
-         Log.Error(
-             "v correction " +
-             ((Vector3d)part_actual_degrees_of_freedom.p - part.rb.velocity));
-         part.rb.position = (Vector3d)part_actual_degrees_of_freedom.q;
-         part.rb.velocity = (Vector3d)part_actual_degrees_of_freedom.p;
+         foreach (Part part in vessel.parts) {
+           if (part.rb == null) {
+             continue;
+           }
+           QP part_actual_degrees_of_freedom =
+               plugin_.GetPartActualDegreesOfFreedom(part.flightID);
+           // TODO(egg): use the centre of mass.  Here it's a bit tedious, some
+           // transform nonsense must probably be done.
+           Log.Error(
+               "q correction " +
+               ((Vector3d)part_actual_degrees_of_freedom.q - part.rb.position - (Vector3d)root_dof.q));
+           Log.Error(
+               "v correction " +
+               ((Vector3d)part_actual_degrees_of_freedom.p - part.rb.velocity));
+           part.rb.position = (Vector3d)part_actual_degrees_of_freedom.q - (Vector3d)root_dof.q;
+           part.rb.velocity = (Vector3d)part_actual_degrees_of_freedom.p;
+         }
        }
-     }
-     if (has_active_vessel_in_space() && !FlightGlobals.ActiveVessel.packed) {
        QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(
            FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex);
        Log.Error("change in framevel: " +
                  (-(Vector3d)main_body_dof.p - krakensbane.FrameVel));
        krakensbane.FrameVel = -(Vector3d)main_body_dof.p;
        Vector3d offset = (Vector3d)main_body_dof.q -
-                         FlightGlobals.ActiveVessel.mainBody.position;
+                         FlightGlobals.ActiveVessel.mainBody.position - (Vector3d)root_dof.q;
        Log.Error("shifting the world by " + offset);
        // We cannot use FloatingOrigin.SetOffset to move the world here, because
        // as far as I can tell, that does not move the bubble relative to the

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -799,9 +799,6 @@ public partial class PrincipiaPluginAdapter
      if (has_active_vessel_in_space() && !FlightGlobals.ActiveVessel.packed) {
        // TODO(egg): move this to the C++, this is just to check that I
        // understand the issue.
-       QP root_dof =
-           plugin_.GetPartActualDegreesOfFreedom(
-               FlightGlobals.ActiveVessel.rootPart.flightID);
        foreach (Vessel vessel in FlightGlobals.VesselsLoaded) {
          // TODO(egg): if I understand anything, there should probably be a
          // special treatment for loaded packed vessels.  I don't understand
@@ -814,26 +811,27 @@ public partial class PrincipiaPluginAdapter
              continue;
            }
            QP part_actual_degrees_of_freedom =
-               plugin_.GetPartActualDegreesOfFreedom(part.flightID);
+               plugin_.GetPartActualDegreesOfFreedom(part.flightID, FlightGlobals.ActiveVessel.rootPart.flightID);
            // TODO(egg): use the centre of mass.  Here it's a bit tedious, some
            // transform nonsense must probably be done.
            Log.Error(
                "q correction " +
-               ((Vector3d)part_actual_degrees_of_freedom.q - part.rb.position - (Vector3d)root_dof.q));
+               ((Vector3d)part_actual_degrees_of_freedom.q - part.rb.position));
            Log.Error(
                "v correction " +
                ((Vector3d)part_actual_degrees_of_freedom.p - part.rb.velocity));
-           part.rb.position = (Vector3d)part_actual_degrees_of_freedom.q - (Vector3d)root_dof.q;
+           part.rb.position = (Vector3d)part_actual_degrees_of_freedom.q;
            part.rb.velocity = (Vector3d)part_actual_degrees_of_freedom.p;
          }
        }
        QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(
-           FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex);
+           FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex,
+           FlightGlobals.ActiveVessel.rootPart.flightID);
        Log.Error("change in framevel: " +
                  (-(Vector3d)main_body_dof.p - krakensbane.FrameVel));
        krakensbane.FrameVel = -(Vector3d)main_body_dof.p;
        Vector3d offset = (Vector3d)main_body_dof.q -
-                         FlightGlobals.ActiveVessel.mainBody.position - (Vector3d)root_dof.q;
+                         FlightGlobals.ActiveVessel.mainBody.position;
        Log.Error("shifting the world by " + offset);
        // We cannot use FloatingOrigin.SetOffset to move the world here, because
        // as far as I can tell, that does not move the bubble relative to the

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -197,6 +197,7 @@ message CelestialWorldDegreesOfFreedom {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
                                  (is_subject) = true];
     required int32 index = 2;
+    required fixed32 part_at_origin = 3;
   }
   message Return {
     required QP result = 1;
@@ -606,6 +607,7 @@ message GetPartActualDegreesOfFreedom {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
                                  (is_subject) = true];
     required fixed32 part_id = 2;
+    required fixed32 part_at_origin = 3;
   }
   message Return {
     required QP result = 1;


### PR DESCRIPTION
Today in "KSP is dumb": the FloatingOrigin system puts the origin where the root part of the vessel is (i.e. at top typically). Then the camera is offset from that so that it's at the barycentre of the vessel. Because putting the barycentre of the thing to which physics happens at 0 and the camera looking there would be too sane.