### PR TITLE
Improve the latency benchmark

### DIFF
--- a/benchmarks/fast_sin_cos_2π_benchmark.cpp
+++ b/benchmarks/fast_sin_cos_2π_benchmark.cpp
@@ -7,23 +7,33 @@
 #include <vector>
 
 #include "benchmark/benchmark.h"
+#include "quantities/numbers.hpp"
 
 namespace principia {
 namespace numerics {
+namespace {
+
+static const __m128d mantissa_bits =
+    _mm_castsi128_pd(_mm_cvtsi64_si128(0x000F'FFFF'FFFF'FFFF));
+// When iterated, the quadrant of the result is unbiased; the latency is
+// between 1 and 2 cycles: at worst this is an and and an xor, at best the xor
+// can only be computed given both trigonometric lines.
+double MixTrigonometricLines(double cos_2πx, double sin_2πx) {
+  __m128d const cos_mantissa_bits =
+      _mm_and_pd(_mm_set_sd(cos_2πx), mantissa_bits);
+  __m128d const sin_all_bits = _mm_set_sd(sin_2πx);
+  __m128d const mixed_bits = _mm_xor_pd(cos_mantissa_bits, sin_all_bits);
+  return _mm_cvtsd_f64(mixed_bits);
+}
+
+}  // namespace
 
 void BM_FastSinCos2πLatency(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> const distribution(-1.0, 1.0);
-  std::vector<double> input;
-  for (int i = 0; i < 1e3; ++i) {
-    input.push_back(distribution(random));
-  }
-
   while (state.KeepRunning()) {
-    double sin = 0.0;
+    double sin = π;
     double cos = 0.0;
-    for (double const x : input) {
-      FastSinCos2π(x + sin + cos, sin, cos);
+    for (int i = 0; i < 1e3; ++i) {
+      FastSinCos2π(MixTrigonometricLines(cos, sin), sin, cos);
     }
   }
 }

--- a/benchmarks/fast_sin_cos_2π_benchmark.cpp
+++ b/benchmarks/fast_sin_cos_2π_benchmark.cpp
@@ -17,11 +17,12 @@ namespace {
 // The result is (cos_2πx bitand cos_mask) bitxor sin_2πx.
 // The latency is between 1 and 2 cycles: at worst this is an and and an xor, at
 // best the xor can only be computed given both trigonometric lines.
-double MixTrigonometricLines(double cos_2πx, double sin_2πx, __m128d const cos_mask) {
-  __m128d const cos_mantissa_bits =
-      _mm_and_pd(_mm_set_sd(cos_2πx), cos_mask);
+double MixTrigonometricLines(double cos_2πx,
+                             double sin_2πx,
+                             __m128d const cos_mask) {
+  __m128d const cos_bits = _mm_and_pd(_mm_set_sd(cos_2πx), cos_mask);
   __m128d const sin_all_bits = _mm_set_sd(sin_2πx);
-  __m128d const mixed_bits = _mm_xor_pd(cos_mantissa_bits, sin_all_bits);
+  __m128d const mixed_bits = _mm_xor_pd(cos_bits, sin_all_bits);
   return _mm_cvtsd_f64(mixed_bits);
 }
 


### PR DESCRIPTION
Compute (cos bitand 2 ** 52 - 1) bitxor sin to induce a data dependency without reading from precomputed random inputs or doing a couple of floating-point additions.
Add a benchmark with constant-quadrant inputs, to see the cost of misprediction on random inputs.
The quadrant is unbiased; below is the histogram of 10000 iterates (mod 1, offset 1/2) for various values of 52.
![](https://i.imgur.com/CbzHmja.png)

Before:
```
Run on (4 X 2808 MHz CPU s)
08/08/18 23:41:59
------------------------------------------------------------------------
Benchmark                                 Time           CPU Iterations
------------------------------------------------------------------------
BM_FastSinCos2?Latency                21272 ns      21197 ns     137846
BM_FastSinCos2?Latency                21226 ns      21197 ns     137846
BM_FastSinCos2?Latency                21279 ns      21310 ns     137846
BM_FastSinCos2?Latency                21262 ns      21197 ns     137846
BM_FastSinCos2?Latency                21225 ns      21083 ns     137846
BM_FastSinCos2?Latency                21809 ns      21537 ns     137846
BM_FastSinCos2?Latency                22997 ns      21877 ns     137846
BM_FastSinCos2?Latency                22022 ns      21423 ns     137846
BM_FastSinCos2?Latency                21969 ns      21537 ns     137846
BM_FastSinCos2?Latency                21644 ns      21423 ns     137846
BM_FastSinCos2?Latency_mean           21671 ns      21378 ns     137846
BM_FastSinCos2?Latency_median         21461 ns      21367 ns     137846
BM_FastSinCos2?Latency_stddev           565 ns        234 ns     137846
BM_FastSinCos2?Throughput              6172 ns       6042 ns     437073
BM_FastSinCos2?Throughput              6055 ns       6042 ns     437073
BM_FastSinCos2?Throughput              6055 ns       5970 ns     437073
BM_FastSinCos2?Throughput              6049 ns       6042 ns     437073
BM_FastSinCos2?Throughput              6003 ns       5970 ns     437073
BM_FastSinCos2?Throughput              5993 ns       6006 ns     437073
BM_FastSinCos2?Throughput              5917 ns       5899 ns     437073
BM_FastSinCos2?Throughput              6083 ns       6042 ns     437073
BM_FastSinCos2?Throughput              6017 ns       5970 ns     437073
BM_FastSinCos2?Throughput              6207 ns       6149 ns     437073
BM_FastSinCos2?Throughput_mean         6055 ns       6013 ns     437073
BM_FastSinCos2?Throughput_median       6052 ns       6024 ns     437073
BM_FastSinCos2?Throughput_stddev         85 ns         67 ns     437073
```
After:
```
Run on (4 X 2808 MHz CPU s)
08/10/18 00:20:51
------------------------------------------------------------------------------------
Benchmark                                             Time           CPU Iterations
------------------------------------------------------------------------------------
BM_FastSinCos2?PoorlyPredictedLatency             19772 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19663 ns      19723 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19695 ns      19496 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19745 ns      19723 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19706 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19613 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19616 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19719 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19689 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency             19636 ns      19496 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency_mean        19685 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency_median      19692 ns      19610 ns     137846
BM_FastSinCos2?PoorlyPredictedLatency_stddev         53 ns         76 ns     137846
BM_FastSinCos2?WellPredictedLatency               19464 ns      19383 ns     137846
BM_FastSinCos2?WellPredictedLatency               19563 ns      19383 ns     137846
BM_FastSinCos2?WellPredictedLatency               19542 ns      19610 ns     137846
BM_FastSinCos2?WellPredictedLatency               19517 ns      19270 ns     137846
BM_FastSinCos2?WellPredictedLatency               19566 ns      19156 ns     137846
BM_FastSinCos2?WellPredictedLatency               19535 ns      19496 ns     137846
BM_FastSinCos2?WellPredictedLatency               19476 ns      19383 ns     137846
BM_FastSinCos2?WellPredictedLatency               19553 ns      19270 ns     137846
BM_FastSinCos2?WellPredictedLatency               19483 ns      19270 ns     137846
BM_FastSinCos2?WellPredictedLatency               19488 ns      19496 ns     137846
BM_FastSinCos2?WellPredictedLatency_mean          19519 ns      19372 ns     137846
BM_FastSinCos2?WellPredictedLatency_median        19526 ns      19383 ns     137846
BM_FastSinCos2?WellPredictedLatency_stddev           38 ns        136 ns     137846
BM_FastSinCos2?Throughput                          5891 ns       5831 ns     471579
BM_FastSinCos2?Throughput                          5912 ns       5931 ns     471579
BM_FastSinCos2?Throughput                          5896 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5898 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5940 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5970 ns       5931 ns     471579
BM_FastSinCos2?Throughput                          5907 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5921 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5898 ns       5898 ns     471579
BM_FastSinCos2?Throughput                          5947 ns       5964 ns     471579
BM_FastSinCos2?Throughput_mean                     5918 ns       5904 ns     471579
BM_FastSinCos2?Throughput_median                   5910 ns       5898 ns     471579
BM_FastSinCos2?Throughput_stddev                     26 ns         34 ns     471579
```
Not sure why the throughput benchmark became faster O_o