### PR TITLE
A new class, Wide, to hold a 128-bit SSE representation of a quantity or double

### DIFF
--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -229,7 +229,7 @@ R3Element<Product<LScalar, RScalar>> operator*(
     LScalar const& left,
     R3Element<RScalar> const& right) {
 #if PRINCIPIA_USE_SSE2_INTRINSICS
-  __m128d const left_128d = Wide<LScalar>(left).m128d();
+  __m128d const left_128d = ToM128D(left);
   return R3Element<Product<LScalar, RScalar>>(_mm_mul_pd(right.xy, left_128d),
                                               _mm_mul_sd(right.zt, left_128d));
 #else

--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -13,6 +13,7 @@
 #include "quantities/elementary_functions.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/serialization.hpp"
+#include "quantities/wide.hpp"
 
 #define PRINCIPIA_USE_SSE2_INTRINSICS 1
 
@@ -25,11 +26,11 @@ using quantities::ArcTan;
 using quantities::Cos;
 using quantities::DebugString;
 using quantities::DoubleOrQuantitySerializer;
-using quantities::FromM128D;
 using quantities::Quantity;
 using quantities::Sin;
 using quantities::SIUnit;
 using quantities::ToM128D;
+using quantities::Wide;
 
 // We want zero initialization here, so the default constructor won't do.
 template<typename Scalar>
@@ -228,7 +229,7 @@ R3Element<Product<LScalar, RScalar>> operator*(
     LScalar const& left,
     R3Element<RScalar> const& right) {
 #if PRINCIPIA_USE_SSE2_INTRINSICS
-  __m128d const left_128d = ToM128D(left);
+  __m128d const left_128d = Wide<LScalar>(left).m128d();
   return R3Element<Product<LScalar, RScalar>>(_mm_mul_pd(right.xy, left_128d),
                                               _mm_mul_sd(right.zt, left_128d));
 #else

--- a/quantities/generators.hpp
+++ b/quantities/generators.hpp
@@ -27,4 +27,4 @@ struct QuotientGenerator;
 }  // namespace principia
 
 // Because of circular dependencies, this file doesn't include
-// generators_body.hpp.  This will be done by quantities_body.hpp.
+// generators_body.hpp.  This will be done by quantities.hpp.

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -13,16 +13,11 @@
 #include "quantities/dimensions.hpp"
 #include "quantities/generators.hpp"
 #include "quantities/traits.hpp"
+#include "quantities/wide.hpp"
 #include "serialization/quantities.pb.h"
 
 namespace principia {
 namespace quantities {
-
-namespace internal_wide {
-template<typename T>
-class Wide;
-}  // namespace internal_wide
-
 namespace internal_quantities {
 
 using base::not_constructible;
@@ -106,18 +101,15 @@ class Quantity final {
       double left,
       Quantity<RDimensions> const& right);
 
-  template<typename T>
-  friend class internal_wide::Wide;
   template<typename Q>
   friend constexpr Q Infinity();
   template<typename Q>
   friend constexpr Q NaN();
   template<typename Q>
   friend constexpr Q SIUnit();
-  template<typename D>
-  friend Quantity<D> FromM128D(__m128d x);
-  template<typename D>
-  friend __m128d ToM128D(Quantity<D> x);
+
+  template<typename U>
+  friend __m128d internal_wide::ToM128D(Quantity<U> x);
 };
 
 template<typename LDimensions, typename RDimensions>
@@ -140,17 +132,6 @@ constexpr Q SIUnit();
 // Returns 1.
 template<>
 constexpr double SIUnit<double>();
-
-// Conversion to and from intrinsic types.  ToM128D fills both halves of the
-// result.
-template<typename D>
-Quantity<D> FromM128D(__m128d x);
-template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-T FromM128D(__m128d x);
-template<typename D>
-__m128d ToM128D(Quantity<D> x);
-template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-__m128d ToM128D(T x);
 
 // Returns a positive infinity of |Q|.
 template<typename Q>
@@ -179,7 +160,6 @@ using internal_quantities::Amount;
 using internal_quantities::Angle;
 using internal_quantities::Current;
 using internal_quantities::DebugString;
-using internal_quantities::FromM128D;
 using internal_quantities::Infinity;
 using internal_quantities::IsFinite;
 using internal_quantities::Length;
@@ -190,9 +170,13 @@ using internal_quantities::Quantity;
 using internal_quantities::SIUnit;
 using internal_quantities::Temperature;
 using internal_quantities::Time;
-using internal_quantities::ToM128D;
 
 }  // namespace quantities
 }  // namespace principia
+
+// Include before quantities_body.hpp all the bodies that want to see the
+// definition of class Quantity.
+#include "quantities/generators_body.hpp"
+#include "quantities/wide_body.hpp"
 
 #include "quantities/quantities_body.hpp"

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -17,6 +17,12 @@
 
 namespace principia {
 namespace quantities {
+
+namespace internal_wide {
+template<typename T>
+class Wide;
+}  // namespace internal_wide
+
 namespace internal_quantities {
 
 using base::not_constructible;
@@ -100,6 +106,8 @@ class Quantity final {
       double left,
       Quantity<RDimensions> const& right);
 
+  template<typename T>
+  friend class internal_wide::Wide;
   template<typename Q>
   friend constexpr Q Infinity();
   template<typename Q>

--- a/quantities/quantities.vcxproj
+++ b/quantities/quantities.vcxproj
@@ -30,10 +30,13 @@
     <ClInclude Include="si_body.hpp" />
     <ClInclude Include="traits.hpp" />
     <ClInclude Include="uk.hpp" />
+    <ClInclude Include="wide.hpp" />
+    <ClInclude Include="wide_body.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="elementary_functions_test.cpp" />
     <ClCompile Include="parser_test.cpp" />
     <ClCompile Include="quantities_test.cpp" />
+    <ClCompile Include="wide_test.cpp" />
   </ItemGroup>
 </Project>

--- a/quantities/quantities.vcxproj.filters
+++ b/quantities/quantities.vcxproj.filters
@@ -80,6 +80,12 @@
     <ClInclude Include="traits.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wide.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wide_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="quantities_test.cpp">
@@ -89,6 +95,9 @@
       <Filter>Test Files</Filter>
     </ClCompile>
     <ClCompile Include="elementary_functions_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wide_test.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/macros.hpp"
-#include "quantities/generators_body.hpp"  // Apologies.
 
 namespace principia {
 namespace quantities {
@@ -171,26 +170,6 @@ constexpr Q SIUnit() {
 template<>
 constexpr double SIUnit<double>() {
   return 1;
-}
-
-template<typename D>
-Quantity<D> FromM128D(__m128d const x) {
-  return Quantity<D>(_mm_cvtsd_f64(x));
-}
-
-template<typename T, typename>
-T FromM128D(__m128d const x) {
-  return static_cast<T>(_mm_cvtsd_f64(x));
-}
-
-template<typename D>
-__m128d ToM128D(Quantity<D> const x) {
-  return _mm_set1_pd(x.magnitude_);
-}
-
-template<typename T, typename>
-inline __m128d ToM128D(T const x) {
-  return _mm_set1_pd(static_cast<double>(x));
 }
 
 template<typename Q>

--- a/quantities/wide.hpp
+++ b/quantities/wide.hpp
@@ -21,7 +21,7 @@ namespace internal_wide {
 using base::not_constructible;
 using internal_quantities::Quantity;
 
-// A wrapper for a quantity already converted to __m128d.
+// A wrapper for a quantity copied to all entries of a SIMD vector.
 template<typename T>
 class Wide final {
   static_assert(is_quantity<T>::value, "Not a quantity type");

--- a/quantities/wide.hpp
+++ b/quantities/wide.hpp
@@ -29,8 +29,6 @@ class Wide final {
   explicit Wide(T x);
 
  private:
-  explicit Wide(__m128d wide);
-
   __m128d wide_;
 
   template<typename U>

--- a/quantities/wide.hpp
+++ b/quantities/wide.hpp
@@ -1,0 +1,55 @@
+
+#pragma once
+
+#include <nmmintrin.h>
+
+#include <type_traits>
+
+#include "quantities/quantities.hpp"
+
+namespace principia {
+namespace quantities {
+namespace internal_wide {
+
+template<typename T>
+class Wide final {
+  static_assert(std::is_arithmetic<T>::value, "Nonarithmetic type");
+ public:
+  explicit Wide(T x);
+
+  __m128d m128d() const;
+
+ private:
+  __m128d wide_;
+};
+
+template<typename D>
+class Wide<Quantity<D>> final {
+ public:
+  explicit Wide(Quantity<D> const& x);
+
+  __m128d m128d() const;
+
+ private:
+  __m128d wide_;
+};
+
+template<typename T>
+class Wide<Wide<T>> final {
+ public:
+  explicit Wide(Wide<T> const& x);
+
+  __m128d m128d() const;
+
+ private:
+  __m128d wide_;
+};
+
+}  // namespace internal_wide
+
+using internal_wide::Wide;
+
+}  // namespace quantities
+}  // namespace principia
+
+#include "quantities/wide_body.hpp"

--- a/quantities/wide_body.hpp
+++ b/quantities/wide_body.hpp
@@ -1,0 +1,37 @@
+
+#pragma once
+
+#include "quantities/wide.hpp"
+
+namespace principia {
+namespace quantities {
+namespace internal_wide {
+
+template<typename T>
+Wide<T>::Wide(T const x) : wide_(_mm_set1_pd(static_cast<double>(x))) {}
+
+template<typename T>
+__m128d Wide<T>::m128d() const {
+  return wide_;
+}
+
+template<typename D>
+Wide<Quantity<D>>::Wide(Quantity<D> const& x)
+    : wide_(_mm_set1_pd(x.magnitude_)) {}
+
+template<typename D>
+__m128d Wide<Quantity<D>>::m128d() const {
+  return wide_;
+}
+
+template<typename T>
+Wide<Wide<T>>::Wide(Wide<T> const& x) : wide_(x.wide_) {}
+
+template<typename T>
+__m128d Wide<Wide<T>>::m128d() const {
+  return wide_;
+}
+
+}  // namespace internal_wide
+}  // namespace quantities
+}  // namespace principia

--- a/quantities/wide_body.hpp
+++ b/quantities/wide_body.hpp
@@ -10,9 +10,6 @@ namespace internal_wide {
 template<typename T>
 Wide<T>::Wide(T const x) : wide_(ToM128D(x)) {}
 
-template<typename T>
-Wide<T>::Wide(__m128d wide) : wide_(wide) {}
-
 template<typename D>
 __m128d ToM128D(Quantity<D> const x) {
   return _mm_set1_pd(x.magnitude_);

--- a/quantities/wide_body.hpp
+++ b/quantities/wide_body.hpp
@@ -8,28 +8,24 @@ namespace quantities {
 namespace internal_wide {
 
 template<typename T>
-Wide<T>::Wide(T const x) : wide_(_mm_set1_pd(static_cast<double>(x))) {}
+Wide<T>::Wide(T const x) : wide_(ToM128D(x)) {}
 
 template<typename T>
-__m128d Wide<T>::m128d() const {
-  return wide_;
-}
+Wide<T>::Wide(__m128d wide) : wide_(wide) {}
 
 template<typename D>
-Wide<Quantity<D>>::Wide(Quantity<D> const& x)
-    : wide_(_mm_set1_pd(x.magnitude_)) {}
-
-template<typename D>
-__m128d Wide<Quantity<D>>::m128d() const {
-  return wide_;
+__m128d ToM128D(Quantity<D> const x) {
+  return _mm_set1_pd(x.magnitude_);
 }
 
 template<typename T>
-Wide<Wide<T>>::Wide(Wide<T> const& x) : wide_(x.wide_) {}
+__m128d ToM128D(Wide<T> x) {
+  return x.wide_;
+}
 
-template<typename T>
-__m128d Wide<Wide<T>>::m128d() const {
-  return wide_;
+template<typename T, typename>
+inline __m128d ToM128D(T const x) {
+  return _mm_set1_pd(static_cast<double>(x));
 }
 
 }  // namespace internal_wide

--- a/quantities/wide_test.cpp
+++ b/quantities/wide_test.cpp
@@ -9,16 +9,26 @@ namespace quantities {
 
 using si::Metre;
 
-TEST(WideTest, ConstructionConversion) {
+TEST(WideTest, Conversions) {
   Wide<Length> const w1(2 * Metre);
-  __m128d m1 = w1.m128d();
-  EXPECT_EQ(2, m1.m128d_f64[0]);
-  EXPECT_EQ(2, m1.m128d_f64[1]);
+  __m128d m1 = ToM128D(w1);
+  EXPECT_EQ(2, _mm_cvtsd_f64(m1));
+  EXPECT_EQ(2, _mm_cvtsd_f64(_mm_unpackhi_pd(m1, m1)));
 
   Wide<double> const w2(3.14);
-  __m128d m2 = w2.m128d();
-  EXPECT_EQ(3.14, m2.m128d_f64[0]);
-  EXPECT_EQ(3.14, m2.m128d_f64[1]);
+  __m128d m2 = ToM128D(w2);
+  EXPECT_EQ(3.14, _mm_cvtsd_f64(m2));
+  EXPECT_EQ(3.14, _mm_cvtsd_f64(_mm_unpackhi_pd(m2, m2)));
+
+  Length const n3(3 * Metre);
+  __m128d m3 = ToM128D(n3);
+  EXPECT_EQ(3, _mm_cvtsd_f64(m3));
+  EXPECT_EQ(3, _mm_cvtsd_f64(_mm_unpackhi_pd(m3, m3)));
+
+  double const n4(2.71);
+  __m128d m4 = ToM128D(n4);
+  EXPECT_EQ(2.71, _mm_cvtsd_f64(m4));
+  EXPECT_EQ(2.71, _mm_cvtsd_f64(_mm_unpackhi_pd(m4, m4)));
 }
 
 }  // namespace quantities

--- a/quantities/wide_test.cpp
+++ b/quantities/wide_test.cpp
@@ -1,0 +1,25 @@
+
+#include "quantities/wide.hpp"
+
+#include "gtest/gtest.h"
+#include "quantities/si.hpp"
+
+namespace principia {
+namespace quantities {
+
+using si::Metre;
+
+TEST(WideTest, ConstructionConversion) {
+  Wide<Length> const w1(2 * Metre);
+  __m128d m1 = w1.m128d();
+  EXPECT_EQ(2, m1.m128d_f64[0]);
+  EXPECT_EQ(2, m1.m128d_f64[1]);
+
+  Wide<double> const w2(3.14);
+  __m128d m2 = w2.m128d();
+  EXPECT_EQ(3.14, m2.m128d_f64[0]);
+  EXPECT_EQ(3.14, m2.m128d_f64[1]);
+}
+
+}  // namespace quantities
+}  // namespace principia

--- a/quantities/wide_test.cpp
+++ b/quantities/wide_test.cpp
@@ -1,34 +1,39 @@
 
 #include "quantities/wide.hpp"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "quantities/si.hpp"
+#include "testing_utilities/matchers.hpp"
 
 namespace principia {
 namespace quantities {
 
 using si::Metre;
+using testing_utilities::SSEHighHalfIs;
+using testing_utilities::SSELowHalfIs;
+using ::testing::Eq;
 
 TEST(WideTest, Conversions) {
   Wide<Length> const w1(2 * Metre);
   __m128d m1 = ToM128D(w1);
-  EXPECT_EQ(2, _mm_cvtsd_f64(m1));
-  EXPECT_EQ(2, _mm_cvtsd_f64(_mm_unpackhi_pd(m1, m1)));
+  EXPECT_THAT(m1, SSEHighHalfIs(2));
+  EXPECT_THAT(m1, SSELowHalfIs(2));
 
   Wide<double> const w2(3.14);
   __m128d m2 = ToM128D(w2);
-  EXPECT_EQ(3.14, _mm_cvtsd_f64(m2));
-  EXPECT_EQ(3.14, _mm_cvtsd_f64(_mm_unpackhi_pd(m2, m2)));
+  EXPECT_THAT(m2, SSEHighHalfIs(3.14));
+  EXPECT_THAT(m2, SSELowHalfIs(3.14));
 
   Length const n3(3 * Metre);
   __m128d m3 = ToM128D(n3);
-  EXPECT_EQ(3, _mm_cvtsd_f64(m3));
-  EXPECT_EQ(3, _mm_cvtsd_f64(_mm_unpackhi_pd(m3, m3)));
+  EXPECT_THAT(m3, SSEHighHalfIs(3));
+  EXPECT_THAT(m3, SSELowHalfIs(3));
 
   double const n4(2.71);
   __m128d m4 = ToM128D(n4);
-  EXPECT_EQ(2.71, _mm_cvtsd_f64(m4));
-  EXPECT_EQ(2.71, _mm_cvtsd_f64(_mm_unpackhi_pd(m4, m4)));
+  EXPECT_THAT(m4, SSEHighHalfIs(2.71));
+  EXPECT_THAT(m4, SSELowHalfIs(2.71));
 }
 
 }  // namespace quantities

--- a/testing_utilities/matchers.hpp
+++ b/testing_utilities/matchers.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <nmmintrin.h>
+
 #include <string>
 
 #include "base/status.hpp"
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/util/message_differencer.h"
+#include "quantities/quantities.hpp"
 #include "serialization/ksp_plugin.pb.h"
 
 namespace principia {
@@ -35,6 +38,20 @@ MATCHER_P(StatusIs,
           std::string(negation ? "does not have" : "has") + " error: " +
               ::principia::base::ErrorToString(error)) {
   return arg.error() == error;
+}
+
+MATCHER_P(SSEHighHalfIs,
+          value,
+          std::string(negation ? "does not have" : "has") + " high half: " +
+              ::principia::quantities::DebugString(value)) {
+  return _mm_cvtsd_f64(_mm_unpackhi_pd(arg, arg)) == value;
+}
+
+MATCHER_P(SSELowHalfIs,
+          value,
+          std::string(negation ? "does not have" : "has") + " low half: " +
+              ::principia::quantities::DebugString(value)) {
+  return _mm_cvtsd_f64(arg) == value;
 }
 
 }  // namespace testing_utilities


### PR DESCRIPTION
I am dropping `FromM128D` because:
1. We don't use it.
1. It doesn't work well with overloading because there's no overloading on the return type.  No tag types today.