### PR TITLE
Change Plugin and Celestial to operate on rotating bodies instead of massive bodies.

### DIFF
--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -101,7 +101,7 @@ class SolarSystemDynamicsTest : public testing::Test {
     auto const parent_name =
         SolarSystemFactory::name(SolarSystemFactory::parent(index));
     auto const body = system.massive_body(ephemeris, name);
-    auto const* const parent =
+    auto const parent =
         dynamic_cast_not_null<RotatingBody<ICRFJ2000Equator> const*>(
             system.massive_body(ephemeris, parent_name));
 

--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -113,13 +113,6 @@ using _checked_not_null = typename std::enable_if<
 template<typename Pointer>
 using is_instance_of_not_null = is_instance_of<not_null, Pointer>;
 
-template<typename Pointer>
-struct is_not_null_non_owner : std::false_type, not_constructible {};
-
-template<typename T>
-struct is_not_null_non_owner<not_null<T*>> : std::true_type,
-                                             not_constructible {};
-
 // |not_null<Pointer>| is a wrapper for a non-null object of type |Pointer|.
 // |Pointer| should be a C-style pointer or a smart pointer.  |Pointer| must not
 // be a const, reference, rvalue reference, or |not_null|.  |not_null<Pointer>|

--- a/base/not_null_test.cpp
+++ b/base/not_null_test.cpp
@@ -149,6 +149,24 @@ TEST_F(NotNullTest, CheckArguments) {
 #endif
 }
 
+TEST_F(NotNullTest, DynamicCast) {
+  class Base {
+   public:
+    virtual ~Base() = default;
+  };
+  class Derived : public Base {};
+  {
+    not_null<Base*> b = new Derived;
+    not_null<Derived*> d = dynamic_cast_not_null<Derived*>(b);
+    delete b;
+  }
+  {
+    not_null<std::unique_ptr<Base>> b = make_not_null_unique<Derived>();
+    not_null<std::unique_ptr<Derived>> d =
+        dynamic_cast_not_null<std::unique_ptr<Derived>>(std::move(b));
+  }
+}
+
 TEST_F(NotNullTest, RValue) {
   std::unique_ptr<int> owner_int = std::make_unique<int>(1);
   not_null<int*> not_null_int = new int(2);

--- a/ksp_plugin/celestial.cpp
+++ b/ksp_plugin/celestial.cpp
@@ -1,13 +1,10 @@
-﻿
-#pragma once
-
-#include "ksp_plugin/celestial.hpp"
+﻿#include "ksp_plugin/celestial.hpp"
 
 namespace principia {
 namespace ksp_plugin {
 namespace internal_celestial {
 
-inline Celestial::Celestial(not_null<MassiveBody const*> body)
+inline Celestial::Celestial(not_null<RotatingBody<Barycentric> const*> body)
     : body_(body),
       current_time_hint_(
           make_not_null_unique<ContinuousTrajectory<Barycentric>::Hint>()) {}
@@ -52,7 +49,7 @@ inline Velocity<Barycentric> Celestial::current_velocity(
   return trajectory().EvaluateVelocity(current_time, current_time_hint());
 }
 
-inline not_null<MassiveBody const*> Celestial::body() const {
+inline not_null<RotatingBody<Barycentric> const*> Celestial::body() const {
   return body_;
 }
 

--- a/ksp_plugin/celestial.cpp
+++ b/ksp_plugin/celestial.cpp
@@ -4,64 +4,64 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_celestial {
 
-inline Celestial::Celestial(not_null<RotatingBody<Barycentric> const*> body)
+Celestial::Celestial(not_null<RotatingBody<Barycentric> const*> body)
     : body_(body),
       current_time_hint_(
           make_not_null_unique<ContinuousTrajectory<Barycentric>::Hint>()) {}
 
-inline bool Celestial::is_initialized() const {
+bool Celestial::is_initialized() const {
   return trajectory_ != nullptr;
 }
 
-inline void Celestial::set_trajectory(
+void Celestial::set_trajectory(
     not_null<ContinuousTrajectory<Barycentric> const*> const trajectory) {
   CHECK(!is_initialized());
   trajectory_ = trajectory;
 }
 
-inline ContinuousTrajectory<Barycentric> const& Celestial::trajectory() const {
+ContinuousTrajectory<Barycentric> const& Celestial::trajectory() const {
   CHECK(is_initialized());
   return *trajectory_;
 }
 
-inline not_null<ContinuousTrajectory<Barycentric>::Hint*>
+not_null<ContinuousTrajectory<Barycentric>::Hint*>
 Celestial::current_time_hint() const {
   CHECK(is_initialized());
   return current_time_hint_.get();
 }
 
-inline DegreesOfFreedom<Barycentric> Celestial::current_degrees_of_freedom(
+DegreesOfFreedom<Barycentric> Celestial::current_degrees_of_freedom(
     Instant const& current_time) const {
   CHECK(is_initialized());
   return trajectory().EvaluateDegreesOfFreedom(current_time,
                                                current_time_hint());
 }
 
-inline Position<Barycentric> Celestial::current_position(
+Position<Barycentric> Celestial::current_position(
     Instant const& current_time) const {
   CHECK(is_initialized());
   return trajectory().EvaluatePosition(current_time, current_time_hint());
 }
 
-inline Velocity<Barycentric> Celestial::current_velocity(
+Velocity<Barycentric> Celestial::current_velocity(
     Instant const& current_time) const {
   CHECK(is_initialized());
   return trajectory().EvaluateVelocity(current_time, current_time_hint());
 }
 
-inline not_null<RotatingBody<Barycentric> const*> Celestial::body() const {
+not_null<RotatingBody<Barycentric> const*> Celestial::body() const {
   return body_;
 }
 
-inline bool Celestial::has_parent() const {
+bool Celestial::has_parent() const {
   return parent_ != nullptr;
 }
 
-inline Celestial const* Celestial::parent() const {
+Celestial const* Celestial::parent() const {
   return parent_;
 }
 
-inline void Celestial::set_parent(not_null<Celestial const*> const parent) {
+void Celestial::set_parent(not_null<Celestial const*> const parent) {
   parent_ = parent;
 }
 

--- a/ksp_plugin/celestial.hpp
+++ b/ksp_plugin/celestial.hpp
@@ -8,7 +8,7 @@
 #include "physics/body.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/continuous_trajectory.hpp"
-#include "physics/massive_body.hpp"
+#include "physics/rotating_body.hpp"
 #include "quantities/named_quantities.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
@@ -24,13 +24,13 @@ using geometry::Velocity;
 using physics::Body;
 using physics::ContinuousTrajectory;
 using physics::DegreesOfFreedom;
-using physics::MassiveBody;
+using physics::RotatingBody;
 using quantities::GravitationalParameter;
 
 // Represents a KSP |CelestialBody|.
 class Celestial final {
  public:
-  explicit Celestial(not_null<MassiveBody const*> body);
+  explicit Celestial(not_null<RotatingBody<Barycentric> const*> body);
   Celestial(Celestial const&) = delete;
   Celestial(Celestial&&) = delete;
 
@@ -45,13 +45,13 @@ class Celestial final {
   Position<Barycentric> current_position(Instant const& current_time) const;
   Velocity<Barycentric> current_velocity(Instant const& current_time) const;
 
-  not_null<MassiveBody const*> body() const;
+  not_null<RotatingBody<Barycentric> const*> body() const;
   bool has_parent() const;
   Celestial const* parent() const;  // Null for the Sun.
   void set_parent(not_null<Celestial const*> parent);
 
  private:
-  not_null<MassiveBody const*> body_;
+  not_null<RotatingBody<Barycentric> const*> body_;
   // The parent body for the 2-body approximation. Not owning, must only
   // be null for the sun.
   Celestial const* parent_ = nullptr;
@@ -67,5 +67,3 @@ using internal_celestial::Celestial;
 
 }  // namespace ksp_plugin
 }  // namespace principia
-
-#include "ksp_plugin/celestial_body.hpp"

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -80,7 +80,7 @@ namespace {
 int const chunk_size = 64 << 10;
 int const number_of_chunks = 8;
 
-base::not_null<std::unique_ptr<MassiveBody>> MakeMassiveBody(
+base::not_null<std::unique_ptr<RotatingBody<Barycentric>>> MakeRotatingBody(
     BodyParameters const& body_parameters) {
   // Logging operators would dereference a null C string.
   auto const make_optional_c_string = [](char const* const c_string) {
@@ -131,7 +131,7 @@ base::not_null<std::unique_ptr<MassiveBody>> MakeMassiveBody(
   if (body_parameters.reference_radius != nullptr) {
     gravity_model.set_reference_radius(body_parameters.reference_radius);
   }
-  return SolarSystem<Barycentric>::MakeMassiveBody(gravity_model);
+  return SolarSystem<Barycentric>::MakeRotatingBody(gravity_model);
 }
 
 }  // namespace
@@ -516,7 +516,7 @@ void principia__InsertCelestialAbsoluteCartesian(
       parent_index == nullptr ? std::experimental::nullopt
                               : std::experimental::make_optional(*parent_index),
       SolarSystem<Barycentric>::MakeDegreesOfFreedom(initial_state),
-      MakeMassiveBody(body_parameters));
+      MakeRotatingBody(body_parameters));
   return m.Return();
 }
 
@@ -541,7 +541,7 @@ void principia__InsertCelestialJacobiKeplerian(
           ? std::experimental::nullopt
           : std::experimental::make_optional(
                 FromKeplerianElements(*keplerian_elements)),
-      MakeMassiveBody(body_parameters));
+      MakeRotatingBody(body_parameters));
   return m.Return();
 }
 

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -330,7 +330,7 @@ copy /Y "$(OutDir)$(TargetName).pdb" "$(SolutionDir)$(Configuration)\GameData\Pr
   <ItemGroup>
     <ClInclude Include="burn.hpp" />
     <ClInclude Include="celestial.hpp" />
-    <ClInclude Include="celestial_body.hpp" />
+    <ClInclude Include="celestial.cpp" />
     <ClInclude Include="identification.hpp" />
     <ClInclude Include="part_subsets.hpp" />
     <ClInclude Include="pile_up.hpp" />

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -330,7 +330,6 @@ copy /Y "$(OutDir)$(TargetName).pdb" "$(SolutionDir)$(Configuration)\GameData\Pr
   <ItemGroup>
     <ClInclude Include="burn.hpp" />
     <ClInclude Include="celestial.hpp" />
-    <ClInclude Include="celestial.cpp" />
     <ClInclude Include="identification.hpp" />
     <ClInclude Include="part_subsets.hpp" />
     <ClInclude Include="pile_up.hpp" />
@@ -357,6 +356,7 @@ copy /Y "$(OutDir)$(TargetName).pdb" "$(SolutionDir)$(Configuration)\GameData\Pr
     <ClCompile Include="..\journal\profiles.cpp" />
     <ClCompile Include="..\journal\recorder.cpp" />
     <ClCompile Include="burn.cpp" />
+    <ClCompile Include="celestial.cpp" />
     <ClCompile Include="flight_plan.cpp" />
     <ClCompile Include="identification.cpp" />
     <ClCompile Include="interface.cpp" />

--- a/ksp_plugin/ksp_plugin.vcxproj.filters
+++ b/ksp_plugin/ksp_plugin.vcxproj.filters
@@ -56,9 +56,6 @@
     <ClInclude Include="identification.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="celestial.cpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="interface.cpp">
@@ -104,6 +101,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="identification.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="celestial.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ksp_plugin/ksp_plugin.vcxproj.filters
+++ b/ksp_plugin/ksp_plugin.vcxproj.filters
@@ -26,9 +26,6 @@
     <ClInclude Include="frames.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="celestial_body.hpp">
-      <Filter>Source Files</Filter>
-    </ClInclude>
     <ClInclude Include="part.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -58,6 +55,9 @@
     </ClInclude>
     <ClInclude Include="identification.hpp">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="celestial.cpp">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -254,18 +254,15 @@ void Plugin::EndInitialization() {
       hex.data[hex.size - 1] = 0;
       file << reinterpret_cast<char const*>(hex.data.get()) << "\n";
 #endif
-      // Moving out of the vector and keeping a pointer in the map requires that
-      // we release and rewrap the pointer.  Apologies.
-      auto const unowned_body =
-          dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
-              system.bodies[i].release());
-      std::unique_ptr<RotatingBody<Barycentric> const> owned_body(unowned_body);
-      Index const celestial_index = bodies_to_indices[unowned_body];
+      auto rotating_body = dynamic_cast_not_null<
+          std::unique_ptr<RotatingBody<Barycentric> const>>(
+              std::move(system.bodies[i]));
+      Index const celestial_index = bodies_to_indices[rotating_body.get()];
       InsertCelestialAbsoluteCartesian(
           celestial_index,
           FindOrDie(parents, celestial_index),
           system.degrees_of_freedom[i],
-          std::move(owned_body));
+          std::move(rotating_body));
     }
 #if LOG_KSP_SYSTEM
     file.close();

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -35,7 +35,7 @@
 #include "physics/body_surface_frame_field.hpp"
 #include "physics/dynamic_frame.hpp"
 #include "physics/frame_field.hpp"
-#include "physics/rotating_body.hpp"
+#include "physics/massive_body.hpp"
 
 namespace principia {
 namespace ksp_plugin {
@@ -69,7 +69,7 @@ using physics::CoordinateFrameField;
 using physics::DynamicFrame;
 using physics::Frenet;
 using physics::KeplerianElements;
-using physics::RotatingBody;
+using physics::MassiveBody;
 using physics::RigidMotion;
 using physics::RigidTransformation;
 using quantities::Force;
@@ -113,7 +113,7 @@ void Plugin::InsertCelestialAbsoluteCartesian(
     Index const celestial_index,
     std::experimental::optional<Index> const& parent_index,
     DegreesOfFreedom<Barycentric> const& initial_state,
-    not_null<std::unique_ptr<MassiveBody const>> body) {
+    not_null<std::unique_ptr<RotatingBody<Barycentric> const>> body) {
   LOG(INFO) << __FUNCTION__ << "\n"
             << NAMED(celestial_index) << "\n"
             << NAMED(parent_index) << "\n"
@@ -156,7 +156,7 @@ void Plugin::InsertCelestialJacobiKeplerian(
     std::experimental::optional<Index> const& parent_index,
     std::experimental::optional<KeplerianElements<Barycentric>> const&
         keplerian_elements,
-    not_null<std::unique_ptr<MassiveBody>> body) {
+    not_null<std::unique_ptr<RotatingBody<Barycentric>>> body) {
   LOG(INFO) << __FUNCTION__ << "\n"
             << NAMED(celestial_index) << "\n"
             << NAMED(parent_index) << "\n"
@@ -167,7 +167,7 @@ void Plugin::InsertCelestialJacobiKeplerian(
   CHECK(!absolute_initialization_);
   CHECK_EQ((bool)parent_index, (bool)keplerian_elements);
   CHECK_EQ((bool)parent_index, (bool)hierarchical_initialization_);
-  MassiveBody* const unowned_body = body.get();
+  RotatingBody<Barycentric>* const unowned_body = body.get();
   if (hierarchical_initialization_) {
     hierarchical_initialization_->system.Add(
         std::move(body),
@@ -209,9 +209,10 @@ void Plugin::EndInitialization() {
 
     HierarchicalSystem<Barycentric>::BarycentricSystem system =
         hierarchical_initialization_->system.ConsumeBarycentricSystem();
-    std::map<not_null<MassiveBody const*>, Index> bodies_to_indices;
+    std::map<not_null<RotatingBody<Barycentric> const*>,
+             Index> bodies_to_indices;
     for (auto const& index_body :
-         hierarchical_initialization_->indices_to_bodies) {
+             hierarchical_initialization_->indices_to_bodies) {
       bodies_to_indices[index_body.second] = index_body.first;
     }
     auto const parents = std::move(hierarchical_initialization_->parents);
@@ -253,12 +254,18 @@ void Plugin::EndInitialization() {
       hex.data[hex.size - 1] = 0;
       file << reinterpret_cast<char const*>(hex.data.get()) << "\n";
 #endif
-      Index const celestial_index = bodies_to_indices[system.bodies[i].get()];
+      // Moving out of the vector and keeping a pointer in the map requires that
+      // we release and rewrap the pointer.  Apologies.
+      auto const unowned_body =
+          dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
+              system.bodies[i].release());
+      std::unique_ptr<RotatingBody<Barycentric> const> owned_body(unowned_body);
+      Index const celestial_index = bodies_to_indices[unowned_body];
       InsertCelestialAbsoluteCartesian(
           celestial_index,
           FindOrDie(parents, celestial_index),
           system.degrees_of_freedom[i],
-          std::move(system.bodies[i]));
+          std::move(owned_body));
     }
 #if LOG_KSP_SYSTEM
     file.close();
@@ -266,8 +273,7 @@ void Plugin::EndInitialization() {
   }
   CHECK(absolute_initialization_);
   CHECK_NOTNULL(sun_);
-  main_body_ = CHECK_NOTNULL(
-      dynamic_cast_not_null<RotatingBody<Barycentric> const*>(sun_->body()));
+  main_body_ = sun_->body();
   UpdatePlanetariumRotation();
   initializing_.Flop();
 
@@ -315,8 +321,7 @@ void Plugin::UpdateCelestialHierarchy(Index const celestial_index,
 }
 
 void Plugin::SetMainBody(Index const index) {
-  main_body_ = dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
-      FindOrDie(celestials_, index)->body());
+  main_body_ = FindOrDie(celestials_, index)->body();
   LOG_IF(FATAL, main_body_ == nullptr) << index;
   UpdatePlanetariumRotation();
 }
@@ -329,8 +334,7 @@ Rotation<BodyWorld, World> Plugin::CelestialRotation(
   Permutation<BodyWorld, BodyFixed> const body_mirror(
       Permutation<BodyWorld, BodyFixed>::XZY);
 
-  auto const& body = dynamic_cast<RotatingBody<Barycentric> const&>(
-      *FindOrDie(celestials_, index)->body());
+  auto const& body = *FindOrDie(celestials_, index)->body();
 
   OrthogonalMap<BodyWorld, World> const result =
       OrthogonalMap<WorldSun, World>::Identity() *
@@ -355,14 +359,12 @@ Rotation<CelestialSphere, World> Plugin::CelestialSphereRotation()
 }
 
 Angle Plugin::CelestialInitialRotation(Index const celestial_index) const {
-  auto const& body = dynamic_cast<RotatingBody<Barycentric> const&>(
-      *FindOrDie(celestials_, celestial_index)->body());
+  auto const& body = *FindOrDie(celestials_, celestial_index)->body();
   return body.AngleAt(game_epoch_);
 }
 
 Time Plugin::CelestialRotationPeriod(Index const celestial_index) const {
-  auto const& body = dynamic_cast<RotatingBody<Barycentric> const&>(
-      *FindOrDie(celestials_, celestial_index)->body());
+  auto const& body = *FindOrDie(celestials_, celestial_index)->body();
   // The result will be negative if the pole is the negative pole
   // (e.g. for Venus).  This is the convention KSP uses for retrograde rotation.
   return 2 * π * Radian / body.angular_frequency();
@@ -868,8 +870,7 @@ Plugin::NewBodySurfaceNavigationFrame(
       *FindOrDie(celestials_, reference_body_index);
   return make_not_null_unique<BodySurfaceDynamicFrame<Barycentric, Navigation>>(
       ephemeris_.get(),
-      dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
-          reference_body.body()));
+      reference_body.body());
 }
 
 void Plugin::SetPlottingFrame(
@@ -958,7 +959,7 @@ std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(
   };
 
   std::unique_ptr<FrameField<Navigation, RightHandedNavball>> frame_field;
-  auto const plotting_frame_as_body_surface_dynamic_frame =
+  auto* const plotting_frame_as_body_surface_dynamic_frame =
       dynamic_cast<BodySurfaceDynamicFrame<Barycentric, Navigation>*>(
           &*plotting_frame_);
   if (plotting_frame_as_body_surface_dynamic_frame == nullptr) {
@@ -972,9 +973,9 @@ std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(
         this,
         make_not_null_unique<
             BodySurfaceFrameField<Barycentric, RightHandedNavball>>(
-            *ephemeris_,
-            current_time_,
-            plotting_frame_as_body_surface_dynamic_frame->centre()),
+                *ephemeris_,
+                current_time_,
+                plotting_frame_as_body_surface_dynamic_frame->centre()),
         sun_world_position);
   }
 }
@@ -1167,9 +1168,7 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
       Angle::ReadFromMessage(message.planetarium_rotation());
 
   plugin->sun_ = FindOrDie(plugin->celestials_, message.sun_index()).get();
-  plugin->main_body_ =
-      CHECK_NOTNULL(dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
-          plugin->sun_->body()));
+  plugin->main_body_ = plugin->sun_->body();
   plugin->UpdatePlanetariumRotation();
 
   std::unique_ptr<NavigationFrame> plotting_frame =
@@ -1203,12 +1202,17 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
 }
 
 std::unique_ptr<Ephemeris<Barycentric>> Plugin::NewEphemeris(
-    std::vector<not_null<std::unique_ptr<MassiveBody const>>>&& bodies,
+    std::vector<
+        not_null<std::unique_ptr<RotatingBody<Barycentric> const>>>&& bodies,
     std::vector<DegreesOfFreedom<Barycentric>> const& initial_state,
     Instant const& initial_time,
     Length const& fitting_tolerance,
     Ephemeris<Barycentric>::FixedStepParameters const& parameters) {
-  return std::make_unique<Ephemeris<Barycentric>>(std::move(bodies),
+  std::vector<not_null<std::unique_ptr<MassiveBody const>>> massive_bodies;
+  for (auto& body : bodies) {
+    massive_bodies.emplace_back(std::move(body));
+  }
+  return std::make_unique<Ephemeris<Barycentric>>(std::move(massive_bodies),
                                                   initial_state,
                                                   initial_time,
                                                   fitting_tolerance,
@@ -1225,7 +1229,8 @@ Plugin::Plugin(
       prediction_parameters_(prediction_parameters) {}
 
 void Plugin::InitializeEphemerisAndSetCelestialTrajectories() {
-  std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
+  std::vector<
+      not_null<std::unique_ptr<RotatingBody<Barycentric> const>>> bodies;
   std::vector<DegreesOfFreedom<Barycentric>> initial_state;
   for (auto& pair : absolute_initialization_->bodies) {
     auto& body = pair.second;
@@ -1253,8 +1258,8 @@ void Plugin::InitializeEphemerisAndSetCelestialTrajectories() {
   SetPlottingFrame(
       make_not_null_unique<
           BodyCentredNonRotatingDynamicFrame<Barycentric, Navigation>>(
-          ephemeris_.get(),
-          sun_->body()));
+              ephemeris_.get(),
+              sun_->body()));
 }
 
 not_null<std::unique_ptr<Vessel>> const& Plugin::find_vessel_by_guid_or_die(
@@ -1324,7 +1329,9 @@ void Plugin::ReadCelestialsFromMessages(
   for (auto const& celestial_message : celestial_messages) {
     auto const inserted = celestials.emplace(
         celestial_message.index(),
-        make_not_null_unique<Celestial>(*bodies_it));
+        make_not_null_unique<Celestial>(
+            dynamic_cast_not_null<RotatingBody<Barycentric> const*>(
+                *bodies_it)));
     CHECK(inserted.second);
     inserted.first->second->set_trajectory(ephemeris.trajectory(*bodies_it));
     ++bodies_it;
@@ -1346,7 +1353,7 @@ std::uint64_t Plugin::FingerprintCelestialJacobiKeplerian(
     std::experimental::optional<Index> const& parent_index,
     std::experimental::optional<physics::KeplerianElements<Barycentric>> const&
         keplerian_elements,
-    MassiveBody const& body) {
+    RotatingBody<Barycentric> const& body) {
   serialization::CelestialJacobiKeplerian message;
   message.set_celestial_index(celestial_index);
   if (parent_index) {

--- a/ksp_plugin_test/celestial_test.cpp
+++ b/ksp_plugin_test/celestial_test.cpp
@@ -3,23 +3,35 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "physics/massive_body.hpp"
+#include "quantities/si.hpp"
 
 namespace principia {
 namespace ksp_plugin {
 namespace internal_celestial {
 
+using physics::MassiveBody;
+using quantities::si::Degree;
 using quantities::si::Kilogram;
 using quantities::si::Metre;
+using quantities::si::Radian;
 using quantities::si::Second;
 
 class CelestialTest : public testing::Test {
  protected:
   CelestialTest()
-      : body_(1 * Kilogram),
+      : body_(MassiveBody::Parameters(1 * Kilogram),
+              RotatingBody<Barycentric>::Parameters(
+                  /*mean_radius=*/1 * Metre,
+                  /*reference_angle=*/0 * Degree,
+                  /*reference_instant=*/astronomy::J2000,
+                  /*angular_frequency=*/1 * Radian / Second,
+                  /*right_ascension_of_pole=*/0 * Degree,
+                  /*declination_of_pole=*/90 * Degree)),
         celestial_(make_not_null_unique<Celestial>(&body_)),
         trajectory_(1 * Second, 1 * Metre) {}
 
-  MassiveBody body_;
+  RotatingBody<Barycentric> body_;
   not_null<std::unique_ptr<Celestial>> celestial_;
   ContinuousTrajectory<Barycentric> trajectory_;
 };

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -299,12 +299,12 @@ TEST_F(InterfaceTest, InsertMassiveCelestialAbsoluteCartesian) {
   BodyParameters const body_parameters = {
       "Brian",
       "1.2345e6  m^3/s^2",
-      std::numeric_limits<double>::quiet_NaN(),
-      /*mean_radius=*/nullptr,
-      /*axis_right_ascension=*/nullptr,
-      /*axis_declination=*/nullptr,
-      /*reference_angle=*/nullptr,
-      /*angular_velocity=*/nullptr,
+      /*reference_instant=*/0.0,
+      /*mean_radius=*/"1 m",
+      /*axis_right_ascension=*/"0 deg",
+      /*axis_declination=*/"90 deg",
+      /*reference_angle=*/"0 deg",
+      /*angular_velocity=*/"1 rad/s",
       /*j2=*/nullptr,
       /*reference_radius=*/nullptr};
   principia__InsertCelestialAbsoluteCartesian(plugin_.get(),
@@ -344,7 +344,7 @@ TEST_F(InterfaceTest, InsertOblateCelestialAbsoluteCartesian) {
                              666 * Kilo(Metre))))));
   BodyParameters const body_parameters = {"that is called Brian",
                                           "1.2345e6  km^3 / s^2",
-                                          999,
+                                          999.0,
                                           "666 km",
                                           "42 deg",
                                           u8"8°",

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="..\journal\profiles.cpp" />
     <ClCompile Include="..\journal\recorder.cpp" />
     <ClCompile Include="..\ksp_plugin\burn.cpp" />
+    <ClCompile Include="..\ksp_plugin\celestial.cpp" />
     <ClCompile Include="..\ksp_plugin\flight_plan.cpp" />
     <ClCompile Include="..\ksp_plugin\identification.cpp" />
     <ClCompile Include="..\ksp_plugin\interface.cpp" />

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClCompile Include="..\ksp_plugin\identification.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ksp_plugin\celestial.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_plugin.hpp">

--- a/ksp_plugin_test/mock_plugin.cpp
+++ b/ksp_plugin_test/mock_plugin.cpp
@@ -15,7 +15,7 @@ void MockPlugin::InsertCelestialAbsoluteCartesian(
       Index const celestial_index,
       std::experimental::optional<Index> const& parent_index,
       DegreesOfFreedom<Barycentric> const& initial_state,
-      base::not_null<std::unique_ptr<MassiveBody const>> body) {
+      base::not_null<std::unique_ptr<RotatingBody<Barycentric> const>> body) {
   InsertCelestialAbsoluteCartesianConstRef(
       celestial_index, parent_index, initial_state, body);
 }

--- a/ksp_plugin_test/mock_plugin.hpp
+++ b/ksp_plugin_test/mock_plugin.hpp
@@ -22,14 +22,16 @@ class MockPlugin : public Plugin {
       Index celestial_index,
       std::experimental::optional<Index> const& parent_index,
       DegreesOfFreedom<Barycentric> const& initial_state,
-      base::not_null<std::unique_ptr<MassiveBody const>> body) override;
+      base::not_null<std::unique_ptr<RotatingBody<Barycentric> const>> body)
+      override;
 
   MOCK_METHOD4(
       InsertCelestialAbsoluteCartesianConstRef,
       void(Index celestial_index,
            std::experimental::optional<Index> const& parent_index,
            DegreesOfFreedom<Barycentric> const& initial_state,
-           base::not_null<std::unique_ptr<MassiveBody const>> const& body));
+           base::not_null<
+               std::unique_ptr<RotatingBody<Barycentric> const>> const& body));
 
   MOCK_METHOD0(EndInitialization,
                void());

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -11,6 +11,7 @@
 #include "geometry/permutation.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "physics/massive_body.hpp"
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/solar_system_factory.hpp"
 
@@ -26,6 +27,7 @@ using geometry::Identity;
 using geometry::Permutation;
 using integrators::DormandElMikkawyPrince1986RKN434FM;
 using physics::KeplerianElements;
+using physics::MassiveBody;
 using physics::SolarSystem;
 using quantities::Abs;
 using quantities::Acceleration;

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "ksp_plugin/celestial.hpp"
 #include "physics/massive_body.hpp"
+#include "physics/rotating_body.hpp"
 #include "physics/mock_ephemeris.hpp"
 #include "quantities/si.hpp"
 #include "testing_utilities/almost_equals.hpp"
@@ -25,8 +26,11 @@ using geometry::Position;
 using geometry::Velocity;
 using physics::MassiveBody;
 using physics::MockEphemeris;
+using physics::RotatingBody;
+using quantities::si::Degree;
 using quantities::si::Kilogram;
 using quantities::si::Metre;
+using quantities::si::Radian;
 using quantities::si::Second;
 using testing_utilities::AlmostEquals;
 using testing_utilities::Componentwise;
@@ -38,7 +42,14 @@ using ::testing::_;
 class VesselTest : public testing::Test {
  protected:
   VesselTest()
-      : body_(MassiveBody::Parameters(1 * Kilogram)),
+      : body_(MassiveBody::Parameters(1 * Kilogram),
+              RotatingBody<Barycentric>::Parameters(
+                  /*mean_radius=*/1 * Metre,
+                  /*reference_angle=*/0 * Degree,
+                  /*reference_instant=*/astronomy::J2000,
+                  /*angular_frequency=*/1 * Radian / Second,
+                  /*right_ascension_of_pole=*/0 * Degree,
+                  /*declination_of_pole=*/90 * Degree)),
         celestial_(&body_),
         vessel_("123",
                 "vessel",
@@ -62,7 +73,7 @@ class VesselTest : public testing::Test {
   }
 
   MockEphemeris<Barycentric> ephemeris_;
-  MassiveBody const body_;
+  RotatingBody<Barycentric> const body_;
   Celestial const celestial_;
   PartId const part_id1_ = 111;
   PartId const part_id2_ = 222;

--- a/physics/solar_system.hpp
+++ b/physics/solar_system.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "base/not_null.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "physics/continuous_trajectory.hpp"
 #include "physics/degrees_of_freedom.hpp"
@@ -78,7 +79,11 @@ class SolarSystem final {
   // structured objects.
   static DegreesOfFreedom<Frame> MakeDegreesOfFreedom(
       serialization::InitialState::Body const& body);
-  static std::unique_ptr<MassiveBody> MakeMassiveBody(
+  static not_null<std::unique_ptr<MassiveBody>> MakeMassiveBody(
+      serialization::GravityModel::Body const& body);
+  static not_null<std::unique_ptr<RotatingBody<Frame>>> MakeRotatingBody(
+      serialization::GravityModel::Body const& body);
+  static not_null<std::unique_ptr<OblateBody<Frame>>> MakeOblateBody(
       serialization::GravityModel::Body const& body);
 
   // Utilities for patching the internal protocol buffers after initialization.
@@ -87,6 +92,17 @@ class SolarSystem final {
   void RemoveOblateness(std::string const& name);
 
  private:
+  // Fails if the given |body| doesn't have a consistent set of fields.
+  static void Check(serialization::GravityModel::Body const& body);
+
+  // Factory functions for the parameter classes of the bodies.
+  static not_null<std::unique_ptr<MassiveBody::Parameters>>
+  MakeMassiveBodyParameters(serialization::GravityModel::Body const& body);
+  static not_null<std::unique_ptr<typename RotatingBody<Frame>::Parameters>>
+  MakeRotatingBodyParameters(serialization::GravityModel::Body const& body);
+  static not_null<std::unique_ptr<typename OblateBody<Frame>::Parameters>>
+  MakeOblateBodyParameters(serialization::GravityModel::Body const& body);
+
   std::vector<not_null<std::unique_ptr<MassiveBody const>>>
   MakeAllMassiveBodies();
   std::vector<DegreesOfFreedom<Frame>> MakeAllDegreesOfFreedom();


### PR DESCRIPTION
The `physics` layer still operates on massive bodies, so a few conversions are needed when crossing from `ksp_plugin` to `physics` and back.

Fix #1112.