### PR TITLE
A bunch of cleanups in the interface

### DIFF
--- a/base/disjoint_sets.hpp
+++ b/base/disjoint_sets.hpp
@@ -35,6 +35,7 @@ class Subset final {
   static Subset MakeSingleton(
       T& element,
       SubsetPropertiesArgs... subset_properties_args);
+
   // The arguments are invalidated; the result may be used to get information
   // about the united subset.
   static Subset Unite(Subset left, Subset right);
@@ -56,12 +57,10 @@ class Subset final {
 
     not_null<Node*> Root();
 
-    // TODO(egg): maybe they should be mutable? those intrusive structures are
-    // confusing...
     not_null<Node*> parent_;
     int rank_ = 0;
 
-    // Do not require a default constructor for |Node|.
+    // Do not require a default constructor for |Properties|.
     std::experimental::optional<Properties> properties_;
 
     friend class Subset<T>;

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -182,10 +182,7 @@ QP principia__CelestialFromParent(Plugin const* const plugin,
                                   int const celestial_index) {
   journal::Method<journal::CelestialFromParent> m({plugin, celestial_index});
   CHECK_NOTNULL(plugin);
-  RelativeDegreesOfFreedom<AliceSun> const result =
-      plugin->CelestialFromParent(celestial_index);
-  return m.Return({ToXYZ(result.displacement().coordinates() / Metre),
-                   ToXYZ(result.velocity().coordinates() / (Metre / Second))});
+  return m.Return(ToQP(plugin->CelestialFromParent(celestial_index)));
 }
 
 double principia__CelestialInitialRotationInDegrees(Plugin const* const plugin,
@@ -223,11 +220,8 @@ QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
   journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
       {plugin, index, part_at_origin});
   CHECK_NOTNULL(plugin);
-  auto const result =
-      plugin->CelestialWorldDegreesOfFreedom(index, part_at_origin);
   return m.Return(
-      {ToXYZ((result.position() - World::origin).coordinates() / Metre),
-       ToXYZ(result.velocity().coordinates() / (Metre / Second))});
+      ToQP(plugin->CelestialWorldDegreesOfFreedom(index, part_at_origin)));
 }
 
 void principia__ClearTargetVessel(Plugin* const plugin) {
@@ -366,13 +360,9 @@ QP principia__GetPartActualDegreesOfFreedom(Plugin const* const plugin,
                                             PartId const part_at_origin) {
   journal::Method<journal::GetPartActualDegreesOfFreedom> m(
       {plugin, part_id, part_at_origin});
-  DegreesOfFreedom<World> const degrees_of_freedom =
-      CHECK_NOTNULL(plugin)->GetPartActualDegreesOfFreedom(part_id,
-                                                           part_at_origin);
-  return m.Return(QP{
-      ToXYZ((degrees_of_freedom.position() - World::origin).coordinates() /
-            Metre),
-      ToXYZ(degrees_of_freedom.velocity().coordinates() / (Metre / Second))});
+  CHECK_NOTNULL(plugin);
+  return m.Return(
+      ToQP(plugin->GetPartActualDegreesOfFreedom(part_id, part_at_origin)));
 }
 
 // Returns the frame last set by |plugin->SetPlottingFrame|.  No transfer of

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -881,7 +881,8 @@ void principia__SetPartApparentDegreesOfFreedom(Plugin* const plugin,
                                                 QP const degrees_of_freedom) {
   journal::Method<journal::SetPartApparentDegreesOfFreedom> m(
       {plugin, part_id, degrees_of_freedom});
-  CHECK_NOTNULL(plugin)->SetPartApparentDegreesOfFreedom(
+  CHECK_NOTNULL(plugin);
+  plugin->SetPartApparentDegreesOfFreedom(
       part_id,
       FromQP<DegreesOfFreedom<World>>(degrees_of_freedom));
   return m.Return();

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -596,15 +596,8 @@ void principia__InsertOrKeepLoadedPart(
       mass_in_tonnes * Tonne,
       vessel_guid,
       main_body_index,
-      {World::origin +
-           Displacement<World>(FromXYZ(main_body_world_degrees_of_freedom.q) *
-                               Metre),
-       Velocity<World>(FromXYZ(main_body_world_degrees_of_freedom.p) *
-                       (Metre / Second))},
-      {World::origin + Displacement<World>(
-                           FromXYZ(part_world_degrees_of_freedom.q) * Metre),
-       Velocity<World>(FromXYZ(part_world_degrees_of_freedom.p) *
-                       (Metre / Second))});
+      FromQP<DegreesOfFreedom<World>>(main_body_world_degrees_of_freedom),
+      FromQP<DegreesOfFreedom<World>>(part_world_degrees_of_freedom));
   return m.Return();
 }
 
@@ -622,9 +615,7 @@ void principia__InsertUnloadedPart(Plugin* const plugin,
       part_id,
       name,
       vessel_guid,
-      RelativeDegreesOfFreedom<AliceSun>(
-          Displacement<AliceSun>(FromXYZ(from_parent.q) * Metre),
-          Velocity<AliceSun>(FromXYZ(from_parent.p) * (Metre / Second))));
+      FromQP<RelativeDegreesOfFreedom<AliceSun>>(from_parent));
   return m.Return();
 }
 
@@ -671,13 +662,10 @@ WXYZ principia__NavballOrientation(
                                                   ship_world_position});
   CHECK_NOTNULL(plugin);
   auto const frame_field = plugin->NavballFrameField(
-      World::origin +
-          Displacement<World>(FromXYZ(sun_world_position) * Metre));
+      FromXYZ<Position<World>>(sun_world_position));
   return m.Return(ToWXYZ(
       frame_field->FromThisFrame(
-          World::origin +
-              Displacement<World>(
-                  FromXYZ(ship_world_position) * Metre)).quaternion()));
+          FromXYZ<Position<World>>(ship_world_position)).quaternion()));
 }
 
 // Calls |plugin| to create a |NavigationFrame| using the given |parameters|.
@@ -720,13 +708,10 @@ Iterator* principia__RenderedPrediction(Plugin* const plugin,
                                                   sun_world_position});
   CHECK_NOTNULL(plugin);
   auto const& prediction = plugin->GetVessel(vessel_guid)->prediction();
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   auto rendered_trajectory = plugin->RenderBarycentricTrajectoryInWorld(
                                  prediction.Begin(),
                                  prediction.End(),
-                                 q_sun);
+                                 FromXYZ<Position<World>>(sun_world_position));
   return m.Return(new TypedIterator<DiscreteTrajectory<World>>(
       std::move(rendered_trajectory),
       plugin));
@@ -743,15 +728,12 @@ void principia__RenderedPredictionApsides(Plugin const* const plugin,
       {apoapsides, periapsides});
   CHECK_NOTNULL(plugin);
   auto const& prediction = plugin->GetVessel(vessel_guid)->prediction();
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_apoapsides;
   std::unique_ptr<DiscreteTrajectory<World>> rendered_periapsides;
   plugin->ComputeAndRenderApsides(celestial_index,
                                   prediction.Begin(),
                                   prediction.End(),
-                                  q_sun,
+                                  FromXYZ<Position<World>>(sun_world_position),
                                   rendered_apoapsides,
                                   rendered_periapsides);
   *apoapsides = new TypedIterator<DiscreteTrajectory<World>>(
@@ -773,14 +755,12 @@ void principia__RenderedPredictionClosestApproaches(
       {closest_approaches});
   CHECK_NOTNULL(plugin);
   auto const& prediction = plugin->GetVessel(vessel_guid)->prediction();
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_closest_approaches;
-  plugin->ComputeAndRenderClosestApproaches(prediction.Begin(),
-                                            prediction.End(),
-                                            q_sun,
-                                            rendered_closest_approaches);
+  plugin->ComputeAndRenderClosestApproaches(
+      prediction.Begin(),
+      prediction.End(),
+      FromXYZ<Position<World>>(sun_world_position),
+      rendered_closest_approaches);
   *closest_approaches = new TypedIterator<DiscreteTrajectory<World>>(
       check_not_null(std::move(rendered_closest_approaches)),
       plugin);
@@ -797,14 +777,11 @@ void principia__RenderedPredictionNodes(Plugin const* const plugin,
       {ascending, descending});
   CHECK_NOTNULL(plugin);
   auto const& prediction = plugin->GetVessel(vessel_guid)->prediction();
-  Position<World> const q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_ascending;
   std::unique_ptr<DiscreteTrajectory<World>> rendered_descending;
   plugin->ComputeAndRenderNodes(prediction.Begin(),
                                 prediction.End(),
-                                q_sun,
+                                FromXYZ<Position<World>>(sun_world_position),
                                 rendered_ascending,
                                 rendered_descending);
   *ascending = new TypedIterator<DiscreteTrajectory<World>>(
@@ -824,13 +801,10 @@ Iterator* principia__RenderedVesselTrajectory(Plugin const* const plugin,
                                                         sun_world_position});
   CHECK_NOTNULL(plugin);
   auto const& psychohistory = plugin->GetVessel(vessel_guid)->psychohistory();
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   auto rendered_trajectory = plugin->RenderBarycentricTrajectoryInWorld(
                                  psychohistory.Begin(),
                                  psychohistory.End(),
-                                 q_sun);
+                                 FromXYZ<Position<World>>(sun_world_position));
   return m.Return(new TypedIterator<DiscreteTrajectory<World>>(
       std::move(rendered_trajectory),
       plugin));
@@ -919,9 +893,7 @@ void principia__SetPartApparentDegreesOfFreedom(Plugin* const plugin,
       {plugin, part_id, degrees_of_freedom});
   CHECK_NOTNULL(plugin)->SetPartApparentDegreesOfFreedom(
       part_id,
-      {World::origin +
-           Displacement<World>(FromXYZ(degrees_of_freedom.q) * Metre),
-       Velocity<World>(FromXYZ(degrees_of_freedom.p) * (Metre / Second))});
+      FromQP<DegreesOfFreedom<World>>(degrees_of_freedom));
   return m.Return();
 }
 

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -33,6 +33,7 @@ using geometry::Instant;
 using geometry::Position;
 using geometry::R3Element;
 using geometry::Velocity;
+using ksp_plugin::AliceSun;
 using ksp_plugin::Barycentric;
 using ksp_plugin::NavigationFrame;
 using ksp_plugin::PileUp;
@@ -142,18 +143,17 @@ T FromQP(QP const& qp);
 template<>
 inline DegreesOfFreedom<World> FromQP<DegreesOfFreedom<World>>(QP const& qp);
 template<>
-inline RelativeDegreesOfFreedom<World> FromQP<RelativeDegreesOfFreedom<World>>(
-    QP const& qp);
+inline RelativeDegreesOfFreedom<AliceSun>
+FromQP<RelativeDegreesOfFreedom<AliceSun>>(QP const& qp);
+template<>
+inline RelativeDegreesOfFreedom<World>
+FromQP<RelativeDegreesOfFreedom<World>>(QP const& qp);
 
 R3Element<double> FromXYZ(XYZ const& xyz);
 template<typename T>
 T FromXYZ(XYZ const& xyz);
 template<>
-inline Displacement<World> FromXYZ<Displacement<World>>(XYZ const& xyz);
-template<>
 inline Position<World> FromXYZ<Position<World>>(XYZ const& xyz);
-template<>
-inline Velocity<World> FromXYZ<Velocity<World>>(XYZ const& xyz);
 
 AdaptiveStepParameters ToAdaptiveStepParameters(
     physics::Ephemeris<Barycentric>::AdaptiveStepParameters const&

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -7,6 +7,7 @@
 #include "base/macros.hpp"
 #include "base/pull_serializer.hpp"
 #include "base/push_deserializer.hpp"
+#include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/quaternion.hpp"
 #include "geometry/r3_element.hpp"
@@ -33,6 +34,7 @@ using geometry::Displacement;
 using geometry::Instant;
 using geometry::Position;
 using geometry::R3Element;
+using geometry::Vector;
 using geometry::Velocity;
 using ksp_plugin::AliceSun;
 using ksp_plugin::Barycentric;
@@ -169,24 +171,15 @@ AdaptiveStepParameters ToAdaptiveStepParameters(
 KeplerianElements ToKeplerianElements(
     physics::KeplerianElements<Barycentric> const& keplerian_elements);
 
-template<typename T>
-QP ToQP(T const& t);
-template<>
-QP ToQP<DegreesOfFreedom<World>>(DegreesOfFreedom<World> const& dof);
-template<>
-QP ToQP<RelativeDegreesOfFreedom<AliceSun>>(
-    RelativeDegreesOfFreedom<AliceSun> const& relative_dof);
+QP ToQP(DegreesOfFreedom<World> const& dof);
+QP ToQP(RelativeDegreesOfFreedom<AliceSun> const& relative_dof);
 
 WXYZ ToWXYZ(geometry::Quaternion const& quaternion);
 
 XYZ ToXYZ(geometry::R3Element<double> const& r3_element);
-template<typename T>
-XYZ ToXYZ(T const& t);
-template<>
-XYZ ToXYZ<Position<World>>(Position<World> const& position);
-template<>
-XYZ ToXYZ<Velocity<Frenet<NavigationFrame>>>(
-    Velocity<Frenet<NavigationFrame>> const& velocity);
+XYZ ToXYZ(Position<World> const& position);
+XYZ ToXYZ(Vector<double, World> const& direction);
+XYZ ToXYZ(Velocity<Frenet<NavigationFrame>> const& velocity);
 
 // Conversions between interchange data and typed data that depend on the state
 // of the plugin.

--- a/ksp_plugin/interface.hpp
+++ b/ksp_plugin/interface.hpp
@@ -16,6 +16,7 @@
 #include "ksp_plugin/vessel.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/discrete_trajectory.hpp"
+#include "physics/dynamic_frame.hpp"
 #include "physics/ephemeris.hpp"
 
 namespace principia {
@@ -42,6 +43,7 @@ using ksp_plugin::Vessel;
 using ksp_plugin::World;
 using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
+using physics::Frenet;
 using physics::RelativeDegreesOfFreedom;
 
 // A wrapper for a container and an iterator into that container.
@@ -132,36 +134,59 @@ bool operator==(WXYZ const& left, WXYZ const& right);
 bool operator==(XYZ const& left, XYZ const& right);
 
 // Conversions between interchange data and typed data.
+
 physics::Ephemeris<Barycentric>::AdaptiveStepParameters
 FromAdaptiveStepParameters(
     AdaptiveStepParameters const& adaptive_step_parameters);
+
 physics::KeplerianElements<Barycentric> FromKeplerianElements(
     KeplerianElements const& keplerian_elements);
 
 template<typename T>
 T FromQP(QP const& qp);
 template<>
-inline DegreesOfFreedom<World> FromQP<DegreesOfFreedom<World>>(QP const& qp);
+DegreesOfFreedom<World> FromQP<DegreesOfFreedom<World>>(QP const& qp);
 template<>
-inline RelativeDegreesOfFreedom<AliceSun>
+RelativeDegreesOfFreedom<AliceSun>
 FromQP<RelativeDegreesOfFreedom<AliceSun>>(QP const& qp);
 template<>
-inline RelativeDegreesOfFreedom<World>
+RelativeDegreesOfFreedom<World>
 FromQP<RelativeDegreesOfFreedom<World>>(QP const& qp);
 
 R3Element<double> FromXYZ(XYZ const& xyz);
 template<typename T>
 T FromXYZ(XYZ const& xyz);
 template<>
-inline Position<World> FromXYZ<Position<World>>(XYZ const& xyz);
+Position<World> FromXYZ<Position<World>>(XYZ const& xyz);
+template<>
+Velocity<Frenet<NavigationFrame>>
+FromXYZ<Velocity<Frenet<NavigationFrame>>>(XYZ const& xyz);
 
 AdaptiveStepParameters ToAdaptiveStepParameters(
     physics::Ephemeris<Barycentric>::AdaptiveStepParameters const&
         adaptive_step_parameters);
+
 KeplerianElements ToKeplerianElements(
     physics::KeplerianElements<Barycentric> const& keplerian_elements);
+
+template<typename T>
+QP ToQP(T const& t);
+template<>
+QP ToQP<DegreesOfFreedom<World>>(DegreesOfFreedom<World> const& dof);
+template<>
+QP ToQP<RelativeDegreesOfFreedom<AliceSun>>(
+    RelativeDegreesOfFreedom<AliceSun> const& relative_dof);
+
 WXYZ ToWXYZ(geometry::Quaternion const& quaternion);
+
 XYZ ToXYZ(geometry::R3Element<double> const& r3_element);
+template<typename T>
+XYZ ToXYZ(T const& t);
+template<>
+XYZ ToXYZ<Position<World>>(Position<World> const& position);
+template<>
+XYZ ToXYZ<Velocity<Frenet<NavigationFrame>>>(
+    Velocity<Frenet<NavigationFrame>> const& velocity);
 
 // Conversions between interchange data and typed data that depend on the state
 // of the plugin.

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -328,16 +328,12 @@ inline KeplerianElements ToKeplerianElements(
           keplerian_elements.mean_anomaly / Radian};
 }
 
-template<>
-inline QP ToQP<DegreesOfFreedom<World>>(DegreesOfFreedom<World> const& dof) {
+inline QP ToQP(DegreesOfFreedom<World> const& dof) {
   return QPConverter<DegreesOfFreedom<World>>::ToQP(dof);
 }
 
-template<>
-inline QP ToQP<RelativeDegreesOfFreedom<AliceSun>>(
-    RelativeDegreesOfFreedom<AliceSun> const& relative_dof) {
-  return QPConverter<RelativeDegreesOfFreedom<AliceSun>>::ToQP(
-      relative_dof);
+inline QP ToQP(RelativeDegreesOfFreedom<AliceSun> const& relative_dof) {
+  return QPConverter<RelativeDegreesOfFreedom<AliceSun>>::ToQP(relative_dof);
 }
 
 inline WXYZ ToWXYZ(geometry::Quaternion const& quaternion) {
@@ -351,19 +347,19 @@ inline XYZ ToXYZ(geometry::R3Element<double> const& r3_element) {
   return {r3_element.x, r3_element.y, r3_element.z};
 }
 
-template<>
-inline XYZ ToXYZ<Position<World>>(Position<World> const& position) {
+inline XYZ ToXYZ(Position<World> const& position) {
   return XYZConverter<Position<World>>::ToXYZ(position);
 }
 
-template<>
-inline XYZ ToXYZ<Velocity<Frenet<NavigationFrame>>>(
-    Velocity<Frenet<NavigationFrame>> const& velocity) {
+inline XYZ ToXYZ(Velocity<Frenet<NavigationFrame>> const& velocity) {
   return XYZConverter<Velocity<Frenet<NavigationFrame>>>::ToXYZ(velocity);
 }
 
-template<>
-inline XYZ ToXYZ<Velocity<World>>(Velocity<World> const& velocity) {
+inline XYZ ToXYZ(Vector<double, World> const& direction) {
+  return ToXYZ(direction.coordinates());
+}
+
+inline XYZ ToXYZ(Velocity<World> const& velocity) {
   return XYZConverter<Velocity<World>>::ToXYZ(velocity);
 }
 

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -6,12 +6,9 @@
 #include <cmath>
 #include <limits>
 
-#include "geometry/pair.hpp"
-
 namespace principia {
 namespace interface {
 
-using geometry::Pair;
 using integrators::AdaptiveStepSizeIntegrator;
 using physics::Ephemeris;
 using quantities::si::Degree;

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -143,7 +143,7 @@ NavigationManoeuvre ToInterfaceNavigationManoeuvre(
       manœuvre.InertialDirection();
   Vector<double, World> const world_inertial_direction =
       barycentric_to_world(barycentric_inertial_direction);
-  result.inertial_direction = ToXYZ(world_inertial_direction.coordinates());
+  result.inertial_direction = ToXYZ(world_inertial_direction);
   return result;
 }
 
@@ -264,14 +264,11 @@ principia__FlightPlanGetManoeuvreFrenetTrihedron(Plugin const* const plugin,
       plotting_frame->ToThisFrameAtTime(initial_time).orthogonal_map() *
       frenet_to_barycentric;
   result.tangent = ToXYZ(
-      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({1, 0, 0}))
-          .coordinates());
+      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({1, 0, 0})));
   result.normal = ToXYZ(
-      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({0, 1, 0}))
-          .coordinates());
+      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({0, 1, 0})));
   result.binormal = ToXYZ(
-      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({0, 0, 1}))
-          .coordinates());
+      frenet_to_plotted_world(Vector<double, Frenet<Navigation>>({0, 0, 1})));
 
   return m.Return(result);
 }

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -51,13 +51,14 @@ ksp_plugin::Burn FromInterfaceBurn(Plugin const& plugin,
           burn.specific_impulse_in_seconds_g0 * Second * StandardGravity,
           NewNavigationFrame(plugin, burn.frame),
           FromGameTime(plugin, burn.initial_time),
+          // One of the few places where we convert to a non-World frame.
           Velocity<Frenet<Navigation>>(
               FromXYZ(burn.delta_v) * (Metre / Second))};
 }
 
 FlightPlan& GetFlightPlan(Plugin const& plugin,
                           char const* const vessel_guid) {
-  Vessel const& vessel = *GetVessel(plugin, vessel_guid);
+  Vessel const& vessel = *plugin.GetVessel(vessel_guid);
   CHECK(vessel.has_flight_plan()) << vessel_guid;
   return vessel.flight_plan();
 }
@@ -178,7 +179,7 @@ void principia__FlightPlanDelete(Plugin const* const plugin,
                                  char const* const vessel_guid) {
   journal::Method<journal::FlightPlanDelete> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  GetVessel(*plugin, vessel_guid)->DeleteFlightPlan();
+  plugin->GetVessel(vessel_guid)->DeleteFlightPlan();
   return m.Return();
 }
 
@@ -187,7 +188,7 @@ bool principia__FlightPlanExists(
     char const* const vessel_guid) {
   journal::Method<journal::FlightPlanExists> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  return m.Return(GetVessel(*plugin, vessel_guid)->has_flight_plan());
+  return m.Return(plugin->GetVessel(vessel_guid)->has_flight_plan());
 }
 
 AdaptiveStepParameters principia__FlightPlanGetAdaptiveStepParameters(
@@ -313,14 +314,11 @@ void principia__FlightPlanRenderedApsides(Plugin const* const plugin,
   DiscreteTrajectory<Barycentric>::Iterator begin;
   DiscreteTrajectory<Barycentric>::Iterator end;
   GetFlightPlan(*plugin, vessel_guid).GetAllSegments(begin, end);
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_apoapsides;
   std::unique_ptr<DiscreteTrajectory<World>> rendered_periapsides;
   plugin->ComputeAndRenderApsides(celestial_index,
                                   begin, end,
-                                  q_sun,
+                                  FromXYZ<Position<World>>(sun_world_position),
                                   rendered_apoapsides,
                                   rendered_periapsides);
   *apoapsides = new TypedIterator<DiscreteTrajectory<World>>(
@@ -344,13 +342,12 @@ void principia__FlightPlanRenderedClosestApproaches(
   DiscreteTrajectory<Barycentric>::Iterator begin;
   DiscreteTrajectory<Barycentric>::Iterator end;
   GetFlightPlan(*plugin, vessel_guid).GetAllSegments(begin, end);
-  Position<World> q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_closest_approaches;
-  plugin->ComputeAndRenderClosestApproaches(begin, end,
-                                            q_sun,
-                                            rendered_closest_approaches);
+  plugin->ComputeAndRenderClosestApproaches(
+      begin,
+      end,
+      FromXYZ<Position<World>>(sun_world_position),
+      rendered_closest_approaches);
   *closest_approaches = new TypedIterator<DiscreteTrajectory<World>>(
       check_not_null(std::move(rendered_closest_approaches)),
       plugin);
@@ -369,13 +366,10 @@ void principia__FlightPlanRenderedNodes(Plugin const* const plugin,
   DiscreteTrajectory<Barycentric>::Iterator begin;
   DiscreteTrajectory<Barycentric>::Iterator end;
   GetFlightPlan(*plugin, vessel_guid).GetAllSegments(begin, end);
-  Position<World> const q_sun =
-      World::origin +
-      Displacement<World>(FromXYZ(sun_world_position) * Metre);
   std::unique_ptr<DiscreteTrajectory<World>> rendered_ascending;
   std::unique_ptr<DiscreteTrajectory<World>> rendered_descending;
   plugin->ComputeAndRenderNodes(begin, end,
-                                q_sun,
+                                FromXYZ<Position<World>>(sun_world_position),
                                 rendered_ascending,
                                 rendered_descending);
   *ascending = new TypedIterator<DiscreteTrajectory<World>>(
@@ -403,8 +397,7 @@ Iterator* principia__FlightPlanRenderedSegment(
   auto rendered_trajectory = CHECK_NOTNULL(plugin)->
       RenderBarycentricTrajectoryInWorld(
           begin, end,
-          World::origin + Displacement<World>(
-                              FromXYZ(sun_world_position) * Metre));
+          FromXYZ<Position<World>>(sun_world_position));
   if (index % 2 == 1 && !rendered_trajectory->Empty() &&
       rendered_trajectory->Begin().time() != begin.time()) {
     // TODO(egg): this is ugly; we should centralize rendering.

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -51,9 +51,7 @@ ksp_plugin::Burn FromInterfaceBurn(Plugin const& plugin,
           burn.specific_impulse_in_seconds_g0 * Second * StandardGravity,
           NewNavigationFrame(plugin, burn.frame),
           FromGameTime(plugin, burn.initial_time),
-          // One of the few places where we convert to a non-World frame.
-          Velocity<Frenet<Navigation>>(
-              FromXYZ(burn.delta_v) * (Metre / Second))};
+          FromXYZ<Velocity<Frenet<NavigationFrame>>>(burn.delta_v)};
 }
 
 FlightPlan& GetFlightPlan(Plugin const& plugin,
@@ -123,7 +121,7 @@ Burn GetBurn(Plugin const& plugin,
           manœuvre.specific_impulse() / (Second * StandardGravity),
           parameters,
           ToGameTime(plugin, manœuvre.initial_time()),
-          ToXYZ(Δv.coordinates() / (Metre / Second))};
+          ToXYZ(Δv)};
 }
 
 NavigationManoeuvre ToInterfaceNavigationManoeuvre(

--- a/ksp_plugin/interface_iterator.cpp
+++ b/ksp_plugin/interface_iterator.cpp
@@ -32,14 +32,7 @@ QP principia__IteratorGetQP(Iterator const* const iterator) {
       dynamic_cast<TypedIterator<DiscreteTrajectory<World>> const*>(iterator));
   return m.Return(typed_iterator->Get<QP>(
       [](DiscreteTrajectory<World>::Iterator const& iterator) -> QP {
-        DegreesOfFreedom<World> const degrees_of_freedom =
-            iterator.degrees_of_freedom();
-        return {
-            ToXYZ(
-                (degrees_of_freedom.position() - World::origin).coordinates() /
-                Metre),
-            ToXYZ(degrees_of_freedom.velocity().coordinates() /
-                  (Metre / Second))};
+        return ToQP(iterator.degrees_of_freedom());
       }));
 }
 
@@ -62,9 +55,7 @@ XYZ principia__IteratorGetXYZ(Iterator const* const iterator) {
       dynamic_cast<TypedIterator<DiscreteTrajectory<World>> const*>(iterator));
   return m.Return(typed_iterator->Get<XYZ>(
       [](DiscreteTrajectory<World>::Iterator const& iterator) -> XYZ {
-        return ToXYZ((iterator.degrees_of_freedom().position() - World::origin)
-                         .coordinates() /
-                     Metre);
+        return ToXYZ(iterator.degrees_of_freedom().position());
       }));
 }
 

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -32,8 +32,8 @@ using quantities::si::Tonne;
 XYZ principia__VesselBinormal(Plugin const* const plugin,
                               char const* const vessel_guid) {
   journal::Method<journal::VesselBinormal> m({plugin, vessel_guid});
-  return m.Return(
-      ToXYZ(CHECK_NOTNULL(plugin)->VesselBinormal(vessel_guid).coordinates()));
+  CHECK_NOTNULL(plugin);
+  return m.Return(ToXYZ(plugin->VesselBinormal(vessel_guid).coordinates()));
 }
 
 // Calls |plugin->VesselFromParent| with the arguments given.
@@ -44,10 +44,7 @@ QP principia__VesselFromParent(Plugin const* const plugin,
   journal::Method<journal::VesselFromParent> m(
       {plugin, parent_index, vessel_guid});
   CHECK_NOTNULL(plugin);
-  RelativeDegreesOfFreedom<AliceSun> const result =
-      plugin->VesselFromParent(parent_index, vessel_guid);
-  return m.Return({ToXYZ(result.displacement().coordinates() / Metre),
-                   ToXYZ(result.velocity().coordinates() / (Metre / Second))});
+  return m.Return(ToQP(plugin->VesselFromParent(parent_index, vessel_guid)));
 }
 
 AdaptiveStepParameters principia__VesselGetPredictionAdaptiveStepParameters(

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -57,7 +57,7 @@ AdaptiveStepParameters principia__VesselGetPredictionAdaptiveStepParameters(
       {plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
   return m.Return(ToAdaptiveStepParameters(
-      GetVessel(*plugin, vessel_guid)->prediction_adaptive_step_parameters()));
+      plugin->GetVessel(vessel_guid)->prediction_adaptive_step_parameters()));
 }
 
 XYZ principia__VesselNormal(Plugin const* const plugin,
@@ -74,7 +74,7 @@ void principia__VesselSetPredictionAdaptiveStepParameters(
   journal::Method<journal::VesselSetPredictionAdaptiveStepParameters> m(
       {plugin, vessel_guid, adaptive_step_parameters});
   CHECK_NOTNULL(plugin);
-  GetVessel(*plugin, vessel_guid)
+  plugin->GetVessel(vessel_guid)
       ->set_prediction_adaptive_step_parameters(
           FromAdaptiveStepParameters(adaptive_step_parameters));
   return m.Return();

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -33,7 +33,7 @@ XYZ principia__VesselBinormal(Plugin const* const plugin,
                               char const* const vessel_guid) {
   journal::Method<journal::VesselBinormal> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  return m.Return(ToXYZ(plugin->VesselBinormal(vessel_guid).coordinates()));
+  return m.Return(ToXYZ(plugin->VesselBinormal(vessel_guid)));
 }
 
 // Calls |plugin->VesselFromParent| with the arguments given.
@@ -61,7 +61,7 @@ XYZ principia__VesselNormal(Plugin const* const plugin,
                             char const* const vessel_guid) {
   journal::Method<journal::VesselNormal> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  return m.Return(ToXYZ(plugin->VesselNormal(vessel_guid).coordinates()));
+  return m.Return(ToXYZ(plugin->VesselNormal(vessel_guid)));
 }
 
 void principia__VesselSetPredictionAdaptiveStepParameters(
@@ -81,15 +81,14 @@ XYZ principia__VesselTangent(Plugin const* const plugin,
                              char const* const vessel_guid) {
   journal::Method<journal::VesselTangent> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  return m.Return(ToXYZ(plugin->VesselTangent(vessel_guid).coordinates()));
+  return m.Return(ToXYZ(plugin->VesselTangent(vessel_guid)));
 }
 
 XYZ principia__VesselVelocity(Plugin const* const plugin,
                               char const* const vessel_guid) {
   journal::Method<journal::VesselVelocity> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
-  return m.Return(ToXYZ(plugin->VesselVelocity(vessel_guid).coordinates() /
-                        (Metre / Second)));
+  return m.Return(ToXYZ(plugin->VesselVelocity(vessel_guid)));
 }
 
 }  // namespace interface

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -754,19 +754,20 @@ public partial class PrincipiaPluginAdapter
           plugin_.HasVessel(active_vessel.id.ToString());
 
       if (ready_to_draw_active_vessel_trajectory) {
-        // TODO(egg): make the speed tolerance independent.  Also max_steps.
-        AdaptiveStepParameters adaptive_step_parameters =
-            new AdaptiveStepParameters {
-              max_steps = (Int64)prediction_steps_[prediction_steps_index_],
-              length_integration_tolerance =
-                  prediction_length_tolerances_[
-                      prediction_length_tolerance_index_],
-              speed_integration_tolerance =
-                  prediction_length_tolerances_[
-                      prediction_length_tolerance_index_]};
-        plugin_.VesselSetPredictionAdaptiveStepParameters(
-            active_vessel.id.ToString(), adaptive_step_parameters);
-        plugin_.SetPredictionLength(double.PositiveInfinity);
+            // TODO(egg): make the speed tolerance independent.  Also max_steps.
+            AdaptiveStepParameters adaptive_step_parameters =
+                plugin_.VesselGetPredictionAdaptiveStepParameters(
+                    active_vessel.id.ToString());
+            adaptive_step_parameters = new AdaptiveStepParameters{
+                integrator_kind = adaptive_step_parameters.integrator_kind,
+                max_steps = (Int64)prediction_steps_[prediction_steps_index_],
+                length_integration_tolerance = prediction_length_tolerances_
+                    [prediction_length_tolerance_index_],
+                speed_integration_tolerance = prediction_length_tolerances_
+                    [prediction_length_tolerance_index_]};
+            plugin_.VesselSetPredictionAdaptiveStepParameters(
+                active_vessel.id.ToString(), adaptive_step_parameters);
+            plugin_.SetPredictionLength(double.PositiveInfinity);
       }
 
       if (ready_to_draw_active_vessel_trajectory) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -754,20 +754,23 @@ public partial class PrincipiaPluginAdapter
           plugin_.HasVessel(active_vessel.id.ToString());
 
       if (ready_to_draw_active_vessel_trajectory) {
-            // TODO(egg): make the speed tolerance independent.  Also max_steps.
-            AdaptiveStepParameters adaptive_step_parameters =
-                plugin_.VesselGetPredictionAdaptiveStepParameters(
-                    active_vessel.id.ToString());
-            adaptive_step_parameters = new AdaptiveStepParameters{
-                integrator_kind = adaptive_step_parameters.integrator_kind,
-                max_steps = (Int64)prediction_steps_[prediction_steps_index_],
-                length_integration_tolerance = prediction_length_tolerances_
-                    [prediction_length_tolerance_index_],
-                speed_integration_tolerance = prediction_length_tolerances_
-                    [prediction_length_tolerance_index_]};
-            plugin_.VesselSetPredictionAdaptiveStepParameters(
-                active_vessel.id.ToString(), adaptive_step_parameters);
-            plugin_.SetPredictionLength(double.PositiveInfinity);
+        // TODO(egg): make the speed tolerance independent.  Also max_steps.
+        AdaptiveStepParameters adaptive_step_parameters =
+            plugin_.VesselGetPredictionAdaptiveStepParameters(
+                active_vessel.id.ToString());
+        adaptive_step_parameters =
+            new AdaptiveStepParameters {
+              integrator_kind = adaptive_step_parameters.integrator_kind,
+              max_steps = (Int64)prediction_steps_[prediction_steps_index_],
+              length_integration_tolerance =
+                  prediction_length_tolerances_[
+                      prediction_length_tolerance_index_],
+              speed_integration_tolerance =
+                  prediction_length_tolerances_[
+                      prediction_length_tolerance_index_]};
+        plugin_.VesselSetPredictionAdaptiveStepParameters(
+            active_vessel.id.ToString(), adaptive_step_parameters);
+        plugin_.SetPredictionLength(double.PositiveInfinity);
       }
 
       if (ready_to_draw_active_vessel_trajectory) {

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -11,6 +11,7 @@
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "journal/recorder.hpp"
 #include "ksp_plugin/frames.hpp"
 #include "ksp_plugin/identification.hpp"
@@ -53,6 +54,7 @@ using ksp_plugin::Part;
 using ksp_plugin::PartId;
 using ksp_plugin::World;
 using ksp_plugin::WorldSun;
+using integrators::DormandElMikkawyPrince1986RKN434FM;
 using physics::CoordinateFrameField;
 using physics::DegreesOfFreedom;
 using physics::DynamicFrame;

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -936,7 +936,8 @@ TEST_F(InterfaceTest, FlightPlan) {
   EXPECT_TRUE(principia__FlightPlanSetAdaptiveStepParameters(
                   plugin_.get(),
                   vessel_guid,
-                  {/*max_step=*/11,
+                  {/*integrator_kind=*/1,
+                   /*max_step=*/11,
                    /*length_integration_tolerance=*/22,
                    /*speed_integration_tolerance=*/33}));
 
@@ -948,6 +949,7 @@ TEST_F(InterfaceTest, FlightPlan) {
   EXPECT_CALL(flight_plan, adaptive_step_parameters())
       .WillOnce(ReturnRef(adaptive_step_parameters));
   AdaptiveStepParameters expected_adaptive_step_parameters = {
+      /*integrator_kind=*/1,
       /*max_step=*/111,
       /*length_integration_tolerance=*/222,
       /*speed_integration_tolerance=*/333};

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -69,6 +69,8 @@ class Ephemeris {
         Length const& length_integration_tolerance,
         Speed const& speed_integration_tolerance);
 
+    AdaptiveStepSizeIntegrator<NewtonianMotionEquation> const&
+    integrator() const;
     std::int64_t max_steps() const;
     Length length_integration_tolerance() const;
     Speed speed_integration_tolerance() const;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -108,6 +108,13 @@ Ephemeris<Frame>::AdaptiveStepParameters::AdaptiveStepParameters(
 }
 
 template<typename Frame>
+AdaptiveStepSizeIntegrator<
+    typename Ephemeris<Frame>::NewtonianMotionEquation> const&
+Ephemeris<Frame>::AdaptiveStepParameters::integrator() const {
+  return *integrator_;
+}
+
+template<typename Frame>
 std::int64_t Ephemeris<Frame>::AdaptiveStepParameters::max_steps() const {
   return max_steps_;
 }

--- a/serialization/integrators.proto
+++ b/serialization/integrators.proto
@@ -6,8 +6,6 @@ import "serialization/quantities.proto";
 
 package principia.serialization;
 
-// TODO(phl): This message seems unused as we don't ever serialize/deserialize
-// an |Integrator|.  Remove it.
 message Integrator {
   extensions 3000 to 3999;  // Last used: 3001.
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -20,6 +20,8 @@ message XYZ {
 }
 
 message AdaptiveStepParameters {
+  // Corresponds to AdaptiveStepSizeIntegrator.Kind.
+  required int64 integrator_kind = 4;
   required int64 max_steps = 1;
   required double length_integration_tolerance = 2;
   required double speed_integration_tolerance = 3;


### PR DESCRIPTION
* Factor out the code that converts `XYZ` and `QP` to and from typed entities.
* The interface should not be the one deciding which integrator we use.
* Remove the `GetVessel` "abstraction".