### PR TITLE
Remove class Wide

### DIFF
--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -30,7 +30,6 @@ using quantities::Quantity;
 using quantities::Sin;
 using quantities::SIUnit;
 using quantities::ToM128D;
-using quantities::Wide;
 
 // We want zero initialization here, so the default constructor won't do.
 template<typename Scalar>

--- a/quantities/wide.hpp
+++ b/quantities/wide.hpp
@@ -5,7 +5,6 @@
 
 #include <type_traits>
 
-#include "base/not_constructible.hpp"
 #include "quantities/traits.hpp"
 
 namespace principia {
@@ -18,35 +17,17 @@ class Quantity;
 
 namespace internal_wide {
 
-using base::not_constructible;
 using internal_quantities::Quantity;
-
-// A wrapper for a quantity copied to all entries of a SIMD vector.
-template<typename T>
-class Wide final {
-  static_assert(is_quantity<T>::value, "Not a quantity type");
- public:
-  explicit Wide(T x);
-
- private:
-  __m128d wide_;
-
-  template<typename U>
-  friend __m128d ToM128D(Wide<U> x);
-};
 
 // Fills both halves of the result.
 template<typename D>
 __m128d ToM128D(Quantity<D> x);
-template<typename T>
-__m128d ToM128D(Wide<T> x);
 template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 __m128d ToM128D(T x);
 
 }  // namespace internal_wide
 
 using internal_wide::ToM128D;
-using internal_wide::Wide;
 
 }  // namespace quantities
 }  // namespace principia

--- a/quantities/wide_body.hpp
+++ b/quantities/wide_body.hpp
@@ -7,17 +7,9 @@ namespace principia {
 namespace quantities {
 namespace internal_wide {
 
-template<typename T>
-Wide<T>::Wide(T const x) : wide_(ToM128D(x)) {}
-
 template<typename D>
 __m128d ToM128D(Quantity<D> const x) {
   return _mm_set1_pd(x.magnitude_);
-}
-
-template<typename T>
-__m128d ToM128D(Wide<T> x) {
-  return x.wide_;
 }
 
 template<typename T, typename>

--- a/quantities/wide_test.cpp
+++ b/quantities/wide_test.cpp
@@ -12,28 +12,15 @@ namespace quantities {
 using si::Metre;
 using testing_utilities::SSEHighHalfIs;
 using testing_utilities::SSELowHalfIs;
-using ::testing::Eq;
 
 TEST(WideTest, Conversions) {
-  Wide<Length> const w1(2 * Metre);
-  __m128d m1 = ToM128D(w1);
+  __m128d m1 = ToM128D(2 * Metre);
   EXPECT_THAT(m1, SSEHighHalfIs(2));
   EXPECT_THAT(m1, SSELowHalfIs(2));
 
-  Wide<double> const w2(3.14);
-  __m128d m2 = ToM128D(w2);
+  __m128d m2 = ToM128D(3.14);
   EXPECT_THAT(m2, SSEHighHalfIs(3.14));
   EXPECT_THAT(m2, SSELowHalfIs(3.14));
-
-  Length const n3(3 * Metre);
-  __m128d m3 = ToM128D(n3);
-  EXPECT_THAT(m3, SSEHighHalfIs(3));
-  EXPECT_THAT(m3, SSELowHalfIs(3));
-
-  double const n4(2.71);
-  __m128d m4 = ToM128D(n4);
-  EXPECT_THAT(m4, SSEHighHalfIs(2.71));
-  EXPECT_THAT(m4, SSELowHalfIs(2.71));
 }
 
 }  // namespace quantities


### PR DESCRIPTION
It didn't give us the speed-up that we were hoping for, and it was making the code a bit clunky.  If someone wants to resurrect it, the full implementation is in [pleroy/WideOp2](https://github.com/pleroy/Principia/tree/WideOp2).