### PR TITLE
 Implement the Cohen-Hubbard-Oesterwinter method

### DIFF
--- a/integrators/cohen_hubbard_oesterwinter.hpp
+++ b/integrators/cohen_hubbard_oesterwinter.hpp
@@ -31,4 +31,4 @@ CohenHubbardOesterwinter<order> const& CohenHubbardOesterwinterOrder();
 }  // namespace integrators
 }  // namespace principia
 
-#include "integrators/backward_difference_body.hpp"
+#include "integrators/cohen_hubbard_oesterwinter_body.hpp"

--- a/integrators/cohen_hubbard_oesterwinter_body.hpp
+++ b/integrators/cohen_hubbard_oesterwinter_body.hpp
@@ -161,5 +161,48 @@ inline CohenHubbardOesterwinter<13> const& CohenHubbardOesterwinterOrder<13>() {
   return cohen_hubbard_oesterwinter;
 }
 
+template<>
+inline CohenHubbardOesterwinter<14> const& CohenHubbardOesterwinterOrder<14>() {
+  static CohenHubbardOesterwinter<14> const cohen_hubbard_oesterwinter{
+      {3222245907974.0,
+       12037738451557.0,
+       -26802725457012.0,
+       61256305132546.0,
+       -111377493654070.0,
+       157573362429387.0,
+       -173081395797144.0,
+       147163097080284.0,
+       -95999978168262.0,
+       47189380167595.0,
+       -16926084595636.0,
+       4184066277762.0,
+       -637654600522.0,
+       45183033541.0},
+      15692092416000.0};
+  return cohen_hubbard_oesterwinter;
+}
+
+template<>
+inline CohenHubbardOesterwinter<15> const& CohenHubbardOesterwinterOrder<15>() {
+  static CohenHubbardOesterwinter<15> const cohen_hubbard_oesterwinter{
+      {12725213787853.0,
+       50443731622830.0,
+       -122113957635961.0,
+       304637443761836.0,
+       -609443588503323.0,
+       958160677491634.0,
+       -1184126424849705.0,
+       1150710493076712.0,
+       -875800754334177.0,
+       516624748444466.0,
+       -231637952269587.0,
+       76348488342700.0,
+       -17453674210001.0,
+       2473509950766.0,
+       -163769844043.0},
+      62768369664000.0};
+  return cohen_hubbard_oesterwinter;
+}
+
 }  // namespace integrators
 }  // namespace principia

--- a/integrators/symmetric_linear_multistep_integrator.hpp
+++ b/integrators/symmetric_linear_multistep_integrator.hpp
@@ -126,7 +126,7 @@ class SymmetricLinearMultistepIntegrator
 
   FixedStepSizeIntegrator<ODE> const& startup_integrator_;
   BackwardDifference<order_ - 1> const& backward_difference_;
-  CohenHubbardOesterwinter<order_ + 1> const& cohen_hubbard_oesterwinter_;
+  CohenHubbardOesterwinter<order_> const& cohen_hubbard_oesterwinter_;
   FixedVector<double, half_order_> const ɑ_;
   FixedVector<double, half_order_> const β_numerator_;
   double const β_denominator_;

--- a/integrators/symmetric_linear_multistep_integrator.hpp
+++ b/integrators/symmetric_linear_multistep_integrator.hpp
@@ -14,6 +14,7 @@
 
 #include "base/status.hpp"
 #include "integrators/backward_difference.hpp"
+#include "integrators/cohen_hubbard_oesterwinter.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "numerics/double_precision.hpp"
 #include "numerics/fixed_arrays.hpp"
@@ -86,9 +87,13 @@ class SymmetricLinearMultistepIntegrator
     // updated more frequently than once every |instance.step_|.
     void StartupSolve(Instant const& t_final);
 
-    // Performs the velocity computation, i.e. a backward difference using the
-    // positions computed by the main integrator.
-    void ComputeVelocity(int dimension);
+    // Performs the velocity computation using a backward difference based on
+    // the positions computed by the main integrator.
+    void ComputeVelocityUsingBackwardDifferences();
+
+    // Performs the velocity computation using the Cohen-Hubbard-Oesterwinter
+    // method based on the accelerations computed by the main integrator.
+    void ComputeVelocityUsingCohenHubbardOesterwinter();
 
     static void FillStepFromSystemState(ODE const& equation,
                                         typename ODE::SystemState const& state,
@@ -121,6 +126,7 @@ class SymmetricLinearMultistepIntegrator
 
   FixedStepSizeIntegrator<ODE> const& startup_integrator_;
   BackwardDifference<order_ - 1> const& backward_difference_;
+  CohenHubbardOesterwinter<order_ + 1> const& cohen_hubbard_oesterwinter_;
   FixedVector<double, half_order_> const ɑ_;
   FixedVector<double, half_order_> const β_numerator_;
   double const β_denominator_;

--- a/integrators/symmetric_linear_multistep_integrator_body.hpp
+++ b/integrators/symmetric_linear_multistep_integrator_body.hpp
@@ -138,8 +138,10 @@ Status SymmetricLinearMultistepIntegrator<Position, order_>::Instance::Solve(
 
     // Note that we only delete the oldest step *after* computing the velocity.
     // This means that the velocity computation has access to |order_ + 1|
-    // points. For backward difference this yields order |order_ - 1|, for
-    // Cohen-Hubbard-Oesterwinter this yields order |order_ + 1|.
+    // points and, for backward difference, it makes it possible to reach order
+    // |order_ - 1|.  For Cohen-Hubbard-Oesterwinter this is not necessary: it
+    // makes no sense to go up to order |order_ + 1| so we really only need
+    // |order_| points.
 #if PRINCIPIA_USE_COHEN_HUBBARD_OESTERWINTER
     ComputeVelocityUsingCohenHubbardOesterwinter();
 #else
@@ -375,8 +377,8 @@ Instance::ComputeVelocityUsingCohenHubbardOesterwinter() {
     auto it = previous_steps_.rbegin();
 
     // Compute the displacement difference using double precision.
-    DoublePrecision<Displacement> displacement_change = 
-      it->displacements[d] - std::next(it)->displacements[d];
+    DoublePrecision<Displacement> displacement_change =
+        it->displacements[d] - std::next(it)->displacements[d];
     velocity = DoublePrecision<Velocity>(
         (displacement_change.value + displacement_change.error) / step);
 
@@ -423,7 +425,7 @@ SymmetricLinearMultistepIntegrator(
       startup_integrator_(startup_integrator),
       backward_difference_(
           FirstDerivativeBackwardDifference<order_ - 1>()),
-      cohen_hubbard_oesterwinter_(CohenHubbardOesterwinterOrder<order_ + 1>()),
+      cohen_hubbard_oesterwinter_(CohenHubbardOesterwinterOrder<order_>()),
       ɑ_(ɑ),
       β_numerator_(β_numerator),
       β_denominator_(β_denominator) {

--- a/integrators/symmetric_linear_multistep_integrator_body.hpp
+++ b/integrators/symmetric_linear_multistep_integrator_body.hpp
@@ -10,6 +10,8 @@
 #include "geometry/serialization.hpp"
 #include "integrators/symplectic_runge_kutta_nyström_integrator.hpp"
 
+#define PRINCIPIA_USE_COHEN_HUBBARD_OESTERWINTER 1
+
 namespace principia {
 namespace integrators {
 namespace internal_symmetric_linear_multistep_integrator {
@@ -136,8 +138,13 @@ Status SymmetricLinearMultistepIntegrator<Position, order_>::Instance::Solve(
 
     // Note that we only delete the oldest step *after* computing the velocity.
     // This means that the velocity computation has access to |order_ + 1|
-    // points and can therefore be of order |order_|.
-    ComputeVelocity(dimension);
+    // points. For backward difference this yields order |order_ - 1|, for
+    // Cohen-Hubbard-Oesterwinter this yields order |order_ + 1|.
+#if PRINCIPIA_USE_COHEN_HUBBARD_OESTERWINTER
+    ComputeVelocityUsingCohenHubbardOesterwinter();
+#else
+    ComputeVelocityUsingBackwardDifferences();
+#endif
     previous_steps_.pop_front();
 
     // Inform the caller of the new state.
@@ -301,7 +308,7 @@ Instance::StartupSolve(Instant const& t_final) {
 
 template<typename Position, int order_>
 void SymmetricLinearMultistepIntegrator<Position, order_>::
-Instance::ComputeVelocity(int const dimension) {
+Instance::ComputeVelocityUsingBackwardDifferences() {
   using Displacement = typename ODE::Displacement;
   using Velocity = typename ODE::Velocity;
 
@@ -311,6 +318,7 @@ Instance::ComputeVelocity(int const dimension) {
   // because we have not computed the future yet.
   auto const& backward_difference = integrator_.backward_difference_;
 
+  int const dimension = previous_steps_.back().displacements.size();
   auto& current_state = this->current_state_;
   auto const& step = this->step_;
 
@@ -340,6 +348,46 @@ Instance::ComputeVelocity(int const dimension) {
     velocity = DoublePrecision<Velocity>(
         (weighted_displacement.value + weighted_displacement.error) /
         (step * backward_difference.denominator));
+  }
+}
+
+template<typename Position, int order_>
+void SymmetricLinearMultistepIntegrator<Position, order_>::
+Instance::ComputeVelocityUsingCohenHubbardOesterwinter() {
+  using Acceleration = typename ODE::Acceleration;
+  using Displacement = typename ODE::Displacement;
+  using Velocity = typename ODE::Velocity;
+
+  // For the computation of the velocity we use a formula similar to that of
+  // Cohen, Hubbard, Oesterwinter (1973), Astronomical papers prepared for the
+  // use of the American ephemeris and nautical almanac, Volume XXII, Part I.
+  // More specifically, we use the coefficients η from
+  // cohen_hubbard_oesterwinter.wl.
+  auto const& cohen_hubbard_oesterwinter =
+      integrator_.cohen_hubbard_oesterwinter_;
+
+  int const dimension = previous_steps_.back().displacements.size();
+  auto& current_state = this->current_state_;
+  auto const& step = this->step_;
+
+  for (int d = 0; d < dimension; ++d) {
+    DoublePrecision<Velocity>& velocity = current_state.velocities[d];
+    auto it = previous_steps_.rbegin();
+
+    // Compute the displacement difference using double precision.
+    DoublePrecision<Displacement> displacement_change = 
+      it->displacements[d] - std::next(it)->displacements[d];
+    velocity = DoublePrecision<Velocity>(
+        (displacement_change.value + displacement_change.error) / step);
+
+    Acceleration weighted_accelerations;
+    for (int i = 0; i < cohen_hubbard_oesterwinter.numerators.size; ++i, ++it) {
+      weighted_accelerations +=
+          cohen_hubbard_oesterwinter.numerators[i] * it->accelerations[d];
+    }
+
+    velocity.value +=
+        weighted_accelerations * step / cohen_hubbard_oesterwinter.denominator;
   }
 }
 
@@ -375,6 +423,7 @@ SymmetricLinearMultistepIntegrator(
       startup_integrator_(startup_integrator),
       backward_difference_(
           FirstDerivativeBackwardDifference<order_ - 1>()),
+      cohen_hubbard_oesterwinter_(CohenHubbardOesterwinterOrder<order_ + 1>()),
       ɑ_(ɑ),
       β_numerator_(β_numerator),
       β_denominator_(β_denominator) {
@@ -510,3 +559,5 @@ QuinlanTremaine1990Order14() {
 
 }  // namespace integrators
 }  // namespace principia
+
+#undef PRINCIPIA_USE_COHEN_HUBBARD_OESTERWINTER

--- a/integrators/symmetric_linear_multistep_integrator_test.cpp
+++ b/integrators/symmetric_linear_multistep_integrator_test.cpp
@@ -245,8 +245,8 @@ void TestConvergence(Integrator const& integrator,
 
 #if !defined(_DEBUG)
   EXPECT_THAT(RelativeError(integrator.order, q_convergence_order),
-              Lt(0.05));
-  EXPECT_THAT(q_correlation, IsNear(1.0, /*tolerance=*/1.01));
+              Lt(0.02));
+  EXPECT_THAT(q_correlation, IsNear(1.0, /*tolerance=*/1.0005));
 #endif
   double const v_convergence_order = Slope(log_step_sizes, log_p_errors);
   double const v_correlation =
@@ -254,8 +254,8 @@ void TestConvergence(Integrator const& integrator,
   LOG(INFO) << "Convergence order in p : " << v_convergence_order;
   LOG(INFO) << "Correlation            : " << v_correlation;
 #if !defined(_DEBUG)
-  EXPECT_THAT(RelativeError(integrator.order, v_convergence_order), Lt(0.035));
-  EXPECT_THAT(v_correlation, IsNear(1.0, /*tolerance=*/1.02));
+  EXPECT_THAT(RelativeError(integrator.order, v_convergence_order), Lt(0.02));
+  EXPECT_THAT(v_correlation, IsNear(1.0, /*tolerance=*/1.0002));
 #endif
 }
 
@@ -431,28 +431,28 @@ std::vector<SimpleHarmonicMotionTestInstance> Instances() {
   return {INSTANCE(Quinlan1999Order8A,
                    0.07 * Second,
                    1.00044972306534419e-13 * Metre,
-                   1.00572328243231368e-13 * Metre / Second,
-                   3.28261265669649305e-07 * Joule),
+                   1.00587940754515159e-13 * Metre / Second,
+                   4.11866032945518157e-08 * Joule),
           INSTANCE(Quinlan1999Order8B,
                    0.055 * Second,
                    9.97882332320898513e-14 * Metre,
-                   1.24972948656321137e-13 * Metre / Second,
-                   4.92124234141577688e-07 * Joule),
+                   1.00953967407946266e-13 * Metre / Second,
+                   2.36733395664323609e-08 * Joule),
           INSTANCE(QuinlanTremaine1990Order8,
                    0.3 * Second,
                    9.98298665955132947e-14 * Metre,
-                   1.01817859698982716e-13 * Metre / Second,
-                   3.58998453353631675e-07 * Joule),
+                   1.00752739484732956e-13 * Metre / Second,
+                   6.59523038959441976e-08 * Joule),
           INSTANCE(QuinlanTremaine1990Order10,
                    0.3 * Second,
                    9.96980276113390573e-14 * Metre,
-                   1.76542808150159658e-13 * Metre / Second,
-                   1.56463170197795876e-08 * Joule),
+                   1.02442360150334366e-13 * Metre / Second,
+                   1.10484732473992153e-09 * Joule),
           INSTANCE(QuinlanTremaine1990Order12,
                    0.21 * Second,
                    9.90457715843717779e-14 * Metre,
-                   4.89830398464619066e-13 * Metre / Second,
-                   8.68691674149602022e-10 * Joule)};
+                   1.05165876007617953e-13 * Metre / Second,
+                   4.37903047156851244e-11 * Joule)};
 }
 
 }  // namespace

--- a/integrators/symmetric_linear_multistep_integrator_test.cpp
+++ b/integrators/symmetric_linear_multistep_integrator_test.cpp
@@ -432,27 +432,27 @@ std::vector<SimpleHarmonicMotionTestInstance> Instances() {
                    0.07 * Second,
                    1.00044972306534419e-13 * Metre,
                    1.00587940754515159e-13 * Metre / Second,
-                   4.11866032945518157e-08 * Joule),
+                   3.93946996135596805e-08 * Joule),
           INSTANCE(Quinlan1999Order8B,
                    0.055 * Second,
                    9.97882332320898513e-14 * Metre,
                    1.00953967407946266e-13 * Metre / Second,
-                   2.36733395664323609e-08 * Joule),
+                   2.19802622769549316e-08 * Joule),
           INSTANCE(QuinlanTremaine1990Order8,
                    0.3 * Second,
                    9.98298665955132947e-14 * Metre,
                    1.00752739484732956e-13 * Metre / Second,
-                   6.59523038959441976e-08 * Joule),
+                   6.42628611435824837e-08 * Joule),
           INSTANCE(QuinlanTremaine1990Order10,
                    0.3 * Second,
                    9.96980276113390573e-14 * Metre,
                    1.02442360150334366e-13 * Metre / Second,
-                   1.10484732473992153e-09 * Joule),
+                   1.03418451580239434e-09 * Joule),
           INSTANCE(QuinlanTremaine1990Order12,
                    0.21 * Second,
                    9.90457715843717779e-14 * Metre,
                    1.05165876007617953e-13 * Metre / Second,
-                   4.37903047156851244e-11 * Joule)};
+                   4.14703826834283973e-11 * Joule)};
 }
 
 }  // namespace

--- a/mathematica/cohen_hubbard_oesterwinter.wl
+++ b/mathematica/cohen_hubbard_oesterwinter.wl
@@ -130,4 +130,4 @@ MapThread[{#1 #2,#2}&,{cho,commondenominators},1]
 ]
 
 
-g=GenerateCohenHubbardOesterwinter[\[Eta],14]
+g=GenerateCohenHubbardOesterwinter[\[Eta],16]

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -499,9 +499,9 @@ TEST_P(EphemerisTest, EarthProbe) {
   // The solution is a line, so the rounding errors dominate.  Different
   // libms result in different errors and thus different numbers of steps.
   EXPECT_THAT(probe_positions.size(),
-              AnyOf(Eq(395), Eq(414), Eq(438), Eq(450)));
+              AnyOf(Eq(395), Eq(414), Eq(434), Eq(438), Eq(450)));
   EXPECT_THAT(probe_positions.back().coordinates().x,
-              AlmostEquals(1.00 * period * v_probe, 244, 259));
+              AlmostEquals(1.00 * period * v_probe, 230, 259));
   EXPECT_THAT(probe_positions.back().coordinates().y,
               Eq(q_probe));
 


### PR DESCRIPTION
This brings significant improvements in accuracy and in speed:
Before:
```
---------------------------------------------------------------------------------
Benchmark                                          Time           CPU Iterations
---------------------------------------------------------------------------------
BM_EphemerisSolarSystemMajorBodiesOnly/-3 90719773589 ns 90371379300 ns          1 +9.92179030813603147e-01 ua
```
After:
```
---------------------------------------------------------------------------------
Benchmark                                          Time           CPU Iterations
---------------------------------------------------------------------------------
BM_EphemerisSolarSystemMajorBodiesOnly/-3 55156286341 ns 54912352000 ns          1 +9.92179030813603147e-01 ua
```