### PR TITLE
All NaNs are almost equal

### DIFF
--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -232,10 +232,11 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
       AngularVelocity<Barycentric>(),
       Velocity<Barycentric>());
   MockRenderer renderer;
+  auto const identity = Rotation<Barycentric, AliceSun>::Identity();
   EXPECT_CALL(*plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*const_plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*plugin_, PlanetariumRotation())
-      .WillRepeatedly(ReturnRef(Rotation<Barycentric, AliceSun>::Identity()));
+      .WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(flight_plan, GetManœuvre(3))
       .WillOnce(ReturnRef(navigation_manœuvre));
   EXPECT_CALL(navigation_manœuvre, InertialDirection())

--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -236,7 +236,7 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
   EXPECT_CALL(*plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*const_plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*plugin_, PlanetariumRotation())
-      .WillRepeatedly(ReturnRef(renderer));
+      .WillRepeatedly(ReturnRef(identity));
   EXPECT_CALL(flight_plan, GetManœuvre(3))
       .WillOnce(ReturnRef(navigation_manœuvre));
   EXPECT_CALL(navigation_manœuvre, InertialDirection())

--- a/ksp_plugin_test/interface_renderer_test.cpp
+++ b/ksp_plugin_test/interface_renderer_test.cpp
@@ -190,10 +190,11 @@ TEST_F(InterfaceRendererTest, Iterator) {
   EXPECT_EQ(mock_navigation_frame, navigation_frame);
 
   MockRenderer renderer;
+  auto const identity = Rotation<Barycentric, AliceSun>::Identity();
   EXPECT_CALL(*plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*const_plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*plugin_, PlanetariumRotation())
-      .WillRepeatedly(ReturnRef(Rotation<Barycentric, AliceSun>::Identity()));
+      .WillRepeatedly(ReturnRef(identity));
   EXPECT_CALL(*plugin_, CurrentTime()).WillOnce(Return(t0_));
   EXPECT_CALL(renderer, SetPlottingFrameConstRef(Ref(*navigation_frame)));
   principia__SetPlottingFrame(plugin_.get(), &navigation_frame);

--- a/ksp_plugin_test/interface_renderer_test.cpp
+++ b/ksp_plugin_test/interface_renderer_test.cpp
@@ -108,9 +108,10 @@ TEST_F(InterfaceRendererTest, RenderedPrediction) {
   EXPECT_EQ(mock_navigation_frame, navigation_frame);
 
   MockRenderer renderer;
+  auto const identity = Rotation<Barycentric, AliceSun>::Identity();
   EXPECT_CALL(*plugin_, renderer()).WillRepeatedly(ReturnRef(renderer));
   EXPECT_CALL(*plugin_, PlanetariumRotation())
-      .WillRepeatedly(ReturnRef(Rotation<Barycentric, AliceSun>::Identity()));
+      .WillRepeatedly(ReturnRef(identity));
   EXPECT_CALL(*plugin_, CurrentTime()).WillOnce(Return(t0_));
   EXPECT_CALL(renderer, SetPlottingFrameConstRef(Ref(*navigation_frame)));
   principia__SetPlottingFrame(plugin_.get(), &navigation_frame);

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -341,7 +341,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
     KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
         *sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
-                AlmostEquals(expected_displacement, 37));
+                AlmostEquals(expected_displacement, 37, 49));
     EXPECT_THAT(voyager_orbit.StateVectors(date).velocity(),
                 AlmostEquals(expected_velocity, 26));
     EXPECT_THAT(*voyager_orbit.elements_at_epoch().hyperbolic_mean_motion,
@@ -354,9 +354,9 @@ TEST_F(KeplerOrbitTest, Voyager1) {
     KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
         *sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
-                AlmostEquals(expected_displacement, 31));
+                AlmostEquals(expected_displacement, 31, 44));
     EXPECT_THAT(voyager_orbit.StateVectors(date).velocity(),
-                AlmostEquals(expected_velocity, 28));
+                AlmostEquals(expected_velocity, 28, 27));
   }
 
   KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
@@ -1473,7 +1473,11 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicMeanMotion) {
                                    /*mean_motion_ulps=*/0,
                                    /*period_ulps=*/0,
                                    /*hyperbolic_mean_motion_ulps=*/0,
+#if PRINCIPIA_COMPILER_MSVC
                                    /*hyperbolic_excess_velocity_ulps=*/1,
+#else
+                                   /*hyperbolic_excess_velocity_ulps=*/0,
+#endif
                                    /*semiminor_axis_ulps=*/0,
                                    /*impact_parameter_ulps=*/1,
                                    /*semilatus_rectum_ulps=*/1,

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -356,7 +356,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 31, 44));
     EXPECT_THAT(voyager_orbit.StateVectors(date).velocity(),
-                AlmostEquals(expected_velocity, 28, 27));
+                AlmostEquals(expected_velocity, 27, 28));
   }
 
   KeplerOrbit<ICRFJ2000Equator> voyager_orbit(

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -20,7 +20,14 @@ namespace principia {
 namespace testing_utilities {
 namespace internal_almost_equals {
 
-using numerics::ULPDistance;
+// Make sure that this matcher treats all NaNs as almost equal to 0 ULPs.
+inline double NormalizeNaN(double const x) {
+  return std::isnan(x) ? std::numeric_limits<double>::quiet_NaN() : x;
+}
+
+inline NormalizedNaNULPDistance(double const x, double const y) {
+  return numerics::ULPDistance(NormalizeNaN(x), NormalizeNaN(y));
+}
 
 template<typename T>
 testing::PolymorphicMatcher<AlmostEqualsMatcher<T>> AlmostEquals(
@@ -57,8 +64,8 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   if (actual == expected_) {
     return MatchAndExplainIdentical(listener);
   }
-  std::int64_t const distance = ULPDistance(DoubleValue(actual),
-                                            DoubleValue(expected_));
+  std::int64_t const distance =
+      NormalizedNaNULPDistance(DoubleValue(actual), DoubleValue(expected_));
   bool const match =  min_ulps_ <= distance && distance <= max_ulps_;
   if (!match) {
     *listener << "the numbers are separated by " << distance << " ULPs";
@@ -74,7 +81,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   if (actual == expected_) {
     return MatchAndExplainIdentical(listener);
   }
-  std::int64_t const distance = ULPDistance(actual, expected_);
+  std::int64_t const distance = NormalizedNaNULPDistance(actual, expected_);
   bool const match =  min_ulps_ <= distance && distance <= max_ulps_;
   if (!match) {
     *listener << "the numbers are separated by " << distance << " ULPs";
@@ -91,12 +98,12 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   if (actual == expected_) {
     return MatchAndExplainIdentical(listener);
   }
-  std::int64_t const x_distance = ULPDistance(DoubleValue(actual.x),
-                                              DoubleValue(expected_.x));
-  std::int64_t const y_distance = ULPDistance(DoubleValue(actual.y),
-                                              DoubleValue(expected_.y));
-  std::int64_t const z_distance = ULPDistance(DoubleValue(actual.z),
-                                              DoubleValue(expected_.z));
+  std::int64_t const x_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.x), DoubleValue(expected_.x));
+  std::int64_t const y_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.y), DoubleValue(expected_.y));
+  std::int64_t const z_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.z), DoubleValue(expected_.z));
   std::int64_t const max_distance =
       std::max({x_distance, y_distance, z_distance});
   bool const x_is_max = x_distance == max_distance;
@@ -122,18 +129,17 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   if (actual == expected_) {
     return MatchAndExplainIdentical(listener);
   }
-  std::int64_t const w_distance = ULPDistance(
-      DoubleValue(actual.real_part()),
-      DoubleValue(expected_.real_part()));
-  std::int64_t const x_distance = ULPDistance(
-      DoubleValue(actual.imaginary_part().x),
-      DoubleValue(expected_.imaginary_part().x));
-  std::int64_t const y_distance = ULPDistance(
-      DoubleValue(actual.imaginary_part().y),
-      DoubleValue(expected_.imaginary_part().y));
-  std::int64_t const z_distance = ULPDistance(
-      DoubleValue(actual.imaginary_part().z),
-      DoubleValue(expected_.imaginary_part().z));
+  std::int64_t const w_distance = NormalizedNaNULPDistance(
+      DoubleValue(actual.real_part()), DoubleValue(expected_.real_part()));
+  std::int64_t const x_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.imaginary_part().x),
+                               DoubleValue(expected_.imaginary_part().x));
+  std::int64_t const y_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.imaginary_part().y),
+                               DoubleValue(expected_.imaginary_part().y));
+  std::int64_t const z_distance =
+      NormalizedNaNULPDistance(DoubleValue(actual.imaginary_part().z),
+                               DoubleValue(expected_.imaginary_part().z));
   bool const w_matches = w_distance <= max_ulps_;
   bool const x_matches = x_distance <= max_ulps_;
   bool const y_matches = y_distance <= max_ulps_;

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <limits>
 #include <string>
 
 #include "geometry/grassmann.hpp"

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -25,7 +25,7 @@ inline double NormalizeNaN(double const x) {
   return std::isnan(x) ? std::numeric_limits<double>::quiet_NaN() : x;
 }
 
-inline NormalizedNaNULPDistance(double const x, double const y) {
+inline std::int64_t NormalizedNaNULPDistance(double const x, double const y) {
   return numerics::ULPDistance(NormalizeNaN(x), NormalizeNaN(y));
 }
 


### PR DESCRIPTION
but some NaNs are less equal than others.
This fixes the Kepler orbit tests on Linux.