### PR TITLE
Fix ForgetBefore when the instance is not aligned with the polynomials

### DIFF
--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -106,7 +106,7 @@ TEST_F(PlayerTest, DISABLED_Debug) {
   LOG(ERROR) << "Last successful method out/return: \n"
               << player.last_method_out_return().DebugString();
 
-#if 1
+#if 0
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -92,7 +92,7 @@ TEST_F(PlayerTest, DISABLED_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Journals\JOURNAL.20170422-143027)";
+      R"(C:\Program Files\Kerbal Space Program\1.2.2\glog\Principia\JOURNAL.20170603-094244)";
   Player player(path);
   int count = 0;
   while (player.Play()) {
@@ -106,30 +106,25 @@ TEST_F(PlayerTest, DISABLED_Debug) {
   LOG(ERROR) << "Last successful method out/return: \n"
               << player.last_method_out_return().DebugString();
 
-#if 0
+#if 1
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(
-        serialization::RenderedPredictionNodes::extension);
+        serialization::SerializePlugin::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(3220795440);
-    in->set_vessel_guid("cf6715cb-8780-4c39-8c01-3cc0cf35683b");
-    in->mutable_sun_world_position()->set_x(-3412377724.9237709);
-    in->mutable_sun_world_position()->set_y(5875636073.1931963);
-    in->mutable_sun_world_position()->set_z(-11782002982.199373);
+    in->set_plugin(1524276256);
+    in->set_serializer(0);
   }
   serialization::Method method_out_return;
   {
     auto* extension = method_out_return.MutableExtension(
-        serialization::RenderedPredictionNodes::extension);
+        serialization::SerializePlugin::extension);
     auto* out = extension->mutable_out();
-    out->set_ascending(1);
-    out->set_descending(2);
   }
   LOG(ERROR) << "Running unpaired method:\n" << method_in.DebugString();
-  CHECK(RunIfAppropriate<RenderedPredictionNodes>(method_in,
-                                                  method_out_return,
-                                                  player));
+  CHECK(RunIfAppropriate<SerializePlugin>(method_in,
+                                          method_out_return,
+                                          player));
 #endif
 }
 

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -92,7 +92,7 @@ TEST_F(PlayerTest, DISABLED_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(C:\Program Files\Kerbal Space Program\1.2.2\glog\Principia\JOURNAL.20170603-094244)";
+      R"(C:\Program Files\Kerbal Space Program\1.2.2\glog\Principia\JOURNAL.20170603-094244)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play()) {

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -141,15 +141,14 @@ class InterfaceTest : public testing::Test {
 
   InterfaceTest()
       : plugin_(make_not_null_unique<StrictMock<MockPlugin>>()),
-        hexadecimal_simple_plugin_(
-            ReadFromHexadecimalFile("simple_plugin.proto.hex")),
-        serialized_simple_plugin_(
-            ReadFromBinaryFile("simple_plugin.proto.bin")) {}
+        hexadecimal_simple_plugin_(ReadFromHexadecimalFile(
+            SOLUTION_DIR / "ksp_plugin_test" / "simple_plugin.proto.hex")),
+        serialized_simple_plugin_(ReadFromBinaryFile(
+            SOLUTION_DIR / "ksp_plugin_test" / "simple_plugin.proto.bin")) {}
 
-  static std::string ReadFromBinaryFile(std::string const& filename) {
-    std::fstream file =
-        std::fstream(SOLUTION_DIR / "ksp_plugin_test" / filename,
-                     std::ios::in | std::ios::binary);
+  static std::string ReadFromBinaryFile(
+      std::experimental::filesystem::path const& filename) {
+    std::fstream file = std::fstream(filename, std::ios::in | std::ios::binary);
     CHECK(file.good());
     std::string binary;
     while (!file.eof()) {
@@ -161,9 +160,9 @@ class InterfaceTest : public testing::Test {
     return binary;
   }
 
-  static std::string ReadFromHexadecimalFile(std::string const& filename) {
-    std::fstream file =
-        std::fstream(SOLUTION_DIR / "ksp_plugin_test" / filename);
+  static std::string ReadFromHexadecimalFile(
+      std::experimental::filesystem::path const& filename) {
+    std::fstream file = std::fstream(filename);
     CHECK(file.good());
     std::string hex;
     while (!file.eof()) {
@@ -605,6 +604,25 @@ TEST_F(InterfaceTest, DeserializePlugin) {
           &deserializer,
           &plugin);
   principia__DeserializePlugin(hexadecimal_simple_plugin_.c_str(),
+                               0,
+                               &deserializer,
+                               &plugin);
+  EXPECT_THAT(plugin, NotNull());
+  principia__DeletePlugin(&plugin);
+}
+
+// Use for debugging saves given by users.
+TEST_F(InterfaceTest, DISABLED_DeserializePluginDebug) {
+  PushDeserializer* deserializer = nullptr;
+  Plugin const* plugin = nullptr;
+  std::string const hexadecimal_plugin = ReadFromHexadecimalFile(
+      R"(P:\Public Mockingbird\Principia\Crashes\1422\persistent.proto.hex)");
+  principia__DeserializePlugin(
+          hexadecimal_plugin.c_str(),
+          hexadecimal_plugin.size(),
+          &deserializer,
+          &plugin);
+  principia__DeserializePlugin(hexadecimal_plugin.c_str(),
                                0,
                                &deserializer,
                                &plugin);

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -103,6 +103,12 @@ class ContinuousTrajectory : public Trajectory<Frame> {
   // |Checkpoint|.  The only thing that clients may do with |Checkpoint| objects
   // is to initialize them with GetCheckpoint.
   class Checkpoint final {
+   public:
+    // Returns true if this checkpoint is after |time| and would remain valid
+    // after a call to |ForgetBefore(time)|.
+    bool IsAfter(Instant const& time) const;
+
+   private:
     // The members have the same meaning as those of class
     // |ContinuousTrajectory|.
     Checkpoint(Instant const& t_max,

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -259,6 +259,12 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
 }
 
 template<typename Frame>
+bool ContinuousTrajectory<Frame>::Checkpoint::IsAfter(
+    Instant const& time) const {
+  return time < t_max_;
+}
+
+template<typename Frame>
 ContinuousTrajectory<Frame>::Checkpoint::Checkpoint(
     Instant const& t_max,
     Length const& adjusted_tolerance,

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -337,7 +337,17 @@ void Ephemeris<Frame>::ForgetBefore(Instant const& t) {
   auto it = std::upper_bound(
                 checkpoints_.begin(), checkpoints_.end(), t,
                 [](Instant const& left, Checkpoint const& right) {
-                  return left < right.instance->time().value;
+                  // This lambda must implement a < comparison.
+                  for (auto const& checkpoint : right.checkpoints) {
+                    if (!checkpoint.IsAfter(left)) {
+                      // The individual |checkpoint| will become invalid, so
+                      // |right| <= |left|.
+                      return false;
+                    }
+                  }
+                  // All the individual checkpoints will remain valid, so
+                  // |left| < |right|.
+                  return true;
                 });
   if (it != checkpoints_.end()) {
     CHECK_LT(t, it->instance->time().value);

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -715,36 +715,6 @@ TEST_P(EphemerisTest, Serialization) {
   EXPECT_THAT(message, EqualsProto(second_message));
 }
 
-// Exercises the bug in #1422.
-TEST_P(EphemerisTest, Checkpointing) {
-  std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
-  std::vector<DegreesOfFreedom<ICRFJ2000Equator>> initial_state;
-  Position<ICRFJ2000Equator> centre_of_mass;
-  Time period;
-  SetUpEarthMoonSystem(bodies, initial_state, centre_of_mass, period);
-
-  // Set up an ephemeris with a step of 1 hour and integrate it to get one
-  // checkpoint.  Because 8 hours divide 1 day, we have an integral number of
-  // series in the continuous trajectories.
-  Ephemeris<ICRFJ2000Equator> ephemeris1(
-      std::move(bodies),
-      initial_state,
-      t0_,
-      5 * Milli(Metre),
-      Ephemeris<ICRFJ2000Equator>::FixedStepParameters(integrator(), 1 * Hour));
-  ephemeris1.Prolong(t0_ + 7.5 * Hour);
-  serialization::Ephemeris message1;
-  ephemeris1.WriteToMessage(&message1);
-
-  auto const ephemeris2 =
-      Ephemeris<ICRFJ2000Equator>::ReadFromMessage(message1);
-  ephemeris2->Prolong(t0_ + 50 * Hour);
-  ephemeris2->ForgetBefore(t0_ + 7 * Hour);
-
-  serialization::Ephemeris message2;
-  ephemeris2->WriteToMessage(&message2);
-}
-
 // The gravitational acceleration on an elephant located at the pole.
 TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
   Time const duration = 1 * Second;
@@ -1047,7 +1017,7 @@ INSTANTIATE_TEST_CASE_P(
     AllEphemerisTests,
     EphemerisTest,
     ::testing::Values(
-        //&McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
+        &McLachlanAtela1992Order5Optimal<Position<ICRFJ2000Equator>>(),
         &Quinlan1999Order8A<Position<ICRFJ2000Equator>>()));
 
 }  // namespace internal_ephemeris

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -112,9 +112,9 @@ class StackTraceDecoder {
   }
 
   private static void PrintUsage() {
-    Console.WriteLine(
-        "Usage: stacktrace_decoder " +
-        "<info_file_uri> <pdb_file> [--unity-crash-at-commit=<sha1>]");
+    Console.WriteLine("Usage: stacktrace_decoder " +
+                      "<info_file_uri> <principia_pdb_file> " +
+                      "[--unity-crash-at-commit=<sha1>]");
   }
 }
 


### PR DESCRIPTION
Unfortunately I wasn't able to write a unit test because I could create the unalignment in the first place.  It's unclear how the unaligned save came to be, but it's possible that this has something to do with #1395.  Anyway with this PR it is possible to read the save and to continue playing.

Fix #1422.