### PR TITLE
Speed indications on markers

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -898,8 +898,7 @@ std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(
       Position<Navigation> const q_in_plotting =
           renderer.WorldToPlotting(current_time,
                                    sun_world_position_,
-                                   planetarium_rotation).
-              rigid_transformation()(q);
+                                   planetarium_rotation)(q);
 
       OrthogonalMap<RightHandedNavball, Barycentric> const
           right_handed_navball_to_barycentric =
@@ -908,10 +907,10 @@ std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(
                         navigation_right_handed_field_->
                             FromThisFrame(q_in_plotting).Forget()
                   : barycentric_right_handed_field_->FromThisFrame(
-                        renderer.WorldToBarycentric(current_time,
-                                                    sun_world_position_,
-                                                    planetarium_rotation).
-                            rigid_transformation()(q)).Forget();
+                        renderer.WorldToBarycentric(
+                            current_time,
+                            sun_world_position_,
+                            planetarium_rotation)(q)).Forget();
 
       // KSP's navball has x west, y up, z south.
       // We want x north, y east, z down.

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1235,7 +1235,8 @@ void Plugin::UpdatePlanetariumRotation() {
 void Plugin::UpdatePredictionForRendering(std::int64_t const size) const {
   auto& vessel = renderer_->GetTargetVessel();
   auto parameters = vessel.prediction_adaptive_step_parameters();
-  parameters.set_max_steps(size);
+  // Adding one to ensure that we set a strictly positive max_steps.
+  parameters.set_max_steps(size + 1);
   vessel.set_prediction_adaptive_step_parameters(parameters);
   vessel.UpdatePrediction(current_time_ + prediction_length_);
 }

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -120,16 +120,37 @@ Renderer::RenderPlottingTrajectoryInWorld(
     Position<World> const& sun_world_position,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
-
-  RigidMotion<Navigation, World> const
+  // This function does unnatural things.
+  // - It identifies positions in the plotting frame with those of world using
+  // the rigid transformation at the current time, instead of transforming each
+  // position according to the transformation at its time.  This hides the fact
+  // that we are considering an observer fixed in the plotting frame.
+  // - Instead of applying the full rigid motion and consistently transforming
+  // the velocities, or even just applying the orthogonal map, it simply
+  // identifies the coordinates of |World| with those of the plotting frame.
+  // This is because we are interested in the magnitude of the velocity (the
+  // speed) in the plotting frame, as well as the coordinates (in frames with a
+  // physically significant plane, the z coordinate becomes the out-of-plane
+  // velocity).
+  // The resulting |DegreesOfFreedom| should be seen as no more than a
+  // convenient hack to send a plottable position together with a velocity in
+  // the coordinates we want.
+  // TODO(phl): This will no longer be needed once we have support for
+  // projections; instead of these convenient lies we can simply say that the
+  // camera is fixed in the plotting frame and project there; additional data
+  // can be gathered from the velocities in the plotting frame as needed and
+  // sent directly to be shown in markers.
+  RigidTransformation<Navigation, World> const
       from_plotting_frame_to_world_at_current_time =
-          PlottingAsWorld(time, sun_world_position, planetarium_rotation);
+          PlottingToWorld(time, sun_world_position, planetarium_rotation);
   for (auto it = begin; it != end; ++it) {
     DegreesOfFreedom<Navigation> const& navigation_degrees_of_freedom =
         it.degrees_of_freedom();
-    DegreesOfFreedom<World> const world_degrees_of_freedom =
+    DegreesOfFreedom<World> const world_degrees_of_freedom = {
         from_plotting_frame_to_world_at_current_time(
-            navigation_degrees_of_freedom);
+            navigation_degrees_of_freedom.position()),
+        geometry::Identity<Navigation, World>{}(
+            navigation_degrees_of_freedom.velocity())};
     trajectory->Append(it.time(), world_degrees_of_freedom);
   }
   VLOG(1) << "Returning a " << trajectory->Size() << "-point trajectory";
@@ -196,16 +217,12 @@ OrthogonalMap<Navigation, Barycentric> Renderer::PlottingToBarycentric(
   return GetPlottingFrame()->FromThisFrameAtTime(time).orthogonal_map();
 }
 
-RigidMotion<Navigation, World> Renderer::PlottingAsWorld(
+RigidTransformation<Navigation, World> Renderer::PlottingToWorld(
     Instant const& time,
     Position<World> const& sun_world_position,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  return RigidMotion<Navigation, World>{
-      /*rigid_transformation=*/BarycentricToWorld(
-          time, sun_world_position, planetarium_rotation) *
-          GetPlottingFrame()->FromThisFrameAtTime(time).rigid_transformation(),
-      AngularVelocity<Navigation>{},
-      Velocity<Navigation>{}};
+  return BarycentricToWorld(time, sun_world_position, planetarium_rotation) *
+         GetPlottingFrame()->FromThisFrameAtTime(time).rigid_transformation();
 }
 
 OrthogonalMap<Navigation, World> Renderer::PlottingToWorld(

--- a/ksp_plugin/renderer.hpp
+++ b/ksp_plugin/renderer.hpp
@@ -31,6 +31,7 @@ using physics::DiscreteTrajectory;
 using physics::Ephemeris;
 using physics::Frenet;
 using physics::RigidMotion;
+using physics::RigidTransformation;
 using quantities::Length;
 
 class Renderer {
@@ -100,7 +101,7 @@ class Renderer {
   virtual RigidMotion<Barycentric, Navigation> BarycentricToPlotting(
       Instant const& time) const;
 
-  virtual RigidMotion<Barycentric, World> BarycentricToWorld(
+  virtual RigidTransformation<Barycentric, World> BarycentricToWorld(
       Instant const& time,
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
@@ -127,7 +128,19 @@ class Renderer {
   virtual OrthogonalMap<Navigation, Barycentric> PlottingToBarycentric(
       Instant const& time) const;
 
-  virtual RigidMotion<Navigation, World> PlottingToWorld(
+  // This function does unnatural things.  It identifies positions in the
+  // plotting frame with those of world using the rigid transformation at the
+  // given |time|, but instead of applying the full rigid motion and
+  // consistently transforming the velocities, it simply applies a linear
+  // transformation to the latter.  The resulting |DegreesOfFreedom| should be
+  // seen as no more than a convenient hack to send a plottable position
+  // together with a velocity in the right coordinates.
+  // TODO(phl): This will no longer be needed once we have support for
+  // projections; instead of these convenient lies we can simply say that the
+  // camera is fixed in the plotting frame and project there; additional data
+  // can be gathered from the velocities as needed and sent directly to be shown
+  // in markers.
+  virtual RigidMotion<Navigation, World> PlottingAsWorld(
       Instant const& time,
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
@@ -136,7 +149,7 @@ class Renderer {
       Instant const& time,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
 
-  virtual RigidMotion<World, Barycentric> WorldToBarycentric(
+  virtual RigidTransformation<World, Barycentric> WorldToBarycentric(
       Instant const& time,
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
@@ -144,7 +157,7 @@ class Renderer {
   virtual OrthogonalMap<World, Barycentric> WorldToBarycentric(
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
 
-  virtual RigidMotion<World, Navigation> WorldToPlotting(
+  virtual RigidTransformation<World, Navigation> WorldToPlotting(
       Instant const& time,
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;

--- a/ksp_plugin/renderer.hpp
+++ b/ksp_plugin/renderer.hpp
@@ -128,19 +128,7 @@ class Renderer {
   virtual OrthogonalMap<Navigation, Barycentric> PlottingToBarycentric(
       Instant const& time) const;
 
-  // This function does unnatural things.  It identifies positions in the
-  // plotting frame with those of world using the rigid transformation at the
-  // given |time|, but instead of applying the full rigid motion and
-  // consistently transforming the velocities, it simply applies a linear
-  // transformation to the latter.  The resulting |DegreesOfFreedom| should be
-  // seen as no more than a convenient hack to send a plottable position
-  // together with a velocity in the right coordinates.
-  // TODO(phl): This will no longer be needed once we have support for
-  // projections; instead of these convenient lies we can simply say that the
-  // camera is fixed in the plotting frame and project there; additional data
-  // can be gathered from the velocities as needed and sent directly to be shown
-  // in markers.
-  virtual RigidMotion<Navigation, World> PlottingAsWorld(
+  virtual RigidTransformation<Navigation, World> PlottingToWorld(
       Instant const& time,
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -212,7 +212,9 @@ internal class MapNodePool {
   private struct MapNodeProperties {
     public MapObject.ObjectType object_type;
     public Vector3d world_position;
-    // Velocity in the plotting frame, expressed in the coordinates of World.
+     // Velocity in the plotting frame.  Note that the handedness is
+     // inconsistent with World; for practical purposes only the norm or
+     // individual coordinates of this vector should be used here.
     public Vector3d velocity;
     public Vessel vessel;
     public CelestialBody celestial;

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -48,12 +48,13 @@ internal class MapNodePool {
                                      CelestialBody celestial) {
     for (; !apsis_iterator.IteratorAtEnd();
          apsis_iterator.IteratorIncrement()) {
-      Vector3d apsis = (Vector3d)apsis_iterator.IteratorGetXYZ();
+      QP apsis = apsis_iterator.IteratorGetQP();
       MapNodeProperties node_properties;
       node_properties.object_type = type;
       node_properties.vessel = vessel;
       node_properties.celestial = celestial;
-      node_properties.world_position = apsis;
+      node_properties.world_position = (Vector3d)apsis.q;
+      node_properties.velocity = (Vector3d)apsis.p;
       node_properties.source = source;
       node_properties.time = apsis_iterator.IteratorGetTime();
 
@@ -147,6 +148,10 @@ internal class MapNodePool {
                     properties_[node].world_position).ToString(
                         "N0",
                         Culture.culture) + " m</color>";
+            caption.captionLine2 =
+                properties_[node].velocity.magnitude.ToString("N0",
+                                                              Culture.culture) +
+                " m/s";
           } else if (properties_[node].object_type ==
                          MapObject.ObjectType.AscendingNode ||
                      properties_[node].object_type ==
@@ -166,6 +171,10 @@ internal class MapNodePool {
                               properties_[node].world_position)
                                  .magnitude.ToString("N0", Culture.culture) +
                              " m</color>";
+            caption.captionLine2 =
+                properties_[node].velocity.magnitude.ToString("N0",
+                                                              Culture.culture) +
+                " m/s";
           }
           caption.captionLine1 =
               "T" +
@@ -178,6 +187,7 @@ internal class MapNodePool {
                              " Impact<color=" +
                              XKCDColors.HexFormat.Chartreuse + "></color>";
             caption.captionLine1 = "";
+            caption.captionLine2 = "";
           }
           switch (properties_[node].source) {
             case NodeSource.FLIGHT_PLAN:
@@ -201,6 +211,8 @@ internal class MapNodePool {
   private struct MapNodeProperties {
     public MapObject.ObjectType object_type;
     public Vector3d world_position;
+    // Velocity in the plotting frame, expressed in the coordinates of World.
+    public Vector3d velocity;
     public Vessel vessel;
     public CelestialBody celestial;
     public NodeSource source;

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -160,9 +160,10 @@ internal class MapNodePool {
                                   MapObject.ObjectType.AscendingNode
                               ? "Ascending Node"
                               : "Descending Node";
-            // TODO(egg): We should show some useful information here, perhaps
-            // out-of-plane (z) speed.
             caption.Header = name;
+            caption.captionLine2 =
+                properties_[node].velocity.z.ToString("N0", Culture.culture) +
+                " m/s out of plane";
           } else if (properties_[node].object_type ==
                      MapObject.ObjectType.ApproachIntersect) {
             caption.Header = "Target Approach : <color=" +


### PR DESCRIPTION
Shows the speed (in the plotting frame) on periapsis, apoapsis, and locally closest approach markers. Shows the speed normal to the reference plane on ascending/descending node markers.