### PR TITLE
Use the the frenet frame of the orbit of the patch, not that of the orbit of the vessel

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -299,11 +299,17 @@ class FlightPlanner : WindowRenderer {
                 }
               }
             }
+            TODO_REMOVE_activate_the_bug_ =
+                UnityEngine.GUILayout.Toggle(TODO_REMOVE_activate_the_bug_,
+                                             "Activate issue #1728");
+            var stock_orbit =
+                TODO_REMOVE_activate_the_bug_ ? vessel_.orbit
+                                              : guidance_node_.patch;
             Vector3d stock_velocity_at_node_time =
-                vessel_.orbit.getOrbitalVelocityAtUT(
+                stock_orbit.getOrbitalVelocityAtUT(
                                   manoeuvre.burn.initial_time).xzy;
             Vector3d stock_displacement_from_parent_at_node_time =
-                vessel_.orbit.getRelativePositionAtUT(
+                stock_orbit.getRelativePositionAtUT(
                                   manoeuvre.burn.initial_time).xzy;
             UnityEngine.Quaternion stock_frenet_frame_to_world =
                 UnityEngine.Quaternion.LookRotation(
@@ -376,6 +382,8 @@ class FlightPlanner : WindowRenderer {
   
   private const double Log10TimeLowerRate = 0.0;
   private const double Log10TimeUpperRate = 7.0;
+
+  private bool TODO_REMOVE_activate_the_bug_ = false;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -299,12 +299,7 @@ class FlightPlanner : WindowRenderer {
                 }
               }
             }
-            TODO_REMOVE_activate_the_bug_ =
-                UnityEngine.GUILayout.Toggle(TODO_REMOVE_activate_the_bug_,
-                                             "Activate issue #1728");
-            var stock_orbit =
-                TODO_REMOVE_activate_the_bug_ ? vessel_.orbit
-                                              : guidance_node_.patch;
+            var stock_orbit = guidance_node_.patch;
             Vector3d stock_velocity_at_node_time =
                 stock_orbit.getOrbitalVelocityAtUT(
                                   manoeuvre.burn.initial_time).xzy;
@@ -382,8 +377,6 @@ class FlightPlanner : WindowRenderer {
   
   private const double Log10TimeLowerRate = 0.0;
   private const double Log10TimeUpperRate = 7.0;
-
-  private bool TODO_REMOVE_activate_the_bug_ = false;
 }
 
 }  // namespace ksp_plugin_adapter


### PR DESCRIPTION
These frames differ significantly when hyperbolic orbits and changes of sphere of influence are involved, as the game will move the node to an orbit around another body as the time moves past the time of the node.
This fixes #1728.

