### PR TITLE
Fix a bug that induced a torque tending to make vessels thrust upwards.

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1101,6 +1101,8 @@ public partial class PrincipiaPluginAdapter
           // TODO(egg): use the centre of mass.  Here it's a bit tedious, some
           // transform nonsense must probably be done.
           part.rb.position = (Vector3d)part_actual_degrees_of_freedom.q;
+          part.rb.transform.position =
+              (Vector3d)part_actual_degrees_of_freedom.q;
           part.rb.velocity = (Vector3d)part_actual_degrees_of_freedom.p;
         }
       }
@@ -1108,6 +1110,7 @@ public partial class PrincipiaPluginAdapter
           physicalObject physical_object in FlightGlobals.physicalObjects.Where(
               o => o != null && o.rb != null)) {
         physical_object.rb.position += q_correction_at_root_part;
+        physical_object.rb.transform.position += q_correction_at_root_part;
         physical_object.rb.velocity += v_correction_at_root_part;
       }
       QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(


### PR DESCRIPTION
The answer to [this question](http://answers.unity3d.com/questions/950463/waitforfixedupdate-coroutine-happens-after-the-int.html) was instrumental in getting a hold on this issue. It appears that setting the position of a rigid body is only reflected on its transform when Unity's physics run. We set the positions right after Unity's physics run (as a corrector), so setting the position only would mean that the position and transform would always be inconsistent; a plausible explanation is that the difference between the two was due to gravity (so vertical), and that the force would then be applied at one of the two while the centre of gravity was at the other (inducing a torque to right the force).