### PR TITLE
Asynchronous catch up

### DIFF
--- a/ksp_plugin/interface_future.cpp
+++ b/ksp_plugin/interface_future.cpp
@@ -17,9 +17,8 @@ using quantities::si::Second;
 
 namespace {
 constexpr int window_size = 500;
-std::array<Time, window_size> Δt_window;
 int window_index = 0;
-Time average_Δt;
+Time total_Δt;
 Time min_Δt = Infinity<Time>();
 Time max_Δt = -Infinity<Time>();
 std::chrono::steady_clock::time_point time_of_last_promise_batch;
@@ -48,13 +47,14 @@ void principia__FutureWait(std::future<void> const** const future) {
                     time_of_last_promise_batch).count() * Nano(Second);
     min_Δt = std::min(min_Δt, Δt);
     max_Δt = std::max(max_Δt, Δt);
-    average_Δt += (Δt - Δt_window[window_index]) / window_size;
+    total_Δt += Δt;
     ++window_index %= window_size;
     if (window_index == 0) {
       LOG(INFO) << "min = " << min_Δt << ", max = " << max_Δt
-                << u8", μ = " << average_Δt;
+                << u8", μ = " << total_Δt / window_size;
       min_Δt = Infinity<Time>();
       max_Δt = -Infinity<Time>();
+      total_Δt = Time();
     }
   }
   TakeOwnership(future)->wait();

--- a/ksp_plugin/interface_future.cpp
+++ b/ksp_plugin/interface_future.cpp
@@ -1,7 +1,6 @@
 ﻿
 #include "ksp_plugin/interface.hpp"
 
-#include <array>
 #include <chrono>
 
 #include "journal/method.hpp"

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -473,19 +473,19 @@ public partial class PrincipiaPluginAdapter
     GameEvents.onHideUI.Add(HideGUI);
     // Timing0, -8008 on the script execution order page.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.ObscenelyEarly,
-                                 DisableVesselPrecalculate);
+                                 ObscenelyEarly);
     // TimingPre, -101 on the script execution order page.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.Precalc,
-                                 SetBodyFramesAndPrecalculateVessels);
+                                 Precalc);
     // Timing1, -99 on the script execution order page.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.Early,
-                                 UpdateVesselOrbits);
+                                 Early);
     // Timing3, 7.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.FashionablyLate,
-                                 ReportVesselsAndParts);
+                                 FashionablyLate);
     // Timing5, 8008.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.BetterLateThanNever,
-                                 StorePartDegreesOfFreedom);
+                                 BetterLateThanNever);
   }
 
   public override void OnSave(ConfigNode node) {
@@ -972,16 +972,16 @@ public partial class PrincipiaPluginAdapter
     WindowUtilities.ClearLock(this);
     Cleanup();
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.ObscenelyEarly,
-                                    DisableVesselPrecalculate);
+                                    ObscenelyEarly);
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.Precalc,
-                                    SetBodyFramesAndPrecalculateVessels);
+                                    Precalc);
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.Early,
-                                    UpdateVesselOrbits);
+                                    Early);
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.FashionablyLate,
-                                    ReportVesselsAndParts);
+                                    FashionablyLate);
     TimingManager.FixedUpdateRemove(
         TimingManager.TimingStage.BetterLateThanNever,
-        StorePartDegreesOfFreedom);
+        BetterLateThanNever);
   }
 
   #endregion
@@ -1227,14 +1227,14 @@ public partial class PrincipiaPluginAdapter
   } catch (Exception e) { Log.Fatal(e.ToString()); }
   }
 
-  private void DisableVesselPrecalculate() {
+  private void ObscenelyEarly() {
     foreach (var vessel in
              FlightGlobals.Vessels.Where(vessel => vessel.precalc != null)) {
       vessel.precalc.enabled = false;
     }
   }
 
-  private void SetBodyFramesAndPrecalculateVessels() {
+  private void Precalc() {
     if (FlightGlobals.ActiveVessel?.situation == Vessel.Situations.PRELAUNCH &&
         FlightGlobals.ActiveVessel?.orbitDriver?.lastMode ==
             OrbitDriver.UpdateMode.TRACK_Phys &&
@@ -1287,14 +1287,14 @@ public partial class PrincipiaPluginAdapter
     }
   }
 
-  private void UpdateVesselOrbits() {
+  private void Early() {
     if (PluginRunning()) {
       ApplyToVesselsOnRails(
           vessel => UpdateVessel(vessel, Planetarium.GetUniversalTime()));
     }
   }
 
-  private void ReportVesselsAndParts() {
+  private void FashionablyLate() {
     // We fetch the forces from the census of nonconservatives here;
     // part.forces, part.force, and part.torque are cleared by the
     // FlightIntegrator's FixedUpdate (while we are yielding).
@@ -1326,7 +1326,7 @@ public partial class PrincipiaPluginAdapter
     }
   }
 
-  private void StorePartDegreesOfFreedom() {
+  private void BetterLateThanNever() {
     if (PluginRunning()) {
       part_id_to_degrees_of_freedom_.Clear();
       foreach (Vessel vessel in

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -388,6 +388,18 @@ public partial class PrincipiaPluginAdapter
     return active_vessel != null && is_manageable(active_vessel);
   }
 
+  private double UpcomingUniversalTime() {
+    var planetarium = Planetarium.fetch;
+    if (planetarium == null) {
+      return HighLogic.CurrentGame.UniversalTime;
+    } else {
+      return planetarium.pause
+                 ? planetarium.time
+                 : planetarium.time +
+                   planetarium.fixedDeltaTime * planetarium.timeScale;
+    }
+  }
+
   private void OverrideRSASTarget(FlightCtrlState state) {
     if (override_rsas_target_ && FlightGlobals.ActiveVessel.Autopilot.Enabled) {
       FlightGlobals.ActiveVessel.Autopilot.SAS.SetTargetOrientation(
@@ -1240,7 +1252,7 @@ public partial class PrincipiaPluginAdapter
     } else {
       if (PluginRunning()) {
         double plugin_time = plugin_.CurrentTime();
-        double universal_time = Planetarium.GetUniversalTime();
+        double universal_time = UpcomingUniversalTime();
         time_is_advancing_ = time_is_advancing(universal_time);
         if (time_is_advancing_) {
           plugin_.AdvanceTime(universal_time, Planetarium.InverseRotAngle);
@@ -1250,7 +1262,8 @@ public partial class PrincipiaPluginAdapter
           }
           foreach (var vessel in FlightGlobals.Vessels) {
             if (vessel.packed && plugin_.HasVessel(vessel.id.ToString())) {
-              vessel_futures_.Add(plugin_.FutureCatchUpVessel(vessel.id.ToString()));
+              vessel_futures_.Add(
+                  plugin_.FutureCatchUpVessel(vessel.id.ToString()));
             }
           }
         }


### PR DESCRIPTION
Use the new futures to catch up asynchronously, log the time between the first promise and the first wait.