### PR TITLE
Do not show the trajectory of the target if there is no active vessel.

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1757,7 +1757,8 @@ public partial class PrincipiaPluginAdapter
           }
           string target_id =
               FlightGlobals.fetch.VesselTarget?.GetVessel()?.id.ToString();
-          if (!plotting_frame_selector_.get().target_override &&
+          if (FlightGlobals.ActiveVessel != null &&
+              !plotting_frame_selector_.get().target_override &&
               target_id != null && plugin_.HasVessel(target_id)) {
             {
               IntPtr rp2_lines_iterator =


### PR DESCRIPTION
Fix #1620.