### PR TITLE
Evaluate discrete, first cut without hinting

### DIFF
--- a/numerics/hermite3.hpp
+++ b/numerics/hermite3.hpp
@@ -23,6 +23,8 @@ class Hermite3 final {
            std::pair<Value, Value> const& values,
            std::pair<Derivative1, Derivative1> const& derivatives);
 
+  // NOTE(egg): this does not appear to use Casteljau's algorithm; perhaps it
+  // should?
   Value Evaluate(Argument const& argument) const;
   Derivative1 EvaluateDerivative(Argument const& argument) const;
 

--- a/numerics/hermite3_body.hpp
+++ b/numerics/hermite3_body.hpp
@@ -23,6 +23,16 @@ Hermite3<Argument, Value>::Hermite3(
   a0_ = values.first;
   a1_ = derivatives.first;
   Difference<Argument> const Δargument = arguments_.second - arguments_.first;
+  // If we were given the same point twice, there is a removable singularity.
+  // Otherwise, if the arguments are the same but not the values or the
+  // derivatives, we proceed to merrily NaN away as we should.
+  if (Δargument == Difference<Argument>{} &&
+      values.first == values.second &&
+      derivatives.first == derivatives.second) {
+    a2_ = {};
+    a3_ = {};
+    return;
+  }
   auto const one_over_Δargument = 1.0 / Δargument;
   auto const one_over_Δargument_squared =
       one_over_Δargument * one_over_Δargument;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -202,8 +202,9 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   // trajectory segment containing the given |time|, or, if |time| is |t_min()|,
   // returns a first-degree polynomial which should be evaluated only at
   // |t_min()|.
-  Hermite3<Instant, Position<Frame>> GetInterpolation(Instant const& time,
-                                                      Hint* hint) const;
+  Hermite3<Instant, Position<Frame>> GetInterpolation(
+      Instant const& time,
+      Trajectory<Frame>::Hint* hint) const;
 
   Timeline timeline_;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -11,6 +11,7 @@
 #include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
+#include "numerics/hermite3.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/forkable.hpp"
 #include "physics/trajectory.hpp"
@@ -62,6 +63,7 @@ using quantities::Acceleration;
 using quantities::Length;
 using quantities::Speed;
 using internal_forkable::DiscreteTrajectoryIterator;
+using numerics::Hermite3;
 
 template<typename Frame>
 class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
@@ -195,6 +197,13 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   void FillSubTreeFromMessage(
       serialization::DiscreteTrajectory const& message,
       std::vector<DiscreteTrajectory<Frame>**> const& forks);
+
+  // Returns the Hermite interpolation for the left-open, right-closed
+  // trajectory segment containing the given |time|, or, if |time| is |t_min()|,
+  // returns a first-degree polynomial which should be evaluated only at
+  // |t_min()|.
+  Hermite3<Instant, Position<Frame>> GetInterpolation(Instant const& time,
+                                                      Hint* hint) const;
 
   Timeline timeline_;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -153,7 +153,7 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
 
   class Hint : public Trajectory<Frame>::Hint {
    private:
-    Hint(Iterator const& it);
+    explicit Hint(Iterator const& it);
     Iterator it_;
     friend class DiscreteTrajectory<Frame>;
   };

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -55,6 +55,7 @@ namespace internal_discrete_trajectory {
 
 using base::not_null;
 using geometry::Instant;
+using geometry::Position;
 using geometry::Vector;
 using geometry::Velocity;
 using quantities::Acceleration;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -13,6 +13,7 @@
 #include "geometry/named_quantities.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/forkable.hpp"
+#include "physics/trajectory.hpp"
 #include "quantities/named_quantities.hpp"
 #include "serialization/physics.pb.h"
 
@@ -63,7 +64,8 @@ using internal_forkable::DiscreteTrajectoryIterator;
 
 template<typename Frame>
 class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
-                                           DiscreteTrajectoryIterator<Frame>> {
+                                           DiscreteTrajectoryIterator<Frame>>,
+                           public Trajectory<Frame> {
   using Timeline = std::map<Instant, DegreesOfFreedom<Frame>>;
   using TimelineConstIterator = typename Forkable<
       DiscreteTrajectory<Frame>,
@@ -125,6 +127,35 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   // there are no child trajectories forked at times (strictly) less than
   // |time|.  This trajectory must be a root.
   void ForgetBefore(Instant const& time);
+
+  // Implementation of the interface |Trajectory|.
+
+  // The bounds are the times of |Begin()| and |last()| if this trajectory is
+  // nonempty, otherwise they are infinities of the appropriate signs.
+  Instant t_min() const override;
+  Instant t_max() const override;
+
+  not_null<std::unique_ptr<typename Trajectory<Frame>::Hint>> NewHint()
+      const override;
+
+  Position<Frame> EvaluatePosition(
+      Instant const& time,
+      typename Trajectory<Frame>::Hint* hint) const override;
+  Velocity<Frame> EvaluateVelocity(
+      Instant const& time,
+      typename Trajectory<Frame>::Hint* hint) const override;
+  DegreesOfFreedom<Frame> EvaluateDegreesOfFreedom(
+      Instant const& time,
+      typename Trajectory<Frame>::Hint* hint) const override;
+
+  // End of the implementation of the interface.
+
+  class Hint : public Trajectory<Frame>::Hint {
+   private:
+    Hint(Iterator const& it);
+    Iterator it_;
+    friend class DiscreteTrajectory<Frame>;
+  };
 
   // This trajectory must be a root.  Only the given |forks| are serialized.
   // They must be descended from this trajectory.  The pointers in |forks| may

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -178,6 +178,46 @@ void DiscreteTrajectory<Frame>::ForgetBefore(Instant const& time) {
 }
 
 template<typename Frame>
+Instant DiscreteTrajectory<Frame>::t_min() const {
+  return Empty() ? InfiniteFuture : Begin().time();
+}
+
+template<typename Frame>
+Instant DiscreteTrajectory<Frame>::t_max() const {
+  return Empty() ? InfinitePast : last().time();
+}
+
+template<typename Frame>
+not_null<std::unique_ptr<typename Trajectory<Frame>::Hint>>
+DiscreteTrajectory<Frame>::NewHint() const {
+  return std::unique_ptr<typename Trajectory<Frame>::Hint>(new Hint(Begin()));
+}
+
+template<typename Frame>
+Position<Frame> DiscreteTrajectory<Frame>::EvaluatePosition(
+    Instant const& time,
+    typename Trajectory<Frame>::Hint* hint) const {
+  return /*TODO*/;
+}
+
+template<typename Frame>
+Velocity<Frame> DiscreteTrajectory<Frame>::EvaluateVelocity(
+    Instant const& time,
+    typename Trajectory<Frame>::Hint* hint) const {
+  return /*TODO*/;
+}
+
+template<typename Frame>
+DegreesOfFreedom<Frame> DiscreteTrajectory<Frame>::EvaluateDegreesOfFreedom(
+    Instant const& time,
+    typename Trajectory<Frame>::Hint* hint) const {
+  return /*TODO*/;
+}
+
+template<typename Frame>
+DiscreteTrajectory<Frame>::Hint::Hint(Iterator const& it) : it_(it) {}
+
+template<typename Frame>
 void DiscreteTrajectory<Frame>::WriteToMessage(
     not_null<serialization::DiscreteTrajectory*> const message,
     std::vector<DiscreteTrajectory<Frame>*> const& forks)

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -199,29 +199,14 @@ template<typename Frame>
 Position<Frame> DiscreteTrajectory<Frame>::EvaluatePosition(
     Instant const& time,
     typename Trajectory<Frame>::Hint* hint) const {
-  Hint* const down_cast_hint =
-      hint == nullptr ? nullptr : CHECK_NOTNULL(dynamic_cast<Hint*>(hint));
-  {
-    Hint* const hint = down_cast_hint;
-    // TODO(egg): do things with the hint.
-    CHECK_LE(t_min(), time);
-    CHECK_GE(t_max(), time);
-    return GetInterpolation(time, hint).Evaluate(time);
-  }
+  return GetInterpolation(time, hint).Evaluate(time);
 }
 
 template<typename Frame>
 Velocity<Frame> DiscreteTrajectory<Frame>::EvaluateVelocity(
     Instant const& time,
-    typename Trajectory<Frame>::Hint* hint) const {
-  Hint* const down_cast_hint =
-      hint == nullptr ? nullptr : CHECK_NOTNULL(dynamic_cast<Hint*>(hint));
-  {
-    Hint* const hint = down_cast_hint;
-    CHECK_LE(t_min(), time);
-    CHECK_GE(t_max(), time);
-    return GetInterpolation(time, hint).EvaluateDerivative(time);
-  }
+    typename Trajectory<Frame>::Hint* hint) const {;
+  return GetInterpolation(time, hint).EvaluateDerivative(time);
 }
 
 template<typename Frame>
@@ -230,14 +215,8 @@ DegreesOfFreedom<Frame> DiscreteTrajectory<Frame>::EvaluateDegreesOfFreedom(
     typename Trajectory<Frame>::Hint* hint) const {
   Hint* const down_cast_hint =
       hint == nullptr ? nullptr : CHECK_NOTNULL(dynamic_cast<Hint*>(hint));
-  {
-    Hint* const hint = down_cast_hint;
-    CHECK_LE(t_min(), time);
-    CHECK_GE(t_max(), time);
-    auto const interpolation = GetInterpolation(time, hint);
-    return {interpolation.Evaluate(time),
-            interpolation.EvaluateDerivative(time)};
-  }
+  auto const interpolation = GetInterpolation(time, hint);
+  return {interpolation.Evaluate(time), interpolation.EvaluateDerivative(time)};
 }
 
 template<typename Frame>
@@ -352,18 +331,25 @@ void DiscreteTrajectory<Frame>::FillSubTreeFromMessage(
 template<typename Frame>
 Hermite3<Instant, Position<Frame>> DiscreteTrajectory<Frame>::GetInterpolation(
     Instant const& time,
-    Hint* hint)  const {
-  // TODO(egg): do things with the hint.
-  // This is the upper bound of the interval upon which we will do the
-  // interpolation.
-  auto const upper = LowerBound(time);
-  auto const lower = upper == Begin() ? upper : --Iterator{upper};
-  return Hermite3<Instant, Position<Frame>> {
-      {lower.time(), upper.time()},
-      {lower.degrees_of_freedom().position(),
-       upper.degrees_of_freedom().position()},
-      {lower.degrees_of_freedom().velocity(),
-       upper.degrees_of_freedom().velocity()}};
+    Trajectory<Frame>::Hint* hint) const {
+  Hint* const down_cast_hint =
+      hint == nullptr ? nullptr : CHECK_NOTNULL(dynamic_cast<Hint*>(hint));
+  CHECK_LE(t_min(), time);
+  CHECK_GE(t_max(), time);
+  {
+    // TODO(egg): do things with the hint.
+    Hint* const hint = down_cast_hint;
+    // This is the upper bound of the interval upon which we will do the
+    // interpolation.
+    auto const upper = LowerBound(time);
+    auto const lower = upper == Begin() ? upper : --Iterator{upper};
+    return Hermite3<Instant, Position<Frame>>{
+        {lower.time(), upper.time()},
+        {lower.degrees_of_freedom().position(),
+         upper.degrees_of_freedom().position()},
+        {lower.degrees_of_freedom().velocity(),
+         upper.degrees_of_freedom().velocity()}};
+  }
 }
 
 }  // namespace internal_discrete_trajectory

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -1,6 +1,7 @@
 ﻿
 #include "physics/discrete_trajectory.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <list>
 #include <map>
@@ -835,7 +836,7 @@ TEST_F(DiscreteTrajectoryTest, QuadrilateralCircle) {
         {World::origin + Displacement<World>{{r * Cos(ω * t),
                                               r * Sin(ω * t),
                                               0 * Metre}},
-         Velocity<World>{{-v * Sin (ω * t),
+         Velocity<World>{{-v * Sin(ω * t),
                           v * Cos(ω * t),
                           0 * Metre / Second}}});
   }

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
+#include "testing_utilities/numerics.hpp"
 
 namespace principia {
 namespace physics {
@@ -28,16 +29,23 @@ using geometry::Point;
 using geometry::Position;
 using geometry::R3Element;
 using geometry::Vector;
+using quantities::AngularFrequency;
 using quantities::Length;
 using quantities::Speed;
 using quantities::SIUnit;
+using quantities::Time;
 using quantities::si::Metre;
+using quantities::si::Radian;
 using quantities::si::Second;
+using testing_utilities::RelativeError;
 using ::std::placeholders::_1;
 using ::std::placeholders::_2;
 using ::std::placeholders::_3;
+using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::Ge;
+using ::testing::Le;
 using ::testing::Pair;
 using ::testing::Ref;
 
@@ -813,6 +821,45 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(d4_, it.degrees_of_freedom());
   ++it;
   EXPECT_TRUE(it == fork->End());
+}
+
+TEST_F(DiscreteTrajectoryTest, QuadrilateralCircle) {
+  DiscreteTrajectory<World> circle;
+  AngularFrequency const ω = 3 * Radian / Second;
+  Length const r = 2 * Metre;
+  Speed const v = ω * r / Radian;
+  Time const period = 2 * π * Radian / ω;
+  for (Time t; t <= period; t += period / 4) {
+    circle.Append(
+        t0_ + t,
+        {World::origin + Displacement<World>{{r * Cos(ω * t),
+                                              r * Sin(ω * t),
+                                              0 * Metre}},
+         Velocity<World>{{-v * Sin (ω * t),
+                          v * Cos(ω * t),
+                          0 * Metre / Second}}});
+  }
+  double max_r_error = 0;
+  double max_v_error = 0;
+  auto hint = circle.NewHint();
+  for (Time t; t < period; t += period / 32) {
+    auto const degrees_of_freedom_interpolated =
+        circle.EvaluateDegreesOfFreedom(t0_ + t, hint.get());
+    auto const& q_interpolated = degrees_of_freedom_interpolated.position();
+    auto const& v_interpolated = degrees_of_freedom_interpolated.velocity();
+    EXPECT_THAT(circle.EvaluatePosition(t0_ + t, /*hint=*/nullptr),
+                Eq(q_interpolated));
+    EXPECT_THAT(circle.EvaluateVelocity(t0_ + t, /*hint=*/nullptr),
+                Eq(v_interpolated));
+    max_r_error = std::max(
+        max_r_error, RelativeError(r, (q_interpolated - World::origin).Norm()));
+    max_v_error =
+        std::max(max_v_error, RelativeError(v, v_interpolated.Norm()));
+  }
+  // The actual error is about 1.5 %.
+  EXPECT_THAT(max_r_error, AllOf(Ge(0.01), Le(0.02)));
+  // The actual error is about 1.2 %.
+  EXPECT_THAT(max_v_error, AllOf(Ge(0.01), Le(0.02)));
 }
 
 }  // namespace internal_discrete_trajectory

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -857,10 +857,8 @@ TEST_F(DiscreteTrajectoryTest, QuadrilateralCircle) {
     max_v_error =
         std::max(max_v_error, RelativeError(v, v_interpolated.Norm()));
   }
-  // The actual error is about 1.5 %.
-  EXPECT_THAT(max_r_error, AllOf(Ge(0.01), Le(0.02)));
-  // The actual error is about 1.2 %.
-  EXPECT_THAT(max_v_error, AllOf(Ge(0.01), Le(0.02)));
+  EXPECT_THAT(max_r_error, AllOf(Ge(0.014), Le(0.016)));
+  EXPECT_THAT(max_v_error, AllOf(Ge(0.011), Le(0.013)));
 }
 
 }  // namespace internal_discrete_trajectory


### PR DESCRIPTION
`DiscreteTrajectory` is now a `Trajectory`. The existing use of `Hermite3` is also for interpolation of discrete trajectories (when computing apsides in `Ephemeris`), we may want to switch to `Evaluate` there too in a future CL.