### PR TITLE
EVA crash

### DIFF
--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -31,7 +31,9 @@ Part::Part(
       degrees_of_freedom_(degrees_of_freedom),
       tail_(make_not_null_unique<DiscreteTrajectory<Barycentric>>()),
       subset_node_(make_not_null_unique<Subset<Part>::Node>()),
-      deletion_callback_(std::move(deletion_callback)) {}
+      deletion_callback_(std::move(deletion_callback)) {
+  CHECK_GT(mass_, Mass{}) << ShortDebugString();
+}
 
 Part::~Part() {
   LOG(INFO) << "Destroying part " << ShortDebugString();
@@ -46,6 +48,7 @@ PartId Part::part_id() const {
 }
 
 void Part::set_mass(Mass const& mass) {
+  CHECK_GT(mass, Mass{}) << ShortDebugString();
   mass_ = mass;
 }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -809,10 +809,12 @@ public partial class PrincipiaPluginAdapter
           Log.Error("insert or keep " + part.name + ": " + part.physicsMass +
                     " tonnes physics, " + part.mass + " tonnes mass, " +
                     part.rb.mass + " tonnes rbmass");
+          // In the first few frames after spawning a Kerbal, its physicsMass is
+          // 0; we use its rb.mass instead.
           plugin_.InsertOrKeepLoadedPart(
               part.flightID,
               part.name,
-              part.physicsMass,
+              part.physicsMass == 0 ? part.rb.mass : part.physicsMass,
               vessel.id.ToString(),
               vessel.mainBody.flightGlobalsIndex,
               main_body_degrees_of_freedom,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -819,7 +819,8 @@ public partial class PrincipiaPluginAdapter
               vessel.mainBody.flightGlobalsIndex,
               main_body_degrees_of_freedom,
               // TODO(egg): use the centre of mass.
-              part_id_to_degrees_of_freedom_[part.flightID]);
+              new QP{q = (XYZ)(Vector3d)part.rb.position,
+                     p = (XYZ)(Vector3d)part.rb.velocity});
           if (part_id_to_intrinsic_force_.ContainsKey(part.flightID)) {
             plugin_.IncrementPartIntrinsicForce(
                 part.flightID,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -804,7 +804,11 @@ public partial class PrincipiaPluginAdapter
         QP main_body_degrees_of_freedom =
             new QP{q = (XYZ)vessel.mainBody.position,
                    p = (XYZ)(-krakensbane.FrameVel)};
+        Log.Error("main body dof: " +  vessel.mainBody.position + ", " + (-krakensbane.FrameVel));
         foreach (Part part in vessel.parts.Where((part) => part.rb != null)) {
+          Log.Error("insert or keep " + part.name + ": " + part.physicsMass +
+                    " tonnes physics, " + part.mass + " tonnes mass, " +
+                    part.rb.mass + " tonnes rbmass");
           plugin_.InsertOrKeepLoadedPart(
               part.flightID,
               part.name,
@@ -903,6 +907,7 @@ public partial class PrincipiaPluginAdapter
         if (part.rb == null) {
           continue;
         }
+        Log.Error("set apparent for " + part.name + ": " + part.rb.position + ", " + part.rb.velocity);
         plugin_.SetPartApparentDegreesOfFreedom(
             part.flightID,
             // TODO(egg): use the centre of mass.
@@ -947,6 +952,12 @@ public partial class PrincipiaPluginAdapter
           QP part_actual_degrees_of_freedom =
               plugin_.GetPartActualDegreesOfFreedom(
                   part.flightID, FlightGlobals.ActiveVessel.rootPart.flightID);
+          Log.Error(
+              "q correction for " + part.name + ": " +
+              ((Vector3d)part_actual_degrees_of_freedom.q - part.rb.position));
+          Log.Error(
+              "v correction for " + part.name + ": " +
+              ((Vector3d)part_actual_degrees_of_freedom.p - part.rb.velocity));
           if (part == FlightGlobals.ActiveVessel.rootPart) {
             q_correction_at_root_part =
                 (Vector3d)part_actual_degrees_of_freedom.q - part.rb.position;


### PR DESCRIPTION
The unmanaged null dereference in Unity is due to putting a Kerbal at NaN because its `physicsMass` is 0.