### PR TITLE
Better benchmarks for Newhall

### DIFF
--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -8,24 +8,40 @@
 // BM_NewhallApproximation/8         657        624    2000000
 // BM_NewhallApproximation/16        754        741    2000000
 
+#include <memory>
 #include <random>
 #include <vector>
 
+#include "astronomy/frames.hpp"
+#include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
 #include "geometry/named_quantities.hpp"
 #include "numerics/newhall.hpp"
+#include "numerics/polynomial.hpp"
+#include "numerics/polynomial_evaluators.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
 
 namespace principia {
 
+using astronomy::ICRFJ2000Ecliptic;
+using base::not_null;
+using geometry::Displacement;
 using geometry::Instant;
 using quantities::Variation;
+using quantities::si::Metre;
 using quantities::si::Second;
 
 namespace numerics {
 
-void BM_NewhallApproximation(benchmark::State& state) {
+template<typename Result,
+         Result (*newhall)(int degree,
+                           std::vector<double> const& q,
+                           std::vector<Variation<double>> const& v,
+                           Instant const& t_min,
+                           Instant const& t_max,
+                           double& error_estimate)>
+void BM_NewhallApproximationDouble(benchmark::State& state) {
   int const degree = state.range_x();
   std::mt19937_64 random(42);
   std::vector<double> p;
@@ -44,15 +60,77 @@ void BM_NewhallApproximation(benchmark::State& state) {
       v.push_back(static_cast<double>(static_cast<double>(random())) / Second);
     }
     state.ResumeTiming();
-    auto const series =
-        NewhallApproximationInЧебышёвBasis<double>(degree,
-                                                   p, v,
-                                                   t_min, t_max,
-                                                   error_estimate);
+    auto const series = newhall(degree, p, v, t_min, t_max, error_estimate);
   }
 }
 
-BENCHMARK(BM_NewhallApproximation)->Arg(4)->Arg(8)->Arg(16);
+template<typename Result,
+         Result (*newhall)(
+             int degree,
+             std::vector<Displacement<ICRFJ2000Ecliptic>> const& q,
+             std::vector<Variation<Displacement<ICRFJ2000Ecliptic>>> const& v,
+             Instant const& t_min,
+             Instant const& t_max,
+             Displacement<ICRFJ2000Ecliptic>& error_estimate)>
+void BM_NewhallApproximationDisplacement(benchmark::State& state) {
+  int const degree = state.range_x();
+  std::mt19937_64 random(42);
+  std::vector<Displacement<ICRFJ2000Ecliptic>> p;
+  std::vector<Variation<Displacement<ICRFJ2000Ecliptic>>> v;
+  Instant const t0;
+  Instant const t_min = t0 + static_cast<double>(random()) * Second;
+  Instant const t_max = t_min + static_cast<double>(random()) * Second;
+
+  Displacement<ICRFJ2000Ecliptic> error_estimate;
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    p.clear();
+    v.clear();
+    for (int i = 0; i <= 8; ++i) {
+      p.push_back(Displacement<ICRFJ2000Ecliptic>(
+          {static_cast<double>(random()) * Metre,
+           static_cast<double>(random()) * Metre,
+           static_cast<double>(random()) * Metre}));
+      v.push_back(Variation<Displacement<ICRFJ2000Ecliptic>>(
+          {static_cast<double>(random()) * Metre / Second,
+           static_cast<double>(random()) * Metre / Second,
+           static_cast<double>(random()) * Metre / Second}));
+    }
+    state.ResumeTiming();
+    auto const series = newhall(degree, p, v, t_min, t_max, error_estimate);
+  }
+}
+
+using ResultЧебышёвDouble =
+    ЧебышёвSeries<double>;
+using ResultЧебышёвDisplacement =
+    ЧебышёвSeries<Displacement<ICRFJ2000Ecliptic>>;
+using ResultMonomialDouble =
+    not_null<std::unique_ptr<Polynomial<double, Instant>>>;
+using ResultMonomialDisplacement = not_null<
+    std::unique_ptr<Polynomial<Displacement<ICRFJ2000Ecliptic>, Instant>>>;
+
+BENCHMARK_TEMPLATE2(
+    BM_NewhallApproximationDouble,
+    ResultЧебышёвDouble,
+    &NewhallApproximationInЧебышёвBasis<double>)
+    ->Arg(4)->Arg(8)->Arg(16);
+BENCHMARK_TEMPLATE2(
+    BM_NewhallApproximationDisplacement,
+    ResultЧебышёвDisplacement,
+    &NewhallApproximationInЧебышёвBasis<Displacement<ICRFJ2000Ecliptic>>)
+    ->Arg(4)->Arg(8)->Arg(16);
+BENCHMARK_TEMPLATE2(
+    BM_NewhallApproximationDouble,
+    ResultMonomialDouble,
+    (&NewhallApproximationInMonomialBasis<double, EstrinEvaluator>))
+    ->Arg(4)->Arg(8)->Arg(16);
+BENCHMARK_TEMPLATE2(
+    BM_NewhallApproximationDisplacement,
+    ResultMonomialDisplacement,
+    (&NewhallApproximationInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,
+                                          EstrinEvaluator>))
+    ->Arg(4)->Arg(8)->Arg(16);
 
 }  // namespace numerics
 }  // namespace principia


### PR DESCRIPTION
Results:
```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_NewhallApproximationDouble<Result???????Double,&NewhallApproximationIn???????Basis<double>>/4
                               933 ns        946 ns    1121788
BM_NewhallApproximationDouble<Result???????Double,&NewhallApproximationIn???????Basis<double>>/8
                               962 ns       1046 ns     641022
BM_NewhallApproximationDouble<Result???????Double,&NewhallApproximationIn???????Basis<double>>/16
                              1149 ns       1265 ns     641022
BM_NewhallApproximationDisplacement<Result???????Displacement,&NewhallApproximationIn???????Basis<Displacement<ICRFJ2000Ecliptic>>>/4
                              1353 ns       1398 ns     747858
BM_NewhallApproximationDisplacement<Result???????Displacement,&NewhallApproximationIn???????Basis<Displacement<ICRFJ2000Ecliptic>>>/8
                              1617 ns       1669 ns     448715
BM_NewhallApproximationDisplacement<Result???????Displacement,&NewhallApproximationIn???????Basis<Displacement<ICRFJ2000Ecliptic>>>/16
                              2129 ns       1808 ns     345165
BM_NewhallApproximationDouble<ResultMonomialDouble,(&NewhallApproximationInMonomialBasis<double, EstrinEvaluator>)>/4
                               783 ns        842 ns    1000000
BM_NewhallApproximationDouble<ResultMonomialDouble,(&NewhallApproximationInMonomialBasis<double, EstrinEvaluator>)>/8
                               879 ns        751 ns     747858
BM_NewhallApproximationDouble<ResultMonomialDouble,(&NewhallApproximationInMonomialBasis<double, EstrinEvaluator>)>/16
                               969 ns       1140 ns     560894
BM_NewhallApproximationDisplacement<ResultMonomialDisplacement,(&NewhallApproximationInMonomialBasis<Displacement<ICRFJ2000Ecliptic>, EstrinEvaluator>)>/4
                              1043 ns       1001 ns    1121788
BM_NewhallApproximationDisplacement<ResultMonomialDisplacement,(&NewhallApproximationInMonomialBasis<Displacement<ICRFJ2000Ecliptic>, EstrinEvaluator>)>/8
                              1251 ns       1033 ns     498572
BM_NewhallApproximationDisplacement<ResultMonomialDisplacement,(&NewhallApproximationInMonomialBasis<Displacement<ICRFJ2000Ecliptic>, EstrinEvaluator>)>/16
                              1651 ns       1721 ns     407923
```