### PR TITLE
Fix compilation errors emitted by Clang 5.0

### DIFF
--- a/geometry/identity_test.cpp
+++ b/geometry/identity_test.cpp
@@ -52,17 +52,20 @@ TEST_F(IdentityTest, Determinant) {
 }
 
 TEST_F(IdentityTest, AppliedToVector) {
-  EXPECT_THAT(Id::Identity()(vector_).coordinates(),
+  Id identity;
+  EXPECT_THAT(identity(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(IdentityTest, AppliedToBivector) {
-  EXPECT_THAT(Id::Identity()(bivector_).coordinates(),
+  Id identity;
+  EXPECT_THAT(identity(bivector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(IdentityTest, AppliedToTrivector) {
-  EXPECT_THAT(Id::Identity()(trivector_).coordinates(),
+  Id identity;
+  EXPECT_THAT(identity(trivector_).coordinates(),
               Eq(4.0 * Metre));
 }
 
@@ -71,7 +74,8 @@ TEST_F(IdentityTest, Inverse) {
   Vector<quantities::Length, World2> const vector2 =
       Vector<quantities::Length, World2>(
           R3(1.0 * Metre, 2.0 * Metre, 3.0 * Metre));
-  EXPECT_THAT(Id::Identity().Inverse()(vector2).coordinates(),
+  Id identity;
+  EXPECT_THAT(identity.Inverse()(vector2).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
   Id id;
   Identity<World1, World1> const identity1 = id.Inverse() * id;
@@ -81,7 +85,8 @@ TEST_F(IdentityTest, Inverse) {
 }
 
 TEST_F(IdentityTest, Forget) {
-  EXPECT_THAT(Id::Identity().Forget()(vector_).coordinates(),
+  Id identity;
+  EXPECT_THAT(identity.Forget()(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 

--- a/geometry/identity_test.cpp
+++ b/geometry/identity_test.cpp
@@ -47,25 +47,21 @@ class IdentityTest : public testing::Test {
 using IdentityDeathTest = IdentityTest;
 
 TEST_F(IdentityTest, Determinant) {
-  Id identity;
-  EXPECT_TRUE(identity.Determinant().Positive());
+  EXPECT_TRUE(Id().Determinant().Positive());
 }
 
 TEST_F(IdentityTest, AppliedToVector) {
-  Id identity;
-  EXPECT_THAT(identity(vector_).coordinates(),
+  EXPECT_THAT(Id()(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(IdentityTest, AppliedToBivector) {
-  Id identity;
-  EXPECT_THAT(identity(bivector_).coordinates(),
+  EXPECT_THAT(Id()(bivector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 
 TEST_F(IdentityTest, AppliedToTrivector) {
-  Id identity;
-  EXPECT_THAT(identity(trivector_).coordinates(),
+  EXPECT_THAT(Id()(trivector_).coordinates(),
               Eq(4.0 * Metre));
 }
 
@@ -74,8 +70,7 @@ TEST_F(IdentityTest, Inverse) {
   Vector<quantities::Length, World2> const vector2 =
       Vector<quantities::Length, World2>(
           R3(1.0 * Metre, 2.0 * Metre, 3.0 * Metre));
-  Id identity;
-  EXPECT_THAT(identity.Inverse()(vector2).coordinates(),
+  EXPECT_THAT(Id().Inverse()(vector2).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
   Id id;
   Identity<World1, World1> const identity1 = id.Inverse() * id;
@@ -85,8 +80,7 @@ TEST_F(IdentityTest, Inverse) {
 }
 
 TEST_F(IdentityTest, Forget) {
-  Id identity;
-  EXPECT_THAT(identity.Forget()(vector_).coordinates(),
+  EXPECT_THAT(Id().Forget()(vector_).coordinates(),
               Eq<R3>({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}));
 }
 


### PR DESCRIPTION
Errors emitted were of the form

```
    geometry/identity_test.cpp:77:19: error: qualified reference to 'Identity' is a
          constructor name rather than a type in this context
      EXPECT_THAT(Id::Identity().Inverse()(vector2).coordinates(),
                      ^
```

To be honest, not sure since this is an actual problem rather than a compiler bug, since the code appears to have always been that way...

The way I fixed the compilation error was chosen because I noticed that the code under `TEST_F(IdentityTest, Determinant)` had a "standalone" (for lack of a better phrase) `Id` object, unlike the code causing the errors.