### PR TITLE
Names

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -390,7 +390,7 @@ void Plugin::InsertOrKeepVessel(GUID const& vessel_guid,
                                                     prediction_parameters_));
   not_null<Vessel*> const vessel = it->second.get();
   if (vessel->name() != vessel_name) {
-    vessel->rename(vessel_name);
+    vessel->set_name(vessel_name);
   }
   kept_vessels_.emplace(vessel);
   vessel->set_parent(parent);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -389,6 +389,9 @@ void Plugin::InsertOrKeepVessel(GUID const& vessel_guid,
                                                     ephemeris_.get(),
                                                     prediction_parameters_));
   not_null<Vessel*> const vessel = it->second.get();
+  if (vessel->name() != vessel_name) {
+    vessel->rename(vessel_name);
+  }
   kept_vessels_.emplace(vessel);
   vessel->set_parent(parent);
   if (loaded) {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -46,6 +46,7 @@ Vessel::Vessel(GUID const& guid,
       prediction_(make_not_null_unique<DiscreteTrajectory<Barycentric>>()) {}
 
 Vessel::~Vessel() {
+  LOG(INFO) << "Destroying vessel " << ShortDebugString();
   // The parts must remove themselves from their pile-ups *before* any of them
   // starts to destroy, otherwise |clear_pile_up| might access destroyed parts.
   for (auto const& pair : parts_) {
@@ -56,6 +57,16 @@ Vessel::~Vessel() {
 
 GUID const& Vessel::guid() const {
   return guid_;
+}
+
+std::string const& Vessel::name() const {
+  return name_;
+}
+
+void Vessel::rename(std::string const& new_name) {
+  LOG(INFO) << "Vessel " << ShortDebugString() << " is now known as "
+            << new_name;
+  name_ = new_name;
 }
 
 not_null<MasslessBody const*> Vessel::body() const {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -63,7 +63,7 @@ std::string const& Vessel::name() const {
   return name_;
 }
 
-void Vessel::rename(std::string const& new_name) {
+void Vessel::set_name(std::string const& new_name) {
   LOG(INFO) << "Vessel " << ShortDebugString() << " is now known as "
             << new_name;
   name_ = new_name;

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -59,6 +59,11 @@ class Vessel {
   // Returns the GUID passed at construction.
   virtual GUID const& guid() const;
 
+  // Returns the name.
+  virtual std::string const& name() const;
+  // Changes the name.
+  virtual void rename(std::string const& new_name);
+
   // Returns the body for this vessel.
   virtual not_null<MasslessBody const*> body() const;
 
@@ -166,7 +171,7 @@ class Vessel {
   DiscreteTrajectory<Barycentric>::Iterator last_authoritative() const;
 
   GUID const guid_;
-  std::string const name_;
+  std::string name_;
 
   MasslessBody const body_;
   Ephemeris<Barycentric>::AdaptiveStepParameters

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -62,7 +62,7 @@ class Vessel {
   // Returns the name.
   virtual std::string const& name() const;
   // Changes the name.
-  virtual void rename(std::string const& new_name);
+  virtual void set_name(std::string const& new_name);
 
   // Returns the body for this vessel.
   virtual not_null<MasslessBody const*> body() const;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -963,6 +963,8 @@ public partial class PrincipiaPluginAdapter
         } else if (inserted) {
           foreach (ProtoPartSnapshot part in
                    vessel.protoVessel.protoPartSnapshots) {
+            // TODO(egg): perhaps we can live with the asteroids if we detect
+            // them here and reassign their flightID.
             plugin_.InsertUnloadedPart(
                 part.flightID,
                 part.partName,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -785,8 +785,8 @@ public partial class PrincipiaPluginAdapter
            var vessel2 = vessel1.evaController.LadderPart.vessel;
            if (vessel2 != null && plugin_.HasVessel(vessel2.id.ToString()) &&
                !vessel2.packed) {
-             plugin_.ReportCollision(vessel2.rootPart.flightID,
-                                     vessel1.rootPart.flightID);
+             plugin_.ReportCollision(vessel1.rootPart.flightID,
+                                     vessel1.evaController.LadderPart.flightID);
            }
          }
          foreach (Part part1 in vessel1.parts) {
@@ -794,8 +794,7 @@ public partial class PrincipiaPluginAdapter
              var part2 = collider.gameObject.GetComponentUpwards<Part>();
              var vessel2 = part2.vessel;
              if (vessel2 != null && plugin_.HasVessel(vessel2.id.ToString())) {
-               plugin_.ReportCollision(vessel1.rootPart.flightID,
-                                       vessel2.rootPart.flightID);
+               plugin_.ReportCollision(part1.flightID, part2.flightID);
              }
            }
          }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -785,8 +785,8 @@ public partial class PrincipiaPluginAdapter
            var vessel2 = vessel1.evaController.LadderPart.vessel;
            if (vessel2 != null && plugin_.HasVessel(vessel2.id.ToString()) &&
                !vessel2.packed) {
-             plugin_.ReportCollision(vessel1.rootPart.flightID,
-                                     vessel1.evaController.LadderPart.flightID);
+             plugin_.ReportCollision(vessel2.rootPart.flightID,
+                                     vessel1.rootPart.flightID);
            }
          }
          foreach (Part part1 in vessel1.parts) {
@@ -794,7 +794,8 @@ public partial class PrincipiaPluginAdapter
              var part2 = collider.gameObject.GetComponentUpwards<Part>();
              var vessel2 = part2.vessel;
              if (vessel2 != null && plugin_.HasVessel(vessel2.id.ToString())) {
-               plugin_.ReportCollision(part1.flightID, part2.flightID);
+               plugin_.ReportCollision(vessel1.rootPart.flightID,
+                                       vessel2.rootPart.flightID);
              }
            }
          }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -423,8 +423,6 @@ public partial class PrincipiaPluginAdapter
       String[] serializations = node.GetValues(principia_key);
       Log.Info("Serialization has " + serializations.Length + " chunks");
       foreach (String serialization in serializations) {
-        Log.Info("serialization is " + serialization.Length +
-                 " characters long");
         Interface.DeserializePlugin(serialization,
                                     serialization.Length,
                                     ref deserializer,
@@ -948,7 +946,7 @@ public partial class PrincipiaPluginAdapter
           foreach (Part part in vessel.parts.Where((part) => part.rb != null)) {
             plugin_.InsertOrKeepLoadedPart(
                 part.flightID,
-                part.partName,
+                part.name,
                 part.physicsMass,
                 vessel.id.ToString(),
                 vessel.mainBody.flightGlobalsIndex,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -924,6 +924,15 @@ public partial class PrincipiaPluginAdapter
     // part.forces, part.force, and part.torque are cleared by the/
     // FlightIntegrator's FixedUpdate (while we are yielding).
     if (PluginRunning()) {
+      if (has_active_vessel_in_space() && FlightGlobals.ActiveVessel.packed) {
+        if (PhysicsGlobals.GraviticForceMultiplier != 0) {  // sic.
+          Log.Info("Killing stock gravity");
+          PhysicsGlobals.GraviticForceMultiplier = 0;
+        }
+      } else if (PhysicsGlobals.GraviticForceMultiplier == 0) {
+        Log.Info("Reinstating stock gravity");
+        PhysicsGlobals.GraviticForceMultiplier = 1;
+      }
       foreach (Vessel vessel in FlightGlobals.Vessels.Where(is_in_space)) {
         bool inserted;
         plugin_.InsertOrKeepVessel(vessel.id.ToString(),

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -924,15 +924,6 @@ public partial class PrincipiaPluginAdapter
     // part.forces, part.force, and part.torque are cleared by the/
     // FlightIntegrator's FixedUpdate (while we are yielding).
     if (PluginRunning()) {
-      if (has_active_vessel_in_space() && FlightGlobals.ActiveVessel.packed) {
-        if (PhysicsGlobals.GraviticForceMultiplier != 0) {  // sic.
-          Log.Info("Killing stock gravity");
-          PhysicsGlobals.GraviticForceMultiplier = 0;
-        }
-      } else if (PhysicsGlobals.GraviticForceMultiplier == 0) {
-        Log.Info("Reinstating stock gravity");
-        PhysicsGlobals.GraviticForceMultiplier = 1;
-      }
       foreach (Vessel vessel in FlightGlobals.Vessels.Where(is_in_space)) {
         bool inserted;
         plugin_.InsertOrKeepVessel(vessel.id.ToString(),


### PR DESCRIPTION
- use the right part names `Part.partName` is always `"Part"`, `part.name` corresponds to `ProtoPartSnapshot.partName`;
- vessel renaming;
- remove a spammy serialization log;
- log on vessel destruction---this one is spammy, but I don't understand why? we should look into that;
- an improvised correction for `physicalObject`s;
- a `TODO` with a suggestion for the asteroid issue.