### PR TITLE
A hack to restore the tests that were lost when adding UTF-8 support to gtest

### DIFF
--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -74,7 +74,7 @@ class ParallelTestRunner {
       granularity_option = null;
       instrument_option = null;
 
-      string[] test_binaries = Directory.GetFiles(arg, "integrators_tests.exe");
+      string[] test_binaries = Directory.GetFiles(arg, "*_tests.exe");
       foreach (string test_binary in test_binaries) {
         if (instrument) {
           instrument_tests.Add(

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -73,7 +74,7 @@ class ParallelTestRunner {
       granularity_option = null;
       instrument_option = null;
 
-      string[] test_binaries = Directory.GetFiles(arg, "*_tests.exe");
+      string[] test_binaries = Directory.GetFiles(arg, "integrators_tests.exe");
       foreach (string test_binary in test_binaries) {
         if (instrument) {
           instrument_tests.Add(
@@ -137,7 +138,8 @@ class ParallelTestRunner {
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.FileName = test_binary;
             process.StartInfo.Arguments =
-                "--gtest_filter=" + test_case + line.Split(' ')[2];
+               Encoding.Default.GetString(Encoding.UTF8.GetBytes(
+                    "--gtest_filter=" + test_case + line.Split(' ')[2]));
             process.StartInfo.Arguments +=
                 " --gtest_output=xml:TestResults\\gtest_results_" +
                 test_process_counter++ + ".xml";


### PR DESCRIPTION
The correct solution would be to:

* Change `gmock_main` to take a `wchar_t` and to use a `wmain`.  This requires to move `InitGoogleLogging` at a place where it can convert `argv[0]` to narrow.
* Change the Principia projects to use `wmainCRTStartup` as the linker entry points.
* Change the `parallel_test_runner.cs` to just pass unencoded strings when starting the test processes.
* Rewrite all the gtest code that has to do with death tests to use the `W` windows entry points, not the `A` entry points.

The latter is quite a bit of work.  Not today.