### PR TITLE
Tweak the arena.

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -937,6 +937,7 @@ char16_t const* principia__SerializePluginBase32768(
   auto base32768 = Base32768Encode(bytes, /*null_terminated=*/true);
   return m.Return(base32768.data.release());
 }
+
 // Same contract as the base 32768 deserialization.
 char const* principia__SerializePluginHexadecimal(
     Plugin const* const plugin,

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -64,7 +64,6 @@ using geometry::Displacement;
 using geometry::RadiusLatitudeLongitude;
 using geometry::Vector;
 using geometry::Velocity;
-using google::protobuf::Arena;
 using integrators::AdaptiveStepSizeIntegrator;
 using integrators::FixedStepSizeIntegrator;
 using integrators::ParseAdaptiveStepSizeIntegrator;
@@ -99,12 +98,21 @@ using quantities::si::Newton;
 using quantities::si::Radian;
 using quantities::si::Second;
 using quantities::si::Tonne;
+using ::google::protobuf::Arena;
+using ::google::protobuf::ArenaOptions;
 
 namespace {
 
 constexpr char gipfeli[] = "gipfeli";
 constexpr int chunk_size = 64 << 10;
 constexpr int number_of_chunks = 8;
+
+static not_null<Arena*> arena = []() {
+  ArenaOptions options;
+  options.initial_block_size = chunk_size;
+  options.max_block_size = 16 * chunk_size;
+  return new Arena(options);
+}();
 
 Ephemeris<Barycentric>::FixedStepParameters MakeFixedStepParameters(
     ConfigurationFixedStepParameters const& parameters) {
@@ -414,8 +422,6 @@ void principia__DeserializePluginHexadecimal(
   CHECK_NOTNULL(serialization);
   CHECK_NOTNULL(deserializer);
   CHECK_NOTNULL(plugin);
-
-  static not_null<Arena*> arena = new Arena;
 
   // Create and start a deserializer if the caller didn't provide one.
   if (*deserializer == nullptr) {
@@ -931,7 +937,6 @@ char16_t const* principia__SerializePluginBase32768(
   auto base32768 = Base32768Encode(bytes, /*null_terminated=*/true);
   return m.Return(base32768.data.release());
 }
-
 // Same contract as the base 32768 deserialization.
 char const* principia__SerializePluginHexadecimal(
     Plugin const* const plugin,
@@ -941,8 +946,6 @@ char const* principia__SerializePluginHexadecimal(
                                                          {serializer});
   CHECK_NOTNULL(plugin);
   CHECK_NOTNULL(serializer);
-
-  static not_null<Arena*> arena = new Arena;
 
   // Create and start a serializer if the caller didn't provide one.
   if (*serializer == nullptr) {


### PR DESCRIPTION
It is not clear whether this is much faster, but it should cost half the memory, and it makes no sense to have a maximum block size smaller than the chunk size when we are trying to optimize saves that have more than a thousand chunks.