### PR TITLE
Improvements to named_quantities

### DIFF
--- a/geometry/grassmann_test.cpp
+++ b/geometry/grassmann_test.cpp
@@ -23,6 +23,7 @@
 namespace principia {
 
 using quantities::Charge;
+using quantities::Inverse;
 using quantities::Length;
 using quantities::Pressure;
 using quantities::Product;
@@ -122,7 +123,7 @@ TEST_F(GrassmannTest, MixedScalarMultiplication) {
       SpeedOfLight / Parsec,
       -π,
        0, 1);
-  Time::Inverse t = -3 / Second;
+  Inverse<Time> t = -3 / Second;
   EXPECT_EQ((t * Vector<Length, World>(u_)), (Vector<Length, World>(u_) * t));
   EXPECT_EQ((Vector<Length, World>(v_) * t) / t, (Vector<Length, World>(v_)));
 }

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -16,20 +16,19 @@ namespace internal_polynomial {
 using base::not_null;
 using geometry::Point;
 using quantities::Derivative;
-using quantities::NthDerivative;
 
 template<typename Value, typename Argument, typename>
-struct NthDerivativesGenerator;
+struct DerivativesGenerator;
 template<typename Value, typename Argument, int... orders>
-struct NthDerivativesGenerator<Value,
-                               Argument,
-                               std::integer_sequence<int, orders...>> {
-  using Type = std::tuple<NthDerivative<Value, Argument, orders>...>;
+struct DerivativesGenerator<Value,
+                            Argument,
+                            std::integer_sequence<int, orders...>> {
+  using Type = std::tuple<Derivative<Value, Argument, orders>...>;
 };
 
 template<typename Value, typename Argument, typename Sequence>
-using NthDerivatives =
-    typename NthDerivativesGenerator<Value, Argument, Sequence>::Type;
+using Derivatives =
+    typename DerivativesGenerator<Value, Argument, Sequence>::Type;
 
 // |Value| must belong to an affine space.  |Argument| must belong to a ring or
 // to Point based on a ring.
@@ -69,9 +68,9 @@ class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
   //              Derivative<Value, Argument>,
   //              Derivative<Derivative<Value, Argument>>...>
   using Coefficients =
-      NthDerivatives<Value,
-                     Argument,
-                     std::make_integer_sequence<int, degree_ + 1>>;
+      Derivatives<Value,
+                  Argument,
+                  std::make_integer_sequence<int, degree_ + 1>>;
 
   // The coefficients are applied to powers of argument.
   explicit PolynomialInMonomialBasis(Coefficients const& coefficients);
@@ -102,9 +101,9 @@ class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
   //              Derivative<Value, Argument>,
   //              Derivative<Derivative<Value, Argument>>...>
   using Coefficients =
-      NthDerivatives<Value,
-                     Argument,
-                     std::make_integer_sequence<int, degree_ + 1>>;
+      Derivatives<Value,
+                  Argument,
+                  std::make_integer_sequence<int, degree_ + 1>>;
 
   // The coefficients are relative to origin; in other words they are applied to
   // powers of (argument - origin).
@@ -130,7 +129,6 @@ class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
 
 }  // namespace internal_polynomial
 
-using internal_polynomial::NthDerivative;
 using internal_polynomial::Polynomial;
 using internal_polynomial::PolynomialInMonomialBasis;
 

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -16,38 +16,7 @@ namespace internal_polynomial {
 using base::not_null;
 using geometry::Point;
 using quantities::Derivative;
-
-// TODO(phl): We would like to define NthDerivative in named_quantities.hpp
-// thus:
-//
-//   template<typename Value, typename Argument, int order>
-//   using NthDerivative = typename std::conditional_t<
-//       order == 0,
-//       Value,
-//       Quotient<Difference<Value>,
-//                Exponentiation<Difference<Argument>, order>>>;
-//
-//   template<typename Value, typename Argument>
-//   using Derivative = NthDerivative<Value, Argument, 1>;
-//
-// Unfortunately VS2015 is buggy and this interacts poorly with the
-// std::integer_sequence below (we get the wrong types).  Revisit once MSFT has
-// fixed their bugs.
-
-template<typename Value, typename Argument, int order>
-struct NthDerivativeGenerator {
-  using Type = Derivative<
-      typename NthDerivativeGenerator<Value, Argument, order - 1>::Type,
-      Argument>;
-};
-template<typename Value, typename Argument>
-struct NthDerivativeGenerator<Value, Argument, 0> {
-  using Type = Value;
-};
-
-template<typename Value, typename Argument, int order>
-using NthDerivative =
-    typename NthDerivativeGenerator<Value, Argument, order>::Type;
+using quantities::NthDerivative;
 
 template<typename Value, typename Argument, typename>
 struct NthDerivativesGenerator;

--- a/numerics/polynomial_evaluators_body.hpp
+++ b/numerics/polynomial_evaluators_body.hpp
@@ -79,11 +79,11 @@ struct InternalEstrinEvaluator {
       typename PolynomialInMonomialBasis<Value, Argument, degree,
                                          EstrinEvaluator>::Coefficients;
 
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> Evaluate(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> Evaluate(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> EvaluateDerivative(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> EvaluateDerivative(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
@@ -99,11 +99,11 @@ struct InternalEstrinEvaluator<Value, Argument, degree, low, 1> {
       typename PolynomialInMonomialBasis<Value, Argument, degree,
                                          EstrinEvaluator>::Coefficients;
 
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> Evaluate(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> Evaluate(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> EvaluateDerivative(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> EvaluateDerivative(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
@@ -119,18 +119,18 @@ struct InternalEstrinEvaluator<Value, Argument, degree, low, 0> {
       typename PolynomialInMonomialBasis<Value, Argument, degree,
                                          EstrinEvaluator>::Coefficients;
 
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> Evaluate(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> Evaluate(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low> EvaluateDerivative(
+  FORCE_INLINE(static) Derivative<Value, Argument, low> EvaluateDerivative(
       Coefficients const& coefficients,
       Argument const& argument,
       ArgumentSquares const& argument_squares);
 };
 
 template<typename Value, typename Argument, int degree, int low, int subdegree>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, subdegree>::Evaluate(
     Coefficients const& coefficients,
     Argument const& argument,
@@ -151,7 +151,7 @@ InternalEstrinEvaluator<Value, Argument, degree, low, subdegree>::Evaluate(
 }
 
 template<typename Value, typename Argument, int degree, int low, int subdegree>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, subdegree>::
 EvaluateDerivative(Coefficients const& coefficients,
                    Argument const& argument,
@@ -173,7 +173,7 @@ EvaluateDerivative(Coefficients const& coefficients,
 }
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, 1>::Evaluate(
     Coefficients const& coefficients,
     Argument const& argument,
@@ -183,7 +183,7 @@ InternalEstrinEvaluator<Value, Argument, degree, low, 1>::Evaluate(
 }
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, 0>::Evaluate(
     Coefficients const& coefficients,
     Argument const& argument,
@@ -192,7 +192,7 @@ InternalEstrinEvaluator<Value, Argument, degree, low, 0>::Evaluate(
 }
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, 1>::EvaluateDerivative(
     Coefficients const& coefficients,
     Argument const& argument,
@@ -202,7 +202,7 @@ InternalEstrinEvaluator<Value, Argument, degree, low, 1>::EvaluateDerivative(
 }
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalEstrinEvaluator<Value, Argument, degree, low, 0>::EvaluateDerivative(
     Coefficients const& coefficients,
     Argument const& argument,
@@ -250,10 +250,10 @@ struct InternalHornerEvaluator {
       typename PolynomialInMonomialBasis<Value, Argument, degree,
                                          HornerEvaluator>::Coefficients;
 
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low>
+  FORCE_INLINE(static) Derivative<Value, Argument, low>
   Evaluate(Coefficients const& coefficients,
            Argument const& argument);
-  FORCE_INLINE(static) NthDerivative<Value, Argument, low>
+  FORCE_INLINE(static) Derivative<Value, Argument, low>
   EvaluateDerivative(Coefficients const& coefficients,
                      Argument const& argument);
 };
@@ -264,16 +264,16 @@ struct InternalHornerEvaluator<Value, Argument, degree, degree> {
       typename PolynomialInMonomialBasis<Value, Argument, degree,
                                          HornerEvaluator>::Coefficients;
 
-  FORCE_INLINE(static) NthDerivative<Value, Argument, degree>
+  FORCE_INLINE(static) Derivative<Value, Argument, degree>
   Evaluate(Coefficients const& coefficients,
            Argument const& argument);
-  FORCE_INLINE(static) NthDerivative<Value, Argument, degree>
+  FORCE_INLINE(static) Derivative<Value, Argument, degree>
   EvaluateDerivative(Coefficients const& coefficients,
                      Argument const& argument);
 };
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalHornerEvaluator<Value, Argument, degree, low>::Evaluate(
     Coefficients const& coefficients,
     Argument const& argument) {
@@ -284,7 +284,7 @@ InternalHornerEvaluator<Value, Argument, degree, low>::Evaluate(
 }
 
 template<typename Value, typename Argument, int degree, int low>
-NthDerivative<Value, Argument, low>
+Derivative<Value, Argument, low>
 InternalHornerEvaluator<Value, Argument, degree, low>::EvaluateDerivative(
     Coefficients const& coefficients,
     Argument const& argument) {
@@ -295,7 +295,7 @@ InternalHornerEvaluator<Value, Argument, degree, low>::EvaluateDerivative(
 }
 
 template<typename Value, typename Argument, int degree>
-NthDerivative<Value, Argument, degree>
+Derivative<Value, Argument, degree>
 InternalHornerEvaluator<Value, Argument, degree, degree>::Evaluate(
     Coefficients const& coefficients,
     Argument const& argument) {
@@ -303,7 +303,7 @@ InternalHornerEvaluator<Value, Argument, degree, degree>::Evaluate(
 }
 
 template<typename Value, typename Argument, int degree>
-NthDerivative<Value, Argument, degree>
+Derivative<Value, Argument, degree>
 InternalHornerEvaluator<Value, Argument, degree, degree>::EvaluateDerivative(
     Coefficients const& coefficients,
     Argument const& argument) {

--- a/numerics/чебышёв_series.hpp
+++ b/numerics/чебышёв_series.hpp
@@ -19,6 +19,7 @@ namespace internal_чебышёв_series {
 
 using base::not_null;
 using geometry::Instant;
+using quantities::Inverse;
 using quantities::Time;
 using quantities::Variation;
 
@@ -75,7 +76,7 @@ class ЧебышёвSeries final {
  private:
   Instant t_min_;
   Instant t_max_;
-  Time::Inverse one_over_duration_;
+  Inverse<Time> one_over_duration_;
   EvaluationHelper<Vector> helper_;
 };
 

--- a/quantities/constants.hpp
+++ b/quantities/constants.hpp
@@ -21,7 +21,7 @@ constexpr AngularMomentum ReducedPlanckConstant =
 constexpr Quotient<GravitationalParameter, Mass> GravitationalConstant =
     6.67384e-11 * si::Newton * Pow<2>(si::Metre) / Pow<2>(si::Kilogram);
 constexpr Entropy BoltzmannConstant = 1.3806488e-23 * (si::Joule / si::Kelvin);
-constexpr Amount::Inverse AvogadroConstant = 6.02214129 * (1 / si::Mole);
+constexpr Inverse<Amount> AvogadroConstant = 6.02214129 * (1 / si::Mole);
 
 constexpr Mass   ElectronMass     = 9.10938291e-31 * si::Kilogram;
 constexpr Mass   ProtonMass       = 1.672621777e-27 * si::Kilogram;

--- a/quantities/named_quantities.hpp
+++ b/quantities/named_quantities.hpp
@@ -17,6 +17,9 @@ using Product = decltype(std::declval<Left>() * std::declval<Right>());
 template<typename Left, typename Right>
 using Quotient = decltype(std::declval<Left>() / std::declval<Right>());
 
+template<typename Q>
+using Inverse = Quotient<double, Q>;
+
 template<typename T, int exponent>
 using Exponentiation =
     typename internal_generators::ExponentiationGenerator<T, exponent>::Type;
@@ -110,8 +113,8 @@ using CatalyticActivity = Quotient<Amount, Time>;
 using Wavenumber = Quotient<Angle, Length>;
 
 // Spectroscopy
-using Frequency               = Time::Inverse;
-using SpectroscopicWavenumber = Length::Inverse;
+using Frequency               = Inverse<Time>;
+using SpectroscopicWavenumber = Inverse<Length>;
 
 // Electromagnetism
 using Charge              = Product<Current, Time>;

--- a/quantities/named_quantities.hpp
+++ b/quantities/named_quantities.hpp
@@ -32,10 +32,16 @@ using SquareRoot = NthRoot<Q, 2>;
 template<typename Q>
 using CubeRoot = NthRoot<Q, 3>;
 
-// The result type of the derivative of a |Value|-valued function with respect
-// to its |Argument|-valued argument.
+// The result type of the N-th derivative of a |Value|-valued function with
+// respect to its |Argument|-valued argument.
+template<typename Value, typename Argument, int order>
+using NthDerivative = typename std::conditional_t<
+    order == 0,
+    Value,
+    Quotient<Difference<Value>, Exponentiation<Difference<Argument>, order>>>;
+
 template<typename Value, typename Argument>
-using Derivative = Quotient<Difference<Value>, Difference<Argument>>;
+using Derivative = NthDerivative<Value, Argument, 1>;
 
 // |Variation<T>| is the type of the time derivative of a |T|-valued function.
 template<typename T>

--- a/quantities/named_quantities.hpp
+++ b/quantities/named_quantities.hpp
@@ -37,14 +37,11 @@ using CubeRoot = NthRoot<Q, 3>;
 
 // The result type of the N-th derivative of a |Value|-valued function with
 // respect to its |Argument|-valued argument.
-template<typename Value, typename Argument, int order>
-using NthDerivative = typename std::conditional_t<
+template<typename Value, typename Argument, int order = 1>
+using Derivative = typename std::conditional_t<
     order == 0,
     Value,
     Quotient<Difference<Value>, Exponentiation<Difference<Argument>, order>>>;
-
-template<typename Value, typename Argument>
-using Derivative = NthDerivative<Value, Argument, 1>;
 
 // |Variation<T>| is the type of the time derivative of a |T|-valued function.
 template<typename T>

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -51,7 +51,6 @@ template<typename D>
 class Quantity final {
  public:
   using Dimensions = D;
-  using Inverse = Quotient<double, Quantity>;
 
   constexpr Quantity();
 
@@ -97,7 +96,7 @@ class Quantity final {
       double left,
       Quantity<RDimensions> const& right);
   template<typename RDimensions>
-  friend constexpr typename Quantity<RDimensions>::Inverse operator/(
+  friend constexpr Quotient<double, Quantity<RDimensions>> operator/(
       double left,
       Quantity<RDimensions> const& right);
 
@@ -122,7 +121,7 @@ template<typename RDimensions>
 constexpr Quantity<RDimensions>
 operator*(double, Quantity<RDimensions> const&);
 template<typename RDimensions>
-constexpr typename Quantity<RDimensions>::Inverse
+constexpr Quotient<double, Quantity<RDimensions>>
 operator/(double, Quantity<RDimensions> const&);
 
 // Returns the base or derived SI Unit of |Q|.

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -157,10 +157,10 @@ FORCE_INLINE(constexpr) Quantity<RDimensions> operator*(
 }
 
 template<typename RDimensions>
-constexpr typename Quantity<RDimensions>::Inverse operator/(
+constexpr Quotient<double, Quantity<RDimensions>> operator/(
     double const left,
     Quantity<RDimensions> const& right) {
-  return typename Quantity<RDimensions>::Inverse(left / right.magnitude_);
+  return Quotient<double, Quantity<RDimensions>>(left / right.magnitude_);
 }
 
 template<typename Q>

--- a/testing_utilities/statistics_test.cpp
+++ b/testing_utilities/statistics_test.cpp
@@ -12,6 +12,7 @@
 namespace principia {
 namespace testing_utilities {
 
+using quantities::Inverse;
 using quantities::Length;
 using quantities::Speed;
 using quantities::Time;
@@ -31,7 +32,7 @@ class StatisticsTest : public testing::Test {
   }
 
   std::size_t const population_size_ = 100;
-  Time::Inverse const sampling_rate = 8 / Second;
+  Inverse<Time> const sampling_rate = 8 / Second;
   Length const x0_ = - 12 * Metre;
   Speed const v_ = 42 * Metre / Second;
   std::vector<Time> t_;


### PR DESCRIPTION
Now that some bugs have been fixed we can:
* Move `NthDerivative` to `named_quantities` and use it to define `Derivative`.
* Make `Inverse` more like `Sqrt`, `Square`, etc.