### PR TITLE
For a few cycles more

### DIFF
--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -32,9 +32,8 @@ using P3 = PolynomialInMonomialBasis</*Value=*/double,
 // 1/24 respectively.  This is where the maximum error is found.
 // The coefficients are scaled to accept arguments scaled to [0, 1/2].
 
-// The sine polynomial uses a custom Estrin-like evaluation, so the individual
-// coefficients are named.
-// The polynomial for Sin(2 π x/4) is s₁ x + s₃ x³ + s₅ x⁵.
+// The sine polynomial uses a custom evaluation, so the individual coefficients
+// are named.  The polynomial for Sin(2 π x/4) is s₁ x + s₃ x³ + s₅ x⁵.
 double const s₁ = 6.28315387593158874093559349802 / 4;
 double const s₃ = -41.3255673715186216778612605095 / (4 * 16);
 double const s₅ = 79.5314110676979262924240784281 / (4 * 16 * 16);
@@ -83,6 +82,9 @@ void FastSinCos2π(double const cycles, double& sin, double& cos) {
   double const cycles_reduced³ = cycles_reduced² * cycles_reduced;
   std::int64_t const quadrant = decomposition.integer_part & 0b11;
 
+  // The custom evaluation, compared to Estrin followed by multiplication by the
+  // argument, i.e., x * (s₁ + s₃ * x² + s₅ * (x² * x²)), avoids having a
+  // multiplication by x at the end.
   double const s =
       s₁ * cycles_reduced + (s₃ + s₅ * cycles_reduced²) * cycles_reduced³;
   // TODO(egg): Considering the above, I'm not sure this is more readable than

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -6,7 +6,7 @@
 #include <intrin.h>
 #include <pmmintrin.h>
 //#include <Intel/IACA 2.1/iacaMarks.h>
-#define VOLATILE
+#define VOLATILE //volatile
 #define IACA_VC64_START
 #define IACA_VC64_END
 
@@ -75,9 +75,14 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
   Decomposition const decomposition = Decompose(4.0 * vcycles);
   double const cycles_reduced = decomposition.fractional_part;
   double const cycles_reduced² = cycles_reduced * cycles_reduced;
+  double const cycles_reduced³ = cycles_reduced² * cycles_reduced;
   std::int64_t const quadrant = decomposition.integer_part & 0b11;
 
-  double const s = sin_polynomial.Evaluate(cycles_reduced²) * cycles_reduced;
+  double const s =
+      (6.28315387593158874093559349802 / 4) * cycles_reduced +
+      ((-41.3255673715186216778612605095 / (4 * 16)) +
+       (79.5314110676979262924240784281 / (4 * 16 * 16)) * cycles_reduced²) *
+          cycles_reduced³;
   double const c = cos_polynomial.Evaluate(cycles_reduced²);
 
   VOLATILE double const vs = s;

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -33,13 +33,13 @@ using P3 = PolynomialInMonomialBasis</*Value=*/double,
 // The coefficients are scaled to accept arguments scaled to [0, 1/2].
 
 // The sine polynomial uses a custom evaluation, so the individual coefficients
-// are named.  The polynomial for Sin(2 π x/4) is s₁ x + s₃ x³ + s₅ x⁵.
+// are named.  The polynomial for Sin(2 π y/4) is s₁ y + s₃ y³ + s₅ y⁵.
 double const s₁ = 6.28315387593158874093559349802 / 4;
 double const s₃ = -41.3255673715186216778612605095 / (4 * 16);
 double const s₅ = 79.5314110676979262924240784281 / (4 * 16 * 16);
 
-// The cosine polynomial for 16 x² ⟼ (Cos(2 π x) - 1)/(16 x²) is turned into a
-// polynomial for 16 x² ⟼ Cos(2 π x) by multiplying by the argument and adding
+// The cosine polynomial for 16 z² ⟼ (Cos(2 π z) - 1)/(16 z²) is turned into a
+// polynomial for 16 z² ⟼ Cos(2 π z) by multiplying by the argument and adding
 // 1, i.e., prepending 1 to the list of coefficients.
 P3 cos_polynomial(P3::Coefficients{
     1.0,
@@ -70,26 +70,26 @@ Decomposition Decompose(double const x) {
 }  // namespace
 
 void FastSinCos2π(double const cycles, double& sin, double& cos) {
-  // Argument reduction.  cycles_reduced is in [-1/2, 1/2] and quadrant goes
-  // from 0 to 3, with 0 indicating the principal quadrant and the others
-  // numbered in the trigonometric direction.  These quantities are computed by
-  // extracting the integer and fractional parts of 4 * cycles.
+  // Argument reduction.
+  // - quadrant goes from 0 to 3, with 0 indicating the principal quadrant and
+  //   the others numbered in the trigonometric direction;
+  // - y is in [-1/2, 1/2], corresponding to reduced angles of [-π/4, π/4] in
+  //   the quadrant.
+  // These quantities are computed by extracting the integer and fractional
+  // parts of 4 * cycles.
   Decomposition const decomposition = Decompose(4.0 * cycles);
-  // TODO(egg): cycles_reduced is no longer an appropriate name.
-  // This now counts a fraction of a right angle/quarter cycle/quadrant.
-  double const cycles_reduced = decomposition.fractional_part;
-  double const cycles_reduced² = cycles_reduced * cycles_reduced;
-  double const cycles_reduced³ = cycles_reduced² * cycles_reduced;
+  double const y = decomposition.fractional_part;
+  double const y² = y * y;
+  double const y³ = y² * y;
   std::int64_t const quadrant = decomposition.integer_part & 0b11;
 
   // The custom evaluation, compared to Estrin followed by multiplication by the
-  // argument, i.e., x * (s₁ + s₃ * x² + s₅ * (x² * x²)), avoids having a
-  // multiplication by x at the end.
-  double const s =
-      s₁ * cycles_reduced + (s₃ + s₅ * cycles_reduced²) * cycles_reduced³;
+  // argument, i.e., y * (s₁ + s₃ * y² + s₅ * (y² * y²)), avoids having a
+  // multiplication by y at the end.
+  double const s = s₁ * y + (s₃ + s₅ * y²) * y³;
   // TODO(egg): Considering the above, I'm not sure this is more readable than
   // just spelling out the Estrin evaluation.
-  double const c = cos_polynomial.Evaluate(cycles_reduced²);
+  double const c = cos_polynomial.Evaluate(y²);
 
   switch (quadrant) {
     case 0:

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -17,7 +17,7 @@ namespace {
 using P2 = PolynomialInMonomialBasis</*Value=*/double,
                                      /*Argument=*/double,
                                      /*degree=*/2,
-                                     /*Evaluator=*/HornerEvaluator>;
+                                     /*Evaluator=*/EstrinEvaluator>;
 
 // 2nd-degree polynomials that minimize the absolute error on sin and cos over
 // the interval [0, 1/8].  The minimization algorithm is run on

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -3,7 +3,12 @@
 
 #include "numerics/fast_sin_cos_2π.hpp"
 
+#include <intrin.h>
 #include <pmmintrin.h>
+//#include <Intel/IACA 2.1/iacaMarks.h>
+#define VOLATILE
+#define IACA_VC64_START
+#define IACA_VC64_END
 
 #include "base/macros.hpp"
 #include "numerics/polynomial.hpp"
@@ -30,13 +35,13 @@ using P3 = PolynomialInMonomialBasis</*Value=*/double,
 // the right behavior near 0 and the proper parity.  Because of extra
 // oscillations, the lower bounds of the minimization intervals are 1/36 and
 // 1/24 respectively.  This is where the maximum error is found.
-P2 sin_polynomial(P2::Coefficients{6.28315387593158874093559349802,
-                                   -41.3255673715186216778612605095,
-                                   79.5314110676979262924240784281});
+P2 sin_polynomial(P2::Coefficients{6.28315387593158874093559349802 / 4,
+                                   -41.3255673715186216778612605095 / (4 * 16),
+                                   79.5314110676979262924240784281 / (4 * 16 * 16)});
 P3 cos_polynomial(P3::Coefficients{1.0,
-                                   -19.7391672615468690589481752820,
-                                   64.9232282990046449731568966307,
-                                   -83.6659064641344641438100039739});
+                                   -19.7391672615468690589481752820 / 16,
+                                   64.9232282990046449731568966307 / (16 * 16),
+                                   -83.6659064641344641438100039739 / (16 * 16 * 16)});
 
 struct Decomposition {
   std::int64_t integer_part;
@@ -61,22 +66,28 @@ Decomposition Decompose(double const x) {
 }  // namespace
 
 void FastSinCos2π(double cycles, double& sin, double& cos) {
+  VOLATILE double vcycles = cycles;
+  IACA_VC64_START
   // Argument reduction.  cycles_reduced is in [-1/8, 1/8] and quadrant goes
   // from 0 to 3, with 0 indicating the principal quadrant and the others
   // numbered in the trigonometric direction.  These quantities are computed by
   // extracting the integer and fractional parts of 4 * cycles.
-  Decomposition const decomposition = Decompose(4.0 * cycles);
-  double const cycles_reduced = 0.25 * decomposition.fractional_part;
+  Decomposition const decomposition = Decompose(4.0 * vcycles);
+  double const cycles_reduced = decomposition.fractional_part;
+  double const cycles_reduced² = cycles_reduced * cycles_reduced;
   std::int64_t const quadrant = decomposition.integer_part & 0b11;
 
-  double const cycles_reduced² = cycles_reduced * cycles_reduced;
   double const s = sin_polynomial.Evaluate(cycles_reduced²) * cycles_reduced;
   double const c = cos_polynomial.Evaluate(cycles_reduced²);
 
+  VOLATILE double const vs = s;
+  VOLATILE double const vc = c;
+
+  IACA_VC64_END
   switch (quadrant) {
     case 0:
-      sin = s;
-      cos = c;
+      sin = vs;
+      cos = vc;
       break;
     case 1:
       sin = c;

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -14,11 +14,6 @@ namespace numerics {
 
 namespace {
 
-using P2 = PolynomialInMonomialBasis</*Value=*/double,
-                                     /*Argument=*/double,
-                                     /*degree=*/2,
-                                     /*Evaluator=*/EstrinEvaluator>;
-
 using P3 = PolynomialInMonomialBasis</*Value=*/double,
                                      /*Argument=*/double,
                                      /*degree=*/3,
@@ -30,7 +25,7 @@ using P3 = PolynomialInMonomialBasis</*Value=*/double,
 // the right behavior near 0 and the proper parity.  Because of extra
 // oscillations, the lower bounds of the minimization intervals are 1/36 and
 // 1/24 respectively.  This is where the maximum error is found.
-// The coefficients are scaled to accept arguments scaled to [0, 1/2].
+// The coefficients are scaled to accept arguments expressed in right angles.
 
 // The sine polynomial uses a custom evaluation, so the individual coefficients
 // are named.  The polynomial for Sin(2 π y/4) is s₁ y + s₃ y³ + s₅ y⁵.
@@ -87,8 +82,6 @@ void FastSinCos2π(double const cycles, double& sin, double& cos) {
   // argument, i.e., y * (s₁ + s₃ * y² + s₅ * (y² * y²)), avoids having a
   // multiplication by y at the end.
   double const s = s₁ * y + (s₃ + s₅ * y²) * y³;
-  // TODO(egg): Considering the above, I'm not sure this is more readable than
-  // just spelling out the Estrin evaluation.
   double const c = cos_polynomial.Evaluate(y²);
 
   switch (quadrant) {

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -19,6 +19,11 @@ using P2 = PolynomialInMonomialBasis</*Value=*/double,
                                      /*degree=*/2,
                                      /*Evaluator=*/EstrinEvaluator>;
 
+using P3 = PolynomialInMonomialBasis</*Value=*/double,
+                                     /*Argument=*/double,
+                                     /*degree=*/3,
+                                     /*Evaluator=*/EstrinEvaluator>;
+
 // 2nd-degree polynomials that minimize the absolute error on sin and cos over
 // the interval [0, 1/8].  The minimization algorithm is run on
 // Sin(2 π √x)/√x and (Cos(2 π √x) - 1)/x to ensure that the functions have
@@ -28,7 +33,8 @@ using P2 = PolynomialInMonomialBasis</*Value=*/double,
 P2 sin_polynomial(P2::Coefficients{6.28315387593158874093559349802,
                                    -41.3255673715186216778612605095,
                                    79.5314110676979262924240784281});
-P2 cos_polynomial(P2::Coefficients{-19.7391672615468690589481752820,
+P3 cos_polynomial(P3::Coefficients{1.0,
+                                   -19.7391672615468690589481752820,
                                    64.9232282990046449731568966307,
                                    -83.6659064641344641438100039739});
 
@@ -65,8 +71,7 @@ void FastSinCos2π(double cycles, double& sin, double& cos) {
 
   double const cycles_reduced² = cycles_reduced * cycles_reduced;
   double const s = sin_polynomial.Evaluate(cycles_reduced²) * cycles_reduced;
-  double const c = 1.0 +
-                   cos_polynomial.Evaluate(cycles_reduced²) * cycles_reduced²;
+  double const c = cos_polynomial.Evaluate(cycles_reduced²);
 
   switch (quadrant) {
     case 0:


### PR DESCRIPTION
This gains between 9 and 11 cycles, from about 55 to about 45 on Skylake and from about 59 to about 48 on Sandy Bridge.

Skylake:
```
Run on (4 X 2808 MHz CPU s)
2018-08-10T00:26:19
------------------------------------------------------------------------------------
Benchmark                                             Time           CPU Iterations
------------------------------------------------------------------------------------
BM_FastSinCos2?PoorlyPredictedLatency             16259 ns      16232 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16273 ns      16323 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16284 ns      16141 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16275 ns      16323 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16313 ns      15960 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16277 ns      16323 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16243 ns      16050 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16253 ns      16141 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16242 ns      16232 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency             16261 ns      15869 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency_mean        16268 ns      16159 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency_median      16267 ns      16186 ns     172308
BM_FastSinCos2?PoorlyPredictedLatency_stddev         22 ns        159 ns     172308
BM_FastSinCos2?WellPredictedLatency               16045 ns      15564 ns     175686
BM_FastSinCos2?WellPredictedLatency               16056 ns      16098 ns     175686
BM_FastSinCos2?WellPredictedLatency               16067 ns      15831 ns     175686
BM_FastSinCos2?WellPredictedLatency               16091 ns      15920 ns     175686
BM_FastSinCos2?WellPredictedLatency               16099 ns      15920 ns     175686
BM_FastSinCos2?WellPredictedLatency               16061 ns      16098 ns     175686
BM_FastSinCos2?WellPredictedLatency               16052 ns      15831 ns     175686
BM_FastSinCos2?WellPredictedLatency               16081 ns      16098 ns     175686
BM_FastSinCos2?WellPredictedLatency               16078 ns      16009 ns     175686
BM_FastSinCos2?WellPredictedLatency               16056 ns      16009 ns     175686
BM_FastSinCos2?WellPredictedLatency_mean          16069 ns      15938 ns     175686
BM_FastSinCos2?WellPredictedLatency_median        16064 ns      15964 ns     175686
BM_FastSinCos2?WellPredictedLatency_stddev           18 ns        167 ns     175686
BM_FastSinCos2?Throughput                          5534 ns       5554 ns     512000
BM_FastSinCos2?Throughput                          5544 ns       5524 ns     512000
BM_FastSinCos2?Throughput                          5544 ns       5524 ns     512000
BM_FastSinCos2?Throughput                          5545 ns       5524 ns     512000
BM_FastSinCos2?Throughput                          5505 ns       5463 ns     512000
BM_FastSinCos2?Throughput                          5594 ns       5585 ns     512000
BM_FastSinCos2?Throughput                          5547 ns       5554 ns     512000
BM_FastSinCos2?Throughput                          5486 ns       5463 ns     512000
BM_FastSinCos2?Throughput                          5516 ns       5493 ns     512000
BM_FastSinCos2?Throughput                          5524 ns       5463 ns     512000
BM_FastSinCos2?Throughput_mean                     5534 ns       5515 ns     512000
BM_FastSinCos2?Throughput_median                   5539 ns       5524 ns     512000
BM_FastSinCos2?Throughput_stddev                     29 ns         43 ns     512000
```

Sandy Bridge:
```
Run on (8 X 2672 MHz CPU s)
2018-08-11T00:15:17
------------------------------------------------------------------------------------
Benchmark                                             Time           CPU Iterations
------------------------------------------------------------------------------------
BM_FastSinCos2?PoorlyPredictedLatency             19689 ns      19321 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19511 ns      18756 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19476 ns      18982 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19491 ns      19095 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19391 ns      18982 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19446 ns      18982 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19332 ns      18756 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19293 ns      18982 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19299 ns      18869 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency             19333 ns      18869 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency_mean        19426 ns      18960 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency_median      19419 ns      18982 ns     138066
BM_FastSinCos2?PoorlyPredictedLatency_stddev        123 ns        167 ns     138066
BM_FastSinCos2?WellPredictedLatency               18202 ns      17736 ns     157444
BM_FastSinCos2?WellPredictedLatency               18202 ns      17736 ns     157444
BM_FastSinCos2?WellPredictedLatency               18340 ns      17736 ns     157444
BM_FastSinCos2?WellPredictedLatency               18214 ns      17736 ns     157444
BM_FastSinCos2?WellPredictedLatency               18297 ns      17934 ns     157444
BM_FastSinCos2?WellPredictedLatency               18262 ns      17934 ns     157444
BM_FastSinCos2?WellPredictedLatency               18242 ns      17835 ns     157444
BM_FastSinCos2?WellPredictedLatency               18300 ns      17835 ns     157444
BM_FastSinCos2?WellPredictedLatency               18226 ns      17835 ns     157444
BM_FastSinCos2?WellPredictedLatency               18189 ns      17736 ns     157444
BM_FastSinCos2?WellPredictedLatency_mean          18247 ns      17805 ns     157444
BM_FastSinCos2?WellPredictedLatency_median        18234 ns      17785 ns     157444
BM_FastSinCos2?WellPredictedLatency_stddev           51 ns         82 ns     157444
BM_FastSinCos2?Throughput                         14697 ns      14388 ns     192996
BM_FastSinCos2?Throughput                         14692 ns      14388 ns     192996
BM_FastSinCos2?Throughput                         14688 ns      14388 ns     192996
BM_FastSinCos2?Throughput                         14680 ns      14145 ns     192996
BM_FastSinCos2?Throughput                         14770 ns      14388 ns     192996
BM_FastSinCos2?Throughput                         14686 ns      14388 ns     192996
BM_FastSinCos2?Throughput                         14686 ns      14307 ns     192996
BM_FastSinCos2?Throughput                         14720 ns      14469 ns     192996
BM_FastSinCos2?Throughput                         14716 ns      14307 ns     192996
BM_FastSinCos2?Throughput                         14805 ns      14469 ns     192996
BM_FastSinCos2?Throughput_mean                    14714 ns      14364 ns     192996
BM_FastSinCos2?Throughput_median                  14694 ns      14388 ns     192996
BM_FastSinCos2?Throughput_stddev                     42 ns         94 ns     192996
```