### PR TITLE
Prevent the sun from slapping interplanetary vessels

### DIFF
--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -39,11 +39,13 @@ XYZ principia__VesselBinormal(Plugin const* const plugin,
 // Calls |plugin->VesselFromParent| with the arguments given.
 // |plugin| must not be null.  No transfer of ownership.
 QP principia__VesselFromParent(Plugin const* const plugin,
+                               int const parent_index,
                                char const* const vessel_guid) {
-  journal::Method<journal::VesselFromParent> m({plugin, vessel_guid});
+  journal::Method<journal::VesselFromParent> m(
+      {plugin, parent_index, vessel_guid});
   CHECK_NOTNULL(plugin);
   RelativeDegreesOfFreedom<AliceSun> const result =
-      plugin->VesselFromParent(vessel_guid);
+      plugin->VesselFromParent(parent_index, vessel_guid);
   return m.Return({ToXYZ(result.displacement().coordinates() / Metre),
                    ToXYZ(result.velocity().coordinates() / (Metre / Second))});
 }

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -250,6 +250,7 @@ class Plugin {
   // A vessel with GUID |vessel_guid| must have been inserted and kept. Must
   // be called after initialization.
   virtual RelativeDegreesOfFreedom<AliceSun> VesselFromParent(
+      Index parent_index,
       GUID const& vessel_guid) const;
 
   // Returns the displacement and velocity of the celestial at index

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -72,6 +72,8 @@ not_null<Celestial const*> Vessel::parent() const {
 }
 
 void Vessel::set_parent(not_null<Celestial const*> const parent) {
+  LOG(INFO) << "Vessel " << ShortDebugString() << " switches parent from "
+            << parent_->body()->name() << " to " << parent->body()->name();
   parent_ = parent;
 }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -256,7 +256,9 @@ public partial class PrincipiaPluginAdapter
 
   private void UpdateVessel(Vessel vessel, double universal_time) {
      if (plugin_.HasVessel(vessel.id.ToString())) {
-       QP from_parent = plugin_.VesselFromParent(vessel.id.ToString());
+       QP from_parent = plugin_.VesselFromParent(
+           vessel.mainBody.flightGlobalsIndex,
+           vessel.id.ToString());
        vessel.orbit.UpdateFromStateVectors(pos : (Vector3d)from_parent.q,
                                            vel : (Vector3d)from_parent.p,
                                            refBody : vessel.orbit.referenceBody,

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -222,7 +222,7 @@ TEST_F(InterfaceDeathTest, Errors) {
                                   parent_relative_degrees_of_freedom);
   }, "plugin.*non NULL");
   EXPECT_DEATH({
-    principia__VesselFromParent(plugin, vessel_guid);
+    principia__VesselFromParent(plugin, celestial_index, vessel_guid);
   }, "plugin.*non NULL");
   EXPECT_DEATH({
     principia__CelestialFromParent(plugin, celestial_index);
@@ -436,7 +436,7 @@ TEST_F(InterfaceTest, ForgetAllHistoriesBefore) {
 
 TEST_F(InterfaceTest, VesselFromParent) {
   EXPECT_CALL(*plugin_,
-              VesselFromParent(vessel_guid))
+              VesselFromParent(celestial_index, vessel_guid))
       .WillOnce(Return(RelativeDegreesOfFreedom<AliceSun>(
                            Displacement<AliceSun>(
                                {parent_position.x * SIUnit<Length>(),
@@ -447,6 +447,7 @@ TEST_F(InterfaceTest, VesselFromParent) {
                                 parent_velocity.y * SIUnit<Speed>(),
                                 parent_velocity.z * SIUnit<Speed>()}))));
   QP const result = principia__VesselFromParent(plugin_.get(),
+                                                celestial_index,
                                                 vessel_guid);
   EXPECT_THAT(result, Eq(parent_relative_degrees_of_freedom));
 }

--- a/ksp_plugin_test/mock_plugin.hpp
+++ b/ksp_plugin_test/mock_plugin.hpp
@@ -61,8 +61,9 @@ class MockPlugin : public Plugin {
 
   MOCK_CONST_METHOD1(ForgetAllHistoriesBefore, void(Instant const& t));
 
-  MOCK_CONST_METHOD1(VesselFromParent,
+  MOCK_CONST_METHOD2(VesselFromParent,
                      RelativeDegreesOfFreedom<AliceSun>(
+                         Index parent_index,
                          GUID const& vessel_guid));
 
   MOCK_CONST_METHOD1(CelestialFromParent,

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -935,14 +935,14 @@ TEST_F(PluginDeathTest, VesselFromParentError) {
   GUID const guid = "Test Satellite";
   EXPECT_DEATH({
     InsertAllSolarSystemBodies();
-    plugin_->VesselFromParent(guid);
+    plugin_->VesselFromParent(SolarSystemFactory::Sun, guid);
   }, "Check failed: !initializing");
   EXPECT_DEATH({
     InsertAllSolarSystemBodies();
     EXPECT_CALL(plugin_->mock_ephemeris(), WriteToMessage(_))
         .WillOnce(SetArgPointee<0>(valid_ephemeris_message_));
     plugin_->EndInitialization();
-    plugin_->VesselFromParent(guid);
+    plugin_->VesselFromParent(SolarSystemFactory::Sun, guid);
   }, "Map key not found");
   EXPECT_DEATH({
     InsertAllSolarSystemBodies();
@@ -957,7 +957,7 @@ TEST_F(PluginDeathTest, VesselFromParentError) {
                                 inserted);
     plugin_->PrepareToReportCollisions();
     plugin_->FreeVesselsAndPartsAndCollectPileUps();
-    plugin_->VesselFromParent(guid);
+    plugin_->VesselFromParent(SolarSystemFactory::Sun, guid);
   }, R"regex(!parts_\.empty\(\))regex");
 }
 
@@ -1006,10 +1006,10 @@ TEST_F(PluginTest, VesselInsertionAtInitialization) {
                                          satellite_initial_velocity_));
   plugin_->PrepareToReportCollisions();
   plugin_->FreeVesselsAndPartsAndCollectPileUps();
-  EXPECT_THAT(plugin_->VesselFromParent(guid),
-              Componentwise(
-                  AlmostEquals(satellite_initial_displacement_, 13556),
-                  AlmostEquals(satellite_initial_velocity_, 1)));
+  EXPECT_THAT(
+      plugin_->VesselFromParent(SolarSystemFactory::Earth, guid),
+      Componentwise(AlmostEquals(satellite_initial_displacement_, 13556),
+                    AlmostEquals(satellite_initial_velocity_, 1)));
 }
 
 TEST_F(PluginTest, UpdateCelestialHierarchy) {

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1292,6 +1292,7 @@ message VesselFromParent {
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
                                  (is_subject) = true];
+    required int32 parent_index = 3;
     required string vessel_guid = 2;
   }
   message Return {


### PR DESCRIPTION
The orbits of KSP's `Vessel`s are updated at `Early/Timing1(-99)`, whereas we updated the parents (in `InsertOrKeepVessel`) at `WaitForFixedUpdate`. This meant that for one frame, we would end up giving KSP offsets around the wrong body. Depending on various factors, this would put the vessel inside the sun, or sometimes merely dewarped to 1x (if the vessel escaped destruction, it would go back to the right place in the next frame).
This pull request also logs main body changes, similarly to vessel renamings.