### PR TITLE
Make the primary_trajectory_ functor return a constreference

### DIFF
--- a/physics/body_centred_body_direction_dynamic_frame.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame.hpp
@@ -49,8 +49,7 @@ class BodyCentredBodyDirectionDynamicFrame
 
   BodyCentredBodyDirectionDynamicFrame(
       not_null<Ephemeris<InertialFrame> const*> ephemeris,
-      std::function<not_null<Trajectory<InertialFrame> const*>()>
-          primary_trajectory,
+      std::function<Trajectory<InertialFrame> const&()> primary_trajectory,
       not_null<MassiveBody const*> secondary);
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
@@ -86,8 +85,7 @@ class BodyCentredBodyDirectionDynamicFrame
   std::function<Vector<Acceleration, InertialFrame>(
       Position<InertialFrame> const& position,
       Instant const& t)> compute_gravitational_acceleration_on_primary_;
-  std::function<not_null<Trajectory<InertialFrame> const*>()> const
-      primary_trajectory_;
+  std::function<Trajectory<InertialFrame> const&()> const primary_trajectory_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const
       secondary_trajectory_;
 };

--- a/physics/body_centred_body_direction_dynamic_frame_body.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame_body.hpp
@@ -40,7 +40,7 @@ BodyCentredBodyDirectionDynamicFrame(
                 primary_, t);
           }),
       primary_trajectory_(
-          [&t = ephemeris_->trajectory(primary_)]() -> auto& { return t; }),
+          [&t = *ephemeris_->trajectory(primary_)]() -> auto& { return t; }),
       secondary_trajectory_(ephemeris_->trajectory(secondary_)) {}
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_body_direction_dynamic_frame_body.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame_body.hpp
@@ -27,10 +27,10 @@ using quantities::si::Radian;
 
 template<typename InertialFrame, typename ThisFrame>
 BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
-BodyCentredBodyDirectionDynamicFrame(
-    not_null<Ephemeris<InertialFrame> const*> const ephemeris,
-    not_null<MassiveBody const*> const primary,
-    not_null<MassiveBody const*> const secondary)
+    BodyCentredBodyDirectionDynamicFrame(
+        not_null<Ephemeris<InertialFrame> const*> const ephemeris,
+        not_null<MassiveBody const*> const primary,
+        not_null<MassiveBody const*> const secondary)
     : ephemeris_(ephemeris),
       primary_(primary),
       secondary_(secondary),
@@ -39,14 +39,15 @@ BodyCentredBodyDirectionDynamicFrame(
             return ephemeris_->ComputeGravitationalAccelerationOnMassiveBody(
                 primary_, t);
           }),
-      primary_trajectory_([t = ephemeris_->trajectory(primary_)] { return t; }),
+      primary_trajectory_(
+          [t = ephemeris_->trajectory(primary_)] { return *t; }),
       secondary_trajectory_(ephemeris_->trajectory(secondary_)) {}
 
 template<typename InertialFrame, typename ThisFrame>
 BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
 BodyCentredBodyDirectionDynamicFrame(
     not_null<Ephemeris<InertialFrame> const*> const ephemeris,
-    std::function<not_null<Trajectory<InertialFrame> const*>()> const
+    std::function<Trajectory<InertialFrame> const&()> const
         primary_trajectory,
     not_null<MassiveBody const*> const secondary)
     : ephemeris_(ephemeris),
@@ -65,7 +66,7 @@ RigidMotion<InertialFrame, ThisFrame>
 BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
     ToThisFrameAtTime(Instant const& t) const {
   DegreesOfFreedom<InertialFrame> const primary_degrees_of_freedom =
-      primary_trajectory_()->EvaluateDegreesOfFreedom(t);
+      primary_trajectory_().EvaluateDegreesOfFreedom(t);
   DegreesOfFreedom<InertialFrame> const secondary_degrees_of_freedom =
       secondary_trajectory_->EvaluateDegreesOfFreedom(t);
 
@@ -123,7 +124,7 @@ AcceleratedRigidMotion<InertialFrame, ThisFrame>
 BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
 MotionOfThisFrame(Instant const& t) const {
   DegreesOfFreedom<InertialFrame> const primary_degrees_of_freedom =
-      primary_trajectory_()->EvaluateDegreesOfFreedom(t);
+      primary_trajectory_().EvaluateDegreesOfFreedom(t);
   DegreesOfFreedom<InertialFrame> const secondary_degrees_of_freedom =
       secondary_trajectory_->EvaluateDegreesOfFreedom(t);
 

--- a/physics/body_centred_body_direction_dynamic_frame_body.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame_body.hpp
@@ -27,10 +27,10 @@ using quantities::si::Radian;
 
 template<typename InertialFrame, typename ThisFrame>
 BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
-    BodyCentredBodyDirectionDynamicFrame(
-        not_null<Ephemeris<InertialFrame> const*> const ephemeris,
-        not_null<MassiveBody const*> const primary,
-        not_null<MassiveBody const*> const secondary)
+BodyCentredBodyDirectionDynamicFrame(
+    not_null<Ephemeris<InertialFrame> const*> const ephemeris,
+    not_null<MassiveBody const*> const primary,
+    not_null<MassiveBody const*> const secondary)
     : ephemeris_(ephemeris),
       primary_(primary),
       secondary_(secondary),

--- a/physics/body_centred_body_direction_dynamic_frame_body.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame_body.hpp
@@ -40,7 +40,7 @@ BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
                 primary_, t);
           }),
       primary_trajectory_(
-          [t = ephemeris_->trajectory(primary_)]() -> auto& { return *t; }),
+          [&t = ephemeris_->trajectory(primary_)]() -> auto& { return t; }),
       secondary_trajectory_(ephemeris_->trajectory(secondary_)) {}
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_body_direction_dynamic_frame_body.hpp
+++ b/physics/body_centred_body_direction_dynamic_frame_body.hpp
@@ -40,7 +40,7 @@ BodyCentredBodyDirectionDynamicFrame<InertialFrame, ThisFrame>::
                 primary_, t);
           }),
       primary_trajectory_(
-          [t = ephemeris_->trajectory(primary_)] { return *t; }),
+          [t = ephemeris_->trajectory(primary_)]() -> auto& { return *t; }),
       secondary_trajectory_(ephemeris_->trajectory(secondary_)) {}
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -489,9 +489,10 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ConstructFromOneBody) {
     barycentre_trajectory.Append(t0_ + t, barycentre);
   }
   BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, BigSmallFrame>
-      barycentric_from_discrete{ephemeris_.get(),
-                                [t = &barycentre_trajectory] { return t; },
-                                small_};
+      barycentric_from_discrete{
+          ephemeris_.get(),
+          [&t = barycentre_trajectory]() -> auto& { return t; },
+          small_};
   BarycentricRotatingDynamicFrame<ICRFJ2000Equator, BigSmallFrame>
       barycentric_from_both_bodies{ephemeris_.get(), big_, small_};
   for (Time t = period_ / 32; t <= period_ / 2; t += period_ / 32) {


### PR DESCRIPTION
Maybe eventually we'll split the classes, for the moment this is more convenient.