### PR TITLE
Trigonometric functions with better invariants

### DIFF
--- a/benchmarks/fast_sin_cos_2π_benchmark.cpp
+++ b/benchmarks/fast_sin_cos_2π_benchmark.cpp
@@ -11,7 +11,24 @@
 namespace principia {
 namespace numerics {
 
-void BM_FastSinCos2π(benchmark::State& state) {
+void BM_FastSinCos2πLatency(benchmark::State& state) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> const distribution(-1.0, 1.0);
+  std::vector<double> input;
+  for (int i = 0; i < 1e3; ++i) {
+    input.push_back(distribution(random));
+  }
+
+  while (state.KeepRunning()) {
+    double sin = 0.0;
+    double cos = 0.0;
+    for (double const x : input) {
+      FastSinCos2π(x + sin + cos, sin, cos);
+    }
+  }
+}
+
+void BM_FastSinCos2πThroughput(benchmark::State& state) {
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> const distribution(-1.0, 1.0);
   std::vector<double> input;
@@ -30,7 +47,8 @@ void BM_FastSinCos2π(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_FastSinCos2π);
+BENCHMARK(BM_FastSinCos2πLatency);
+BENCHMARK(BM_FastSinCos2πThroughput);
 
 }  // namespace numerics
 }  // namespace principia

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -14,25 +14,23 @@ namespace numerics {
 
 namespace {
 
-using P3 = PolynomialInMonomialBasis</*Value=*/double,
+using P2 = PolynomialInMonomialBasis</*Value=*/double,
                                      /*Argument=*/double,
-                                     /*degree=*/3,
+                                     /*degree=*/2,
                                      /*Evaluator=*/EstrinEvaluator>;
 
-// 3rd-degree polynomials that minimize the absolute error on sin and cos over
-// the interval [0, 1/4].  The minimization algorithm is run on
+// 2nd-degree polynomials that minimize the absolute error on sin and cos over
+// the interval [0, 1/8].  The minimization algorithm is run on
 // Sin(2 π √x)/√x and (Cos(2 π √x) - 1)/x to ensure that the functions have
 // the right behavior near 0 and the proper parity.  Because of extra
-// oscillations, the lower bounds of the minimization intervals are 1/23 and
-// 1/15 respectively.  This is where the maximum error is found.
-P3 sin_polynomial(P3::Coefficients{6.28316404405113818577981340506,
-                                   -41.3371423477858688509416864345,
-                                   81.3407682603799599938651480917,
-                                   -70.9934281315300026308830925659});
-P3 cos_polynomial(P3::Coefficients{-19.7391820689166533085010275514,
-                                   64.9352211775039525420259682190,
-                                   -85.2540004035261113433497714557,
-                                   56.3405940928237075549636782571});
+// oscillations, the lower bounds of the minimization intervals are 1/36 and
+// 1/24 respectively.  This is where the maximum error is found.
+P2 sin_polynomial(P2::Coefficients{6.28315387593158874093559349802,
+                                   -41.3255673715186216778612605095,
+                                   79.5314110676979262924240784281});
+P2 cos_polynomial(P2::Coefficients{-19.7391672615468690589481752820,
+                                   64.9232282990046449731568966307,
+                                   -83.6659064641344641438100039739});
 
 }  // namespace
 

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -17,7 +17,7 @@ namespace {
 using P2 = PolynomialInMonomialBasis</*Value=*/double,
                                      /*Argument=*/double,
                                      /*degree=*/2,
-                                     /*Evaluator=*/EstrinEvaluator>;
+                                     /*Evaluator=*/HornerEvaluator>;
 
 // 2nd-degree polynomials that minimize the absolute error on sin and cos over
 // the interval [0, 1/8].  The minimization algorithm is run on
@@ -64,7 +64,6 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
   double const c =
       1.0 + cos_polynomial.Evaluate(cycles_fractional²) * cycles_fractional²;
 
-  //LOG(ERROR)<<quadrant<<" "<<cycles_fractional;
   switch (quadrant) {
     case 0:
       sin = s;

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -42,8 +42,8 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
   std::int64_t quadrant;  // 0..3
 #if PRINCIPIA_USE_SSE3_INTRINSICS
   __m128d const cycles_128d = _mm_set_sd(cycles);
-  __m128d const two_cycles_128d = _mm_add_sd(cycles_128d, cycles_128d);
-  __m128d const four_cycles_128d = _mm_add_sd(two_cycles_128d, two_cycles_128d);
+  __m128d const four = _mm_set_sd(4.0);
+  __m128d const four_cycles_128d = _mm_mul_sd(four, cycles_128d);
   __int64 const four_cycles_64 = _mm_cvtsd_si64(four_cycles_128d);
   quadrant = four_cycles_64 & 0b11;
   __m128d const four_cycles_integer_128d =

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -37,10 +37,11 @@ P2 cos_polynomial(P2::Coefficients{-19.7391672615468690589481752820,
 void FastSinCos2π(double cycles, double& sin, double& cos) {
   // Argument reduction.  Since the argument is in cycles, we just drop the
   // integer part.
+  //TODO(phl):comment.
   double cycles_fractional;
   std::int64_t quadrant;  // 0..3
 #if PRINCIPIA_USE_SSE3_INTRINSICS
-  __m128d const cycles_128d = _mm_load1_pd(&cycles);
+  __m128d const cycles_128d = _mm_set_sd(cycles);
   __m128d const two_cycles_128d = _mm_add_sd(cycles_128d, cycles_128d);
   __m128d const four_cycles_128d = _mm_add_sd(two_cycles_128d, two_cycles_128d);
   __int64 const four_cycles_64 = _mm_cvtsd_si64(four_cycles_128d);
@@ -49,7 +50,7 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
       _mm_cvtsi64_sd(four_cycles_128d, four_cycles_64);
   __m128d const four_cycles_fractional_128d =
       _mm_sub_sd(four_cycles_128d, four_cycles_integer_128d);
-  __m128d const one_fourth = _mm_set1_pd(0.25);
+  __m128d const one_fourth = _mm_set_sd(0.25);
   __m128d const cycles_fractional_128d =
       _mm_mul_sd(one_fourth, four_cycles_fractional_128d);
   cycles_fractional = _mm_cvtsd_f64(cycles_fractional_128d);
@@ -57,6 +58,7 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
   double const cycles_integer = std::nearbyint(cycles);
   cycles_fractional = cycles - cycles_integer;
 #endif
+  //TODO(phl):debug.
 
   double const cycles_fractional² = cycles_fractional * cycles_fractional;
   double const s =

--- a/numerics/fast_sin_cos_2π_test.cpp
+++ b/numerics/fast_sin_cos_2π_test.cpp
@@ -76,10 +76,10 @@ TEST_F(FastSinCos2πTest, Random1) {
     }
   }
   // These numbers come from the Mathematica minimax computation.
-  EXPECT_LT(max_sin_error, 5.90e-7);
-  EXPECT_LT(max_cos_error, 5.28e-8);
-  EXPECT_THAT(max_sin_error_x, IsNear(-1.0 + 1.0 / 23.0));
-  EXPECT_THAT(max_cos_error_x, IsNear(1.0 - 1.0 / 15.0));
+  EXPECT_LT(max_sin_error, 5.61e-7);
+  EXPECT_LT(max_cos_error, 5.61e-7);
+  EXPECT_THAT(max_sin_error_x, IsNear(1.0 - 1.0 / 36.0));
+  EXPECT_THAT(max_cos_error_x, IsNear(-0.75 + 1.0 / 36.0));
 }
 
 // Arguments in the range [-1e6, 1e6 + 1] to test argument reduction.

--- a/numerics/fast_sin_cos_2π_test.cpp
+++ b/numerics/fast_sin_cos_2π_test.cpp
@@ -78,8 +78,10 @@ TEST_F(FastSinCos2πTest, Random1) {
   // These numbers come from the Mathematica minimax computation.
   EXPECT_LT(max_sin_error, 5.61e-7);
   EXPECT_LT(max_cos_error, 5.61e-7);
-  EXPECT_THAT(max_sin_error_x, IsNear(1.0 - 1.0 / 36.0));
-  EXPECT_THAT(max_cos_error_x, IsNear(-0.75 + 1.0 / 36.0));
+  EXPECT_THAT(std::fmod(std::fabs(max_sin_error_x), 1.0 / 8.0),
+              IsNear(1.0 / 8.0 - 1.0 / 36.0));
+  EXPECT_THAT(std::fmod(std::fabs(max_cos_error_x), 1.0 / 8.0),
+              IsNear(1.0 / 8.0 - 1.0 / 36.0));
 }
 
 // Arguments in the range [-1e6, 1e6 + 1] to test argument reduction.

--- a/numerics/fast_sin_cos_2π_test.cpp
+++ b/numerics/fast_sin_cos_2π_test.cpp
@@ -37,14 +37,14 @@ TEST_F(FastSinCos2πTest, SpecialValues) {
   EXPECT_THAT(sin, AlmostEquals(0.0, 0));
   EXPECT_THAT(cos, AlmostEquals(1.0, 0));
   FastSinCos2π(0.25, sin, cos);
-  EXPECT_THAT(sin, IsNear(1.0, 1.00001));
-  EXPECT_THAT(cos, VanishesBefore(1.0, 0, 3e8));
+  EXPECT_THAT(sin, AlmostEquals(1.0, 0));
+  EXPECT_THAT(cos, AlmostEquals(0.0, 0));
   FastSinCos2π(0.5, sin, cos);
   EXPECT_THAT(sin, AlmostEquals(0.0, 0));
   EXPECT_THAT(cos, AlmostEquals(-1.0, 0));
   FastSinCos2π(0.75, sin, cos);
-  EXPECT_THAT(sin, IsNear(-1.0));
-  EXPECT_THAT(cos, VanishesBefore(1.0, 0, 3e8));
+  EXPECT_THAT(sin, AlmostEquals(-1.0, 0));
+  EXPECT_THAT(cos, AlmostEquals(0.0, 0));
   FastSinCos2π(1.0, sin, cos);
   EXPECT_THAT(sin, AlmostEquals(0.0, 0));
   EXPECT_THAT(cos, AlmostEquals(1.0, 0));


### PR DESCRIPTION
```
Run on (4 X 3310 MHz CPU s)
08/07/18 23:31:10
------------------------------------------------------------------------
Benchmark                                 Time           CPU Iterations
------------------------------------------------------------------------
BM_FastSinCos2?Latency                18233 ns      18203 ns     153407
BM_FastSinCos2?Latency                18381 ns      18304 ns     153407
BM_FastSinCos2?Latency                18316 ns      18101 ns     153407
BM_FastSinCos2?Latency                18147 ns      18101 ns     153407
BM_FastSinCos2?Latency                18110 ns      18101 ns     153407
BM_FastSinCos2?Latency                18118 ns      18203 ns     153407
BM_FastSinCos2?Latency                18125 ns      18101 ns     153407
BM_FastSinCos2?Latency                18184 ns      18101 ns     153407
BM_FastSinCos2?Latency                18149 ns      18101 ns     153407
BM_FastSinCos2?Latency                18107 ns      18101 ns     153407
BM_FastSinCos2?Latency_mean           18187 ns      18142 ns     153407
BM_FastSinCos2?Latency_median         18148 ns      18101 ns     153407
BM_FastSinCos2?Latency_stddev            94 ns         71 ns     153407
BM_FastSinCos2?Throughput              6307 ns       6327 ns     448715
BM_FastSinCos2?Throughput              6287 ns       6293 ns     448715
BM_FastSinCos2?Throughput              6308 ns       6293 ns     448715
BM_FastSinCos2?Throughput              6320 ns       6327 ns     448715
BM_FastSinCos2?Throughput              6321 ns       6327 ns     448715
BM_FastSinCos2?Throughput              6339 ns       6293 ns     448715
BM_FastSinCos2?Throughput              6408 ns       6362 ns     448715
BM_FastSinCos2?Throughput              6317 ns       6327 ns     448715
BM_FastSinCos2?Throughput              6319 ns       6327 ns     448715
BM_FastSinCos2?Throughput              6306 ns       6223 ns     448715
BM_FastSinCos2?Throughput_mean         6323 ns       6310 ns     448715
BM_FastSinCos2?Throughput_median       6318 ns       6327 ns     448715
BM_FastSinCos2?Throughput_stddev         33 ns         38 ns     448715
```