### PR TITLE
Initialize an out parameter that was causing serialization to die

### DIFF
--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -369,7 +369,8 @@ TEST_F(InterfaceTest, InsertOrKeepVessel) {
                                  vessel_name,
                                  parent_index,
                                  /*loaded=*/false,
-                                 Ref(inserted)));
+                                 Ref(inserted)))
+      .WillOnce(SetArgReferee<4>(true));
   EXPECT_CALL(*plugin_, HasVessel(vessel_guid))
       .WillOnce(Return(false))
       .WillOnce(Return(true));


### PR DESCRIPTION
See the attempts at running tests for #1761.