### PR TITLE
Disable resonance tests on Linux

### DIFF
--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -242,7 +242,7 @@ class KSPResonanceTest : public ::testing::Test {
 
 #if !defined(_DEBUG)
 
-TEST_F(KSPResonanceTest, Stock) {
+TEST_F(KSPResonanceTest, MSVC_ONLY_TEST(Stock)) {
   auto const ephemeris = MakeEphemeris();
   ephemeris->Prolong(short_term_);
   EXPECT_OK(ephemeris->last_severe_integration_status());
@@ -297,7 +297,7 @@ TEST_F(KSPResonanceTest, Stock) {
                "stock");
 }
 
-TEST_F(KSPResonanceTest, Corrected) {
+TEST_F(KSPResonanceTest, MSVC_ONLY_TEST(Corrected)) {
   StabilizeKSP(solar_system_);
 
   auto const ephemeris = MakeEphemeris();

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -199,6 +199,12 @@ inline void noreturn() { std::exit(0); }
 #  define CONSTEXPR_INFINITY constexpr
 #endif
 
+#if PRINCIPIA_COMPILER_MSVC
+#define MSVC_ONLY_TEST(test_name) test_name
+#else
+#define MSVC_ONLY_TEST(test_name) DISABLED_##test_name
+#endif
+
 // For templates in macro parameters.
 #define TEMPLATE(...) template<__VA_ARGS__>
 


### PR DESCRIPTION
All tests pass on Linux now.