### PR TITLE
Reunification of the egg and ferram4 sector

### DIFF
--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -116,7 +116,7 @@ Planetarium* principia__PlanetariumCreate(
   constexpr Length const olympus_mons_peak = 21'230 * Metre;
   constexpr Length const mars_mean_radius = 3389.50 * Kilo(Metre);
   Planetarium::Parameters parameters(
-      /*sphere_radius_multiplier=*/1.0 + olympus_mons_peak / mars_mean_radius,
+      /*sphere_radius_multiplier=*/1.0 + 0 * olympus_mons_peak / mars_mean_radius,
       /*angular_resolution=*/0.4 * ArcMinute,
       field_of_view * Radian);
   Perspective<Navigation, Camera> perspective(

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -109,14 +109,8 @@ Planetarium* principia__PlanetariumCreate(
                                    FromXYZ<Position<World>>(sun_world_position),
                                    plugin->PlanetariumRotation());
 
-  // The radius multiplier is appropriate for Olympus Mons, the largest mountain
-  // in the solar system.
-  // The angular resolution of the human eye is from
-  // https://en.wikipedia.org/wiki/Visual_acuity#Physiology
-  constexpr Length const olympus_mons_peak = 21'230 * Metre;
-  constexpr Length const mars_mean_radius = 3389.50 * Kilo(Metre);
   Planetarium::Parameters parameters(
-      /*sphere_radius_multiplier=*/1.0 + 0 * olympus_mons_peak / mars_mean_radius,
+      /*sphere_radius_multiplier=*/1.0,
       /*angular_resolution=*/0.4 * ArcMinute,
       field_of_view * Radian);
   Perspective<Navigation, Camera> perspective(

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -430,13 +430,6 @@ public partial class PrincipiaPluginAdapter
           vessel.situation == Vessel.Situations.FLYING)) {
       reasons.Add("vessel situation is " + vessel.situation);
     }
-    if (!vessel.packed && vessel.mainBody.atmosphere &&
-        vessel.altitude <= vessel.mainBody.atmosphereDepth) {
-      reasons.Add("vessel is unpacked at an altitude of " + vessel.altitude +
-                  " m above " + vessel.mainBody.NameWithArticle() +
-                  " whose atmosphere extends to " +
-                  vessel.mainBody.atmosphereDepth + " m");
-    }
     double height;
     double vertical_speed;
     if (!vessel.packed &&


### PR DESCRIPTION
This is a follow-up of the work done in [Chasles](https://github.com/mockingbirdnest/Principia/wiki/Change-Log#chasles) on #1413,
see #1583, #1584, #1585, #1586, #1588, #1589, #1590, #1596, and #1601.

Specifically, this reverts #1589 now that Principia supports only versions of KSP supported by versions of FAR that add forces to the parts, rather than the rigid bodies.
This fixes #848.

In order for histories to be visible in the atmosphere, the radius multiplier is set to 1; this will result in histories behind a mountain being drawn in front.


![](https://i.imgur.com/TT7NTkQ.png)
![](https://i.imgur.com/cLjk36n.png)
![](https://i.imgur.com/ftAgNBf.png)

