### PR TITLE
1.4.3

### DIFF
--- a/ksp_plugin_adapter/compatibility_extensions.cs
+++ b/ksp_plugin_adapter/compatibility_extensions.cs
@@ -3,7 +3,7 @@ namespace ksp_plugin_adapter {
 
 internal static class CompatibilityExtensions {
   public static string NameWithArticle(this CelestialBody body) {
-#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_2
+#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_3
     // We are not writing string templates for this mod, sorry.
     return body.displayName.StartsWith("The ") ? "the " + body.name : body.name;
 #elif KSP_VERSION_1_2_2

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -255,7 +255,7 @@ public partial class PrincipiaPluginAdapter
 #elif KSP_VERSION_1_4_3
     if (!(Versioning.version_major == 1 &&
           Versioning.version_minor == 4 &&
-          (Versioning.Revision == 1 || Versioning.Revision == 2))) {
+          (Versioning.Revision >= 1 && Versioning.Revision <= 3))) {
       string expected_version = "1.4.3, 1.4.2, and 1.4.1";
 #endif
       Log.Fatal("Unexpected KSP version " + Versioning.version_major + "." +

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -252,11 +252,11 @@ public partial class PrincipiaPluginAdapter
         Versioning.version_minor != 3 ||
         Versioning.Revision != 1) {
       string expected_version = "1.3.1";
-#elif KSP_VERSION_1_4_2
+#elif KSP_VERSION_1_4_3
     if (!(Versioning.version_major == 1 &&
           Versioning.version_minor == 4 &&
           (Versioning.Revision == 1 || Versioning.Revision == 2))) {
-      string expected_version = "1.4.2 and 1.4.1";
+      string expected_version = "1.4.3 and 1.4.1";
 #endif
       Log.Fatal("Unexpected KSP version " + Versioning.version_major + "." +
                 Versioning.version_minor + "." + Versioning.Revision +
@@ -500,7 +500,7 @@ public partial class PrincipiaPluginAdapter
         path;
     if (File.Exists(full_path)) {
       var texture2d = new UnityEngine.Texture2D(2, 2);
-#if KSP_VERSION_1_4_2
+#if KSP_VERSION_1_4_3
       bool success = UnityEngine.ImageConversion.LoadImage(
           texture2d, File.ReadAllBytes(full_path));
 #elif KSP_VERSION_1_2_2 || KSP_VERSION_1_3_1
@@ -674,7 +674,7 @@ public partial class PrincipiaPluginAdapter
       PopupDialog.SpawnPopupDialog(
           anchorMin           : default(UnityEngine.Vector2),
           anchorMax           : default(UnityEngine.Vector2),
-#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_2
+#if KSP_VERSION_1_3_1 || KSP_VERSION_1_4_3
           dialogName          : "Principia error",
 #endif
           title               : "Principia",

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -256,7 +256,7 @@ public partial class PrincipiaPluginAdapter
     if (!(Versioning.version_major == 1 &&
           Versioning.version_minor == 4 &&
           (Versioning.Revision == 1 || Versioning.Revision == 2))) {
-      string expected_version = "1.4.3 and 1.4.1";
+      string expected_version = "1.4.3, 1.4.2, and 1.4.1";
 #endif
       Log.Fatal("Unexpected KSP version " + Versioning.version_major + "." +
                 Versioning.version_minor + "." + Versioning.Revision +

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Debug\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_4_2</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_4_3</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Release\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;KSP_VERSION_1_4_2</DefineConstants>
+    <DefineConstants>TRACE;KSP_VERSION_1_4_3</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
@@ -57,36 +57,36 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' Or '$(Configuration)' == 'Debug'">
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\KSP Assemblies\1.4.2\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule" Condition="'$(OS)' == 'Unix'">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\KSP Assemblies\1.4.2\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.4.3\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
1.4.1 and 1.4.2 are still supported when targeting 1.4.3, under the assumption that they are ABI compatible.

