### PR TITLE
Pass a time to CelestialWorldDegreesOfFreedom

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -224,13 +224,12 @@ QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
                                              PartId const part_at_origin,
                                              double const time) {
   journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
-      {plugin, index, part_at_origin, time});
+      {plugin, index, part_at_origin});
   CHECK_NOTNULL(plugin);
-  return m.Return(
-      ToQP(plugin->CelestialWorldDegreesOfFreedom(
-          index,
-          part_at_origin,
-          FromGameTime(*plugin, time))));
+  return m.Return(ToQP(plugin->CelestialWorldDegreesOfFreedom(
+                           index,
+                           part_at_origin,
+                           FromGameTime(*plugin, time))));
 }
 
 double principia__CurrentTime(Plugin const* const plugin) {

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -224,7 +224,7 @@ QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
                                              PartId const part_at_origin,
                                              double const time) {
   journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
-      {plugin, index, part_at_origin});
+      {plugin, index, part_at_origin, time});
   CHECK_NOTNULL(plugin);
   return m.Return(ToQP(plugin->CelestialWorldDegreesOfFreedom(
                            index,

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -221,12 +221,16 @@ WXYZ principia__CelestialSphereRotation(Plugin const* const plugin) {
 
 QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
                                              int const index,
-                                             PartId const part_at_origin) {
+                                             PartId const part_at_origin,
+                                             double const time) {
   journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
       {plugin, index, part_at_origin});
   CHECK_NOTNULL(plugin);
   return m.Return(
-      ToQP(plugin->CelestialWorldDegreesOfFreedom(index, part_at_origin)));
+      ToQP(plugin->CelestialWorldDegreesOfFreedom(
+          index,
+          part_at_origin,
+          FromGameTime(*plugin, time))));
 }
 
 double principia__CurrentTime(Plugin const* const plugin) {

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -224,7 +224,7 @@ QP principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
                                              PartId const part_at_origin,
                                              double const time) {
   journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
-      {plugin, index, part_at_origin});
+      {plugin, index, part_at_origin, time});
   CHECK_NOTNULL(plugin);
   return m.Return(
       ToQP(plugin->CelestialWorldDegreesOfFreedom(

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -71,8 +71,8 @@ class Part final {
   DegreesOfFreedom<Barycentric> const& degrees_of_freedom() const;
 
   // This temporarily holds the trajectory followed by the part during the call
-  // to |PileUp::AdvanceTime| for the containing |PileUp|.  It read and cleared
-  // by |Part::AdvanceTime| for the containing |Part|.
+  // to |PileUp::AdvanceTime| for the containing |PileUp|.  It is read and
+  // cleared by |Vessel::AdvanceTime| for the containing |Vessel|.
   DiscreteTrajectory<Barycentric>& tail();
   DiscreteTrajectory<Barycentric> const& tail() const;
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -568,9 +568,9 @@ DegreesOfFreedom<World> Plugin::GetPartActualDegreesOfFreedom(
 DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
     Index const index,
     PartId const part_at_origin) const {
-  auto const world_origin = FindOrDie(part_id_to_vessel_, part_at_origin)->
-                                part(part_at_origin)->
-                                degrees_of_freedom();
+  auto const part =
+      FindOrDie(part_id_to_vessel_, part_at_origin)->part(part_at_origin);
+  auto const world_origin = part->degrees_of_freedom();
   RigidMotion<Barycentric, World> barycentric_to_world{
       RigidTransformation<Barycentric, World>{
           world_origin.position(),
@@ -578,9 +578,10 @@ DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
           renderer_->BarycentricToWorld(PlanetariumRotation())},
       AngularVelocity<Barycentric>{},
       world_origin.velocity()};
+  CHECK(!part->tail().Empty());
   return barycentric_to_world(
       FindOrDie(celestials_, index)->
-          trajectory().EvaluateDegreesOfFreedom(current_time_));
+          trajectory().EvaluateDegreesOfFreedom(part->tail().last().time()));
 }
 
 void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -579,7 +579,6 @@ DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
           renderer_->BarycentricToWorld(PlanetariumRotation())},
       AngularVelocity<Barycentric>{},
       world_origin.velocity()};
-  CHECK(!part->tail().Empty());
   return barycentric_to_world(
       FindOrDie(celestials_,
                 index)->trajectory().EvaluateDegreesOfFreedom(time));

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -568,7 +568,7 @@ DegreesOfFreedom<World> Plugin::GetPartActualDegreesOfFreedom(
 DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
     Index const index,
     PartId const part_at_origin,
-    Instant const time) const {
+    Instant const& time) const {
   auto const part =
       FindOrDie(part_id_to_vessel_, part_at_origin)->part(part_at_origin);
   auto const world_origin = part->degrees_of_freedom();

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -580,8 +580,8 @@ DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
       AngularVelocity<Barycentric>{},
       world_origin.velocity()};
   return barycentric_to_world(
-      FindOrDie(celestials_,
-                index)->trajectory().EvaluateDegreesOfFreedom(time));
+      FindOrDie(celestials_, index)->
+          trajectory().EvaluateDegreesOfFreedom(time));
 }
 
 void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -567,7 +567,8 @@ DegreesOfFreedom<World> Plugin::GetPartActualDegreesOfFreedom(
 
 DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
     Index const index,
-    PartId const part_at_origin) const {
+    PartId const part_at_origin,
+    Instant const time) const {
   auto const part =
       FindOrDie(part_id_to_vessel_, part_at_origin)->part(part_at_origin);
   auto const world_origin = part->degrees_of_freedom();
@@ -580,8 +581,8 @@ DegreesOfFreedom<World> Plugin::CelestialWorldDegreesOfFreedom(
       world_origin.velocity()};
   CHECK(!part->tail().Empty());
   return barycentric_to_world(
-      FindOrDie(celestials_, index)->
-          trajectory().EvaluateDegreesOfFreedom(part->tail().last().time()));
+      FindOrDie(celestials_,
+                index)->trajectory().EvaluateDegreesOfFreedom(time));
 }
 
 void Plugin::AdvanceTime(Instant const& t, Angle const& planetarium_rotation) {

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -227,7 +227,7 @@ class Plugin {
   virtual DegreesOfFreedom<World> CelestialWorldDegreesOfFreedom(
       Index const index,
       PartId part_at_origin,
-      Instant const time) const;
+      Instant const& time) const;
 
   // Simulates the system until instant |t|.  Sets |current_time_| to |t|.
   // Must be called after initialization.

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -224,6 +224,7 @@ class Plugin {
 
   // Returns the |World| degrees of freedom of the |Celestial| with the given
   // |Index|, identifying the origin of |World| with that of |Bubble|.
+  // |AdvanceParts| must have been called since the last call to |AdvanceTime|.
   virtual DegreesOfFreedom<World> CelestialWorldDegreesOfFreedom(
       Index const index,
       PartId part_at_origin) const;

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -224,10 +224,10 @@ class Plugin {
 
   // Returns the |World| degrees of freedom of the |Celestial| with the given
   // |Index|, identifying the origin of |World| with that of |Bubble|.
-  // |AdvanceParts| must have been called since the last call to |AdvanceTime|.
   virtual DegreesOfFreedom<World> CelestialWorldDegreesOfFreedom(
       Index const index,
-      PartId part_at_origin) const;
+      PartId part_at_origin,
+      Instant const time) const;
 
   // Simulates the system until instant |t|.  Sets |current_time_| to |t|.
   // Must be called after initialization.

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1151,7 +1151,8 @@ public partial class PrincipiaPluginAdapter
       }
       QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(
           FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex,
-          FlightGlobals.ActiveVessel.rootPart.flightID);
+          FlightGlobals.ActiveVessel.rootPart.flightID,
+          universal_time);
       DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude =
           ((Vector3d)main_body_dof.q).magnitude -
           FlightGlobals.ActiveVessel.orbit.referenceBody.Radius;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1293,7 +1293,8 @@ public partial class PrincipiaPluginAdapter
           plugin_.HasVessel(FlightGlobals.ActiveVessel.id.ToString())) {
         QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(
             FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex,
-            FlightGlobals.ActiveVessel.rootPart.flightID);
+            FlightGlobals.ActiveVessel.rootPart.flightID,
+            Planetarium.GetUniversalTime());
         krakensbane.FrameVel = -(Vector3d)main_body_dof.p;
         offset = (Vector3d)main_body_dof.q -
                  FlightGlobals.ActiveVessel.mainBody.position;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -263,29 +263,21 @@ public partial class PrincipiaPluginAdapter
     body.CBUpdate();
   }
 
-  private double DO_NOT_SUBMIT_VesselFromParentAltitude;
-  private double DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude;
-
   private void UpdateVessel(Vessel vessel, double universal_time) {
      if (plugin_.HasVessel(vessel.id.ToString())) {
        QP from_parent = plugin_.VesselFromParent(
            vessel.mainBody.flightGlobalsIndex,
            vessel.id.ToString());
-       //vessel.orbitDriver.UpdateOrbit(true);
+       vessel.orbitDriver.UpdateOrbit(true);
        vessel.orbit.UpdateFromStateVectors(pos : (Vector3d)from_parent.q,
                                            vel : (Vector3d)from_parent.p,
                                            refBody : vessel.orbit.referenceBody,
                                            UT : universal_time);
        var q = (Vector3d)from_parent.q;
        q.Swizzle();
-       if (vessel.isActiveVessel) {
-         DO_NOT_SUBMIT_VesselFromParentAltitude =
-             q.magnitude - vessel.orbit.referenceBody.Radius;
-       }
        vessel.SetPosition(vessel.orbit.referenceBody.position + q -
                           vessel.orbitDriver.driverTransform.rotation *
-                              vessel.localCoM,
-                          false);
+                              vessel.localCoM);
      }
   }
 
@@ -1153,9 +1145,6 @@ public partial class PrincipiaPluginAdapter
           FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex,
           FlightGlobals.ActiveVessel.rootPart.flightID,
           universal_time);
-      DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude =
-          ((Vector3d)main_body_dof.q).magnitude -
-          FlightGlobals.ActiveVessel.orbit.referenceBody.Radius;
       krakensbane.FrameVel = -(Vector3d)main_body_dof.p;
       Vector3d offset = (Vector3d)main_body_dof.q -
                         FlightGlobals.ActiveVessel.mainBody.position;
@@ -1756,10 +1745,6 @@ public partial class PrincipiaPluginAdapter
       if (!PluginRunning()) {
         UnityEngine.GUILayout.TextArea(text : "Plugin is not started");
       }
-      UnityEngine.GUILayout.TextArea(
-        DO_NOT_SUBMIT_VesselFromParentAltitude.ToString());
-      UnityEngine.GUILayout.TextArea(
-        DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude.ToString());
       String version;
       String unused_build_date;
       Interface.GetVersion(build_date: out unused_build_date,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -268,16 +268,10 @@ public partial class PrincipiaPluginAdapter
        QP from_parent = plugin_.VesselFromParent(
            vessel.mainBody.flightGlobalsIndex,
            vessel.id.ToString());
-       vessel.orbitDriver.UpdateOrbit(true);
        vessel.orbit.UpdateFromStateVectors(pos : (Vector3d)from_parent.q,
                                            vel : (Vector3d)from_parent.p,
                                            refBody : vessel.orbit.referenceBody,
                                            UT : universal_time);
-       var q = (Vector3d)from_parent.q;
-       q.Swizzle();
-       vessel.SetPosition(vessel.orbit.referenceBody.position + q -
-                          vessel.orbitDriver.driverTransform.rotation *
-                              vessel.localCoM);
      }
   }
 
@@ -1208,14 +1202,6 @@ public partial class PrincipiaPluginAdapter
         continue;
       }
       vessel.precalc.enabled = true;
-      if (vessel.orbitDriver.updateMode == OrbitDriver.UpdateMode.UPDATE &&
-          PluginRunning() &&
-          plugin_.HasVessel(vessel.id.ToString())) {
-        vessel.precalc.updateOrbit = false;
-        UpdateVessel(vessel, Planetarium.GetUniversalTime());
-      } else {
-        vessel.precalc.updateOrbit = true;
-      }
       // In stock this is equivalent to |FixedUpdate()|.  With
       // ModularFlightIntegrator's ModularVesselPrecalculate, which gets run
       // in TimingPre like us, this comes with a flag that ensures it only gets
@@ -1225,12 +1211,10 @@ public partial class PrincipiaPluginAdapter
   }
 
   private void UpdateVesselOrbits() {
-    /*
     if (PluginRunning()) {
       ApplyToVesselsOnRails(
           vessel => UpdateVessel(vessel, Planetarium.GetUniversalTime()));
     }
-    */
   }
 
   private void ReportVesselsAndParts() {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -263,21 +263,29 @@ public partial class PrincipiaPluginAdapter
     body.CBUpdate();
   }
 
+  private double DO_NOT_SUBMIT_VesselFromParentAltitude;
+  private double DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude;
+
   private void UpdateVessel(Vessel vessel, double universal_time) {
      if (plugin_.HasVessel(vessel.id.ToString())) {
        QP from_parent = plugin_.VesselFromParent(
            vessel.mainBody.flightGlobalsIndex,
            vessel.id.ToString());
-       vessel.orbitDriver.UpdateOrbit(true);
+       //vessel.orbitDriver.UpdateOrbit(true);
        vessel.orbit.UpdateFromStateVectors(pos : (Vector3d)from_parent.q,
                                            vel : (Vector3d)from_parent.p,
                                            refBody : vessel.orbit.referenceBody,
                                            UT : universal_time);
        var q = (Vector3d)from_parent.q;
        q.Swizzle();
+       if (vessel.isActiveVessel) {
+         DO_NOT_SUBMIT_VesselFromParentAltitude =
+             q.magnitude - vessel.orbit.referenceBody.Radius;
+       }
        vessel.SetPosition(vessel.orbit.referenceBody.position + q -
                           vessel.orbitDriver.driverTransform.rotation *
-                              vessel.localCoM);
+                              vessel.localCoM,
+                          false);
      }
   }
 
@@ -1144,6 +1152,9 @@ public partial class PrincipiaPluginAdapter
       QP main_body_dof = plugin_.CelestialWorldDegreesOfFreedom(
           FlightGlobals.ActiveVessel.mainBody.flightGlobalsIndex,
           FlightGlobals.ActiveVessel.rootPart.flightID);
+      DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude =
+          ((Vector3d)main_body_dof.q).magnitude -
+          FlightGlobals.ActiveVessel.orbit.referenceBody.Radius;
       krakensbane.FrameVel = -(Vector3d)main_body_dof.p;
       Vector3d offset = (Vector3d)main_body_dof.q -
                         FlightGlobals.ActiveVessel.mainBody.position;
@@ -1743,6 +1754,10 @@ public partial class PrincipiaPluginAdapter
       if (!PluginRunning()) {
         UnityEngine.GUILayout.TextArea(text : "Plugin is not started");
       }
+      UnityEngine.GUILayout.TextArea(
+        DO_NOT_SUBMIT_VesselFromParentAltitude.ToString());
+      UnityEngine.GUILayout.TextArea(
+        DO_NOT_SUBMIT_CelestialWorldDegreesOfFreedomAltitude.ToString());
       String version;
       String unused_build_date;
       Interface.GetVersion(build_date: out unused_build_date,

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -204,6 +204,7 @@ message CelestialWorldDegreesOfFreedom {
                                  (is_subject) = true];
     required int32 index = 2;
     required fixed32 part_at_origin = 3;
+    required double time = 4;
   }
   message Return {
     required QP result = 1;


### PR DESCRIPTION
Since it is sometimes called when the parts are ahead of `current_time_`.
Fix #1416.

Also fix a nonsensical comment.