### PR TITLE
Fix a bug in the generation of the RSS config

### DIFF
--- a/astronomy/sol_initial_state_jd_2433282_500000000.cfg
+++ b/astronomy/sol_initial_state_jd_2433282_500000000.cfg
@@ -1,6 +1,6 @@
 principia_initial_state:NEEDS[RealSolarSystem] {
   game_epoch = JD2433647.5
-  solar_system_epoch = -1.57788000000000000e+09 s
+  solar_system_epoch = JD2433282.500000000
   body {
     name = Ariel
     x    = -1.854514651748800e+08 km

--- a/physics/solar_system.hpp
+++ b/physics/solar_system.hpp
@@ -47,6 +47,7 @@ class SolarSystem final {
 
   // The time origin for the initial state.
   Instant const& epoch() const;
+  std::string const& epoch_literal() const;
 
   // The names of the bodies, sorted alphabetically.
   std::vector<std::string> const& names() const;

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -171,6 +171,11 @@ Instant const& SolarSystem<Frame>::epoch() const {
 }
 
 template<typename Frame>
+std::string const& SolarSystem<Frame>::epoch_literal() const {
+  return initial_state_.epoch();
+}
+
+template<typename Frame>
 std::vector<std::string> const& SolarSystem<Frame>::names() const {
   return names_;
 }

--- a/tools/generate_configuration.cpp
+++ b/tools/generate_configuration.cpp
@@ -97,7 +97,7 @@ void GenerateConfiguration(std::string const& game_epoch,
   initial_state_cfg << "principia_initial_state:NEEDS[RealSolarSystem] {\n";
   initial_state_cfg << "  game_epoch = " << game_epoch << "\n";
   initial_state_cfg << "  solar_system_epoch = "
-                    << solar_system.epoch() << "\n";
+                    << solar_system.epoch_literal() << "\n";
   for (std::string const& name : solar_system.names()) {
     serialization::InitialState::Cartesian::Body const& body =
         solar_system.cartesian_initial_state_message(name);


### PR DESCRIPTION
This was broken in Catalan, but fixed in a hurry by a patch to the configuration.  This is the proper change for Cauchy.