### PR TITLE
Change the default integrator

### DIFF
--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -35,6 +35,7 @@ using geometry::Sign;
 using geometry::Vector;
 using integrators::FixedStepSizeIntegrator;
 using integrators::BlanesMoan2002SRKN11B;
+using integrators::BlanesMoan2002SRKN14A;
 using integrators::McLachlanAtela1992Order5Optimal;
 using integrators::Quinlan1999Order8A;
 using integrators::QuinlanTremaine1990Order10;
@@ -472,10 +473,13 @@ INSTANTIATE_TEST_CASE_P(
     AllKSPSystemConvergenceTests,
     KSPSystemConvergenceTest,
     ::testing::Values(
+        // This is our preferred integrator.  For a step of 1680 s it gives a
+        // position error of about 29 m on Laythe and takes about 0.6 s of
+        // elapsed time.
         ConvergenceTestParameters{
-            BlanesMoan2002SRKN11B<Position<KSP>>(),
-            /*iterations=*/8,
-            /*first_step_in_seconds=*/64},
+            BlanesMoan2002SRKN14A<Position<KSP>>(),
+            /*iterations=*/7,
+            /*first_step_in_seconds=*/105},
         ConvergenceTestParameters{
             McLachlanAtela1992Order5Optimal<Position<KSP>>(),
             /*iterations=*/8,
@@ -493,9 +497,10 @@ INSTANTIATE_TEST_CASE_P(
             /*iterations=*/6,
             /*first_step_in_seconds=*/64},
 
-        // This is our favorite integrator.  For a step of 600 s it gives a
-        // position error of about 28 m on Bop and takes about 0.7 s of elapsed
-        // time.
+        // This is a nice integrator but unfortunately it becomes unstable when
+        // Pol and Bop get too close to one another.  For a step of 600 s it
+        // gives a position error of about 28 m on Bop and takes about 0.7 s of
+        // elapsed time.
         ConvergenceTestParameters{
             QuinlanTremaine1990Order12<Position<KSP>>(),
             /*iterations=*/5,

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -473,9 +473,9 @@ INSTANTIATE_TEST_CASE_P(
     AllKSPSystemConvergenceTests,
     KSPSystemConvergenceTest,
     ::testing::Values(
-        // This is our preferred integrator.  For a step of 2100 s it gives a
-        // position error of about 111 m on Laythe and takes about 0.44 s of
-        // elapsed time.
+        // This is our preferred integrator.  For a step of 2100 s and an 
+        // integration over a year, it gives a position error of about 111 m on
+        // Laythe and takes about 0.44 s of elapsed time.
         ConvergenceTestParameters{
             BlanesMoan2002SRKN14A<Position<KSP>>(),
             /*iterations=*/7,
@@ -498,9 +498,9 @@ INSTANTIATE_TEST_CASE_P(
             /*first_step_in_seconds=*/64},
 
         // This is a nice integrator but unfortunately it becomes unstable when
-        // Pol and Bop get too close to one another.  For a step of 600 s it
-        // gives a position error of about 28 m on Bop and takes about 0.7 s of
-        // elapsed time.
+        // Pol and Bop get too close to one another.  For a step of 600 s and an
+        // integration over a year, it gives a position error of about 28 m on
+        // Bop and takes about 0.7 s of elapsed time.
         ConvergenceTestParameters{
             QuinlanTremaine1990Order12<Position<KSP>>(),
             /*iterations=*/5,

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -473,7 +473,7 @@ INSTANTIATE_TEST_CASE_P(
     AllKSPSystemConvergenceTests,
     KSPSystemConvergenceTest,
     ::testing::Values(
-        // This is our preferred integrator.  For a step of 2100 s and an 
+        // This is our preferred integrator.  For a step of 2100 s and an
         // integration over a year, it gives a position error of about 111 m on
         // Laythe and takes about 0.44 s of elapsed time.
         ConvergenceTestParameters{

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -389,7 +389,7 @@ class KSPSystemConvergenceTest
     return GetParam().iterations;
   }
 
-  int first_step_in_seconds() const {
+  double first_step_in_seconds() const {
     return GetParam().first_step_in_seconds;
   }
 
@@ -473,13 +473,13 @@ INSTANTIATE_TEST_CASE_P(
     AllKSPSystemConvergenceTests,
     KSPSystemConvergenceTest,
     ::testing::Values(
-        // This is our preferred integrator.  For a step of 1680 s it gives a
-        // position error of about 29 m on Laythe and takes about 0.6 s of
+        // This is our preferred integrator.  For a step of 2100 s it gives a
+        // position error of about 111 m on Laythe and takes about 0.44 s of
         // elapsed time.
         ConvergenceTestParameters{
             BlanesMoan2002SRKN14A<Position<KSP>>(),
             /*iterations=*/7,
-            /*first_step_in_seconds=*/105},
+            /*first_step_in_seconds=*/65.625},
         ConvergenceTestParameters{
             McLachlanAtela1992Order5Optimal<Position<KSP>>(),
             /*iterations=*/8,

--- a/ksp_plugin/integrators.cpp
+++ b/ksp_plugin/integrators.cpp
@@ -12,16 +12,16 @@ namespace ksp_plugin {
 namespace internal_integrators {
 
 using geometry::Position;
+using integrators::BlanesMoan2002SRKN14A;
 using integrators::DormandElMikkawyPrince1986RKN434FM;
 using integrators::Quinlan1999Order8A;
-using integrators::QuinlanTremaine1990Order12;
 using quantities::si::Minute;
 using quantities::si::Second;
 
 Ephemeris<Barycentric>::FixedStepParameters DefaultEphemerisParameters() {
   return Ephemeris<Barycentric>::FixedStepParameters(
-             QuinlanTremaine1990Order12<Position<Barycentric>>(),
-             /*step=*/10 * Minute);
+             BlanesMoan2002SRKN14A<Position<Barycentric>>(),
+             /*step=*/35 * Minute);
 }
 
 Ephemeris<Barycentric>::FixedStepParameters DefaultHistoryParameters() {

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -744,7 +744,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
       AbsoluteError(rendered_prediction->last().degrees_of_freedom().position(),
                     Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre}) +
                         World::origin),
-      IsNear(32 * Milli(Metre), 1.05));
+      IsNear(29 * Milli(Metre), 1.05));
 }
 
 }  // namespace internal_plugin

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -469,7 +469,7 @@ TEST_F(PluginTest, Initialization) {
                 Componentwise(
                     AlmostEquals(to_icrf(plugin_->CelestialFromParent(index)
                                              .displacement()),
-                                 0, 32764),
+                                 0, 458752),
                     AlmostEquals(
                         to_icrf(plugin_->CelestialFromParent(index).velocity()),
                         441, 9400740)))
@@ -596,11 +596,11 @@ TEST_F(PluginTest, HierarchicalInitialization) {
   plugin_->EndInitialization();
   EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_)).Times(AnyNumber());
   EXPECT_THAT(plugin_->CelestialFromParent(1).displacement().Norm(),
-              AlmostEquals(3 * Kilo(Metre), 1, 2));
+              AlmostEquals(3 * Kilo(Metre), 1, 7));
   EXPECT_THAT(plugin_->CelestialFromParent(2).displacement().Norm(),
-              AlmostEquals(1 * Kilo(Metre), 3));
+              AlmostEquals(1 * Kilo(Metre), 17));
   EXPECT_THAT(plugin_->CelestialFromParent(3).displacement().Norm(),
-              AlmostEquals(1 * Kilo(Metre), 1, 6));
+              AlmostEquals(1 * Kilo(Metre), 1, 17));
 }
 
 TEST_F(PluginDeathTest, InsertCelestialError) {
@@ -999,12 +999,12 @@ TEST_F(PluginTest, UpdateCelestialHierarchy) {
     EXPECT_THAT(
         (initial_from_parent.displacement() -
          computed_from_parent.displacement()).Norm(),
-        VanishesBefore(initial_from_parent.displacement().Norm(), 0, 6))
+        VanishesBefore(initial_from_parent.displacement().Norm(), 0, 30))
         << SolarSystemFactory::name(index);
     EXPECT_THAT(
         (initial_from_parent.velocity() -
          computed_from_parent.velocity()).Norm(),
-        VanishesBefore(initial_from_parent.velocity().Norm(), 1117, 1915381))
+        VanishesBefore(initial_from_parent.velocity().Norm(), 277, 3170840))
         << SolarSystemFactory::name(index);
   }
 }

--- a/mathematica/main.cpp
+++ b/mathematica/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char const* argv[]) {
         out,
         ParseFixedStepSizeIntegrator<
             Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation>(
-            flags["integrator"].value_or("BLANES_MOAN_2002_SRKN_14A")),
+            flags["fine_integrator"].value_or("BLANES_MOAN_2002_SRKN_14A")),
         ParseQuantity<Time>(flags["fine_step"].value_or("1 min")),
         ParseQuantity<Time>(flags["granularity"].value_or("1 d")),
         ParseQuantity<Time>(flags["duration"].value_or("500 d")));

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -132,7 +132,7 @@ constexpr std::array<char const*, 17> names = {
 
 constexpr Instant ksp_epoch;
 constexpr Instant a_century_hence = ksp_epoch + 100 * JulianYear;
-constexpr Time step = 5 * Minute;
+constexpr Time step = 35 * Minute;
 
 constexpr Length jool_system_radius_bound = 3e8 * Metre;
 
@@ -235,7 +235,7 @@ MakePerturbedEphemerides(int const count,
     for (Celestial const celestial : jool_system) {
       system.degrees_of_freedom[celestial] = {
           system.degrees_of_freedom[celestial].position() +
-              RandomUnitVector(generator) * Milli(Metre),
+              5 * RandomUnitVector(generator) * Milli(Metre),
           system.degrees_of_freedom[celestial].velocity()};
     }
     result.emplace_back(MakeEphemeris(std::move(system), integrator, step));
@@ -418,7 +418,7 @@ void ComputeHighestMoonError(Ephemeris<Barycentric> const& left,
 void PlotPredictableYears() {
   auto const ephemeris = MakeEphemeris(
       MakeStabilizedKSPSystem(),
-      integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+      integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
       step);
 
   for (int i = 1; i <= 5; ++i) {
@@ -451,23 +451,23 @@ void PlotPredictableYears() {
 void PlotCentury() {
   ProduceCenturyPlots(*MakeEphemeris(
       MakeStabilizedKSPSystem(),
-      integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+      integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
       step));
 }
 
 void AnalyseGlobalError() {
   auto const reference_ephemeris = MakeEphemeris(
       MakeStabilizedKSPSystem(),
-      integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+      integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
       step);
   std::unique_ptr<Ephemeris<Barycentric>> refined_ephemeris = MakeEphemeris(
       MakeStabilizedKSPSystem(),
-      integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+      integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
       step / 2);
   std::list<not_null<std::unique_ptr<Ephemeris<Barycentric>>>>
       perturbed_ephemerides = MakePerturbedEphemerides(
           100,
-          integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+          integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
           step);
 
   bool log_radius = true;
@@ -555,7 +555,7 @@ void StatisticallyAnalyseStability() {
   std::list<not_null<std::unique_ptr<Ephemeris<Barycentric>>>>
       perturbed_ephemerides = MakePerturbedEphemerides(
           100,
-          integrators::QuinlanTremaine1990Order12<Position<Barycentric>>(),
+          integrators::BlanesMoan2002SRKN14A<Position<Barycentric>>(),
           step);
 
   std::map<not_null<Ephemeris<Barycentric>*>, bool> numerically_unsound;
@@ -596,7 +596,7 @@ void StatisticallyAnalyseStability() {
             ephemeris->t_min(),
             1 * Milli(Metre),
             Ephemeris<Barycentric>::FixedStepParameters(
-                integrators::QuinlanTremaine1990Order12<
+                integrators::BlanesMoan2002SRKN14A<
                     Position<Barycentric>>(),
                 step / 2));
         ephemeris->Prolong(t);

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -50,6 +50,8 @@ class ApsidesTest : public ::testing::Test {
       Frame<serialization::Frame::TestTag, serialization::Frame::TEST1, true>;
 };
 
+#if !defined(_DEBUG)
+
 TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
   Instant const t0;
   GravitationalParameter const μ = GravitationalConstant * SolarMass;
@@ -260,6 +262,8 @@ TEST_F(ApsidesTest, ComputeNodes) {
     EXPECT_THAT(south_descending_it.time(), Eq(ascending_it.time()));
   }
 }
+
+#endif
 
 }  // namespace internal_apsides
 }  // namespace physics


### PR DESCRIPTION
This PR does a number of changes to address the instabilities in the orbits of Pol and Bop:

* It adds a benchmark for integrating the KSP system as we were only looking at the performance for the real solar system.
* It changes the default integrator from a Quinlan-Tremaine to a Blanes-Moan.  The integration step is chosen to yield similar performance.  The accuracy is degraded a bit (from 20 to 100 m) but the stability is greatly improved and the spurious oscillations caused by Quinlan-Tremaine are gone.
* It fixes a buglet in the local error analysis.
* It changes the retrobop stability analysis to use the Blanes-Moan integrator.

Fix #1741.