### PR TITLE
Rename the body-centred-body-direction frame

### DIFF
--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -77,7 +77,6 @@ class ReferenceFrameSelector : WindowRenderer {
           throw Log.Fatal(
               "Naming parent-direction rotating frame of root body");
         } else {
-          // TODO(egg): find a proper name...
           return selected.name + "-Centred " + selected.referenceBody.name +
                  "-Aligned";
         }

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -94,14 +94,14 @@ class ReferenceFrameSelector : WindowRenderer {
         return selected.name[0] + "CI";
       case FrameType.BARYCENTRIC_ROTATING:
         if (selected.is_root()) {
-          throw Log.Fatal(
-              "Naming parent-direction rotating frame of root body");
+          throw Log.Fatal("Naming barycentric rotating frame of root body");
         } else {
           return selected.referenceBody.name[0] + (selected.name[0] + "B");
         }
       case FrameType.BODY_CENTRED_PARENT_DIRECTION:
         if (selected.is_root()) {
-          throw Log.Fatal("Naming barycentric rotating frame of root body");
+          throw Log.Fatal(
+              "Naming parent-direction rotating frame of root body");
         } else {
           return selected.name[0] + "C" + selected.referenceBody.name[0] +
                  "A";

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -79,7 +79,7 @@ class ReferenceFrameSelector : WindowRenderer {
         } else {
           // TODO(egg): find a proper name...
           return selected.name + "-Centred " + selected.referenceBody.name +
-                 "-Fixed";
+                 "-Aligned";
         }
      case FrameType.BODY_SURFACE:
        return selected.name + "-Centred " + selected.name + "-Fixed";
@@ -104,7 +104,7 @@ class ReferenceFrameSelector : WindowRenderer {
           throw Log.Fatal("Naming barycentric rotating frame of root body");
         } else {
           return selected.name[0] + "C" + selected.referenceBody.name[0] +
-                 "F";
+                 "A";
         }
       case FrameType.BODY_SURFACE:
         return selected.name[0] + "C" + selected.name[0] + "F";


### PR DESCRIPTION
Earth-Centred Sun-Fixed is confusing (the sun isn't really fixed, because of the excentricity), it sounds too much like Earth-Centred Earth-Fixed, and it can lead to unnecessary acronym collisions, e.g. SCSF for either Saturn-Centred Saturn-Fixed or Saturn-Centred Sun-Fixed (SCSA with the new convention).