### PR TITLE
Correctly read the NavigationFrameParameters in the ReferenceFrameSelector

### DIFF
--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -202,8 +202,10 @@ class ReferenceFrameSelector : WindowRenderer {
         selected_celestial_ = FlightGlobals.Bodies[parameters.centre_index];
         break;
       case FrameType.BARYCENTRIC_ROTATING:
-      case FrameType.BODY_CENTRED_PARENT_DIRECTION:
         selected_celestial_ = FlightGlobals.Bodies[parameters.secondary_index];
+        break;
+      case FrameType.BODY_CENTRED_PARENT_DIRECTION:
+        selected_celestial_ = FlightGlobals.Bodies[parameters.primary_index];
         break;
     }
   }


### PR DESCRIPTION
`primary` and `secondary` for the body-centred, body direction frame are confusing, especially since we use the secondary as primary and vice-versa; perhaps we should use centre (as is the convention for the other body-centred frames) and [something, maybe `primary` would be fine in that case] instead.