### PR TITLE
Use IsNear where appropriate in SymplecticRungeKuttaNyströmIntegratorTest

### DIFF
--- a/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
@@ -47,7 +47,6 @@ using testing_utilities::ComputeHarmonicOscillatorAcceleration1D;
 using testing_utilities::EqualsProto;
 using testing_utilities::IsNear;
 using testing_utilities::PearsonProductMomentCorrelationCoefficient;
-using testing_utilities::RelativeError;
 using testing_utilities::Slope;
 using testing_utilities::VanishesBefore;
 using ::std::placeholders::_1;
@@ -527,8 +526,7 @@ TEST_P(SymplecticRungeKuttaNyströmIntegratorTest, Convergence) {
   LOG(INFO) << "Correlation            : " << q_correlation;
 
 #if !defined(_DEBUG)
-  EXPECT_THAT(RelativeError(GetParam().order, q_convergence_order),
-              Lt(0.02));
+  EXPECT_THAT(q_convergence_order, IsNear(static_cast<double>(GetParam().order), 1.04));
   EXPECT_THAT(q_correlation, IsNear(1.0, /*tolerance=*/1.02));
 #endif
   double const v_convergence_order = Slope(log_step_sizes, log_p_errors);
@@ -538,9 +536,8 @@ TEST_P(SymplecticRungeKuttaNyströmIntegratorTest, Convergence) {
   LOG(INFO) << "Correlation            : " << v_correlation;
 #if !defined(_DEBUG)
   // SPRKs with odd convergence order have a higher convergence order in p.
-  EXPECT_THAT(RelativeError(GetParam().order + (GetParam().order % 2),
-                            v_convergence_order),
-              Lt(0.02));
+  EXPECT_THAT(v_convergence_order,
+              IsNear(GetParam().order + (GetParam().order % 2), 1.05));
   EXPECT_THAT(v_correlation, IsNear(1.0, /*tolerance=*/1.02));
 #endif
 }

--- a/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
@@ -526,7 +526,8 @@ TEST_P(SymplecticRungeKuttaNyströmIntegratorTest, Convergence) {
   LOG(INFO) << "Correlation            : " << q_correlation;
 
 #if !defined(_DEBUG)
-  EXPECT_THAT(q_convergence_order, IsNear(static_cast<double>(GetParam().order), 1.04));
+  EXPECT_THAT(q_convergence_order,
+              IsNear(static_cast<double>(GetParam().order), 1.04));
   EXPECT_THAT(q_correlation, IsNear(1.0, /*tolerance=*/1.02));
 #endif
   double const v_convergence_order = Slope(log_step_sizes, log_p_errors);

--- a/testing_utilities/is_near.hpp
+++ b/testing_utilities/is_near.hpp
@@ -15,7 +15,8 @@ template<typename T>
 class IsNearMatcher;
 
 template<typename T>
-using ExpectedType = std::conditional_t<std::is_arithmetic<T>::value, double, T>;
+using ExpectedType =
+    std::conditional_t<std::is_arithmetic<T>::value, double, T>;
 
 // Calls the next function with |tolerance| set to 1.1.
 template<typename T>

--- a/testing_utilities/is_near.hpp
+++ b/testing_utilities/is_near.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include "gmock/gmock.h"
 #include "quantities/quantities.hpp"
@@ -13,15 +14,18 @@ namespace internal_is_near {
 template<typename T>
 class IsNearMatcher;
 
+template<typename T>
+using ExpectedType = std::conditional_t<std::is_arithmetic<T>::value, double, T>;
+
 // Calls the next function with |tolerance| set to 1.1.
 template<typename T>
-testing::PolymorphicMatcher<IsNearMatcher<T>> IsNear(
+testing::PolymorphicMatcher<IsNearMatcher<ExpectedType<T>>> IsNear(
     T const& expected);
 
 // Checks that |expected| is in the range
 // [expected / √tolerance, expected √tolerance].
 template<typename T>
-testing::PolymorphicMatcher<IsNearMatcher<T>> IsNear(
+testing::PolymorphicMatcher<IsNearMatcher<ExpectedType<T>>> IsNear(
     T const& expected,
     double tolerance);
 

--- a/testing_utilities/is_near_body.hpp
+++ b/testing_utilities/is_near_body.hpp
@@ -3,11 +3,9 @@
 
 #include "testing_utilities/is_near.hpp"
 
-#include <float.h>
-#include <math.h>
-#include <stdint.h>
-
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <limits>
 #include <string>
 
@@ -25,19 +23,19 @@ using quantities::DebugString;
 using quantities::Pow;
 
 template<typename T>
-testing::PolymorphicMatcher<IsNearMatcher<T>> IsNear(
+testing::PolymorphicMatcher<IsNearMatcher<ExpectedType<T>>> IsNear(
     T const& expected) {
   return testing::MakePolymorphicMatcher(
-      IsNearMatcher<T>(expected, /*tolerance=*/1.1));
+      IsNearMatcher<ExpectedType<T>>(expected, /*tolerance=*/1.1));
 }
 
 template<typename T>
-testing::PolymorphicMatcher<IsNearMatcher<T>> IsNear(
+testing::PolymorphicMatcher<IsNearMatcher<ExpectedType<T>>> IsNear(
     T const& expected,
     double const tolerance) {
   CHECK_LE(1.0, tolerance);
   return testing::MakePolymorphicMatcher(
-      IsNearMatcher<T>(expected, tolerance));
+      IsNearMatcher<ExpectedType<T>>(expected, tolerance));
 }
 
 template<typename T>
@@ -57,7 +55,7 @@ bool IsNearMatcher<T>::MatchAndExplain(
   bool const match =  low_ <= actual && actual <= high_;
   if (!match) {
     *listener << "which is not in the range [" << low_ << ", " << high_
-              << "] and is a factor of "
+              << u8"] and is a factor of √"
               << Pow<2>(std::max(actual / expected_, expected_ / actual))
               << " from the expected value";
   }
@@ -70,9 +68,10 @@ bool IsNearMatcher<T>::MatchAndExplain(
     testing::MatchResultListener* listener) const {
   bool const match =  low_ <= actual && actual <= high_;
   if (!match) {
-    *listener << "which is not in the range [" << DebugString(low_)
-              << ", " << DebugString(high_) << "] and is off by "
-              << std::max(actual / expected_, expected_ / actual);
+    *listener << "which is not in the range [" << DebugString(low_) << ", "
+              << DebugString(high_) << u8"] and is a factor of √"
+              << Pow<2>(std::max(actual / expected_, expected_ / actual))
+              << " from the expected value";
   }
   return match;
 }
@@ -80,14 +79,14 @@ bool IsNearMatcher<T>::MatchAndExplain(
 template<typename T>
 void IsNearMatcher<T>::DescribeTo(std::ostream* out) const {
   *out << "is within ["<< low_
-       << ", " << high_ << "], i.e., a factor " << tolerance_
+       << ", " << high_ << u8"], i.e., a factor √" << tolerance_
        << " away from " << expected_;
 }
 
 template<typename T>
 void IsNearMatcher<T>::DescribeNegationTo(std::ostream* out) const {
   *out << "is not within ["<< low_
-       << ", " << high_ << "], i.e., a factor " << tolerance_
+       << ", " << high_ << u8"], i.e., a factor √" << tolerance_
        << " away from " << expected_;
 }
 

--- a/testing_utilities/is_near_test.cpp
+++ b/testing_utilities/is_near_test.cpp
@@ -30,7 +30,7 @@ TEST_F(IsNearTest, Quantity) {
 }
 
 TEST_F(IsNearTest, Negatives) {
-  EXPECT_THAT(π - std::exp(π), IsNear(-20, 1.00001));
+  EXPECT_THAT(π - std::exp(π), IsNear(-20, 1.0001));
 }
 
 }  // namespace testing_utilities


### PR DESCRIPTION
Improve `IsNear` so that it is usable for integer arguments, and accurately reports the error.