### PR TITLE
Optimize some R3Element operators and FixedVector scalar products

### DIFF
--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -85,34 +85,56 @@ Scalar const& R3Element<Scalar>::operator[](
 template<typename Scalar>
 R3Element<Scalar>& R3Element<Scalar>::operator+=(
     R3Element<Scalar> const& right) {
+#if PRINCIPIA_USE_SSE3_INTRINSICS
+  xy = _mm_add_pd(xy, right.xy);
+  zt = _mm_add_sd(zt, right.zt);
+#else
   x += right.x;
   y += right.y;
   z += right.z;
+#endif
   return *this;
 }
 
 template<typename Scalar>
 R3Element<Scalar>& R3Element<Scalar>::operator-=(
     R3Element<Scalar> const& right) {
+#if PRINCIPIA_USE_SSE3_INTRINSICS
+  xy = _mm_sub_pd(xy, right.xy);
+  zt = _mm_sub_sd(zt, right.zt);
+#else
   x -= right.x;
   y -= right.y;
   z -= right.z;
+#endif
   return *this;
 }
 
 template<typename Scalar>
 R3Element<Scalar>& R3Element<Scalar>::operator*=(double const right) {
+#if PRINCIPIA_USE_SSE3_INTRINSICS
+  __m128d const right_128d = ToM128D(right);
+  xy = _mm_mul_pd(xy, right_128d);
+  zt = _mm_mul_sd(zt, right_128d);
+#else
   x *= right;
   y *= right;
   z *= right;
+#endif
   return *this;
 }
 
 template<typename Scalar>
 R3Element<Scalar>& R3Element<Scalar>::operator/=(double const right) {
+#if PRINCIPIA_USE_SSE3_INTRINSICS
+  __m128d const right_128d = ToM128D(right);
+  xy = _mm_div_pd(xy, right_128d);
+  zt = _mm_div_sd(zt, right_128d);
+#else
   x /= right;
   y /= right;
   z /= right;
+#endif
   return *this;
 }
 

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -21,6 +21,7 @@ class FixedVector final {
  public:
   constexpr FixedVector();  // Zero-initialized.
   constexpr explicit FixedVector(std::array<Scalar, size_> const& data);
+  constexpr explicit FixedVector(std::array<Scalar, size_>&& data);
   FixedVector(
       std::initializer_list<Scalar> const& data);  // NOLINT(runtime/explicit)
 


### PR DESCRIPTION
This results in a 5-15% speedup depending on the benchmark.
Before:
```
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                               Time           CPU Iterations
----------------------------------------------------------------------------------------------------------------------
BM_EphemerisMultithreadingBenchmark/3/1                                         114441042 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/2                                          85154387 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/3                                          54361796 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/4                                          50985410 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/5                                          50595831 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisSolarSystemMajorBodiesOnly/-3                                      51739177083 ns 51698731400 ns          1 +9.92179030813603147e-01 ua
BM_EphemerisSolarSystemMinorAndMajorBodies/-3                                  121662692316 ns 121290777500 ns          1 +9.92179031500272979e-01 ua
BM_EphemerisSolarSystemAllBodiesAndOblateness/-3                               164717831260 ns 162475041500 ns          1 +9.92178865022683709e-01 ua
BM_EphemerisL4ProbeMajorBodiesOnly<&FlowEphemerisWithAdaptiveStep>/-3          1242213984 ns 1248008000 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 78.839016
BM_EphemerisL4ProbeMinorAndMajorBodies<&FlowEphemerisWithAdaptiveStep>/-3      3191989626 ns 3198020500 ns          1 154375 steps, +9.91602312429101684e-01 ua, +1.07738938749610558e+00 ua, degree 177.897618
BM_EphemerisL4ProbeAllBodiesAndOblateness<&FlowEphemerisWithAdaptiveStep>/-3   3231924588 ns 3229220700 ns          1 154375 steps, +9.91602312327637625e-01 ua, +1.07738926882840014e+00 ua, degree 177.851767
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithAdaptiveStep>/-3         2577187161 ns 2558416400 ns          1 750001 steps, +9.91871700412957913e-01 ua, +9.99471786353781368e+01 nmi
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithFixedStepSLMS>/-3        5278535223 ns 5257233700 ns          1 3155761 steps, +9.91888191584786028e-01 ua, +9.99957028991727839e+01 nmi
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithFixedStepSRKN>/-3        19612611158 ns 19609325700 ns          1 3155761 steps, +9.91888190770475076e-01 ua, +9.99957014032675744e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithAdaptiveStep>/-3     4665861591 ns 4664429900 ns          1 750001 steps, +9.91871709024946702e-01 ua, +9.99471977522207453e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithFixedStepSLMS>/-3    8637034089 ns 8626855300 ns          1 3155761 steps, +9.91888192034501626e-01 ua, +9.99957081922148916e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithFixedStepSRKN>/-3    37351195026 ns 37315439200 ns          1 3155761 steps, +9.91888191491747340e-01 ua, +9.99957068526476718e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithAdaptiveStep>/-3  5442288397 ns 5428834800 ns          1 752025 steps, +9.91854976486674311e-01 ua, +8.93202207256108522e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithFixedStepSLMS>/-3 9737172589 ns 9734462400 ns          1 3155761 steps, +9.91841968998422918e-01 ua, +8.91413416084843533e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithFixedStepSRKN>/-3 43288398421 ns 43274677400 ns          1 3155761 steps, +9.91841969520586897e-01 ua, +8.91413306715298859e+01 nmi
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-4                1268696152 ns 1232407900 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 82.853624
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-3                1234140946 ns 1232407900 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 78.839016
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-2                1197096590 ns 1170007500 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581442912e+00 ua, degree 75.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-1                1178436004 ns 1185607600 ns          1 154375 steps, +9.91602312582899215e-01 ua, +1.07738936581441114e+00 ua, degree 70.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/0                 1155397448 ns 1138807300 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581437006e+00 ua, degree 63.205200
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/1                 1145395072 ns 1123207200 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581451372e+00 ua, degree 61.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/2                 1126887586 ns 1107607100 ns          1 154375 steps, +9.91602312582899992e-01 ua, +1.07738936581437228e+00 ua, degree 57.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/3                 1111345243 ns 1123207200 ns          1 154375 steps, +9.91602312582900658e-01 ua, +1.07738936581427458e+00 ua, degree 55.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/4                 1052209059 ns 1029606600 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581444644e+00 ua, degree 54.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSLMS>/3                            1430672 ns    1438085 ns        499 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSRKN>/3                              55406 ns      55625 ns      11218 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
```
After:
```
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                               Time           CPU Iterations
----------------------------------------------------------------------------------------------------------------------
BM_EphemerisMultithreadingBenchmark/3/1                                         109776224 ns     312002 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/2                                          80764783 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/3                                          51637804 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/4                                          49705214 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisMultithreadingBenchmark/3/5                                          53588372 ns          0 ns        100 +9.98765334517185204e+06 m +1.99941208075259104e+07 m +2.99993670271172673e+07 m
BM_EphemerisSolarSystemMajorBodiesOnly/-3                                      49710957643 ns 49280715900 ns          1 +9.92179030813603147e-01 ua
BM_EphemerisSolarSystemMinorAndMajorBodies/-3                                  114895617142 ns 114130331600 ns          1 +9.92179031500272979e-01 ua
BM_EphemerisSolarSystemAllBodiesAndOblateness/-3                               142007915919 ns 141118504600 ns          1 +9.92178865022683709e-01 ua
BM_EphemerisL4ProbeMajorBodiesOnly<&FlowEphemerisWithAdaptiveStep>/-3          1203574008 ns 1201207700 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 78.839016
BM_EphemerisL4ProbeMinorAndMajorBodies<&FlowEphemerisWithAdaptiveStep>/-3      3197511036 ns 3166820300 ns          1 154375 steps, +9.91602312429101684e-01 ua, +1.07738938749610558e+00 ua, degree 177.897618
BM_EphemerisL4ProbeAllBodiesAndOblateness<&FlowEphemerisWithAdaptiveStep>/-3   3195480559 ns 3198020500 ns          1 154375 steps, +9.91602312327637625e-01 ua, +1.07738926882840014e+00 ua, degree 177.851767
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithAdaptiveStep>/-3         2413529868 ns 2386815300 ns          1 750001 steps, +9.91871700412957913e-01 ua, +9.99471786353781368e+01 nmi
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithFixedStepSLMS>/-3        5194817138 ns 5194833300 ns          1 3155761 steps, +9.91888191584786028e-01 ua, +9.99957028991727839e+01 nmi
BM_EphemerisLEOProbeMajorBodiesOnly<&FlowEphemerisWithFixedStepSRKN>/-3        19151910535 ns 19125722600 ns          1 3155761 steps, +9.91888190770475076e-01 ua, +9.99957014032675744e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithAdaptiveStep>/-3     4565314212 ns 4570829300 ns          1 750001 steps, +9.91871709024946702e-01 ua, +9.99471977522207453e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithFixedStepSLMS>/-3    7920370701 ns 7909250700 ns          1 3155761 steps,  +9.91888192034501626e-01 ua, +9.99957081922148916e+01 nmi
BM_EphemerisLEOProbeMinorAndMajorBodies<&FlowEphemerisWithFixedStepSRKN>/-3    35463426071 ns 35412227000 ns          1 3155761 steps, +9.91888191491747340e-01 ua, +9.99957068526476718e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithAdaptiveStep>/-3  5058410593 ns 5054432400 ns          1 752025 steps, +9.91854976486674311e-01 ua, +8.93202207256108522e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithFixedStepSLMS>/-3 8833678190 ns 8829656600 ns          1 3155761 steps, +9.91841968998422918e-01 ua, +8.91413416084843533e+01 nmi
BM_EphemerisLEOProbeAllBodiesAndOblateness<&FlowEphemerisWithFixedStepSRKN>/-3 41817256850 ns 41730267500 ns          1 3155761 steps, +9.91841969520586897e-01 ua, +8.91413306715298859e+01 nmi
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-4                1214614972 ns 1216807800 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 82.853624
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-3                1202747281 ns 1201207700 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581440137e+00 ua, degree 78.839016
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-2                1172124054 ns 1170007500 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581442912e+00 ua, degree 75.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-1                1164527938 ns 1170007500 ns          1 154375 steps, +9.91602312582899215e-01 ua, +1.07738936581441114e+00 ua, degree 70.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/0                 1128957341 ns 1138807300 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581437006e+00 ua, degree 63.205200
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/1                 1112913332 ns 1107607100 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581451372e+00 ua, degree 61.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/2                 1073032804 ns 1060806800 ns          1 154375 steps, +9.91602312582899992e-01 ua, +1.07738936581437228e+00 ua, degree 57.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/3                 1067337573 ns 1076406900 ns          1 154375 steps, +9.91602312582900658e-01 ua, +1.07738936581427458e+00 ua, degree 55.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/4                 1037768709 ns 1045206700 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581444644e+00 ua, degree 54.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSLMS>/3                            1357416 ns    1334768 ns        561 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSRKN>/3                              53591 ns      61188 ns      11218 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
```
