### PR TITLE
Move the code that extends the prediction to Renderer

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -792,14 +792,6 @@ void principia__SetPartApparentDegreesOfFreedom(Plugin* const plugin,
   return m.Return();
 }
 
-void principia__SetPredictionLength(Plugin* const plugin,
-                                    double const t) {
-  journal::Method<journal::SetPredictionLength> m({plugin, t});
-  CHECK_NOTNULL(plugin);
-  plugin->SetPredictionLength(t * Second);
-  return m.Return();
-}
-
 // Make it so that all log messages of at least |min_severity| are logged to
 // stderr (in addition to logging to the usual log file(s)).
 void principia__SetStderrLogging(int const min_severity) {

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -70,9 +70,9 @@ void principia__VesselSetPredictionAdaptiveStepParameters(
   journal::Method<journal::VesselSetPredictionAdaptiveStepParameters> m(
       {plugin, vessel_guid, adaptive_step_parameters});
   CHECK_NOTNULL(plugin);
-  plugin->GetVessel(vessel_guid)
-      ->set_prediction_adaptive_step_parameters(
-          FromAdaptiveStepParameters(adaptive_step_parameters));
+  plugin->SetPredictionAdaptiveStepParameters(
+      vessel_guid,
+      FromAdaptiveStepParameters(adaptive_step_parameters));
   return m.Return();
 }
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -686,8 +686,8 @@ void Plugin::SetPredictionAdaptiveStepParameters(
     Ephemeris<Barycentric>::AdaptiveStepParameters const&
         prediction_adaptive_step_parameters) const {
   // If there is a target vessel, it is integrated with the same parameters as
-  // the given (current) vessel.  This makes it possible to plot things like the
-  // closest approaches.
+  // the given (current) vessel.  This makes it possible to the prediction of
+  // the current vessel.
   if (renderer_->HasTargetVessel()) {
     renderer_->GetTargetVessel().set_prediction_adaptive_step_parameters(
         prediction_adaptive_step_parameters);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -681,6 +681,22 @@ RelativeDegreesOfFreedom<AliceSun> Plugin::CelestialFromParent(
   return result;
 }
 
+void Plugin::SetPredictionAdaptiveStepParameters(
+    GUID const& vessel_guid,
+    Ephemeris<Barycentric>::AdaptiveStepParameters const&
+        prediction_adaptive_step_parameters) const {
+  // If there is a target vessel, it is integrated with the same parameters as
+  // the given (current) vessel.  This makes it possible to plot things like the
+  // closest approaches.
+  if (renderer_->HasTargetVessel()) {
+    renderer_->GetTargetVessel().set_prediction_adaptive_step_parameters(
+        prediction_adaptive_step_parameters);
+  }
+  FindOrDie(vessels_, vessel_guid)
+      ->set_prediction_adaptive_step_parameters(
+          prediction_adaptive_step_parameters);
+}
+
 void Plugin::UpdatePrediction(GUID const& vessel_guid) const {
   CHECK(!initializing_);
   FindOrDie(vessels_, vessel_guid)->UpdatePrediction(InfiniteFuture);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -686,8 +686,8 @@ void Plugin::SetPredictionAdaptiveStepParameters(
     Ephemeris<Barycentric>::AdaptiveStepParameters const&
         prediction_adaptive_step_parameters) const {
   // If there is a target vessel, it is integrated with the same parameters as
-  // the given (current) vessel.  This makes it possible to the prediction of
-  // the current vessel.
+  // the given (current) vessel.  This makes it possible to plot the prediction
+  // of the current vessel.
   if (renderer_->HasTargetVessel()) {
     renderer_->GetTargetVessel().set_prediction_adaptive_step_parameters(
         prediction_adaptive_step_parameters);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -51,6 +51,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_plugin {
 
+using astronomy::InfiniteFuture;
 using astronomy::ParseTT;
 using astronomy::KSPStockSystemFingerprint;
 using astronomy::KSPStabilizedSystemFingerprint;
@@ -682,8 +683,7 @@ RelativeDegreesOfFreedom<AliceSun> Plugin::CelestialFromParent(
 
 void Plugin::UpdatePrediction(GUID const& vessel_guid) const {
   CHECK(!initializing_);
-  FindOrDie(vessels_, vessel_guid)->UpdatePrediction(
-      current_time_ + prediction_length_);
+  FindOrDie(vessels_, vessel_guid)->UpdatePrediction(InfiniteFuture);
 }
 
 void Plugin::CreateFlightPlan(GUID const& vessel_guid,
@@ -777,10 +777,6 @@ void Plugin::ComputeAndRenderNodes(
                    PlanetariumRotation());
 }
 
-void Plugin::SetPredictionLength(Time const& t) {
-  prediction_length_ = t;
-}
-
 void Plugin::SetPredictionAdaptiveStepParameters(
     Ephemeris<Barycentric>::AdaptiveStepParameters const&
         prediction_adaptive_step_parameters) {
@@ -868,12 +864,7 @@ void Plugin::SetTargetVessel(GUID const& vessel_guid,
   not_null<Celestial const*> const celestial =
       FindOrDie(celestials_, reference_body_index).get();
   not_null<Vessel*> const vessel = FindOrDie(vessels_, vessel_guid).get();
-  renderer_->SetTargetVessel(vessel,
-                             celestial,
-                             ephemeris_.get(),
-                             /*prediction_last_time=*/[this]() {
-                               return current_time_ + prediction_length_;
-                             });
+  renderer_->SetTargetVessel(vessel, celestial, ephemeris_.get());
 }
 
 std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -278,6 +278,11 @@ class Plugin {
   virtual RelativeDegreesOfFreedom<AliceSun> CelestialFromParent(
       Index celestial_index) const;
 
+  virtual void SetPredictionAdaptiveStepParameters(
+      GUID const& vessel_guid,
+      Ephemeris<Barycentric>::AdaptiveStepParameters const&
+          prediction_adaptive_step_parameters) const;
+
   // Updates the prediction for the vessel with guid |vessel_guid|.
   void UpdatePrediction(GUID const& vessel_guid) const;
 

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -406,10 +406,6 @@ class Plugin {
   // whenever |main_body_| or |planetarium_rotation_| changes.
   void UpdatePlanetariumRotation();
 
-  // NOTE(egg): this is an ugly hack to try to get a long enough trajectory
-  // while retaining a timeout.
-  void UpdatePredictionForRendering(std::int64_t size) const;
-
   Velocity<World> VesselVelocity(
       Instant const& time,
       DegreesOfFreedom<Barycentric> const& degrees_of_freedom) const;

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -312,8 +312,6 @@ class Plugin {
       std::unique_ptr<DiscreteTrajectory<World>>& ascending,
       std::unique_ptr<DiscreteTrajectory<World>>& descending) const;
 
-  virtual void SetPredictionLength(Time const& t);
-
   virtual void SetPredictionAdaptiveStepParameters(
       Ephemeris<Barycentric>::AdaptiveStepParameters const&
           prediction_adaptive_step_parameters);
@@ -451,7 +449,6 @@ class Plugin {
   Ephemeris<Barycentric>::FixedStepParameters history_parameters_;
   Ephemeris<Barycentric>::AdaptiveStepParameters prolongation_parameters_;
   Ephemeris<Barycentric>::AdaptiveStepParameters prediction_parameters_;
-  Time prediction_length_ = 1 * Hour;
 
   // The thread pool for advancing vessels.
   ThreadPool<void> vessel_thread_pool_;

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -39,12 +39,13 @@ not_null<NavigationFrame const*> Renderer::GetPlottingFrame() const {
 void Renderer::SetTargetVessel(
     not_null<Vessel*> const vessel,
     not_null<Celestial const*> const celestial,
-    not_null<Ephemeris<Barycentric> const*> const ephemeris) {
-  CHECK(!vessel->prediction().Empty());
+    not_null<Ephemeris<Barycentric> const*> const ephemeris,
+    std::function<Instant()> prediction_last_time) {
   if (!target_ ||
       target_->vessel != vessel ||
       target_->celestial != celestial) {
-    target_.emplace(vessel, celestial, ephemeris);
+    target_.emplace(
+        vessel, celestial, ephemeris, std::move(prediction_last_time));
   }
 }
 
@@ -72,6 +73,17 @@ Vessel const& Renderer::GetTargetVessel() const {
   return *target_->vessel;
 }
 
+DiscreteTrajectory<Barycentric> const& Renderer::GetTargetVesselPrediction(
+    Instant const& time) const {
+  CHECK(target_);
+  target_->vessel->UpdatePrediction(
+      std::max(time, target_->prediction_last_time()));
+  // The prediction may not have been prolonged to |time| if we are near a
+  // singularity.
+  CHECK_LE(time, target_->vessel->prediction().last().time());
+  return target_->vessel->prediction();
+}
+
 not_null<std::unique_ptr<DiscreteTrajectory<World>>>
 Renderer::RenderBarycentricTrajectoryInWorld(
     Instant const& time,
@@ -94,19 +106,20 @@ not_null<std::unique_ptr<DiscreteTrajectory<Navigation>>>
 Renderer::RenderBarycentricTrajectoryInPlotting(
     DiscreteTrajectory<Barycentric>::Iterator const& begin,
     DiscreteTrajectory<Barycentric>::Iterator const& end) const {
-  CHECK(!target_ || !target_->vessel->prediction().Empty());
-
   auto trajectory = make_not_null_unique<DiscreteTrajectory<Navigation>>();
   for (auto it = begin; it != end; ++it) {
+    Instant const& t = it.time();
     if (target_) {
-      if (it.time() < target_->vessel->prediction().t_min()) {
+      target_->vessel->UpdatePrediction(
+          std::max(t, target_->prediction_last_time()));
+      if (t < target_->vessel->prediction().t_min()) {
         continue;
-      } else if (it.time() > target_->vessel->prediction().t_max()) {
+      } else if (t > target_->vessel->prediction().t_max()) {
         break;
       }
     }
     trajectory->Append(
-        it.time(),
+        t,
         BarycentricToPlotting(it.time())(it.degrees_of_freedom()));
   }
   return trajectory;
@@ -158,7 +171,7 @@ Renderer::RenderPlottingTrajectoryInWorld(
 
 RigidMotion<Barycentric, Navigation> Renderer::BarycentricToPlotting(
     Instant const& time) const {
-  return GetPlottingFrame()->ToThisFrameAtTime(time);
+  return GetPlottingFrame(time)->ToThisFrameAtTime(time);
 }
 
 RigidTransformation<Barycentric, World> Renderer::BarycentricToWorld(
@@ -187,7 +200,6 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
     NavigationManœuvre const& manœuvre,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
   Instant const initial_time = manœuvre.initial_time();
-  NavigationFrame const& plotting_frame = *GetPlottingFrame();
   return PlottingToWorld(time, planetarium_rotation) *
          BarycentricToPlotting(initial_time).orthogonal_map() *
          manœuvre.FrenetFrame();
@@ -204,8 +216,9 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
       BarycentricToPlotting(time)(barycentric_degrees_of_freedom);
   Rotation<Frenet<Navigation>, Navigation> const
       frenet_frame_to_plotting_frame =
-          GetPlottingFrame()->FrenetFrame(time,
-                                          plotting_frame_degrees_of_freedom);
+          GetPlottingFrame(time)->FrenetFrame(
+              time,
+              plotting_frame_degrees_of_freedom);
 
   return PlottingToWorld(time, planetarium_rotation) *
          frenet_frame_to_plotting_frame.Forget();
@@ -230,7 +243,7 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
 
 OrthogonalMap<Navigation, Barycentric> Renderer::PlottingToBarycentric(
     Instant const& time) const {
-  return GetPlottingFrame()->FromThisFrameAtTime(time).orthogonal_map();
+  return GetPlottingFrame(time)->FromThisFrameAtTime(time).orthogonal_map();
 }
 
 RigidTransformation<Navigation, World> Renderer::PlottingToWorld(
@@ -238,7 +251,8 @@ RigidTransformation<Navigation, World> Renderer::PlottingToWorld(
     Position<World> const& sun_world_position,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
   return BarycentricToWorld(time, sun_world_position, planetarium_rotation) *
-         GetPlottingFrame()->FromThisFrameAtTime(time).rigid_transformation();
+         GetPlottingFrame(time)->
+             FromThisFrameAtTime(time).rigid_transformation();
 }
 
 OrthogonalMap<Navigation, World> Renderer::PlottingToWorld(
@@ -287,15 +301,25 @@ not_null<std::unique_ptr<Renderer>> Renderer::ReadFromMessage(
 Renderer::Target::Target(
     not_null<Vessel*> const vessel,
     not_null<Celestial const*> const celestial,
-    not_null<Ephemeris<Barycentric> const*> const ephemeris)
+    not_null<Ephemeris<Barycentric> const*> const ephemeris,
+    std::function<Instant()> prediction_last_time)
     : vessel(vessel),
       celestial(celestial),
       target_frame(
           make_not_null_unique<
               BodyCentredBodyDirectionDynamicFrame<Barycentric, Navigation>>(
-                  ephemeris,
-                  [this]() -> auto& { return this->vessel->prediction(); },
-                  celestial->body())) {}
+              ephemeris,
+              [this]() -> auto& { return this->vessel->prediction(); },
+              celestial->body())),
+      prediction_last_time(std::move(prediction_last_time)) {}
+
+not_null<NavigationFrame const*> Renderer::GetPlottingFrame(
+    Instant const& time) const {
+  if (target_) {
+    GetTargetVesselPrediction(time);
+  }
+  return GetPlottingFrame();
+}
 
 }  // namespace internal_renderer
 }  // namespace ksp_plugin

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -118,9 +118,7 @@ Renderer::RenderBarycentricTrajectoryInPlotting(
         break;
       }
     }
-    trajectory->Append(
-        t,
-        BarycentricToPlotting(it.time())(it.degrees_of_freedom()));
+    trajectory->Append(t, BarycentricToPlotting(t)(it.degrees_of_freedom()));
   }
   return trajectory;
 }

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -1,6 +1,8 @@
 ﻿
 #include "ksp_plugin/renderer.hpp"
 
+#include <algorithm>
+
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "physics/apsides.hpp"

--- a/ksp_plugin/renderer.hpp
+++ b/ksp_plugin/renderer.hpp
@@ -49,13 +49,11 @@ class Renderer {
   virtual not_null<NavigationFrame const*> GetPlottingFrame() const;
 
   // Overrides the current plotting frame with one that is centred on the given
-  // |vessel|.  The time returned by |prediction_last_time| is used to prolong
-  // the prediction of the |vessel| when needed.
+  // |vessel|.
   virtual void SetTargetVessel(
       not_null<Vessel*> vessel,
       not_null<Celestial const*> celestial,
-      not_null<Ephemeris<Barycentric> const*> ephemeris,
-      std::function<Instant()> prediction_last_time);
+      not_null<Ephemeris<Barycentric> const*> ephemeris);
 
   // Reverts to frame last set by |SetPlottingFrame|.  The second version only
   // has an effect if the given |vessel| is the current target vessel.
@@ -175,12 +173,10 @@ class Renderer {
   struct Target {
     Target(not_null<Vessel*> vessel,
            not_null<Celestial const*> celestial,
-           not_null<Ephemeris<Barycentric> const*> ephemeris,
-           std::function<Instant()> prediction_last_time);
+           not_null<Ephemeris<Barycentric> const*> ephemeris);
     not_null<Vessel*> const vessel;
     not_null<Celestial const*> const celestial;
     not_null<std::unique_ptr<NavigationFrame>> const target_frame;
-    std::function<Instant()> prediction_last_time;
   };
 
   // Returns a plotting frame suitable for evaluation at |time|, possibly by

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -229,9 +229,17 @@ void Vessel::DeleteFlightPlan() {
 }
 
 void Vessel::UpdatePrediction(Instant const& last_time) {
-  prediction_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();
-  auto const last = psychohistory_->last();
-  prediction_->Append(last.time(), last.degrees_of_freedom());
+  // TODO(phl): The prediction should probably be a fork of the psychohistory.
+  auto const psychohistory_last = psychohistory_->last();
+  auto const prediction_begin = prediction_->Begin();
+  if (prediction_->Empty() ||
+      prediction_begin.time() != psychohistory_last.time() ||
+      prediction_begin.degrees_of_freedom() !=
+          psychohistory_last.degrees_of_freedom()) {
+    prediction_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();
+    prediction_->Append(psychohistory_last.time(),
+                        psychohistory_last.degrees_of_freedom());
+  }
   FlowPrediction(last_time);
 }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -936,7 +936,6 @@ public partial class PrincipiaPluginAdapter
                       prediction_length_tolerance_index_]};
         plugin_.VesselSetPredictionAdaptiveStepParameters(
             main_vessel.id.ToString(), adaptive_step_parameters);
-        plugin_.SetPredictionLength(double.PositiveInfinity);
         plugin_.UpdatePrediction(main_vessel.id.ToString());
         string target_id =
             FlightGlobals.fetch.VesselTarget?.GetVessel()?.id.ToString();

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -952,7 +952,7 @@ public partial class PrincipiaPluginAdapter
       // TODO(egg): Set the degrees of freedom of the origin of |World| (by
       // toying with Krakensbane and FloatingOrigin) here.
 
-      // Now we let the game and Unity do their thing. among other things,
+      // Now we let the game and Unity do their thing.  Among other things,
       // the FashionablyLate callbacks, including ReportNonConservativeForces,
       // then the FlightIntegrator's FixedUpdate will run, then the Vessel's,
       // and eventually the physics simulation.

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -485,11 +485,6 @@ TEST_F(InterfaceTest, NewNavigationFrame) {
   EXPECT_EQ(mock_navigation_frame, navigation_frame.get());
 }
 
-TEST_F(InterfaceTest, PredictionGettersAndSetters) {
-  EXPECT_CALL(*plugin_, SetPredictionLength(42 * Second));
-  principia__SetPredictionLength(plugin_.get(), 42);
-}
-
 TEST_F(InterfaceTest, NavballOrientation) {
   StrictMock<MockDynamicFrame<Barycentric, Navigation>>* const
      mock_navigation_frame =

--- a/ksp_plugin_test/mock_plugin.hpp
+++ b/ksp_plugin_test/mock_plugin.hpp
@@ -68,8 +68,6 @@ class MockPlugin : public Plugin {
                           Instant const& final_time,
                           Mass const& initial_mass));
 
-  MOCK_METHOD1(SetPredictionLength, void(Time const& t));
-
   MOCK_METHOD1(SetPredictionAdaptiveStepParameters,
                void(Ephemeris<Barycentric>::AdaptiveStepParameters const&
                         prediction_adaptive_step_parameters));

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -704,10 +704,9 @@ TEST_F(PluginIntegrationTest, Prediction) {
 
   plugin.renderer().SetPlottingFrame(
       plugin.NewBodyCentredNonRotatingNavigationFrame(celestial));
-  plugin.SetPredictionLength(2 * π * Second);
   Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters(
       DormandElMikkawyPrince1986RKN434FM<Position<Barycentric>>(),
-      /*max_steps=*/1000,
+      /*max_steps=*/14,
       /*length_integration_tolerance=*/1 * Milli(Metre),
       /*speed_integration_tolerance=*/1 * Milli(Metre) / Second);
   plugin.SetPredictionAdaptiveStepParameters(adaptive_step_parameters);
@@ -739,7 +738,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
       AbsoluteError(rendered_prediction->last().degrees_of_freedom().position(),
                     Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre}) +
                         World::origin),
-      AllOf(Gt(2 * Milli(Metre)), Lt(3 * Milli(Metre))));
+      AllOf(Gt(31 * Milli(Metre)), Lt(32 * Milli(Metre))));
 }
 
 }  // namespace internal_plugin

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -850,13 +850,13 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeAfterPredictionFork) {
       .WillOnce(DoAll(SaveArg<0>(&trajectories),
                       Return(ByMove(std::move(instance)))));
   EXPECT_CALL(plugin_->mock_ephemeris(), t_max())
-      .WillRepeatedly(Return(Instant()));
+      .WillRepeatedly(Return(Instant() + 12 * Hour));
   EXPECT_CALL(plugin_->mock_ephemeris(), empty()).WillRepeatedly(Return(false));
   EXPECT_CALL(plugin_->mock_ephemeris(), trajectory(_))
       .WillOnce(Return(plugin_->trajectory(SolarSystemFactory::Sun)));
   EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_)).Times(AnyNumber());
   EXPECT_CALL(plugin_->mock_ephemeris(), FlowWithAdaptiveStep(_, _, _, _, _, _))
-      .WillRepeatedly(DoAll(AppendToDiscreteTrajectory(dof), Return(true)));
+      .WillRepeatedly(DoAll(AppendToDiscreteTrajectory(dof), Return(false)));
   EXPECT_CALL(plugin_->mock_ephemeris(), FlowWithFixedStep(_, _))
       .WillRepeatedly(AppendToDiscreteTrajectory2(&trajectories[0], dof));
   EXPECT_CALL(plugin_->mock_ephemeris(), planetary_integrator())

--- a/ksp_plugin_test/renderer_test.cpp
+++ b/ksp_plugin_test/renderer_test.cpp
@@ -100,7 +100,10 @@ TEST_F(RendererTest, TargetVessel) {
   EXPECT_CALL(vessel, prediction())
       .WillRepeatedly(ReturnRef(vessel_trajectory));
 
-  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
+  renderer_.SetTargetVessel(&vessel,
+                            &celestial_,
+                            &ephemeris,
+                            /*prediction_last_time=*/[this]() { return t0_; });
   EXPECT_TRUE(renderer_.HasTargetVessel());
   EXPECT_THAT(renderer_.GetTargetVessel(), Ref(vessel));
   MockVessel other_vessel;
@@ -108,7 +111,10 @@ TEST_F(RendererTest, TargetVessel) {
   EXPECT_THAT(renderer_.GetTargetVessel(), Ref(vessel));
   renderer_.ClearTargetVesselIf(&vessel);
   EXPECT_FALSE(renderer_.HasTargetVessel());
-  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
+  renderer_.SetTargetVessel(&vessel,
+                            &celestial_,
+                            &ephemeris,
+                            /*prediction_last_time=*/[this]() { return t0_; });
   renderer_.ClearTargetVessel();
   EXPECT_FALSE(renderer_.HasTargetVessel());
 }
@@ -225,7 +231,10 @@ TEST_F(RendererTest, RenderBarycentricTrajectoryInPlottingWithTargetVessel) {
             Velocity<Barycentric>())));
   }
 
-  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
+  renderer_.SetTargetVessel(&vessel,
+                            &celestial_,
+                            &ephemeris,
+                            /*prediction_last_time=*/[this]() { return t0_; });
   auto const rendered_trajectory =
       renderer_.RenderBarycentricTrajectoryInPlotting(
           trajectory_to_render.Begin(),

--- a/ksp_plugin_test/renderer_test.cpp
+++ b/ksp_plugin_test/renderer_test.cpp
@@ -100,10 +100,7 @@ TEST_F(RendererTest, TargetVessel) {
   EXPECT_CALL(vessel, prediction())
       .WillRepeatedly(ReturnRef(vessel_trajectory));
 
-  renderer_.SetTargetVessel(&vessel,
-                            &celestial_,
-                            &ephemeris,
-                            /*prediction_last_time=*/[this]() { return t0_; });
+  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
   EXPECT_TRUE(renderer_.HasTargetVessel());
   EXPECT_THAT(renderer_.GetTargetVessel(), Ref(vessel));
   MockVessel other_vessel;
@@ -111,10 +108,7 @@ TEST_F(RendererTest, TargetVessel) {
   EXPECT_THAT(renderer_.GetTargetVessel(), Ref(vessel));
   renderer_.ClearTargetVesselIf(&vessel);
   EXPECT_FALSE(renderer_.HasTargetVessel());
-  renderer_.SetTargetVessel(&vessel,
-                            &celestial_,
-                            &ephemeris,
-                            /*prediction_last_time=*/[this]() { return t0_; });
+  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
   renderer_.ClearTargetVessel();
   EXPECT_FALSE(renderer_.HasTargetVessel());
 }
@@ -231,10 +225,7 @@ TEST_F(RendererTest, RenderBarycentricTrajectoryInPlottingWithTargetVessel) {
             Velocity<Barycentric>())));
   }
 
-  renderer_.SetTargetVessel(&vessel,
-                            &celestial_,
-                            &ephemeris,
-                            /*prediction_last_time=*/[this]() { return t0_; });
+  renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
   auto const rendered_trajectory =
       renderer_.RenderBarycentricTrajectoryInPlotting(
           trajectory_to_render.Begin(),

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1500,17 +1500,6 @@ message SetPlottingFrame {
   optional Out out = 2;
 }
 
-message SetPredictionLength {
-  extend Method {
-    optional SetPredictionLength extension = 5042;
-  }
-  message In {
-    required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
-    required double t = 2;
-  }
-  optional In in = 1;
-}
-
 message SetTargetVessel {
   extend Method {
     optional SetTargetVessel extension = 5121;


### PR DESCRIPTION
This was noticed when investigating #1561 (the new test show a case where we evaluate the prediction after its last point) but this is really unrelated because #1561 is about evaluating the prediction before its first point.

Also making `Vessel::UpdatePrediction` idempotent for performance.