### PR TITLE
Fix an issue with ModularVesselPrecalculate

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -922,7 +922,11 @@ public partial class PrincipiaPluginAdapter
         continue;
       }
       vessel.precalc.enabled = true;
-      vessel.precalc.FixedUpdate();
+      // In stock this is equivalent to |FixedUpdate()|.  With
+      // ModularFlightIntegrator's ModularVesselPrecalculate, which gets run
+      // in TimingPre like us, this comes with a flag that ensures it only gets
+      // run once.
+      vessel.precalc.MainPhysics(true);
     }
   }
 


### PR DESCRIPTION
Together with @sarbian's commits on ModularFlightIntegrator, see https://github.com/sarbian/ModularFlightIntegrator/compare/89c79c0fa26b95989e49e4c37e72835693228aff...448a324efa30c4f47f9198c68982e0df5ada5bc9, this fixes an issue where vessels spawned in space, e.g. by decoupling, would measure an incorrect acceleration and prevent timewarp.