### PR TITLE
Add BoundedArray and use it to avoid allocating vectors

### DIFF
--- a/base/array.hpp
+++ b/base/array.hpp
@@ -58,14 +58,26 @@ struct UniqueArray final {
 
 // A simple container for an array and a size.  The client is expected to use
 // aggregate initialization for this type, and to ensure that the values passed
-// for |data| and |size| are consistent.
+// for |data| and |size| are consistent.  This type is *not* self-initializing.
 template<typename Element, std::int32_t size_>
 struct BoundedArray final {
+  using iterator = typename std::array<Element, size_>::iterator;
   using const_iterator = typename std::array<Element, size_>::const_iterator;
+  using const_reverse_iterator =
+      typename std::array<Element, size_>::const_reverse_iterator;
   using value_type = Element;
 
+  void push_back(const Element& value);
+  void push_back(Element&& value);
+
+  iterator begin();
+  iterator end();
   const_iterator begin() const;
   const_iterator end() const;
+
+  const_reverse_iterator rbegin() const;
+  const_reverse_iterator rend() const;
+
   bool empty() const;
   std::size_t size() const;
 

--- a/base/array.hpp
+++ b/base/array.hpp
@@ -1,6 +1,7 @@
 ﻿
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -54,6 +55,19 @@ struct UniqueArray final {
   std::unique_ptr<Element[]> data;
   std::int64_t size;  // In number of elements.
 };
+
+// A simple container for an array and a size.  The client is expected to use
+// aggregate initialization for this type, and to ensure that the values passed
+// for |data| and |size| are consistent.
+template<typename Element, std::int32_t size_>
+struct BoundedArray final {
+  typename std::array<Element, size_>::const_iterator begin() const;
+  typename std::array<Element, size_>::const_iterator end() const;
+
+  std::array<Element, size_> data;
+  std::int32_t size;
+};
+
 
 // Specializations.
 using Bytes = Array<std::uint8_t>;

--- a/base/array.hpp
+++ b/base/array.hpp
@@ -61,11 +61,16 @@ struct UniqueArray final {
 // for |data| and |size| are consistent.
 template<typename Element, std::int32_t size_>
 struct BoundedArray final {
-  typename std::array<Element, size_>::const_iterator begin() const;
-  typename std::array<Element, size_>::const_iterator end() const;
+  using const_iterator = typename std::array<Element, size_>::const_iterator;
+  using value_type = Element;
+
+  const_iterator begin() const;
+  const_iterator end() const;
+  bool empty() const;
+  std::size_t size() const;
 
   std::array<Element, size_> data;
-  std::int32_t size;
+  std::int32_t actual_size;
 };
 
 

--- a/base/array_body.hpp
+++ b/base/array_body.hpp
@@ -42,6 +42,18 @@ Array<Element> UniqueArray<Element>::get() const {
   return Array<Element>(data.get(), size);
 }
 
+template<typename Element, std::int32_t size_>
+typename std::array<Element, size_>::const_iterator
+BoundedArray<Element, size_>::begin() const {
+  return data.begin();
+}
+
+template<typename Element, std::int32_t size_>
+typename std::array<Element, size_>::const_iterator
+BoundedArray<Element, size_>::end() const {
+  return data.begin() + size;
+}
+
 template<typename Element>
 bool operator==(Array<Element> left, Array<Element> right) {
   if (left.size != right.size) {
@@ -53,18 +65,18 @@ bool operator==(Array<Element> left, Array<Element> right) {
 }
 
 template<typename Element>
-inline bool operator==(Array<Element> left, UniqueArray<Element> const& right) {
+bool operator==(Array<Element> left, UniqueArray<Element> const& right) {
   return left == right.get();
 }
 
 template<typename Element>
-inline bool operator==(UniqueArray<Element> const& left, Array<Element> right) {
+bool operator==(UniqueArray<Element> const& left, Array<Element> right) {
   return left.get() == right;
 }
 
 template<typename Element>
-inline bool operator==(UniqueArray<Element> const& left,
-                       UniqueArray<Element> const& right) {
+bool operator==(UniqueArray<Element> const& left,
+                UniqueArray<Element> const& right) {
   return left.get() == right.get();
 }
 

--- a/base/array_body.hpp
+++ b/base/array_body.hpp
@@ -43,15 +43,25 @@ Array<Element> UniqueArray<Element>::get() const {
 }
 
 template<typename Element, std::int32_t size_>
-typename std::array<Element, size_>::const_iterator
+typename BoundedArray<Element, size_>::const_iterator
 BoundedArray<Element, size_>::begin() const {
   return data.begin();
 }
 
 template<typename Element, std::int32_t size_>
-typename std::array<Element, size_>::const_iterator
+typename BoundedArray<Element, size_>::const_iterator
 BoundedArray<Element, size_>::end() const {
-  return data.begin() + size;
+  return data.begin() + actual_size;
+}
+
+template<typename Element, std::int32_t size_>
+bool BoundedArray<Element, size_>::empty() const {
+  return actual_size == 0;
+}
+
+template<typename Element, std::int32_t size_>
+std::size_t BoundedArray<Element, size_>::size() const {
+  return actual_size;
 }
 
 template<typename Element>

--- a/base/array_body.hpp
+++ b/base/array_body.hpp
@@ -43,6 +43,28 @@ Array<Element> UniqueArray<Element>::get() const {
 }
 
 template<typename Element, std::int32_t size_>
+void BoundedArray<Element, size_>::push_back(const Element& value) {
+  data[actual_size++] = value;
+}
+
+template<typename Element, std::int32_t size_>
+void BoundedArray<Element, size_>::push_back(Element&& value) {
+  data[actual_size++] = value;
+}
+
+template<typename Element, std::int32_t size_>
+typename BoundedArray<Element, size_>::iterator
+BoundedArray<Element, size_>::begin() {
+  return data.begin();
+}
+
+template<typename Element, std::int32_t size_>
+typename BoundedArray<Element, size_>::iterator
+BoundedArray<Element, size_>::end() {
+  return data.begin() + actual_size;
+}
+
+template<typename Element, std::int32_t size_>
 typename BoundedArray<Element, size_>::const_iterator
 BoundedArray<Element, size_>::begin() const {
   return data.begin();
@@ -52,6 +74,18 @@ template<typename Element, std::int32_t size_>
 typename BoundedArray<Element, size_>::const_iterator
 BoundedArray<Element, size_>::end() const {
   return data.begin() + actual_size;
+}
+
+template<typename Element, std::int32_t size_>
+typename BoundedArray<Element, size_>::const_reverse_iterator
+BoundedArray<Element, size_>::rbegin() const {
+  return data.rend() - actual_size;
+}
+
+template<typename Element, std::int32_t size_>
+typename BoundedArray<Element, size_>::const_reverse_iterator
+BoundedArray<Element, size_>::rend() const {
+  return data.rend();
 }
 
 template<typename Element, std::int32_t size_>

--- a/base/array_test.cpp
+++ b/base/array_test.cpp
@@ -1,0 +1,46 @@
+
+#include "base/array.hpp"
+
+#include "gtest/gtest.h"
+
+namespace principia {
+namespace base {
+
+TEST(ArrayTest, BoundedArray0) {
+  BoundedArray<double, 3> a{{}, 0};
+  double sum = 0.0;
+  for (double const value : a) {
+    sum += value;
+  }
+  EXPECT_EQ(0.0, sum);
+}
+
+TEST(ArrayTest, BoundedArray1) {
+  BoundedArray<double, 3> a{{1.0}, 1};
+  double sum = 0.0;
+  for (double const value : a) {
+    sum += value;
+  }
+  EXPECT_EQ(1.0, sum);
+}
+
+TEST(ArrayTest, BoundedArray2) {
+  BoundedArray<double, 3> a{{1.0, 10.0}, 2};
+  double sum = 0.0;
+  for (double const value : a) {
+    sum += value;
+  }
+  EXPECT_EQ(11.0, sum);
+}
+
+TEST(ArrayTest, BoundedArray3) {
+  BoundedArray<double, 3> a{{1.0, 10.0, 100.0}, 3};
+  double sum = 0.0;
+  for (double const value : a) {
+    sum += value;
+  }
+  EXPECT_EQ(111.0, sum);
+}
+
+}  // namespace base
+}  // namespace principia

--- a/base/array_test.cpp
+++ b/base/array_test.cpp
@@ -42,5 +42,12 @@ TEST(ArrayTest, BoundedArray3) {
   EXPECT_EQ(111.0, sum);
 }
 
+TEST(ArrayTest, Return) {
+  std::string s;
+  auto fn = [s]() -> BoundedArray<std::string, 3> {
+    return {{s}, 1};
+  };
+}
+
 }  // namespace base
 }  // namespace principia

--- a/base/base.vcxproj
+++ b/base/base.vcxproj
@@ -302,6 +302,7 @@
     <ClInclude Include="version.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="array_test.cpp" />
     <ClCompile Include="bundle.cpp" />
     <ClCompile Include="bundle_test.cpp" />
     <ClCompile Include="disjoint_sets_test.cpp" />

--- a/base/base.vcxproj.filters
+++ b/base/base.vcxproj.filters
@@ -169,5 +169,8 @@
     <ClCompile Include="version.generated.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="array_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/geometry/perspective.hpp
+++ b/geometry/perspective.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/array.hpp"
 #include "geometry/affine_map.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/point.hpp"
@@ -14,6 +15,8 @@
 namespace principia {
 namespace geometry {
 namespace internal_perspective {
+
+using base::BoundedArray;
 
 template<typename Vector>
 using Segment = std::pair<Point<Vector>, Point<Vector>>;
@@ -60,7 +63,7 @@ class Perspective final {
   // Returns the (sub)segments of |segment| that are visible in this perspective
   // after taking into account the hiding by |sphere|.  The returned vector has
   // 0, 1, or 2 elements.
-  Segments<Vector<Scalar, FromFrame>> VisibleSegments(
+  BoundedArray<Segment<Vector<Scalar, FromFrame>>, 2> VisibleSegments(
       Segment<Vector<Scalar, FromFrame>> const& segment,
       Sphere<Scalar, FromFrame> const& sphere) const;
 

--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -177,7 +177,7 @@ template<typename FromFrame,
          typename ToFrame,
          typename Scalar,
          template<typename, typename> class LinearMap>
-Segments<Vector<Scalar, FromFrame>>
+BoundedArray<Segment<Vector<Scalar, FromFrame>>, 2>
 Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
     Segment<Vector<Scalar, FromFrame>> const& segment,
     Sphere<Scalar, FromFrame> const& sphere) const {
@@ -197,7 +197,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   // trouble below, so we might as well handle it first.
   auto const KC² = InnerProduct(KC, KC);
   if (KC² <= sphere.radius²()) {
-    return {};
+    return {{}, 0};
   }
 
   // Consider the plane that contains K and is orthogonal to KC.  If the segment
@@ -206,7 +206,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   auto const KAKC = InnerProduct(KA, KC);
   auto const KBKC = InnerProduct(KB, KC);
   if (KAKC <= Square<Scalar>{} && KBKC <= Square<Scalar>{}) {
-    return {segment};
+    return {{segment}, 1};
   }
 
   // H is the projection of C on the plane KAB.  It is such that:
@@ -228,7 +228,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   Vector<Scalar, FromFrame> const CH = KH - KC;
   auto const CH² = InnerProduct(CH, CH);
   if (CH² >= sphere.radius²()) {
-    return {segment};
+    return {{segment}, 1};
   }
 
   // The sphere intersects the plane KAB.  r² = R² - CH² is the square of the
@@ -241,7 +241,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   // to the line KA.
   if ((ɑ < 0 && ɑ * ɑ >= r² * KB² / determinant) ||
       (β < 0 && β * β >= r² * KA² / determinant)) {
-    return {segment};
+    return {{segment}, 1};
   }
 
   // P is a point of the plane KAB where a line going through K is tangent to
@@ -343,7 +343,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   // The line AB doesn't have an interesting intersection with the cone and
   // doesn't intersect the sphere.  There is no hiding.
   if (λs.empty()) {
-    return {segment};
+    return {{segment}, 1};
   }
 
   // Now we have all the interesting intersections of the cone+sphere with the
@@ -353,26 +353,27 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   double const λ_max = *λs.rbegin();
   if (λ_min >= 1.0 || λ_max <= 0.0) {
     // All the intersections are outside of the segment AB.
-    return {segment};
+    return {{segment}, 1};
   }
   if (λ_min <= 0.0 && λ_max >= 1.0) {
     // The cone+sphere swallows the segment.
-    return {};
+    return {{}, 0};
   }
   if (λ_min > 0.0 && λ_max < 1.0) {
     // The cone+sphere hides the middle of the segment.
-    return {{A, A + λ_min * AB}, {A + λ_max * AB, B}};
+    return {{Segment<Vector<Scalar, FromFrame>>{A, A + λ_min * AB},
+             Segment<Vector<Scalar, FromFrame>>{A + λ_max * AB, B}}, 2};
   }
   if (λ_min <= 0.0) {
     // The cone+sphere hides the beginning of the segment.
     DCHECK_GT(λ_max, 0.0);
-    return {{A + λ_max * AB, B}};
+    return {{Segment<Vector<Scalar, FromFrame>>{A + λ_max * AB, B}}, 1};
   }
   {
     DCHECK_GT(λ_max, 1.0);
     DCHECK_LE(λ_min, 1.0);
     // The cone+sphere hides the end of the segment.
-    return {{A, A + λ_min * AB}};
+    return {{Segment<Vector<Scalar, FromFrame>>{A, A + λ_min * AB}}, 1};
   }
 }
 

--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -283,8 +283,7 @@ Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
   // part that is on the other side of T with respect to S.
   // For each solution δ of the above quadratic equation, this loop computes PH
   // and obtains the values of λ and τ.
-  std::vector<double> λs;
-  λs.reserve(4);
+  BoundedArray<double, 4> λs = {{}, 0};
   bool λ_lt_σ = false;
   bool λ_gt_σ = false;
   double infinity = 0.0;  // Might be NaN in cases where it's not used.

--- a/ksp_plugin/planetarium.cpp
+++ b/ksp_plugin/planetarium.cpp
@@ -146,8 +146,7 @@ std::vector<Sphere<Length, Navigation>> Planetarium::ComputePlottableSpheres(
   return plottable_spheres;
 }
 
-std::vector<Segment<Displacement<Navigation>>>
-Planetarium::ComputePlottableSegments(
+Segments<Displacement<Navigation>> Planetarium::ComputePlottableSegments(
     const std::vector<Sphere<Length, Navigation>>& plottable_spheres,
     DiscreteTrajectory<Barycentric>::Iterator const& begin,
     DiscreteTrajectory<Barycentric>::Iterator const& end) const {

--- a/ksp_plugin/planetarium.hpp
+++ b/ksp_plugin/planetarium.hpp
@@ -28,6 +28,7 @@ using geometry::Perspective;
 using geometry::RP2Lines;
 using geometry::RP2Point;
 using geometry::Segment;
+using geometry::Segments;
 using geometry::Sphere;
 using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
@@ -88,7 +89,7 @@ class Planetarium {
 
   // Computes the segments of the trajectory defined by |begin| and |end| that
   // are not hidden by the |plottable_spheres|.
-  std::vector<Segment<Displacement<Navigation>>> ComputePlottableSegments(
+  Segments<Displacement<Navigation>> ComputePlottableSegments(
       const std::vector<Sphere<Length, Navigation>>& plottable_spheres,
       DiscreteTrajectory<Barycentric>::Iterator const& begin,
       DiscreteTrajectory<Barycentric>::Iterator const& end) const;

--- a/numerics/root_finders.hpp
+++ b/numerics/root_finders.hpp
@@ -24,6 +24,7 @@ Argument Bisect(Function f,
 // Returns the solutions of the quadratic equation:
 //   a2 * (x - origin)^2 + a1 * (x - origin) + a0 == 0
 // The result may have 0, 1 or 2 values and is sorted.
+// TODO(phl): Use BoundedArray here.
 template<typename Argument, typename Value>
 std::vector<Argument> SolveQuadraticEquation(
     Argument const& origin,


### PR DESCRIPTION
Before:
```
Benchmark                                            Time           CPU Iterations
----------------------------------------------------------------------------------
BM_VisibleSegmentsOrbit/10                        2014 ns       1943 ns     345165 average visible segments: 1.000000
BM_VisibleSegmentsOrbit/100                      12250 ns      12238 ns      56089 average visible segments: 0.980000
BM_VisibleSegmentsOrbit/1000                    116502 ns     114385 ns       6410 average visible segments: 0.966000
BM_VisibleSegmentsRandomEverywhere/1000         128759 ns     127938 ns       5609 average visible segments: 1.073000
BM_VisibleSegmentsRandomNoIntersection/1000      93610 ns      93863 ns       7479 average visible segments: 1.000000
```

After:
```
Benchmark                                            Time           CPU Iterations
----------------------------------------------------------------------------------
BM_VisibleSegmentsOrbit/10                        1196 ns       1196 ns     560894 average visible segments: 1.000000
BM_VisibleSegmentsOrbit/100                       6736 ns       6606 ns      89743 average visible segments: 0.980000
BM_VisibleSegmentsOrbit/1000                     63809 ns      63969 ns      11218 average visible segments: 0.966000
BM_VisibleSegmentsRandomEverywhere/1000          68781 ns      68141 ns      11218 average visible segments: 1.073000
BM_VisibleSegmentsRandomNoIntersection/1000      44980 ns      44778 ns      16026 average visible segments: 1.000000
```

Another contribution to #973.