### PR TITLE
Reduce dynamic allocation in multi-sphere hiding

### DIFF
--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -384,8 +384,8 @@ Segments<Vector<Scalar, FromFrame>>
 Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
     Segment<Vector<Scalar, FromFrame>> const& segment,
     std::vector<Sphere<Scalar, FromFrame>> const& spheres) const {
-  std::vector<Segment<Vector<Scalar, FromFrame>>> old_segments = {segment};
-  std::vector<Segment<Vector<Scalar, FromFrame>>> new_segments;
+  Segments<Vector<Scalar, FromFrame>> old_segments = {segment};
+  Segments<Vector<Scalar, FromFrame>> new_segments;
   for (auto const& sphere : spheres) {
     for (auto const& old_segment : old_segments) {
       auto new_segments_for_sphere = VisibleSegments(old_segment, sphere);

--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -384,19 +384,52 @@ Segments<Vector<Scalar, FromFrame>>
 Perspective<FromFrame, ToFrame, Scalar, LinearMap>::VisibleSegments(
     Segment<Vector<Scalar, FromFrame>> const& segment,
     std::vector<Sphere<Scalar, FromFrame>> const& spheres) const {
-  Segments<Vector<Scalar, FromFrame>> old_segments = {segment};
-  Segments<Vector<Scalar, FromFrame>> new_segments;
+  Segments<Vector<Scalar, FromFrame>> segments;
+  segments.reserve(spheres.size() + 1);
+  segments.push_back(segment);
+
+  // The range [in_begin, in_end[ contains the segments that have been produced
+  // so far by iterating through the outer loop.
+  int in_begin = 0;
+  int in_end = 1;
+
+  // The range [out_begin, out_end[ contains the segments that have been
+  // produced by the current iterations of the outer loop.  It grows in both
+  // directions.  If VisibleSegments returns 0 segments, the out_ indices are
+  // unaffected.  If VisibleSegments returns at least 1 segment, that segment is
+  // inserted before out_begin (effectively replacing the segment that was just
+  // processed) and out_begin is decremented.  If VisibleSegments returns 2
+  // segments the second one is push at the end of the vector after out_end and
+  // out_end is incremented.
+  int out_begin = 1;
+  int out_end = 1;
+
+  // At the beginning and end of the outer loop below all the active segments
+  // are stored in a contiguous slice of the vector segments.  That slice
+  // doesn't start at 0 iff at least one call to VisibleSegments returned 0
+  // segments.
   for (auto const& sphere : spheres) {
-    for (auto const& old_segment : old_segments) {
-      auto new_segments_for_sphere = VisibleSegments(old_segment, sphere);
-      std::move(new_segments_for_sphere.begin(),
-                new_segments_for_sphere.end(),
-                std::back_inserter(new_segments));
+    for (int i = in_end - 1; i >= in_begin; --i) {
+      auto const& old_segment = segments[i];
+      auto const new_segments_for_sphere = VisibleSegments(old_segment, sphere);
+      int const new_segments_for_sphere_size = new_segments_for_sphere.size();
+      if (new_segments_for_sphere_size >= 1) {
+        segments[--out_begin] = std::move(*new_segments_for_sphere.begin());
+        if (new_segments_for_sphere_size == 2) {
+          segments.push_back(std::move(*new_segments_for_sphere.rbegin()));
+          ++out_end;
+        }
+      }
     }
-    old_segments = std::move(new_segments);
-    new_segments.clear();
+    in_begin = out_begin;
+    in_end = out_end;
+    out_begin = in_end;
+    out_end = in_end;
   }
-  return old_segments;
+  if (in_begin > 0) {
+    segments.erase(segments.begin(), segments.begin() + in_begin);
+  }
+  return segments;
 }
 
 }  // namespace internal_perspective


### PR DESCRIPTION
Also added a new benchmark for that method.  Before:
```
Benchmark                                               Time           CPU Iterations
-------------------------------------------------------------------------------------
BM_VisibleSegmentsOrbit/10                            998 ns        998 ns     641022 average visible segments: 1.000000
BM_VisibleSegmentsOrbit/100                          6246 ns       6258 ns     112179 average visible segments: 0.980000
BM_VisibleSegmentsOrbit/1000                        60119 ns      59797 ns      11218 average visible segments: 0.966000
BM_VisibleSegmentsRandomEverywhere/1000             61236 ns      61188 ns      11218 average visible segments: 1.073000
BM_VisibleSegmentsRandomNoIntersection/1000         44509 ns      44778 ns      16026 average visible segments: 1.000000
BM_VisibleSegmentsOrbitMultipleSpheres/20/1000    1506517 ns    1493996 ns        449 average visible segments: 0.550000
```

After:
```
Benchmark                                               Time           CPU Iterations
-------------------------------------------------------------------------------------
BM_VisibleSegmentsOrbit/10                            979 ns        973 ns     641022 average visible segments: 1.000000
BM_VisibleSegmentsOrbit/100                          6162 ns       6240 ns     100000 average visible segments: 0.980000
BM_VisibleSegmentsOrbit/1000                        59771 ns      59797 ns      11218 average visible segments: 0.966000
BM_VisibleSegmentsRandomEverywhere/1000             61043 ns      61188 ns      11218 average visible segments: 1.073000
BM_VisibleSegmentsRandomNoIntersection/1000         44517 ns      44361 ns      15473 average visible segments: 1.000000
BM_VisibleSegmentsOrbitMultipleSpheres/20/1000     692990 ns     695657 ns        897 average visible segments: 0.550000
```