### PR TITLE
Compile against 1.4.2, deprecate 1.2.2.

### DIFF
--- a/ksp_plugin_adapter/compatibility_extensions.cs
+++ b/ksp_plugin_adapter/compatibility_extensions.cs
@@ -3,7 +3,7 @@ namespace ksp_plugin_adapter {
 
 internal static class CompatibilityExtensions {
   public static string NameWithArticle(this CelestialBody body) {
-#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_1
+#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_2
     // We are not writing string templates for this mod, sorry.
     return body.displayName.StartsWith("The ") ? "the " + body.name : body.name;
 #elif KSP_VERSION_1_2_2

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -248,11 +248,11 @@ public partial class PrincipiaPluginAdapter
         Versioning.version_minor != 3 ||
         Versioning.Revision != 1) {
       string expected_version = "1.3.1";
-#elif KSP_VERSION_1_4_1
-    if (Versioning.version_major != 1 ||
-        Versioning.version_minor != 4 ||
-        Versioning.Revision != 1) {
-      string expected_version = "1.4.1";
+#elif KSP_VERSION_1_4_2
+    if (!(Versioning.version_major == 1 &&
+          Versioning.version_minor == 4 &&
+          (Versioning.Revision == 1 || Versioning.Revision == 2))) {
+      string expected_version = "1.4.2 and 1.4.1";
 #endif
       Log.Fatal("Unexpected KSP version " + Versioning.version_major + "." +
                 Versioning.version_minor + "." + Versioning.Revision +
@@ -496,7 +496,7 @@ public partial class PrincipiaPluginAdapter
         path;
     if (File.Exists(full_path)) {
       var texture2d = new UnityEngine.Texture2D(2, 2);
-#if KSP_VERSION_1_4_1
+#if KSP_VERSION_1_4_2
       bool success = UnityEngine.ImageConversion.LoadImage(
           texture2d, File.ReadAllBytes(full_path));
 #elif KSP_VERSION_1_2_2 || KSP_VERSION_1_3_1
@@ -660,7 +660,7 @@ public partial class PrincipiaPluginAdapter
       PopupDialog.SpawnPopupDialog(
           anchorMin           : default(UnityEngine.Vector2),
           anchorMax           : default(UnityEngine.Vector2),
-#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_1
+#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_2
           dialogName          : "Principia error",
 #endif
           title               : "Principia",
@@ -2049,11 +2049,20 @@ public partial class PrincipiaPluginAdapter
         UnityEngine.GUILayout.TextArea(text : "Plugin is not started");
       }
       if (DateTimeOffset.Now > next_release_date_) {
+#if KSP_VERSION_1_2_2
+        UnityEngine.GUILayout.TextArea(
+            "Announcement: the new moon of lunation number " +
+            next_release_lunation_number_ +
+            " has come; please update KSP to version 1.3.1 and download the " +
+            "latest Principia release, " + next_release_name_ + ". Note that " +
+            "RealismOverhaul and RealSolarSystem now support KSP 1.3.1.");
+#else
         UnityEngine.GUILayout.TextArea(
             "Announcement: the new moon of lunation number " +
             next_release_lunation_number_ +
             " has come; please download the latest Principia release, " +
             next_release_name_ + ".");
+#endif
       }
       String version;
       String unused_build_date;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Debug\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_4_1</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_4_2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Release\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;KSP_VERSION_1_4_1</DefineConstants>
+    <DefineConstants>TRACE;KSP_VERSION_1_4_2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
@@ -57,36 +57,36 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' Or '$(Configuration)' == 'Debug'">
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\KSP Assemblies\1.4.1\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\KSP Assemblies\1.4.1\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
This fixes #1791.
1.4.1 is still supported by the when targeting 1.4.2, under the assumption that they are ABI compatible.