### PR TITLE
Clarify reference frames.

### DIFF
--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -42,6 +42,94 @@ using ICRFJ2000Equator =
     Frame<serialization::Frame::SolarSystemTag,
           serialization::Frame::ICRF_J2000_EQUATOR, true>;
 
+// The Geocentric Celestial Reference System.
+// The origin is the centre of mass of the whole Earth system, including oceans
+// and atmosphere; the axes are those of the ICRS.
+// To be honest:
+// - The BCRS and GCRS are relativistic reference systems.
+// - The transformation between BCRS and GCRS spatial coordinates has no
+//   rotational component, i.e., the GCRS is kinematically non-rotating with
+//   respect to the BCRS; as a result, it rotates dynamically with respect to
+//   the BCRS.
+// - The time coordinate of the BCRS is TCB, and the time coordinate of the GCRS
+//   is TCG; TT is a linear scaling of TCG, and TDB is a linear scaling of TDB;
+//   for practical purposes TT and TDB are within 2 ms of each other;
+//   Principia's Instant is TT.
+using GCRS = Frame<serialization::Frame::SolarSystemTag,
+                   serialization::Frame::GCRS,
+                   /*frame_is_inertial=*/false>;
+
+// The International Terrestrial Reference System.
+// The origin is the centre of mass of the whole Earth system, including oceans
+// and atmosphere; there is no global residual rotation with respect to
+// horizontal motions at the earth's surface.
+// Practical notes:
+// - This is identical to WGS84 at 1 m level, and to recent realizations of WGS
+//   84 at 10 cm level; the xz plane is a bit over a hundred metres from the
+//   Royal Observatory in Greenwich.
+//   Caveat: using |SphericalCoordinates<Length>| on ITRS coordinates is
+//   inconsistent with WGS 84 latitudes; the WGS 84 geoid should be used.
+// - The ITRS is related to the European Terrestrial Reference System (ETRS89)
+//   by a time-dependent rigid transformation.
+// To be honest:
+// - There are many realizations of the ITRS; as of this writing, ICRFs 89, 90,
+//   91, 92, 93, 94, 96, 97, 2000, 2005, 2008, and 2014.  They are related by
+//   linearly time-dependent linearized similarity transformations with nonzero
+//   scaling, which the current abstractions of Principia cannot support; see
+//   Transformation parameters from ITRF2014 to past ITRFs,
+//   http://itrf.ensg.ign.fr/doc_ITRF/Transfo-ITRF2014_ITRFs.txt.  Identifying
+//   recent ITRFs (2005 and later) results in errors of a few millimetres at the
+//   geocentre, scale errors on the order of 1 part-per-billion, and angular
+//   errors below 1 μas.  Identifying earlier ITRFs results in errors may result
+//   in errors of tens of centimetres at the geocentre, scale errors on the
+//   order of ten parts per billion, and arcsecond-level angular errors.
+// - ETRFyy is always related to the corresponding ITRFyy by a linearized rigid
+//   transformation depending linearly on time, however it is related to other
+//   ITRFs by time-dependent similarity with time-dependent nonzero scaling; see
+//   the tables in EUREF Technical Note 1,
+//   http://etrs89.ensg.ign.fr/pub/EUREF-TN-1.pdf
+using ITRS = Frame<serialization::Frame::SolarSystemTag,
+                   serialization::Frame::ITRS,
+                   /*frame_is_inertial=*/false>;
+
+// The following two reference systems are both geocentric, and they share the
+// same z axis, the Celestial Intermediate Pole.  Their common xy plane is the
+// intermediate equator.
+// The rotation around the z axis relating the Terrestrial and Celestial
+// Intermediate Reference Systems, i.e., the angle between the Terrestrial and
+// Celestial Intermediate Origins, is the Earth Rotation Angle (ERA); the Earth
+// Rotation Angle is an affine function of UT1 defined by equation 5.14 of the
+// IERS conventions (2010).  Note the rate is faster than 2π radians per UT1
+// day, as UT1 is notionally mean solar days, whereas revolutions of the ERA are
+// stellar days.
+
+// The glossary of the Nomenclature for Fundamental Astronomy notes for both
+// that "since the acronym for this system is close to another acronym (namely
+// [ITRS, respectively ICRS]), it is suggested that wherever possible the
+// complete name be used".
+
+// The Terrestrial Intermediate Reference System.
+// The x axis is the Terrestrial Intermediate Origin.
+// The ITRS is related to the Terrestrial Intermediate Reference System by polar
+// motion, as described in sections 5.4.1 and 5.5.1 of the IERS conventions
+// (2010).
+// TODO(egg): identifying this with the ITRS, besides leading to acronym
+// confusion, results in arcsecond-level errors.
+using TerrestrialIntermediateReferenceSystem = ITRS;
+
+// The origin is geocentric; the basis is right-handed and orthonormal, the xy
+// plane is the same as that of the Terrestrial Intermediate Reference System,
+// i.e., the intermediate equator.
+// The x axis is the Celestial Intermediate Origin.
+// The GCRS is related to the Celestial Intermediate Reference System by
+// precession-nutation and frame biases, see sections 5.4.4 and 5.5.4 of the
+// IERS conventions (2010).
+// TODO(egg): identifying this with the GCRS leads to errors on the order of 10
+// arcminutes at the time of this writing, and on the order of a degree over a
+// century.
+using CelestialIntermediateReferenceSystem = GCRS;
+
+// A reference frame for transit exoplanetology.
 // The xy plane is the plane of the sky.  The origin is at the barycentre of the
 // extrasolar system.  The z axis goes from the extrasolar system to the Earth.
 // The xz plane is (approximately) the plane of the extrasolar system.

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -26,6 +26,7 @@ using quantities::si::Degree;
 // The x axis is close to the dynamical equinox at J2000.
 // The z axis is perpendicular to the xy plane and points to the northern side
 // of the xy plane.
+// To be honest:
 using ICRS = Frame<serialization::Frame::SolarSystemTag,
                    serialization::Frame::ICRS,
                    /*frame_is_inertial=*/true>;

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -19,19 +19,6 @@ using quantities::si::ArcMinute;
 using quantities::si::ArcSecond;
 using quantities::si::Degree;
 
-// A reference frame with a basis.
-// The frame is the International Celestial Reference Frame.
-// The basis is defined from the orbit of the Earth at J2000.0 as follows:
-// The xy plane is the plane of the Earth's orbit at J2000.0.
-// The x axis is out along the ascending node of the instantaneous plane of the
-// Earth's orbit and the Earth's mean equator at J2000.0.
-// The z axis is perpendicular to the xy-plane in the directional (+ or -) sense
-// of Earth's north pole at J2000.0.
-// The basis is right-handed and orthonormal.
-using ICRFJ2000Ecliptic =
-    Frame<serialization::Frame::SolarSystemTag,
-          serialization::Frame::ICRF_J2000_ECLIPTIC, true>;
-
 // The International Celestial Reference System.
 // The origin is the barycentre of the solar system.  The axes are fixed with
 // respect to the quasars.
@@ -139,26 +126,11 @@ using Sky =
     Frame<serialization::Frame::SolarSystemTag,
           serialization::Frame::SKY, true>;
 
-// Rotation around the common x axis mapping equatorial coordinates to ecliptic
-// coordinates.  The angle is the one defined by the XVIth General Assembly of
-// the International Astronomical Union.
-geometry::Rotation<ICRS, ICRFJ2000Ecliptic> const
-    ICRFJ200EquatorialToEcliptic =
-        geometry::Rotation<ICRS, ICRFJ2000Ecliptic>(
-            23 * Degree + 26 * ArcMinute + 21.448 * ArcSecond,
-            geometry::Bivector<double, ICRS>({1, 0, 0}),
-            geometry::DefinesFrame<ICRFJ2000Ecliptic>{});
-
-geometry::Position<ICRFJ2000Ecliptic> const SolarSystemBarycentreEcliptic;
-geometry::Position<ICRS> const SolarSystemBarycentreEquator;
-
 }  // namespace internal_frames
 
-using internal_frames::ICRFJ2000Ecliptic;
 using internal_frames::ICRS;
-using internal_frames::ICRFJ200EquatorialToEcliptic;
-using internal_frames::SolarSystemBarycentreEcliptic;
-using internal_frames::SolarSystemBarycentreEquator;
+using internal_frames::GCRS;
+using internal_frames::ITRS;
 using internal_frames::Sky;
 
 }  // namespace astronomy

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -27,6 +27,15 @@ using quantities::si::Degree;
 // The z axis is perpendicular to the xy plane and points to the northern side
 // of the xy plane.
 // To be honest:
+// - There are several realizations of the ICRS, namely ICRF (ICRF1) and its
+//   extensions, ICRF2, and the optical Hipparcos Celestial Reference Frame
+//   (HCRF); these realizations have different errors, but are consistent. ICRF3
+//   is in preparation, as well as an optical realization based on Gaia data.
+// - The terms Barycentric Celestial Reference System (BCRS) and ICRS are often
+//   used interchangeably; the relativistic framework, including the metric
+//   tensor, is defined for the BCRS (IAU 2000 resolution B1.3); the orientation
+//   of the BCRS is given by the ICRS axes unless otherwise stated (IAU 2006
+//   resolution B2 recommendation 2).
 using ICRS = Frame<serialization::Frame::SolarSystemTag,
                    serialization::Frame::ICRS,
                    /*frame_is_inertial=*/true>;

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -138,10 +138,12 @@ using Sky =
 
 }  // namespace internal_frames
 
-using internal_frames::ICRS;
 using internal_frames::GCRS;
+using internal_frames::ICRS;
 using internal_frames::ITRS;
 using internal_frames::Sky;
+using internal_frames::TerrestrialIntermediateReferenceSystem;
+using internal_frames::CelestialIntermediateReferenceSystem;
 
 }  // namespace astronomy
 }  // namespace principia

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -79,9 +79,9 @@ using GCRS = Frame<serialization::Frame::SolarSystemTag,
 //   http://itrf.ensg.ign.fr/doc_ITRF/Transfo-ITRF2014_ITRFs.txt.  Identifying
 //   recent ITRFs (2005 and later) results in errors of a few millimetres at the
 //   geocentre, scale errors on the order of 1 part-per-billion, and angular
-//   errors below 1 μas.  Identifying earlier ITRFs results in errors may result
-//   in errors of tens of centimetres at the geocentre, scale errors on the
-//   order of ten parts per billion, and arcsecond-level angular errors.
+//   errors below 1 μas.  Identifying earlier ITRFs may result in errors of tens
+//   of centimetres at the geocentre, scale errors on the order of ten parts per
+//   billion, and arcsecond-level angular errors.
 // - ETRFyy is always related to the corresponding ITRFyy by a linearized rigid
 //   transformation depending linearly on time, however it is related to other
 //   ITRFs by time-dependent similarity with time-dependent nonzero scaling; see

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -147,11 +147,11 @@ using Sky =
 
 }  // namespace internal_frames
 
+using internal_frames::CelestialIntermediateReferenceSystem;
 using internal_frames::GCRS;
 using internal_frames::ICRS;
 using internal_frames::ITRS;
 using internal_frames::Sky;
-using internal_frames::CelestialIntermediateReferenceSystem;
 using internal_frames::TerrestrialIntermediateReferenceSystem;
 
 }  // namespace astronomy

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -32,10 +32,18 @@ using quantities::si::Degree;
 //   (HCRF); these realizations have different errors, but are consistent. ICRF3
 //   is in preparation, as well as an optical realization based on Gaia data.
 // - The terms Barycentric Celestial Reference System (BCRS) and ICRS are often
-//   used interchangeably; the relativistic framework, including the metric
-//   tensor, is defined for the BCRS (IAU 2000 resolution B1.3); the orientation
-//   of the BCRS is given by the ICRS axes unless otherwise stated (IAU 2006
-//   resolution B2 recommendation 2).
+//   used interchangeably:
+//   - the ICRS has its origin at the barycentre (IAU 1997 resolution B2; Arias
+//     et al. 1995 "The extragalactic reference system of the International
+//     Earth Rotation Service", IAU 1991 recommendations);
+//   - the relativistic framework, including the metric
+//     tensor, is defined for the BCRS (IAU 2000 resolution B1.3);
+//   - the orientation of the BCRS is given by the ICRS axes unless otherwise
+//     stated (IAU 2006 resolution B2 recommendation 2).
+//   However, the term BCRS tends to be used in practice when the time scale
+//   in use is the time coordinate of the BCRS, namely TCB.  Since Principia
+//   does not support general relativity, and uses only one time scale (TT
+//   identified with TCB), we call this ICRS.
 using ICRS = Frame<serialization::Frame::SolarSystemTag,
                    serialization::Frame::ICRS,
                    /*frame_is_inertial=*/true>;
@@ -47,7 +55,8 @@ using ICRS = Frame<serialization::Frame::SolarSystemTag,
 // - The BCRS and GCRS are relativistic reference systems.
 // - The transformation between BCRS and GCRS spatial coordinates has no
 //   rotational component, i.e., the GCRS is kinematically non-rotating with
-//   respect to the BCRS; as a result, it rotates dynamically with respect to
+//   respect to the BCRS; since its origin moves in the BCRS, it follows from
+//   general relativistic effects that it rotates dynamically with respect to
 //   the BCRS; in particular, the equations of motion in the GCRS include de
 //   Sitter and Lense–Thirring precession.
 // - The time coordinate of the BCRS is TCB, and the time coordinate of the GCRS

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -88,9 +88,9 @@ using ITRS = Frame<serialization::Frame::SolarSystemTag,
 // Intermediate Reference Systems, i.e., the angle between the Terrestrial and
 // Celestial Intermediate Origins, is the Earth Rotation Angle (ERA); the Earth
 // Rotation Angle is an affine function of UT1 defined by equation 5.14 of the
-// IERS conventions (2010).  Note the rate is faster than 2π radians per UT1
-// day, as UT1 is notionally mean solar days, whereas revolutions of the ERA are
-// stellar days.
+// IERS conventions (2010).  Note that the rate is faster than 2π radians per
+// UT1 day, as UT1 is notionally mean solar days, whereas revolutions of the ERA
+// are stellar days.
 
 // The glossary of the Nomenclature for Fundamental Astronomy notes for both
 // that "since the acronym for this system is close to another acronym (namely

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -32,15 +32,16 @@ using ICRFJ2000Ecliptic =
     Frame<serialization::Frame::SolarSystemTag,
           serialization::Frame::ICRF_J2000_ECLIPTIC, true>;
 
-// The xy plane is the plane of the Earth's mean equator at J2000.0.
-// The x axis is out along the ascending node of the instantaneous plane of the
-// Earth's orbit and the Earth's mean equator at J2000.0.
-// The z axis is along the Earth's mean north pole at J2000.0.
-// The basis is right-handed and orthonormal.
-// Note that |ICRFJ2000Equator| and |ICRFJ2000Ecliptic| share their x axis.
-using ICRFJ2000Equator =
-    Frame<serialization::Frame::SolarSystemTag,
-          serialization::Frame::ICRF_J2000_EQUATOR, true>;
+// The International Celestial Reference System.
+// The origin is the barycentre of the solar system.  The axes are fixed with
+// respect to the quasars.
+// The xy plane is close to the mean equator at J2000.0.
+// The x axis is close to the dynamical equinox at J2000.
+// The z axis is perpendicular to the xy plane and points to the northern side
+// of the xy plane.
+using ICRS = Frame<serialization::Frame::SolarSystemTag,
+                   serialization::Frame::ICRS,
+                   /*frame_is_inertial=*/true>;
 
 // The Geocentric Celestial Reference System.
 // The origin is the centre of mass of the whole Earth system, including oceans
@@ -50,11 +51,12 @@ using ICRFJ2000Equator =
 // - The transformation between BCRS and GCRS spatial coordinates has no
 //   rotational component, i.e., the GCRS is kinematically non-rotating with
 //   respect to the BCRS; as a result, it rotates dynamically with respect to
-//   the BCRS.
+//   the BCRS; in particular, the equations of motion in the GCRS include de
+//   Sitter and Lense–Thirring precession.
 // - The time coordinate of the BCRS is TCB, and the time coordinate of the GCRS
 //   is TCG; TT is a linear scaling of TCG, and TDB is a linear scaling of TDB;
 //   for practical purposes TT and TDB are within 2 ms of each other;
-//   Principia's Instant is TT.
+//   Principia's |Instant| is TT.
 using GCRS = Frame<serialization::Frame::SolarSystemTag,
                    serialization::Frame::GCRS,
                    /*frame_is_inertial=*/false>;
@@ -140,20 +142,20 @@ using Sky =
 // Rotation around the common x axis mapping equatorial coordinates to ecliptic
 // coordinates.  The angle is the one defined by the XVIth General Assembly of
 // the International Astronomical Union.
-geometry::Rotation<ICRFJ2000Equator, ICRFJ2000Ecliptic> const
+geometry::Rotation<ICRS, ICRFJ2000Ecliptic> const
     ICRFJ200EquatorialToEcliptic =
-        geometry::Rotation<ICRFJ2000Equator, ICRFJ2000Ecliptic>(
+        geometry::Rotation<ICRS, ICRFJ2000Ecliptic>(
             23 * Degree + 26 * ArcMinute + 21.448 * ArcSecond,
-            geometry::Bivector<double, ICRFJ2000Equator>({1, 0, 0}),
+            geometry::Bivector<double, ICRS>({1, 0, 0}),
             geometry::DefinesFrame<ICRFJ2000Ecliptic>{});
 
 geometry::Position<ICRFJ2000Ecliptic> const SolarSystemBarycentreEcliptic;
-geometry::Position<ICRFJ2000Equator> const SolarSystemBarycentreEquator;
+geometry::Position<ICRS> const SolarSystemBarycentreEquator;
 
 }  // namespace internal_frames
 
 using internal_frames::ICRFJ2000Ecliptic;
-using internal_frames::ICRFJ2000Equator;
+using internal_frames::ICRS;
 using internal_frames::ICRFJ200EquatorialToEcliptic;
 using internal_frames::SolarSystemBarycentreEcliptic;
 using internal_frames::SolarSystemBarycentreEquator;

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -151,8 +151,8 @@ using internal_frames::GCRS;
 using internal_frames::ICRS;
 using internal_frames::ITRS;
 using internal_frames::Sky;
-using internal_frames::TerrestrialIntermediateReferenceSystem;
 using internal_frames::CelestialIntermediateReferenceSystem;
+using internal_frames::TerrestrialIntermediateReferenceSystem;
 
 }  // namespace astronomy
 }  // namespace principia

--- a/astronomy/generate_initial_state.awk
+++ b/astronomy/generate_initial_state.awk
@@ -3,7 +3,7 @@
 # |principia.serialization.SolarSystemFile| containing an |initial_state| field.
 BEGIN {
   print "initial_state {"
-  print "  solar_system_frame : ICRF_J2000_EQUATOR"
+  print "  solar_system_frame : ICRS"
   n = 0
   skip = 1
 }

--- a/astronomy/lunar_eclipse_test.cpp
+++ b/astronomy/lunar_eclipse_test.cpp
@@ -63,9 +63,9 @@ class LunarEclipseTest : public ::testing::Test {
     google::LogToStderr();
     ephemeris_ = solar_system_1950_.MakeEphemeris(
         /*fitting_tolerance=*/5 * Milli(Metre),
-        Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+        Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*step=*/10 * Minute));
     r_sun_ = solar_system_1950_.mean_radius("Sun");
     r_moon_ = solar_system_1950_.mean_radius("Moon");
@@ -212,19 +212,19 @@ class LunarEclipseTest : public ::testing::Test {
               << " " << actual_contact_time - current_time;
   }
 
-  static SolarSystem<ICRFJ2000Equator> solar_system_1950_;
-  static std::unique_ptr<Ephemeris<ICRFJ2000Equator>> ephemeris_;
+  static SolarSystem<ICRS> solar_system_1950_;
+  static std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
   static Length r_sun_;
   static Length r_earth_;
   static Length r_moon_;
   static Length atmospheric_depth_;
 };
 
-SolarSystem<ICRFJ2000Equator> LunarEclipseTest::solar_system_1950_(
+SolarSystem<ICRS> LunarEclipseTest::solar_system_1950_(
     SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
     SOLUTION_DIR / "astronomy" /
         "sol_initial_state_jd_2433282_500000000.proto.txt");
-std::unique_ptr<Ephemeris<ICRFJ2000Equator>> LunarEclipseTest::ephemeris_;
+std::unique_ptr<Ephemeris<ICRS>> LunarEclipseTest::ephemeris_;
 Length LunarEclipseTest::r_sun_;
 Length LunarEclipseTest::r_earth_;
 Length LunarEclipseTest::r_moon_;

--- a/astronomy/mercury_perihelion_test.cpp
+++ b/astronomy/mercury_perihelion_test.cpp
@@ -61,9 +61,9 @@ class MercuryPerihelionTest : public testing::Test {
     google::LogToStderr();
     ephemeris_ = solar_system_1950_.MakeEphemeris(
         /*fitting_tolerance=*/5 * Milli(Metre),
-        Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+        Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*step=*/10 * Minute));
   }
 
@@ -110,24 +110,24 @@ class MercuryPerihelionTest : public testing::Test {
     keplerian_elements_2050_.mean_anomaly = 3.105229688140852e+01 * Degree;
   }
 
-  static SolarSystem<ICRFJ2000Equator> solar_system_1950_;
-  static std::unique_ptr<Ephemeris<ICRFJ2000Equator>> ephemeris_;
+  static SolarSystem<ICRS> solar_system_1950_;
+  static std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
 
   not_null<MassiveBody const*> sun_;
   not_null<MassiveBody const*> mercury_;
   Instant t_1950_;
   Instant t_1960_;
   Instant t_2050_;
-  KeplerianElements<ICRFJ2000Equator> keplerian_elements_1950_;
-  KeplerianElements<ICRFJ2000Equator> keplerian_elements_1960_;
-  KeplerianElements<ICRFJ2000Equator> keplerian_elements_2050_;
+  KeplerianElements<ICRS> keplerian_elements_1950_;
+  KeplerianElements<ICRS> keplerian_elements_1960_;
+  KeplerianElements<ICRS> keplerian_elements_2050_;
 };
 
-SolarSystem<ICRFJ2000Equator> MercuryPerihelionTest::solar_system_1950_(
+SolarSystem<ICRS> MercuryPerihelionTest::solar_system_1950_(
     SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
     SOLUTION_DIR / "astronomy" /
         "sol_initial_state_jd_2433282_500000000.proto.txt");
-std::unique_ptr<Ephemeris<ICRFJ2000Equator>> MercuryPerihelionTest::ephemeris_;
+std::unique_ptr<Ephemeris<ICRS>> MercuryPerihelionTest::ephemeris_;
 
 TEST_F(MercuryPerihelionTest, Year1950) {
   ephemeris_->Prolong(t_1950_);
@@ -137,13 +137,12 @@ TEST_F(MercuryPerihelionTest, Year1950) {
   auto const& mercury_trajectory =
       solar_system_1950_.trajectory(*ephemeris_, "Mercury");
 
-  RelativeDegreesOfFreedom<ICRFJ2000Equator> const relative_degrees_of_freedom =
+  RelativeDegreesOfFreedom<ICRS> const relative_degrees_of_freedom =
       mercury_trajectory.EvaluateDegreesOfFreedom(t_1950_) -
       sun_trajectory.EvaluateDegreesOfFreedom(t_1950_);
-  KeplerOrbit<ICRFJ2000Equator> orbit(
+  KeplerOrbit<ICRS> orbit(
       *sun_, *mercury_, relative_degrees_of_freedom, t_1950_);
-  KeplerianElements<ICRFJ2000Equator> const keplerian_elements =
-      orbit.elements_at_epoch();
+  KeplerianElements<ICRS> const keplerian_elements = orbit.elements_at_epoch();
 
   EXPECT_THAT(RelativeError(*keplerian_elements.eccentricity,
                              *keplerian_elements_1950_.eccentricity),
@@ -178,13 +177,12 @@ TEST_F(MercuryPerihelionTest, Year1960) {
   auto const& mercury_trajectory =
       solar_system_1950_.trajectory(*ephemeris_, "Mercury");
 
-  RelativeDegreesOfFreedom<ICRFJ2000Equator> const relative_degrees_of_freedom =
+  RelativeDegreesOfFreedom<ICRS> const relative_degrees_of_freedom =
       mercury_trajectory.EvaluateDegreesOfFreedom(t_1960_) -
       sun_trajectory.EvaluateDegreesOfFreedom(t_1960_);
-  KeplerOrbit<ICRFJ2000Equator> orbit(
+  KeplerOrbit<ICRS> orbit(
       *sun_, *mercury_, relative_degrees_of_freedom, t_1960_);
-  KeplerianElements<ICRFJ2000Equator> const keplerian_elements =
-      orbit.elements_at_epoch();
+  KeplerianElements<ICRS> const keplerian_elements = orbit.elements_at_epoch();
 
   EXPECT_LT(RelativeError(*keplerian_elements.eccentricity,
                           *keplerian_elements_1960_.eccentricity), 5.3e-7);
@@ -213,13 +211,12 @@ TEST_F(MercuryPerihelionTest, DISABLED_Year2050) {
   auto const& mercury_trajectory =
       solar_system_1950_.trajectory(*ephemeris_, "Mercury");
 
-  RelativeDegreesOfFreedom<ICRFJ2000Equator> const relative_degrees_of_freedom =
+  RelativeDegreesOfFreedom<ICRS> const relative_degrees_of_freedom =
       mercury_trajectory.EvaluateDegreesOfFreedom(t_2050_) -
       sun_trajectory.EvaluateDegreesOfFreedom(t_2050_);
-  KeplerOrbit<ICRFJ2000Equator> orbit(
+  KeplerOrbit<ICRS> orbit(
       *sun_, *mercury_, relative_degrees_of_freedom, t_2050_);
-  KeplerianElements<ICRFJ2000Equator> const keplerian_elements =
-      orbit.elements_at_epoch();
+  KeplerianElements<ICRS> const keplerian_elements = orbit.elements_at_epoch();
 
   EXPECT_LT(RelativeError(*keplerian_elements.eccentricity,
                           *keplerian_elements_2050_.eccentricity), 9.8e-8);

--- a/astronomy/sol_gravity_model.proto.txt
+++ b/astronomy/sol_gravity_model.proto.txt
@@ -1,5 +1,5 @@
 gravity_model {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
 
   # Unless otherwise mentioned, axis directions, mean radii, reference angles
   # and angular frequencies are from "Report of the IAU Working Group on

--- a/astronomy/sol_initial_state_jd_2433282_500000000.proto.txt
+++ b/astronomy/sol_initial_state_jd_2433282_500000000.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1950-Jan-01 00:00:00.0000 TDB.
   epoch : "JD2433282.500000000"

--- a/astronomy/sol_initial_state_jd_2433292_500000000.proto.txt
+++ b/astronomy/sol_initial_state_jd_2433292_500000000.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1950-Jan-11 00:00:00.0000 TDB.
   epoch : "JD2433292.500000000"

--- a/astronomy/sol_initial_state_jd_2433374_257884090.proto.txt
+++ b/astronomy/sol_initial_state_jd_2433374_257884090.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1950-Apr-02 18:11:21.1854 TDB.
   epoch : "JD2433374.257884090"

--- a/astronomy/sol_initial_state_jd_2433374_470754460.proto.txt
+++ b/astronomy/sol_initial_state_jd_2433374_470754460.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1950-Apr-02 23:17:53.1853 TDB.
   epoch : "JD2433374.470754460"

--- a/astronomy/sol_initial_state_jd_2436116_311504629.proto.txt
+++ b/astronomy/sol_initial_state_jd_2436116_311504629.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1957-Oct-04 19:28:34.0000 TDB.
   epoch : "JD2436116.311504629"

--- a/astronomy/sol_initial_state_jd_2436145_604166667.proto.txt
+++ b/astronomy/sol_initial_state_jd_2436145_604166667.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 1957-Nov-03 02:30:00.0000 TDB.
   epoch : "JD2436145.604166667"

--- a/astronomy/sol_initial_state_jd_2451545_000000000.proto.txt
+++ b/astronomy/sol_initial_state_jd_2451545_000000000.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 2000-Jan-01 12:00:00.0000 TDB.
   epoch : "JD2451545.000000000"

--- a/astronomy/sol_initial_state_jd_2451564_587154910.proto.txt
+++ b/astronomy/sol_initial_state_jd_2451564_587154910.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 2000-Jan-21 02:05:30.1842 TDB.
   epoch : "JD2451564.58715491"

--- a/astronomy/sol_initial_state_jd_2451564_808127140.proto.txt
+++ b/astronomy/sol_initial_state_jd_2451564_808127140.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 2000-Jan-21 07:23:42.1849 TDB.
   epoch : "JD2451564.80812714"

--- a/astronomy/sol_initial_state_jd_2455200_500000000.proto.txt
+++ b/astronomy/sol_initial_state_jd_2455200_500000000.proto.txt
@@ -1,5 +1,5 @@
 initial_state {
-  solar_system_frame : ICRF_J2000_EQUATOR
+  solar_system_frame : ICRS
   # The time of the initial state, as a TDB Julian date.
   # This is 2010-Jan-04 00:00:00.0000 TDB.
   epoch : "JD2455200.500000000"

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -108,11 +108,10 @@ class SolarSystemDynamicsTest : public ::testing::Test {
     }
   }
 
-  OrbitError CompareOrbits(
-      int const index,
-      Ephemeris<ICRS> const& ephemeris,
-      SolarSystem<ICRS> const& system,
-      SolarSystem<ICRS> const& expected_system) {
+  OrbitError CompareOrbits(int const index,
+                           Ephemeris<ICRS> const& ephemeris,
+                           SolarSystem<ICRS> const& system,
+                           SolarSystem<ICRS> const& expected_system) {
     Instant const& epoch = expected_system.epoch();
     Time const duration = epoch - system.epoch();
 
@@ -120,9 +119,8 @@ class SolarSystemDynamicsTest : public ::testing::Test {
     auto const parent_name =
         SolarSystemFactory::name(SolarSystemFactory::parent(index));
     auto const body = system.massive_body(ephemeris, name);
-    auto const parent =
-        dynamic_cast_not_null<RotatingBody<ICRS> const*>(
-            system.massive_body(ephemeris, parent_name));
+    auto const parent = dynamic_cast_not_null<RotatingBody<ICRS> const*>(
+        system.massive_body(ephemeris, parent_name));
 
     BarycentreCalculator<DegreesOfFreedom<ICRS>,
                          GravitationalParameter> actual_subsystem_barycentre;
@@ -193,27 +191,21 @@ class SolarSystemDynamicsTest : public ::testing::Test {
       auto const declination_of_invariable_plane =
           OrientedAngleBetween(z, solar_system_angular_momentum, normal);
       EXPECT_THAT(declination_of_invariable_plane, Gt(0 * Radian));
-      rotation =
-          Rotation<ICRS, ParentEquator>(
-              declination_of_invariable_plane,
-              normal,
-              DefinesFrame<ParentEquator>{});
+      rotation = Rotation<ICRS, ParentEquator>(declination_of_invariable_plane,
+                                               normal,
+                                               DefinesFrame<ParentEquator>{});
     } else {
       auto const ω = parent->angular_velocity();
-      Bivector<double, ICRS> const normal =
-          Commutator(z, Normalize(ω));
+      Bivector<double, ICRS> const normal = Commutator(z, Normalize(ω));
       auto const parent_axis_declination = OrientedAngleBetween(z, ω, normal);
       EXPECT_THAT(parent_axis_declination, Gt(0 * Radian));
       rotation = Rotation<ICRS, ParentEquator>(
           parent_axis_declination, normal, DefinesFrame<ParentEquator>{});
     }
-    RigidMotion<ICRS, ParentEquator> const
-        to_parent_equator(
-            {ICRS::origin,
-             ParentEquator::origin,
-             rotation->Forget()},
-            /*angular_velocity_of_to_frame=*/{},
-            /*velocity_of_to_frame_origin=*/{});
+    RigidMotion<ICRS, ParentEquator> const to_parent_equator(
+        {ICRS::origin, ParentEquator::origin, rotation->Forget()},
+        /*angular_velocity_of_to_frame=*/{},
+        /*velocity_of_to_frame_origin=*/{});
 
     KeplerOrbit<ParentEquator> actual_osculating_orbit(
         /*primary=*/*parent,

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -110,9 +110,9 @@ class SolarSystemDynamicsTest : public ::testing::Test {
 
   OrbitError CompareOrbits(
       int const index,
-      Ephemeris<ICRFJ2000Equator> const& ephemeris,
-      SolarSystem<ICRFJ2000Equator> const& system,
-      SolarSystem<ICRFJ2000Equator> const& expected_system) {
+      Ephemeris<ICRS> const& ephemeris,
+      SolarSystem<ICRS> const& system,
+      SolarSystem<ICRS> const& expected_system) {
     Instant const& epoch = expected_system.epoch();
     Time const duration = epoch - system.epoch();
 
@@ -121,12 +121,12 @@ class SolarSystemDynamicsTest : public ::testing::Test {
         SolarSystemFactory::name(SolarSystemFactory::parent(index));
     auto const body = system.massive_body(ephemeris, name);
     auto const parent =
-        dynamic_cast_not_null<RotatingBody<ICRFJ2000Equator> const*>(
+        dynamic_cast_not_null<RotatingBody<ICRS> const*>(
             system.massive_body(ephemeris, parent_name));
 
-    BarycentreCalculator<DegreesOfFreedom<ICRFJ2000Equator>,
+    BarycentreCalculator<DegreesOfFreedom<ICRS>,
                          GravitationalParameter> actual_subsystem_barycentre;
-    BarycentreCalculator<DegreesOfFreedom<ICRFJ2000Equator>,
+    BarycentreCalculator<DegreesOfFreedom<ICRS>,
                          GravitationalParameter> expected_subsystem_barycentre;
 
     actual_subsystem_barycentre.Add(
@@ -162,28 +162,25 @@ class SolarSystemDynamicsTest : public ::testing::Test {
     // celestial reference frame, we'll use that in the plugin too.
     enum LocalFrameTag { tag };
     using ParentEquator = Frame<LocalFrameTag, tag, /*frame_is_inertial=*/true>;
-    auto const z = Bivector<double, ICRFJ2000Equator>({0, 0, 1});
-    std::optional<Rotation<ICRFJ2000Equator, ParentEquator>> rotation;
+    auto const z = Bivector<double, ICRS>({0, 0, 1});
+    std::optional<Rotation<ICRS, ParentEquator>> rotation;
 
     if (SolarSystemFactory::parent(index) == SolarSystemFactory::Sun) {
-      Bivector<AngularMomentum, ICRFJ2000Equator>
-          solar_system_angular_momentum;
+      Bivector<AngularMomentum, ICRS> solar_system_angular_momentum;
       for (int i = SolarSystemFactory::Sun + 1;
            i <= SolarSystemFactory::LastBody;
            ++i) {
         auto const body_name = SolarSystemFactory::name(i);
         auto const body = system.massive_body(ephemeris, body_name);
-        RelativeDegreesOfFreedom<ICRFJ2000Equator> const
-            from_solar_system_barycentre =
-                expected_system.degrees_of_freedom(body_name) -
-                DegreesOfFreedom<ICRFJ2000Equator>(ICRFJ2000Equator::origin,
-                                                   {});
+        RelativeDegreesOfFreedom<ICRS> const from_solar_system_barycentre =
+            expected_system.degrees_of_freedom(body_name) -
+            DegreesOfFreedom<ICRS>(ICRS::origin, {});
         solar_system_angular_momentum +=
             Wedge(from_solar_system_barycentre.displacement(),
                   body->mass() * from_solar_system_barycentre.velocity()) *
             Radian;
       }
-      Bivector<double, ICRFJ2000Equator> const normal =
+      Bivector<double, ICRS> const normal =
           Commutator(z, Normalize(solar_system_angular_momentum));
       // Check that we computed the invariable plane properly by computing its
       // angle to the Sun's equator.
@@ -197,22 +194,22 @@ class SolarSystemDynamicsTest : public ::testing::Test {
           OrientedAngleBetween(z, solar_system_angular_momentum, normal);
       EXPECT_THAT(declination_of_invariable_plane, Gt(0 * Radian));
       rotation =
-          Rotation<ICRFJ2000Equator, ParentEquator>(
+          Rotation<ICRS, ParentEquator>(
               declination_of_invariable_plane,
               normal,
               DefinesFrame<ParentEquator>{});
     } else {
       auto const ω = parent->angular_velocity();
-      Bivector<double, ICRFJ2000Equator> const normal =
+      Bivector<double, ICRS> const normal =
           Commutator(z, Normalize(ω));
       auto const parent_axis_declination = OrientedAngleBetween(z, ω, normal);
       EXPECT_THAT(parent_axis_declination, Gt(0 * Radian));
-      rotation = Rotation<ICRFJ2000Equator, ParentEquator>(
+      rotation = Rotation<ICRS, ParentEquator>(
           parent_axis_declination, normal, DefinesFrame<ParentEquator>{});
     }
-    RigidMotion<ICRFJ2000Equator, ParentEquator> const
+    RigidMotion<ICRS, ParentEquator> const
         to_parent_equator(
-            {ICRFJ2000Equator::origin,
+            {ICRS::origin,
              ParentEquator::origin,
              rotation->Forget()},
             /*angular_velocity_of_to_frame=*/{},
@@ -264,21 +261,21 @@ class SolarSystemDynamicsTest : public ::testing::Test {
 
 // This takes a minute to run.
 TEST_F(SolarSystemDynamicsTest, DISABLED_TenYearsFromJ2000) {
-  SolarSystem<ICRFJ2000Equator> solar_system_at_j2000(
+  SolarSystem<ICRS> solar_system_at_j2000(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2451545_000000000.proto.txt");
 
-  SolarSystem<ICRFJ2000Equator> ten_years_later(
+  SolarSystem<ICRS> ten_years_later(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2455200_500000000.proto.txt");
 
   auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
       /*fitting_tolerance=*/5 * Milli(Metre),
-      Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+      Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
-                                                Position<ICRFJ2000Equator>>(),
+                                                Position<ICRS>>(),
           /*step=*/45 * Minute));
   ephemeris->Prolong(ten_years_later.epoch());
 
@@ -385,32 +382,32 @@ TEST_F(SolarSystemDynamicsTest, DISABLED_TenYearsFromJ2000) {
 // This test produces the file phobos.generated.wl which is consumed by the
 // notebook phobos.nb.
 TEST(MarsTest, Phobos) {
-  SolarSystem<ICRFJ2000Equator> solar_system_at_j2000(
+  SolarSystem<ICRS> solar_system_at_j2000(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2451545_000000000.proto.txt");
   auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
       /*fitting_tolerance=*/5 * Milli(Metre),
-      Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+      Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
-                                                Position<ICRFJ2000Equator>>(),
+                                                Position<ICRS>>(),
           /*step=*/45 * Minute));
   ephemeris->Prolong(J2000 + 1 * JulianYear);
 
-  ContinuousTrajectory<ICRFJ2000Equator> const& mars_trajectory =
+  ContinuousTrajectory<ICRS> const& mars_trajectory =
       solar_system_at_j2000.trajectory(*ephemeris, "Mars");
 
-  std::vector<Position<ICRFJ2000Equator>> mars_positions;
-  std::vector<Velocity<ICRFJ2000Equator>> mars_velocities;
+  std::vector<Position<ICRS>> mars_positions;
+  std::vector<Velocity<ICRS>> mars_velocities;
 
-  ContinuousTrajectory<ICRFJ2000Equator> const& phobos_trajectory =
+  ContinuousTrajectory<ICRS> const& phobos_trajectory =
       solar_system_at_j2000.trajectory(*ephemeris, "Phobos");
 
-  std::vector<Position<ICRFJ2000Equator>> phobos_positions;
-  std::vector<Velocity<ICRFJ2000Equator>> phobos_velocities;
+  std::vector<Position<ICRS>> phobos_positions;
+  std::vector<Velocity<ICRS>> phobos_velocities;
 
-  std::vector<Displacement<ICRFJ2000Equator>> mars_phobos_displacements;
-  std::vector<Velocity<ICRFJ2000Equator>> mars_phobos_velocities;
+  std::vector<Displacement<ICRS>> mars_phobos_displacements;
+  std::vector<Velocity<ICRS>> mars_phobos_velocities;
   for (Instant t = J2000; t < J2000 + 30 * Day; t += 5 * Minute) {
     mars_positions.push_back(mars_trajectory.EvaluatePosition(t));
     mars_velocities.push_back(mars_trajectory.EvaluateVelocity(t));
@@ -433,7 +430,7 @@ TEST(MarsTest, Phobos) {
 
 struct ConvergenceTestParameters {
   FixedStepSizeIntegrator<
-      Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const& integrator;
+      Ephemeris<ICRS>::NewtonianMotionEquation> const& integrator;
   int iterations;
   double first_step_in_seconds;
 };
@@ -451,8 +448,7 @@ class SolarSystemDynamicsConvergenceTest
   }
 
  protected:
-  FixedStepSizeIntegrator<
-      Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const&
+  FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
   integrator() const {
     return GetParam().integrator;
   }
@@ -475,13 +471,13 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
   google::LogToStderr();
   Time const integration_duration = 1 * JulianYear;
 
-  SolarSystem<ICRFJ2000Equator> solar_system_at_j2000(
+  SolarSystem<ICRS> solar_system_at_j2000(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2451545_000000000.proto.txt");
   std::vector<std::string> const& body_names = solar_system_at_j2000.names();
 
-  std::map<std::string, std::vector<DegreesOfFreedom<ICRFJ2000Equator>>>
+  std::map<std::string, std::vector<DegreesOfFreedom<ICRS>>>
       name_to_degrees_of_freedom;
   std::vector<Time> steps;
   std::vector<std::chrono::duration<double>> durations;
@@ -493,7 +489,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
     auto const start = std::chrono::system_clock::now();
     auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
         /*fitting_tolerance=*/5 * Milli(Metre),
-        Ephemeris<ICRFJ2000Equator>::FixedStepParameters(integrator(), step));
+        Ephemeris<ICRS>::FixedStepParameters(integrator(), step));
     ephemeris->Prolong(solar_system_at_j2000.epoch() + integration_duration);
     auto const end = std::chrono::system_clock::now();
     durations.push_back(end - start);
@@ -507,7 +503,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
     }
   }
 
-  std::map<std::string, std::vector<RelativeDegreesOfFreedom<ICRFJ2000Equator>>>
+  std::map<std::string, std::vector<RelativeDegreesOfFreedom<ICRS>>>
       name_to_errors;
   for (auto const& pair : name_to_degrees_of_freedom) {
     auto const& name = pair.first;
@@ -554,28 +550,28 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Values(
         ConvergenceTestParameters{
             SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN11B,
-                                                  Position<ICRFJ2000Equator>>(),
+                                                  Position<ICRS>>(),
             /*iterations=*/8,
             /*first_step_in_seconds=*/64},
         ConvergenceTestParameters{
             SymplecticRungeKuttaNyströmIntegrator<
                  McLachlanAtela1992Order5Optimal,
-                 Position<ICRFJ2000Equator>>(),
+                 Position<ICRS>>(),
              /*iterations=*/8,
              /*first_step_in_seconds=*/32},
         ConvergenceTestParameters{
             SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*iterations=*/6,
             /*first_step_in_seconds=*/64},
         ConvergenceTestParameters{
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order8,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*iterations=*/6,
             /*first_step_in_seconds=*/64},
         ConvergenceTestParameters{
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order10,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*iterations=*/6,
             /*first_step_in_seconds=*/64},
 
@@ -584,7 +580,7 @@ INSTANTIATE_TEST_CASE_P(
         // elapsed time.  For steps larger than about 680 s, the errors explode.
         ConvergenceTestParameters{
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*iterations=*/5,
             /*first_step_in_seconds=*/75}));
 

--- a/astronomy/молния_orbit_test.cpp
+++ b/astronomy/молния_orbit_test.cpp
@@ -91,9 +91,8 @@ std::unique_ptr<Ephemeris<ICRS>> МолнияOrbitTest::ephemeris_;
 #if !defined(_DEBUG)
 
 TEST_F(МолнияOrbitTest, Satellite) {
-  auto const earth_body =
-      dynamic_cast_not_null<OblateBody<ICRS> const*>(
-          solar_system_2000_.massive_body(*ephemeris_, "Earth"));
+  auto const earth_body = dynamic_cast_not_null<OblateBody<ICRS> const*>(
+      solar_system_2000_.massive_body(*ephemeris_, "Earth"));
   auto const earth_degrees_of_freedom =
       solar_system_2000_.degrees_of_freedom("Earth");
 

--- a/astronomy/молния_orbit_test.cpp
+++ b/astronomy/молния_orbit_test.cpp
@@ -28,7 +28,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::J2000;
 using base::dynamic_cast_not_null;
 using base::OFStream;
@@ -72,27 +72,27 @@ class МолнияOrbitTest : public ::testing::Test {
     google::LogToStderr();
     ephemeris_ = solar_system_2000_.MakeEphemeris(
         /*fitting_tolerance=*/5 * Milli(Metre),
-        Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+        Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
-                                               Position<ICRFJ2000Equator>>(),
+                                               Position<ICRS>>(),
             /*step=*/10 * Minute));
   }
 
-  static SolarSystem<ICRFJ2000Equator> solar_system_2000_;
-  static std::unique_ptr<Ephemeris<ICRFJ2000Equator>> ephemeris_;
+  static SolarSystem<ICRS> solar_system_2000_;
+  static std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
 };
 
-SolarSystem<ICRFJ2000Equator> МолнияOrbitTest::solar_system_2000_(
+SolarSystem<ICRS> МолнияOrbitTest::solar_system_2000_(
     SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
     SOLUTION_DIR / "astronomy" /
         "sol_initial_state_jd_2451545_000000000.proto.txt");
-std::unique_ptr<Ephemeris<ICRFJ2000Equator>> МолнияOrbitTest::ephemeris_;
+std::unique_ptr<Ephemeris<ICRS>> МолнияOrbitTest::ephemeris_;
 
 #if !defined(_DEBUG)
 
 TEST_F(МолнияOrbitTest, Satellite) {
   auto const earth_body =
-      dynamic_cast_not_null<OblateBody<ICRFJ2000Equator> const*>(
+      dynamic_cast_not_null<OblateBody<ICRS> const*>(
           solar_system_2000_.massive_body(*ephemeris_, "Earth"));
   auto const earth_degrees_of_freedom =
       solar_system_2000_.degrees_of_freedom("Earth");
@@ -103,7 +103,7 @@ TEST_F(МолнияOrbitTest, Satellite) {
 
   // These data are from https://en.wikipedia.org/wiki/Molniya_orbit.  The
   // eccentricity is from the "External links" section.
-  KeplerianElements<ICRFJ2000Equator> initial_elements;
+  KeplerianElements<ICRS> initial_elements;
   initial_elements.eccentricity = 0.74105;
   initial_elements.mean_motion = 2.0 * π * Radian / (sidereal_day / 2.0);
   initial_elements.inclination = ArcSin(2.0 / Sqrt(5.0));
@@ -112,18 +112,18 @@ TEST_F(МолнияOrbitTest, Satellite) {
   initial_elements.mean_anomaly = 2 * Radian;
 
   MasslessBody const satellite{};
-  KeplerOrbit<ICRFJ2000Equator> initial_orbit(
+  KeplerOrbit<ICRS> initial_orbit(
       *earth_body, satellite, initial_elements, J2000);
   auto const satellite_state_vectors = initial_orbit.StateVectors(J2000);
 
-  DiscreteTrajectory<ICRFJ2000Equator> trajectory;
+  DiscreteTrajectory<ICRS> trajectory;
   trajectory.Append(J2000, earth_degrees_of_freedom + satellite_state_vectors);
   auto const instance = ephemeris_->NewInstance(
       {&trajectory},
-      Ephemeris<ICRFJ2000Equator>::NoIntrinsicAccelerations,
-      Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+      Ephemeris<ICRS>::NoIntrinsicAccelerations,
+      Ephemeris<ICRS>::FixedStepParameters(
           SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
-                                             Position<ICRFJ2000Equator>>(),
+                                             Position<ICRS>>(),
           integration_step));
 
   // Remember that because of #228 we need to loop over FlowWithFixedStep.
@@ -137,7 +137,7 @@ TEST_F(МолнияOrbitTest, Satellite) {
   // at parsing them.
   base::OFStream file(SOLUTION_DIR / "mathematica" /
                       UNICODE_PATH("молния_orbit.generated.wl"));
-  std::vector<geometry::Vector<double, ICRFJ2000Equator>> mma_displacements;
+  std::vector<geometry::Vector<double, ICRS>> mma_displacements;
   std::vector<double> mma_arguments_of_periapsis;
   std::vector<double> mma_longitudes_of_ascending_nodes;
 
@@ -146,13 +146,10 @@ TEST_F(МолнияOrbitTest, Satellite) {
 
   for (Instant t = J2000; t <= J2000 + integration_duration;
        t += integration_duration / 100000.0) {
-    RelativeDegreesOfFreedom<ICRFJ2000Equator> const relative_dof =
+    RelativeDegreesOfFreedom<ICRS> const relative_dof =
         trajectory.EvaluateDegreesOfFreedom(t) -
         ephemeris_->trajectory(earth_body)->EvaluateDegreesOfFreedom(t);
-    KeplerOrbit<ICRFJ2000Equator> actual_orbit(*earth_body,
-                                               satellite,
-                                               relative_dof,
-                                               t);
+    KeplerOrbit<ICRS> actual_orbit(*earth_body, satellite, relative_dof, t);
     auto actual_elements = actual_orbit.elements_at_epoch();
 
     if (actual_elements.longitude_of_ascending_node >

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -226,10 +226,10 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
         DefinesFrame<Ecliptic>{});
     auto const ecliptic_to_equatorial = equatorial_to_ecliptic.Inverse();
 
-        Displacement<Ecliptic> const sun_earth_displacement =
-            equatorial_to_ecliptic(
-                from_barycentric(earth_degrees_of_freedom.position() -
-                                 sun_degrees_of_freedom.position()));
+    Displacement<Ecliptic> const sun_earth_displacement =
+        equatorial_to_ecliptic(
+            from_barycentric(earth_degrees_of_freedom.position() -
+                             sun_degrees_of_freedom.position()));
     Rotation<Ecliptic, Ecliptic> const l4_rotation(
         Quaternion(cos(π / 6), {0, 0, sin(π / 6)}));
     Displacement<Ecliptic> const sun_l4_displacement =

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -37,7 +37,7 @@
 namespace principia {
 
 using astronomy::ICRFJ2000Ecliptic;
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::ICRFJ200EquatorialToEcliptic;
 using base::make_not_null_unique;
 using base::not_null;
@@ -200,8 +200,8 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
   while (state.KeepRunning()) {
     state.PauseTiming();
     // A probe near the L4 point of the Sun-Earth system.
-    Identity<ICRFJ2000Equator, Barycentric> to_barycentric;
-    Identity<Barycentric, ICRFJ2000Equator> from_barycentric;
+    Identity<ICRS, Barycentric> to_barycentric;
+    Identity<Barycentric, ICRS> from_barycentric;
     MasslessBody probe;
     DiscreteTrajectory<Barycentric> trajectory;
     DegreesOfFreedom<Barycentric> const sun_degrees_of_freedom =

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -36,9 +36,7 @@
 
 namespace principia {
 
-using astronomy::Ecliptic;
 using astronomy::ICRS;
-using astronomy::equatorial_to_ecliptic;
 using base::make_not_null_unique;
 using base::not_null;
 using base::ThreadPool;
@@ -69,7 +67,10 @@ using quantities::Sqrt;
 using quantities::Time;
 using quantities::astronomy::JulianYear;
 using quantities::bipm::NauticalMile;
+using quantities::si::ArcMinute;
+using quantities::si::ArcSecond;
 using quantities::si::AstronomicalUnit;
+using quantities::si::Degree;
 using quantities::si::Hertz;
 using quantities::si::Kilo;
 using quantities::si::Metre;

--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -24,7 +24,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Ecliptic;
+using astronomy::ICRS;
 using base::not_null;
 using geometry::Displacement;
 using geometry::Instant;
@@ -67,31 +67,31 @@ void BM_NewhallApproximationDouble(benchmark::State& state) {
 template<typename Result,
          Result (*newhall)(
              int degree,
-             std::vector<Displacement<ICRFJ2000Ecliptic>> const& q,
-             std::vector<Variation<Displacement<ICRFJ2000Ecliptic>>> const& v,
+             std::vector<Displacement<ICRS>> const& q,
+             std::vector<Variation<Displacement<ICRS>>> const& v,
              Instant const& t_min,
              Instant const& t_max,
-             Displacement<ICRFJ2000Ecliptic>& error_estimate)>
+             Displacement<ICRS>& error_estimate)>
 void BM_NewhallApproximationDisplacement(benchmark::State& state) {
   int const degree = state.range_x();
   std::mt19937_64 random(42);
-  std::vector<Displacement<ICRFJ2000Ecliptic>> p;
-  std::vector<Variation<Displacement<ICRFJ2000Ecliptic>>> v;
+  std::vector<Displacement<ICRS>> p;
+  std::vector<Variation<Displacement<ICRS>>> v;
   Instant const t0;
   Instant const t_min = t0 + static_cast<double>(random()) * Second;
   Instant const t_max = t_min + static_cast<double>(random()) * Second;
 
-  Displacement<ICRFJ2000Ecliptic> error_estimate;
+  Displacement<ICRS> error_estimate;
   while (state.KeepRunning()) {
     state.PauseTiming();
     p.clear();
     v.clear();
     for (int i = 0; i <= 8; ++i) {
-      p.push_back(Displacement<ICRFJ2000Ecliptic>(
+      p.push_back(Displacement<ICRS>(
           {static_cast<double>(random()) * Metre,
            static_cast<double>(random()) * Metre,
            static_cast<double>(random()) * Metre}));
-      v.push_back(Variation<Displacement<ICRFJ2000Ecliptic>>(
+      v.push_back(Variation<Displacement<ICRS>>(
           {static_cast<double>(random()) * Metre / Second,
            static_cast<double>(random()) * Metre / Second,
            static_cast<double>(random()) * Metre / Second}));
@@ -104,11 +104,11 @@ void BM_NewhallApproximationDisplacement(benchmark::State& state) {
 using ResultЧебышёвDouble =
     ЧебышёвSeries<double>;
 using ResultЧебышёвDisplacement =
-    ЧебышёвSeries<Displacement<ICRFJ2000Ecliptic>>;
+    ЧебышёвSeries<Displacement<ICRS>>;
 using ResultMonomialDouble =
     not_null<std::unique_ptr<Polynomial<double, Instant>>>;
 using ResultMonomialDisplacement = not_null<
-    std::unique_ptr<Polynomial<Displacement<ICRFJ2000Ecliptic>, Instant>>>;
+    std::unique_ptr<Polynomial<Displacement<ICRS>, Instant>>>;
 
 BENCHMARK_TEMPLATE2(
     BM_NewhallApproximationDouble,
@@ -118,7 +118,7 @@ BENCHMARK_TEMPLATE2(
 BENCHMARK_TEMPLATE2(
     BM_NewhallApproximationDisplacement,
     ResultЧебышёвDisplacement,
-    &NewhallApproximationInЧебышёвBasis<Displacement<ICRFJ2000Ecliptic>>)
+    &NewhallApproximationInЧебышёвBasis<Displacement<ICRS>>)
     ->Arg(4)->Arg(8)->Arg(16);
 // No space or line break in the second argument, that confuses automation.
 BENCHMARK_TEMPLATE2(
@@ -130,7 +130,7 @@ BENCHMARK_TEMPLATE2(
 BENCHMARK_TEMPLATE2(
     BM_NewhallApproximationDisplacement,
     ResultMonomialDisplacement,
-    (&NewhallApproximationInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,EstrinEvaluator>))  // NOLINT
+    (&NewhallApproximationInMonomialBasis<Displacement<ICRS>,EstrinEvaluator>))  // NOLINT
     ->Arg(4)->Arg(8)->Arg(16);
 
 }  // namespace numerics

--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -65,13 +65,12 @@ void BM_NewhallApproximationDouble(benchmark::State& state) {
 }
 
 template<typename Result,
-         Result (*newhall)(
-             int degree,
-             std::vector<Displacement<ICRS>> const& q,
-             std::vector<Variation<Displacement<ICRS>>> const& v,
-             Instant const& t_min,
-             Instant const& t_max,
-             Displacement<ICRS>& error_estimate)>
+         Result (*newhall)(int degree,
+                           std::vector<Displacement<ICRS>> const& q,
+                           std::vector<Variation<Displacement<ICRS>>> const& v,
+                           Instant const& t_min,
+                           Instant const& t_max,
+                           Displacement<ICRS>& error_estimate)>
 void BM_NewhallApproximationDisplacement(benchmark::State& state) {
   int const degree = state.range_x();
   std::mt19937_64 random(42);
@@ -87,10 +86,9 @@ void BM_NewhallApproximationDisplacement(benchmark::State& state) {
     p.clear();
     v.clear();
     for (int i = 0; i <= 8; ++i) {
-      p.push_back(Displacement<ICRS>(
-          {static_cast<double>(random()) * Metre,
-           static_cast<double>(random()) * Metre,
-           static_cast<double>(random()) * Metre}));
+      p.push_back(Displacement<ICRS>({static_cast<double>(random()) * Metre,
+                                      static_cast<double>(random()) * Metre,
+                                      static_cast<double>(random()) * Metre}));
       v.push_back(Variation<Displacement<ICRS>>(
           {static_cast<double>(random()) * Metre / Second,
            static_cast<double>(random()) * Metre / Second,
@@ -101,14 +99,12 @@ void BM_NewhallApproximationDisplacement(benchmark::State& state) {
   }
 }
 
-using ResultЧебышёвDouble =
-    ЧебышёвSeries<double>;
-using ResultЧебышёвDisplacement =
-    ЧебышёвSeries<Displacement<ICRS>>;
+using ResultЧебышёвDouble = ЧебышёвSeries<double>;
+using ResultЧебышёвDisplacement = ЧебышёвSeries<Displacement<ICRS>>;
 using ResultMonomialDouble =
     not_null<std::unique_ptr<Polynomial<double, Instant>>>;
-using ResultMonomialDisplacement = not_null<
-    std::unique_ptr<Polynomial<Displacement<ICRS>, Instant>>>;
+using ResultMonomialDisplacement =
+    not_null<std::unique_ptr<Polynomial<Displacement<ICRS>, Instant>>>;
 
 BENCHMARK_TEMPLATE2(
     BM_NewhallApproximationDouble,

--- a/benchmarks/polynomial.cpp
+++ b/benchmarks/polynomial.cpp
@@ -14,7 +14,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Ecliptic;
+using astronomy::ICRS;
 using geometry::Displacement;
 using geometry::Multivector;
 using geometry::R3Element;
@@ -154,32 +154,28 @@ void BM_EvaluatePolynomialInMonomialBasisVectorDouble(benchmark::State& state) {
   int const degree = state.range_x();
   switch (degree) {
     case 4:
-      EvaluatePolynomialInMonomialBasis<
-          Multivector<double, ICRFJ2000Ecliptic, 1>,
-          Time,
-          4,
-          Evaluator>(state);
+      EvaluatePolynomialInMonomialBasis<Multivector<double, ICRS, 1>,
+                                        Time,
+                                        4,
+                                        Evaluator>(state);
       break;
     case 8:
-      EvaluatePolynomialInMonomialBasis<
-          Multivector<double, ICRFJ2000Ecliptic, 1>,
-          Time,
-          8,
-          Evaluator>(state);
+      EvaluatePolynomialInMonomialBasis<Multivector<double, ICRS, 1>,
+                                        Time,
+                                        8,
+                                        Evaluator>(state);
       break;
     case 12:
-      EvaluatePolynomialInMonomialBasis<
-          Multivector<double, ICRFJ2000Ecliptic, 1>,
-          Time,
-          12,
-          Evaluator>(state);
+      EvaluatePolynomialInMonomialBasis<Multivector<double, ICRS, 1>,
+                                        Time,
+                                        12,
+                                        Evaluator>(state);
       break;
     case 16:
-      EvaluatePolynomialInMonomialBasis<
-          Multivector<double, ICRFJ2000Ecliptic, 1>,
-          Time,
-          16,
-          Evaluator>(state);
+      EvaluatePolynomialInMonomialBasis<Multivector<double, ICRS, 1>,
+                                        Time,
+                                        16,
+                                        Evaluator>(state);
       break;
     default:
       LOG(FATAL) << "Degree " << degree
@@ -192,25 +188,25 @@ void BM_EvaluatePolynomialInMonomialBasisDisplacement(benchmark::State& state) {
   int const degree = state.range_x();
   switch (degree) {
     case 4:
-      EvaluatePolynomialInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,
+      EvaluatePolynomialInMonomialBasis<Displacement<ICRS>,
                                         Time,
                                         4,
                                         Evaluator>(state);
       break;
     case 8:
-      EvaluatePolynomialInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,
+      EvaluatePolynomialInMonomialBasis<Displacement<ICRS>,
                                         Time,
                                         8,
                                         Evaluator>(state);
       break;
     case 12:
-      EvaluatePolynomialInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,
+      EvaluatePolynomialInMonomialBasis<Displacement<ICRS>,
                                         Time,
                                         12,
                                         Evaluator>(state);
       break;
     case 16:
-      EvaluatePolynomialInMonomialBasis<Displacement<ICRFJ2000Ecliptic>,
+      EvaluatePolynomialInMonomialBasis<Displacement<ICRS>,
                                         Time,
                                         16,
                                         Evaluator>(state);

--- a/benchmarks/чебышёв_series.cpp
+++ b/benchmarks/чебышёв_series.cpp
@@ -31,7 +31,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Ecliptic;
+using astronomy::ICRS;
 using geometry::Displacement;
 using geometry::Instant;
 using geometry::Multivector;
@@ -141,23 +141,22 @@ void BM_EvaluateR3ElementDouble(benchmark::State& state) {
 void BM_EvaluateVectorDouble(benchmark::State& state) {
   int const degree = state.range_x();
   std::mt19937_64 random(42);
-  std::vector<Multivector<double, ICRFJ2000Ecliptic, 1>> coefficients;
+  std::vector<Multivector<double, ICRS, 1>> coefficients;
   for (int i = 0; i <= degree; ++i) {
     coefficients.push_back(
-        Multivector<double, ICRFJ2000Ecliptic, 1>(
-            {static_cast<double>(random()),
-             static_cast<double>(random()),
-             static_cast<double>(random())}));
+        Multivector<double, ICRS, 1>({static_cast<double>(random()),
+                                      static_cast<double>(random()),
+                                      static_cast<double>(random())}));
   }
   Instant const t0;
   Instant const t_min = t0 + static_cast<double>(random()) * Second;
   Instant const t_max = t_min + static_cast<double>(random()) * Second;
-  ЧебышёвSeries<Multivector<double, ICRFJ2000Ecliptic, 1>> const series(
+  ЧебышёвSeries<Multivector<double, ICRS, 1>> const series(
       coefficients, t_min, t_max);
 
   Instant t = t_min;
   Time const Δt = (t_max - t_min) * 1e-9;
-  Multivector<double, ICRFJ2000Ecliptic, 1> result{};
+  Multivector<double, ICRS, 1> result{};
 
   while (state.KeepRunning()) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
@@ -176,23 +175,21 @@ void BM_EvaluateVectorDouble(benchmark::State& state) {
 void BM_EvaluateDisplacement(benchmark::State& state) {
   int const degree = state.range_x();
   std::mt19937_64 random(42);
-  std::vector<Displacement<ICRFJ2000Ecliptic>> coefficients;
+  std::vector<Displacement<ICRS>> coefficients;
   for (int i = 0; i <= degree; ++i) {
     coefficients.push_back(
-        Displacement<ICRFJ2000Ecliptic>(
-            {static_cast<double>(random()) * Metre,
-             static_cast<double>(random()) * Metre,
-             static_cast<double>(random()) * Metre}));
+        Displacement<ICRS>({static_cast<double>(random()) * Metre,
+                            static_cast<double>(random()) * Metre,
+                            static_cast<double>(random()) * Metre}));
   }
   Instant const t0;
   Instant const t_min = t0 + static_cast<double>(random()) * Second;
   Instant const t_max = t_min + static_cast<double>(random()) * Second;
-  ЧебышёвSeries<Displacement<ICRFJ2000Ecliptic>> const series(
-    coefficients, t_min, t_max);
+  ЧебышёвSeries<Displacement<ICRS>> const series(coefficients, t_min, t_max);
 
   Instant t = t_min;
   Time const Δt = (t_max - t_min) * 1e-9;
-  Displacement<ICRFJ2000Ecliptic> result{};
+  Displacement<ICRS> result{};
 
   while (state.KeepRunning()) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {

--- a/geometry/frame_test.cpp
+++ b/geometry/frame_test.cpp
@@ -18,7 +18,7 @@ class FrameTest : public testing::Test {
   using World3 = Frame<serialization::Frame::TestTag,
                        serialization::Frame::TEST1, false>;
   using World4 = Frame<serialization::Frame::SolarSystemTag,
-                       serialization::Frame::ICRF_J2000_EQUATOR, true>;
+                       serialization::Frame::ICRS, true>;
 };
 
 using FrameDeathTest = FrameTest;

--- a/ksp_physics/ksp_physics_lib.hpp
+++ b/ksp_physics/ksp_physics_lib.hpp
@@ -31,8 +31,7 @@ PHYSICS_DLL_TEMPLATE_CLASS
 // TODO(egg): ifdef this out for the actual plugin.
 PHYSICS_DLL_TEMPLATE_CLASS
     internal_rotating_body::RotatingBody<astronomy::ICRS>;
-PHYSICS_DLL_TEMPLATE_CLASS
-    internal_oblate_body::OblateBody<astronomy::ICRS>;
+PHYSICS_DLL_TEMPLATE_CLASS internal_oblate_body::OblateBody<astronomy::ICRS>;
 #endif  // OS_WIN
 
 }  // namespace physics

--- a/ksp_physics/ksp_physics_lib.hpp
+++ b/ksp_physics/ksp_physics_lib.hpp
@@ -30,9 +30,9 @@ PHYSICS_DLL_TEMPLATE_CLASS
 // For the plugin tests.
 // TODO(egg): ifdef this out for the actual plugin.
 PHYSICS_DLL_TEMPLATE_CLASS
-    internal_rotating_body::RotatingBody<astronomy::ICRFJ2000Equator>;
+    internal_rotating_body::RotatingBody<astronomy::ICRS>;
 PHYSICS_DLL_TEMPLATE_CLASS
-    internal_oblate_body::OblateBody<astronomy::ICRFJ2000Equator>;
+    internal_oblate_body::OblateBody<astronomy::ICRS>;
 #endif  // OS_WIN
 
 }  // namespace physics

--- a/ksp_plugin_test/fake_plugin.cpp
+++ b/ksp_plugin_test/fake_plugin.cpp
@@ -17,7 +17,7 @@ using quantities::si::Radian;
 using quantities::si::Second;
 using testing_utilities::SolarSystemFactory;
 
-FakePlugin::FakePlugin(SolarSystem<ICRFJ2000Equator> const& solar_system)
+FakePlugin::FakePlugin(SolarSystem<ICRS> const& solar_system)
     : Plugin(/*game_epoch=*/solar_system.epoch_literal(),
              /*solar_system_epoch=*/solar_system.epoch_literal(),
              /*planetarium_rotation=*/0 * Radian) {

--- a/ksp_plugin_test/fake_plugin.hpp
+++ b/ksp_plugin_test/fake_plugin.hpp
@@ -11,7 +11,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_fake_plugin {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using physics::KeplerianElements;
 using physics::SolarSystem;
 
@@ -19,7 +19,7 @@ class FakePlugin : public Plugin {
  public:
   // Creates a test plugin with the bodies of the given |solar_system|.  The
   // system must be the Sol system.
-  explicit FakePlugin(SolarSystem<ICRFJ2000Equator> const& solar_system);
+  explicit FakePlugin(SolarSystem<ICRS> const& solar_system);
 
   // Adds an unloaded vessel with a single part with the given osculating
   // elements around the Earth at |CurrentTime()|.

--- a/ksp_plugin_test/interface_external_test.cpp
+++ b/ksp_plugin_test/interface_external_test.cpp
@@ -12,7 +12,7 @@
 namespace principia {
 namespace interface {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::make_not_null_unique;
 using ksp_plugin::GUID;
 using ksp_plugin::Navigation;
@@ -45,7 +45,7 @@ constexpr char const* vessel_name = "Enterprise";
 class InterfaceExternalTest : public ::testing::Test {
  protected:
   InterfaceExternalTest()
-      : plugin_(SolarSystem<ICRFJ2000Equator>(
+      : plugin_(SolarSystem<ICRS>(
             SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
             SOLUTION_DIR / "astronomy" /
                 "sol_initial_state_jd_2451545_000000000.proto.txt")) {

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -80,7 +80,7 @@ class PluginIntegrationTest : public testing::Test {
   PluginIntegrationTest()
       : icrs_to_barycentric_positions_(ICRS::origin,
                                        Barycentric::origin,
-                                       ircf_to_barycentric_linear_),
+                                       icrs_to_barycentric_linear_),
         looking_glass_(Permutation<ICRS, AliceSun>::XZY),
         solar_system_(
             SolarSystemFactory::AtСпутник1Launch(
@@ -112,7 +112,7 @@ class PluginIntegrationTest : public testing::Test {
   DegreesOfFreedom<Barycentric> icrsToBarycentric(
       DegreesOfFreedom<ICRS> const& degrees_of_freedom) {
     return {icrs_to_barycentric_positions_(degrees_of_freedom.position()),
-            ircf_to_barycentric_linear_(degrees_of_freedom.velocity())};
+            icrs_to_barycentric_linear_(degrees_of_freedom.velocity())};
   }
 
   void InsertAllSolarSystemBodies() {
@@ -133,7 +133,7 @@ class PluginIntegrationTest : public testing::Test {
     }
   }
 
-  Identity<ICRS, Barycentric> ircf_to_barycentric_linear_;
+  Identity<ICRS, Barycentric> icrs_to_barycentric_linear_;
   AffineMap<ICRS, Barycentric, Length, Identity> icrs_to_barycentric_positions_;
   Permutation<ICRS, AliceSun> looking_glass_;
   not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -134,10 +134,7 @@ class PluginIntegrationTest : public testing::Test {
   }
 
   Identity<ICRS, Barycentric> ircf_to_barycentric_linear_;
-  AffineMap<ICRS,
-            Barycentric,
-            Length,
-            Identity> icrf_to_barycentric_positions_;
+  AffineMap<ICRS, Barycentric, Length, Identity> icrf_to_barycentric_positions_;
   Permutation<ICRS, AliceSun> looking_glass_;
   not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string initial_time_;

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -78,7 +78,7 @@ std::string const vessel_name = "NCC-1701-D";
 class PluginIntegrationTest : public testing::Test {
  protected:
   PluginIntegrationTest()
-      : icrf_to_barycentric_positions_(ICRS::origin,
+      : icrs_to_barycentric_positions_(ICRS::origin,
                                        Barycentric::origin,
                                        ircf_to_barycentric_linear_),
         looking_glass_(Permutation<ICRS, AliceSun>::XZY),
@@ -109,9 +109,9 @@ class PluginIntegrationTest : public testing::Test {
                  satellite_initial_displacement_.Norm()) * unit_tangent;
   }
 
-  DegreesOfFreedom<Barycentric> ICRFToBarycentric(
+  DegreesOfFreedom<Barycentric> icrsToBarycentric(
       DegreesOfFreedom<ICRS> const& degrees_of_freedom) {
-    return {icrf_to_barycentric_positions_(degrees_of_freedom.position()),
+    return {icrs_to_barycentric_positions_(degrees_of_freedom.position()),
             ircf_to_barycentric_linear_(degrees_of_freedom.velocity())};
   }
 
@@ -134,7 +134,7 @@ class PluginIntegrationTest : public testing::Test {
   }
 
   Identity<ICRS, Barycentric> ircf_to_barycentric_linear_;
-  AffineMap<ICRS, Barycentric, Length, Identity> icrf_to_barycentric_positions_;
+  AffineMap<ICRS, Barycentric, Length, Identity> icrs_to_barycentric_positions_;
   Permutation<ICRS, AliceSun> looking_glass_;
   not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string initial_time_;

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -24,7 +24,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_plugin {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::ParseTT;
 using base::make_not_null_unique;
 using geometry::AffineMap;
@@ -78,10 +78,10 @@ std::string const vessel_name = "NCC-1701-D";
 class PluginIntegrationTest : public testing::Test {
  protected:
   PluginIntegrationTest()
-      : icrf_to_barycentric_positions_(ICRFJ2000Equator::origin,
+      : icrf_to_barycentric_positions_(ICRS::origin,
                                        Barycentric::origin,
                                        ircf_to_barycentric_linear_),
-        looking_glass_(Permutation<ICRFJ2000Equator, AliceSun>::XZY),
+        looking_glass_(Permutation<ICRS, AliceSun>::XZY),
         solar_system_(
             SolarSystemFactory::AtСпутник1Launch(
                 SolarSystemFactory::Accuracy::MinorAndMajorBodies)),
@@ -110,7 +110,7 @@ class PluginIntegrationTest : public testing::Test {
   }
 
   DegreesOfFreedom<Barycentric> ICRFToBarycentric(
-      DegreesOfFreedom<ICRFJ2000Equator> const& degrees_of_freedom) {
+      DegreesOfFreedom<ICRS> const& degrees_of_freedom) {
     return {icrf_to_barycentric_positions_(degrees_of_freedom.position()),
             ircf_to_barycentric_linear_(degrees_of_freedom.velocity())};
   }
@@ -133,13 +133,13 @@ class PluginIntegrationTest : public testing::Test {
     }
   }
 
-  Identity<ICRFJ2000Equator, Barycentric> ircf_to_barycentric_linear_;
-  AffineMap<ICRFJ2000Equator,
+  Identity<ICRS, Barycentric> ircf_to_barycentric_linear_;
+  AffineMap<ICRS,
             Barycentric,
             Length,
             Identity> icrf_to_barycentric_positions_;
-  Permutation<ICRFJ2000Equator, AliceSun> looking_glass_;
-  not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>> solar_system_;
+  Permutation<ICRS, AliceSun> looking_glass_;
+  not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string initial_time_;
   Angle planetarium_rotation_;
 

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -78,10 +78,7 @@ std::string const vessel_name = "NCC-1701-D";
 class PluginIntegrationTest : public testing::Test {
  protected:
   PluginIntegrationTest()
-      : icrs_to_barycentric_positions_(ICRS::origin,
-                                       Barycentric::origin,
-                                       icrs_to_barycentric_linear_),
-        looking_glass_(Permutation<ICRS, AliceSun>::XZY),
+      : looking_glass_(Permutation<ICRS, AliceSun>::XZY),
         solar_system_(
             SolarSystemFactory::AtСпутник1Launch(
                 SolarSystemFactory::Accuracy::MinorAndMajorBodies)),
@@ -109,12 +106,6 @@ class PluginIntegrationTest : public testing::Test {
                  satellite_initial_displacement_.Norm()) * unit_tangent;
   }
 
-  DegreesOfFreedom<Barycentric> icrsToBarycentric(
-      DegreesOfFreedom<ICRS> const& degrees_of_freedom) {
-    return {icrs_to_barycentric_positions_(degrees_of_freedom.position()),
-            icrs_to_barycentric_linear_(degrees_of_freedom.velocity())};
-  }
-
   void InsertAllSolarSystemBodies() {
     for (int index = SolarSystemFactory::Sun;
          index <= SolarSystemFactory::LastBody;
@@ -133,8 +124,6 @@ class PluginIntegrationTest : public testing::Test {
     }
   }
 
-  Identity<ICRS, Barycentric> icrs_to_barycentric_linear_;
-  AffineMap<ICRS, Barycentric, Length, Identity> icrs_to_barycentric_positions_;
   Permutation<ICRS, AliceSun> looking_glass_;
   not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string initial_time_;

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -284,14 +284,13 @@ class PluginTest : public testing::Test {
   Velocity<AliceSun> satellite_initial_velocity_;
 };
 
-RigidMotion<ICRS, Barycentric> const
-    PluginTest::id_icrf_barycentric_(
-        RigidTransformation<ICRS, Barycentric>(
-            ICRS::origin,
-            Barycentric::origin,
-            OrthogonalMap<ICRS, Barycentric>::Identity()),
-        AngularVelocity<ICRS>(),
-        Velocity<ICRS>());
+RigidMotion<ICRS, Barycentric> const PluginTest::id_icrf_barycentric_(
+    RigidTransformation<ICRS, Barycentric>(
+        ICRS::origin,
+        Barycentric::origin,
+        OrthogonalMap<ICRS, Barycentric>::Identity()),
+    AngularVelocity<ICRS>(),
+    Velocity<ICRS>());
 
 using PluginDeathTest = PluginTest;
 

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -272,7 +272,7 @@ class PluginTest : public testing::Test {
         serialized.get());
   }
 
-  static RigidMotion<ICRS, Barycentric> const id_icrf_barycentric_;
+  static RigidMotion<ICRS, Barycentric> const id_icrs_barycentric_;
   not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string const initial_time_;
   Angle planetarium_rotation_;
@@ -284,7 +284,7 @@ class PluginTest : public testing::Test {
   Velocity<AliceSun> satellite_initial_velocity_;
 };
 
-RigidMotion<ICRS, Barycentric> const PluginTest::id_icrf_barycentric_(
+RigidMotion<ICRS, Barycentric> const PluginTest::id_icrs_barycentric_(
     RigidTransformation<ICRS, Barycentric>(
         ICRS::origin,
         Barycentric::origin,
@@ -461,7 +461,7 @@ TEST_F(PluginTest, Initialization) {
   for (int index = SolarSystemFactory::Sun + 1;
        index <= SolarSystemFactory::LastMajorBody;
        ++index) {
-    auto const to_icrf = id_icrf_barycentric_.orthogonal_map().Inverse() *
+    auto const to_icrs = id_icrs_barycentric_.orthogonal_map().Inverse() *
                          plugin_->InversePlanetariumRotation().Forget();
     Index const parent_index = SolarSystemFactory::parent(index);
     RelativeDegreesOfFreedom<ICRS> const from_parent =
@@ -470,11 +470,11 @@ TEST_F(PluginTest, Initialization) {
             SolarSystemFactory::name(parent_index));
     EXPECT_THAT(from_parent,
                 Componentwise(
-                    AlmostEquals(to_icrf(plugin_->CelestialFromParent(index)
+                    AlmostEquals(to_icrs(plugin_->CelestialFromParent(index)
                                              .displacement()),
                                  0, 458752),
                     AlmostEquals(
-                        to_icrf(plugin_->CelestialFromParent(index).velocity()),
+                        to_icrs(plugin_->CelestialFromParent(index).velocity()),
                         441, 9400740)))
         << SolarSystemFactory::name(index);
   }
@@ -992,15 +992,15 @@ TEST_F(PluginTest, UpdateCelestialHierarchy) {
   for (int index = SolarSystemFactory::Sun + 1;
        index <= SolarSystemFactory::LastMajorBody;
        ++index) {
-    auto const to_icrf = id_icrf_barycentric_.orthogonal_map().Inverse() *
+    auto const to_icrs = id_icrs_barycentric_.orthogonal_map().Inverse() *
                          plugin_->InversePlanetariumRotation().Forget();
     RelativeDegreesOfFreedom<ICRS> const initial_from_parent =
         solar_system_->degrees_of_freedom(SolarSystemFactory::name(index)) -
         solar_system_->degrees_of_freedom(
             SolarSystemFactory::name(SolarSystemFactory::Sun));
     RelativeDegreesOfFreedom<ICRS> const computed_from_parent(
-        to_icrf(plugin_->CelestialFromParent(index).displacement()),
-        to_icrf(plugin_->CelestialFromParent(index).velocity()));
+        to_icrs(plugin_->CelestialFromParent(index).displacement()),
+        to_icrs(plugin_->CelestialFromParent(index).velocity()));
     EXPECT_THAT(
         (initial_from_parent.displacement() -
          computed_from_parent.displacement()).Norm(),

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -47,7 +47,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_plugin {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::ParseTT;
 using base::Error;
 using base::FindOrDie;
@@ -272,8 +272,8 @@ class PluginTest : public testing::Test {
         serialized.get());
   }
 
-  static RigidMotion<ICRFJ2000Equator, Barycentric> const id_icrf_barycentric_;
-  not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>> solar_system_;
+  static RigidMotion<ICRS, Barycentric> const id_icrf_barycentric_;
+  not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
   std::string const initial_time_;
   Angle planetarium_rotation_;
 
@@ -284,14 +284,14 @@ class PluginTest : public testing::Test {
   Velocity<AliceSun> satellite_initial_velocity_;
 };
 
-RigidMotion<ICRFJ2000Equator, Barycentric> const
+RigidMotion<ICRS, Barycentric> const
     PluginTest::id_icrf_barycentric_(
-        RigidTransformation<ICRFJ2000Equator, Barycentric>(
-            ICRFJ2000Equator::origin,
+        RigidTransformation<ICRS, Barycentric>(
+            ICRS::origin,
             Barycentric::origin,
-            OrthogonalMap<ICRFJ2000Equator, Barycentric>::Identity()),
-        AngularVelocity<ICRFJ2000Equator>(),
-        Velocity<ICRFJ2000Equator>());
+            OrthogonalMap<ICRS, Barycentric>::Identity()),
+        AngularVelocity<ICRS>(),
+        Velocity<ICRS>());
 
 using PluginDeathTest = PluginTest;
 
@@ -333,7 +333,7 @@ TEST_F(PluginTest, Serialization) {
     Index const parent_index = SolarSystemFactory::parent(index);
     std::string const parent_name = SolarSystemFactory::name(parent_index);
     RelativeDegreesOfFreedom<Barycentric> const state_vectors =
-        Identity<ICRFJ2000Equator, Barycentric>()(
+        Identity<ICRS, Barycentric>()(
             solar_system_->degrees_of_freedom(name) -
             solar_system_->degrees_of_freedom(parent_name));
     Instant const t;
@@ -465,7 +465,7 @@ TEST_F(PluginTest, Initialization) {
     auto const to_icrf = id_icrf_barycentric_.orthogonal_map().Inverse() *
                          plugin_->InversePlanetariumRotation().Forget();
     Index const parent_index = SolarSystemFactory::parent(index);
-    RelativeDegreesOfFreedom<ICRFJ2000Equator> const from_parent =
+    RelativeDegreesOfFreedom<ICRS> const from_parent =
         solar_system_->degrees_of_freedom(SolarSystemFactory::name(index)) -
         solar_system_->degrees_of_freedom(
             SolarSystemFactory::name(parent_index));
@@ -995,11 +995,11 @@ TEST_F(PluginTest, UpdateCelestialHierarchy) {
        ++index) {
     auto const to_icrf = id_icrf_barycentric_.orthogonal_map().Inverse() *
                          plugin_->InversePlanetariumRotation().Forget();
-    RelativeDegreesOfFreedom<ICRFJ2000Equator> const initial_from_parent =
+    RelativeDegreesOfFreedom<ICRS> const initial_from_parent =
         solar_system_->degrees_of_freedom(SolarSystemFactory::name(index)) -
         solar_system_->degrees_of_freedom(
             SolarSystemFactory::name(SolarSystemFactory::Sun));
-    RelativeDegreesOfFreedom<ICRFJ2000Equator> const computed_from_parent(
+    RelativeDegreesOfFreedom<ICRS> const computed_from_parent(
         to_icrf(plugin_->CelestialFromParent(index).displacement()),
         to_icrf(plugin_->CelestialFromParent(index).velocity()));
     EXPECT_THAT(

--- a/mathematica/local_error_analysis.cpp
+++ b/mathematica/local_error_analysis.cpp
@@ -30,8 +30,8 @@ constexpr Length fitting_tolerance = 1 * Milli(Metre);
 
 LocalErrorAnalyser::LocalErrorAnalyser(
     not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system,
-    FixedStepSizeIntegrator<
-        Ephemeris<ICRS>::NewtonianMotionEquation> const& integrator,
+    FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
+        integrator,
     Time const& step)
     : solar_system_(std::move(solar_system)),
       integrator_(integrator),
@@ -47,8 +47,7 @@ LocalErrorAnalyser::LocalErrorAnalyser(
 
 void LocalErrorAnalyser::WriteLocalErrors(
     std::filesystem::path const& path,
-    FixedStepSizeIntegrator<
-        Ephemeris<ICRS>::NewtonianMotionEquation> const&
+    FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
         fine_integrator,
     Time const& fine_step,
     Time const& granularity,

--- a/mathematica/local_error_analysis.hpp
+++ b/mathematica/local_error_analysis.hpp
@@ -24,8 +24,7 @@ class LocalErrorAnalyser {
  public:
   LocalErrorAnalyser(
       not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system,
-      FixedStepSizeIntegrator<
-          Ephemeris<ICRS>::NewtonianMotionEquation> const&
+      FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
           integrator,
       Time const& step);
 
@@ -34,8 +33,7 @@ class LocalErrorAnalyser {
   // system epoch.  Writes the errors to a file with the given |path|.
   void WriteLocalErrors(
       std::filesystem::path const& path,
-      FixedStepSizeIntegrator<
-          Ephemeris<ICRS>::NewtonianMotionEquation> const&
+      FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
           fine_integrator,
       Time const& fine_step,
       Time const& granularity,
@@ -45,8 +43,7 @@ class LocalErrorAnalyser {
   not_null<std::unique_ptr<Ephemeris<ICRS>>> ForkEphemeris(
       Ephemeris<ICRS> const& original,
       Instant const& t,
-      FixedStepSizeIntegrator<
-          Ephemeris<ICRS>::NewtonianMotionEquation> const&
+      FixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation> const&
           integrator,
       Time const& step) const;
 

--- a/mathematica/local_error_analysis.hpp
+++ b/mathematica/local_error_analysis.hpp
@@ -10,7 +10,7 @@
 namespace principia {
 namespace mathematica {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::not_null;
 using geometry::Instant;
 using integrators::FixedStepSizeIntegrator;
@@ -23,9 +23,9 @@ using quantities::Time;
 class LocalErrorAnalyser {
  public:
   LocalErrorAnalyser(
-      not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>> solar_system,
+      not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system,
       FixedStepSizeIntegrator<
-          Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const&
+          Ephemeris<ICRS>::NewtonianMotionEquation> const&
           integrator,
       Time const& step);
 
@@ -35,24 +35,24 @@ class LocalErrorAnalyser {
   void WriteLocalErrors(
       std::filesystem::path const& path,
       FixedStepSizeIntegrator<
-          Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const&
+          Ephemeris<ICRS>::NewtonianMotionEquation> const&
           fine_integrator,
       Time const& fine_step,
       Time const& granularity,
       Time const& duration) const;
 
  private:
-  not_null<std::unique_ptr<Ephemeris<ICRFJ2000Equator>>> ForkEphemeris(
-      Ephemeris<ICRFJ2000Equator> const& original,
+  not_null<std::unique_ptr<Ephemeris<ICRS>>> ForkEphemeris(
+      Ephemeris<ICRS> const& original,
       Instant const& t,
       FixedStepSizeIntegrator<
-          Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const&
+          Ephemeris<ICRS>::NewtonianMotionEquation> const&
           integrator,
       Time const& step) const;
 
-  not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>> const solar_system_;
+  not_null<std::unique_ptr<SolarSystem<ICRS>>> const solar_system_;
   FixedStepSizeIntegrator<
-      Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation> const& integrator_;
+      Ephemeris<ICRS>::NewtonianMotionEquation> const& integrator_;
   Time const step_;
 };
 

--- a/mathematica/main.cpp
+++ b/mathematica/main.cpp
@@ -95,9 +95,9 @@ int main(int argc, char const* argv[]) {
         std::filesystem::path(*flags["initial_state"]);
     auto solar_system = make_not_null_unique<SolarSystem<ICRS>>(
         gravity_model_path, initial_state_path, /*ignore_frame=*/true);
-    auto const& integrator = ParseFixedStepSizeIntegrator<
-        Ephemeris<ICRS>::NewtonianMotionEquation>(
-        *flags["integrator"]);
+    auto const& integrator =
+        ParseFixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation>(
+            *flags["integrator"]);
     auto const time_step = ParseQuantity<Time>(*flags["time_step"]);
     auto const out =
         std::filesystem::path(
@@ -108,8 +108,7 @@ int main(int argc, char const* argv[]) {
     LocalErrorAnalyser analyser(std::move(solar_system), integrator, time_step);
     analyser.WriteLocalErrors(
         out,
-        ParseFixedStepSizeIntegrator<
-            Ephemeris<ICRS>::NewtonianMotionEquation>(
+        ParseFixedStepSizeIntegrator<Ephemeris<ICRS>::NewtonianMotionEquation>(
             flags["fine_integrator"].value_or("BLANES_MOAN_2002_SRKN_14A")),
         ParseQuantity<Time>(flags["fine_step"].value_or("1 min")),
         ParseQuantity<Time>(flags["granularity"].value_or("1 d")),

--- a/mathematica/main.cpp
+++ b/mathematica/main.cpp
@@ -15,7 +15,7 @@
 #include "physics/solar_system.hpp"
 #include "quantities/parser.hpp"
 
-using ::principia::astronomy::ICRFJ2000Equator;
+using ::principia::astronomy::ICRS;
 using ::principia::base::Contains;
 using ::principia::base::make_not_null_unique;
 using ::principia::quantities::ParseQuantity;
@@ -93,10 +93,10 @@ int main(int argc, char const* argv[]) {
         std::filesystem::path(*flags["gravity_model"]);
     auto const initial_state_path =
         std::filesystem::path(*flags["initial_state"]);
-    auto solar_system = make_not_null_unique<SolarSystem<ICRFJ2000Equator>>(
+    auto solar_system = make_not_null_unique<SolarSystem<ICRS>>(
         gravity_model_path, initial_state_path, /*ignore_frame=*/true);
     auto const& integrator = ParseFixedStepSizeIntegrator<
-        Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation>(
+        Ephemeris<ICRS>::NewtonianMotionEquation>(
         *flags["integrator"]);
     auto const time_step = ParseQuantity<Time>(*flags["time_step"]);
     auto const out =
@@ -109,7 +109,7 @@ int main(int argc, char const* argv[]) {
     analyser.WriteLocalErrors(
         out,
         ParseFixedStepSizeIntegrator<
-            Ephemeris<ICRFJ2000Equator>::NewtonianMotionEquation>(
+            Ephemeris<ICRS>::NewtonianMotionEquation>(
             flags["fine_integrator"].value_or("BLANES_MOAN_2002_SRKN_14A")),
         ParseQuantity<Time>(flags["fine_step"].value_or("1 min")),
         ParseQuantity<Time>(flags["granularity"].value_or("1 d")),

--- a/numerics/чебышёв_series_test.cpp
+++ b/numerics/чебышёв_series_test.cpp
@@ -13,7 +13,7 @@ namespace principia {
 namespace numerics {
 namespace internal_чебышёв_series {
 
-using astronomy::ICRFJ2000Ecliptic;
+using astronomy::ICRS;
 using geometry::Instant;
 using geometry::Vector;
 using quantities::Length;
@@ -112,7 +112,7 @@ TEST_F(ЧебышёвSeriesTest, T2Dimension) {
 }
 
 TEST_F(ЧебышёвSeriesTest, X6Vector) {
-  using V = Vector<Length, ICRFJ2000Ecliptic>;
+  using V = Vector<Length, ICRS>;
   // {T3, X5, X6}
   V const c0 = V({0.0 * Metre, 0.0 * Metre, 10.0 / 32.0 * Metre});
   V const c1 = V({0.0 * Metre, 10.0 / 16.0 * Metre, 0.0 * Metre});
@@ -121,7 +121,7 @@ TEST_F(ЧебышёвSeriesTest, X6Vector) {
   V const c4 = V({0.0 * Metre, 0.0 * Metre, 6.0 / 32.0 * Metre});
   V const c5 = V({0.0 * Metre, 1.0 / 16.0 * Metre, 0 * Metre});
   V const c6 = V({0.0 * Metre, 0.0 * Metre, 1.0 / 32.0 * Metre});
-  ЧебышёвSeries<Vector<Length, ICRFJ2000Ecliptic>> x6(
+  ЧебышёвSeries<Vector<Length, ICRS>> x6(
       {c0, c1, c2, c3, c4, c5, c6},
       t_min_, t_max_);
   EXPECT_EQ(V({-1 * Metre, -1 * Metre, 1 * Metre}),

--- a/numerics/чебышёв_series_test.cpp
+++ b/numerics/чебышёв_series_test.cpp
@@ -121,9 +121,8 @@ TEST_F(ЧебышёвSeriesTest, X6Vector) {
   V const c4 = V({0.0 * Metre, 0.0 * Metre, 6.0 / 32.0 * Metre});
   V const c5 = V({0.0 * Metre, 1.0 / 16.0 * Metre, 0 * Metre});
   V const c6 = V({0.0 * Metre, 0.0 * Metre, 1.0 / 32.0 * Metre});
-  ЧебышёвSeries<Vector<Length, ICRS>> x6(
-      {c0, c1, c2, c3, c4, c5, c6},
-      t_min_, t_max_);
+  ЧебышёвSeries<Vector<Length, ICRS>> x6({c0, c1, c2, c3, c4, c5, c6},
+                                         t_min_, t_max_);
   EXPECT_EQ(V({-1 * Metre, -1 * Metre, 1 * Metre}),
             x6.Evaluate(t0_ + -1 * Second));
   EXPECT_EQ(V({0 * Metre, 0 * Metre, 0 * Metre}),

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -29,7 +29,7 @@ namespace principia {
 namespace physics {
 namespace internal_barycentric_rotating_dynamic_frame {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::check_not_null;
 using geometry::Barycentre;
 using geometry::Bivector;
@@ -80,10 +80,10 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
             /*fitting_tolerance=*/1 * Milli(Metre),
-            Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+            Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,
-                    Position<ICRFJ2000Equator>>(),
+                    Position<ICRS>>(),
                 /*step=*/10 * Milli(Second)))),
         big_(solar_system_.massive_body(*ephemeris_, big)),
         big_initial_state_(solar_system_.degrees_of_freedom(big)),
@@ -94,7 +94,7 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
         small_gravitational_parameter_(
             solar_system_.gravitational_parameter(small)),
         centre_of_mass_initial_state_(
-            Barycentre<DegreesOfFreedom<ICRFJ2000Equator>,
+            Barycentre<DegreesOfFreedom<ICRS>,
                        GravitationalParameter>(
                 {big_initial_state_, small_initial_state_},
                 {big_gravitational_parameter_,
@@ -106,36 +106,36 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
                 trajectory(solar_system_.massive_body(*ephemeris_, small)))
         .WillOnce(Return(&mock_small_trajectory_));
     mock_frame_ = std::make_unique<
-        BarycentricRotatingDynamicFrame<ICRFJ2000Equator, MockFrame>>(
+        BarycentricRotatingDynamicFrame<ICRS, MockFrame>>(
         &mock_ephemeris_, big_, small_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_small_frame_ =
         std::make_unique<
-            BarycentricRotatingDynamicFrame<ICRFJ2000Equator, BigSmallFrame>>(
+            BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>(
                 ephemeris_.get(), big_, small_);
   }
 
   Time const period_;
-  SolarSystem<ICRFJ2000Equator> solar_system_;
+  SolarSystem<ICRS> solar_system_;
   Instant const t0_;
-  std::unique_ptr<Ephemeris<ICRFJ2000Equator>> const ephemeris_;
+  std::unique_ptr<Ephemeris<ICRS>> const ephemeris_;
   MassiveBody const* const big_;
-  DegreesOfFreedom<ICRFJ2000Equator> const big_initial_state_;
+  DegreesOfFreedom<ICRS> const big_initial_state_;
   GravitationalParameter const big_gravitational_parameter_;
   MassiveBody const* const small_;
-  DegreesOfFreedom<ICRFJ2000Equator> const small_initial_state_;
+  DegreesOfFreedom<ICRS> const small_initial_state_;
   GravitationalParameter const small_gravitational_parameter_;
-  DegreesOfFreedom<ICRFJ2000Equator> const centre_of_mass_initial_state_;
-  StrictMock<MockEphemeris<ICRFJ2000Equator>> mock_ephemeris_;
+  DegreesOfFreedom<ICRS> const centre_of_mass_initial_state_;
+  StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
-  std::unique_ptr<BarycentricRotatingDynamicFrame<ICRFJ2000Equator, MockFrame>>
+  std::unique_ptr<BarycentricRotatingDynamicFrame<ICRS, MockFrame>>
       mock_frame_;
   std::unique_ptr<
-      BarycentricRotatingDynamicFrame<ICRFJ2000Equator, BigSmallFrame>>
+      BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>
           big_small_frame_;
-  StrictMock<MockContinuousTrajectory<ICRFJ2000Equator>> mock_big_trajectory_;
-  StrictMock<MockContinuousTrajectory<ICRFJ2000Equator>> mock_small_trajectory_;
+  StrictMock<MockContinuousTrajectory<ICRS>> mock_big_trajectory_;
+  StrictMock<MockContinuousTrajectory<ICRS>> mock_small_trajectory_;
 };
 
 
@@ -156,10 +156,10 @@ TEST_F(BarycentricRotatingDynamicFrameTest, ToBigSmallFrameAtTime) {
                 Lt(1.1e-11 * Metre / Second));
 
     // Check that the bodies don't move and are at the right locations.
-    DegreesOfFreedom<ICRFJ2000Equator> const big_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const big_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, big).
             EvaluateDegreesOfFreedom(t);
-    DegreesOfFreedom<ICRFJ2000Equator> const small_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const small_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, small).
             EvaluateDegreesOfFreedom(t);
 
@@ -219,26 +219,26 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({(80 - 30) * Metre / Second,
                             (-60 - 40) * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({-16 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({-16 * Metre / Second,
                                    12 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const barycentre_dof =
-      Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
+  DegreesOfFreedom<ICRS> const barycentre_dof =
+      Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
-  EXPECT_THAT(barycentre_dof.position() - ICRFJ2000Equator::origin,
-              Eq(Displacement<ICRFJ2000Equator>(
+  EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
+              Eq(Displacement<ICRS>(
                      {2 * Metre, 1 * Metre, 0 * Metre})));
-  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRFJ2000Equator>()));
+  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -251,20 +251,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CoriolisAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              120 * Metre / Pow<2>(Second),
                              160 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -300 * Metre / Pow<2>(Second),
                              -400 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The Coriolis acceleration is towards the centre and opposed to the motion.
@@ -285,26 +285,26 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({-16 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({-16 * Metre / Second,
                                    12 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const barycentre_dof =
-      Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
+  DegreesOfFreedom<ICRS> const barycentre_dof =
+      Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
-  EXPECT_THAT(barycentre_dof.position() - ICRFJ2000Equator::origin,
-              Eq(Displacement<ICRFJ2000Equator>(
+  EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
+              Eq(Displacement<ICRS>(
                      {2 * Metre, 1 * Metre, 0 * Metre})));
-  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRFJ2000Equator>()));
+  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -317,20 +317,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              120 * Metre / Pow<2>(Second),
                              160 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -300 * Metre / Pow<2>(Second),
                              -400 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   EXPECT_THAT(mock_frame_->GeometricAcceleration(t, point_dof),
@@ -351,26 +351,26 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({-16 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({-16 * Metre / Second,
                                    12 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const barycentre_dof =
-      Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
+  DegreesOfFreedom<ICRS> const barycentre_dof =
+      Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
-  EXPECT_THAT(barycentre_dof.position() - ICRFJ2000Equator::origin,
-              Eq(Displacement<ICRFJ2000Equator>(
+  EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
+              Eq(Displacement<ICRS>(
                      {2 * Metre, 1 * Metre, 0 * Metre})));
-  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRFJ2000Equator>()));
+  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -384,20 +384,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (120 - 160) * Metre / Pow<2>(Second),
                              (160 + 120) * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (-300 + 400) * Metre / Pow<2>(Second),
                              (-400 - 300) * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The acceleration is centrifugal + Euler.
@@ -419,26 +419,26 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({-16 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({-16 * Metre / Second,
                                    12 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const barycentre_dof =
-      Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
+  DegreesOfFreedom<ICRS> const barycentre_dof =
+      Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
-  EXPECT_THAT(barycentre_dof.position() - ICRFJ2000Equator::origin,
-              Eq(Displacement<ICRFJ2000Equator>(
+  EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
+              Eq(Displacement<ICRS>(
                      {2 * Metre, 1 * Metre, 0 * Metre})));
-  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRFJ2000Equator>()));
+  EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -452,20 +452,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (-160 + 120) * Metre / Pow<2>(Second),
                              (120 + 160) * Metre / Pow<2>(Second),
                              300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (-160 - 300) * Metre / Pow<2>(Second),
                              (120 - 400) * Metre / Pow<2>(Second),
                              300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The acceleration is linear + centrifugal.
@@ -507,7 +507,7 @@ TEST_F(BarycentricRotatingDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.secondary());
 
   auto const read_big_small_frame =
-      DynamicFrame<ICRFJ2000Equator, BigSmallFrame>::ReadFromMessage(
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
           message, ephemeris_.get());
   EXPECT_THAT(read_big_small_frame, Not(IsNull()));
 

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -94,8 +94,7 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
         small_gravitational_parameter_(
             solar_system_.gravitational_parameter(small)),
         centre_of_mass_initial_state_(
-            Barycentre<DegreesOfFreedom<ICRS>,
-                       GravitationalParameter>(
+            Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
                 {big_initial_state_, small_initial_state_},
                 {big_gravitational_parameter_,
                  small_gravitational_parameter_})) {
@@ -105,15 +104,14 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
     EXPECT_CALL(mock_ephemeris_,
                 trajectory(solar_system_.massive_body(*ephemeris_, small)))
         .WillOnce(Return(&mock_small_trajectory_));
-    mock_frame_ = std::make_unique<
-        BarycentricRotatingDynamicFrame<ICRS, MockFrame>>(
-        &mock_ephemeris_, big_, small_);
+    mock_frame_ =
+        std::make_unique<BarycentricRotatingDynamicFrame<ICRS, MockFrame>>(
+            &mock_ephemeris_, big_, small_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_small_frame_ =
-        std::make_unique<
-            BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>(
-                ephemeris_.get(), big_, small_);
+        std::make_unique<BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>(
+            ephemeris_.get(), big_, small_);
   }
 
   Time const period_;
@@ -129,11 +127,9 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
   DegreesOfFreedom<ICRS> const centre_of_mass_initial_state_;
   StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
-  std::unique_ptr<BarycentricRotatingDynamicFrame<ICRS, MockFrame>>
-      mock_frame_;
-  std::unique_ptr<
-      BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>
-          big_small_frame_;
+  std::unique_ptr<BarycentricRotatingDynamicFrame<ICRS, MockFrame>> mock_frame_;
+  std::unique_ptr<BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>>
+      big_small_frame_;
   StrictMock<MockContinuousTrajectory<ICRS>> mock_big_trajectory_;
   StrictMock<MockContinuousTrajectory<ICRS>> mock_small_trajectory_;
 };
@@ -157,11 +153,10 @@ TEST_F(BarycentricRotatingDynamicFrameTest, ToBigSmallFrameAtTime) {
 
     // Check that the bodies don't move and are at the right locations.
     DegreesOfFreedom<ICRS> const big_in_inertial_frame_at_t =
-        solar_system_.trajectory(*ephemeris_, big).
-            EvaluateDegreesOfFreedom(t);
+        solar_system_.trajectory(*ephemeris_, big).EvaluateDegreesOfFreedom(t);
     DegreesOfFreedom<ICRS> const small_in_inertial_frame_at_t =
-        solar_system_.trajectory(*ephemeris_, small).
-            EvaluateDegreesOfFreedom(t);
+        solar_system_.trajectory(*ephemeris_, small)
+            .EvaluateDegreesOfFreedom(t);
 
     DegreesOfFreedom<BigSmallFrame> const big_in_big_small_at_t =
         to_big_small_frame_at_t(big_in_inertial_frame_at_t);
@@ -219,25 +214,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({(80 - 30) * Metre / Second,
                             (-60 - 40) * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({-16 * Metre / Second,
-                                   12 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
   EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
-              Eq(Displacement<ICRS>(
-                     {2 * Metre, 1 * Metre, 0 * Metre})));
+              Eq(Displacement<ICRS>({2 * Metre, 1 * Metre, 0 * Metre})));
   EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -285,25 +275,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({-16 * Metre / Second,
-                                   12 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
   EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
-              Eq(Displacement<ICRS>(
-                     {2 * Metre, 1 * Metre, 0 * Metre})));
+              Eq(Displacement<ICRS>({2 * Metre, 1 * Metre, 0 * Metre})));
   EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -314,20 +299,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
       .WillRepeatedly(Return(small_dof));
   {
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             120 * Metre / Pow<2>(Second),
-                             160 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({120 * Metre / Pow<2>(Second),
+                                               160 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             -300 * Metre / Pow<2>(Second),
-                             -400 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({-300 * Metre / Pow<2>(Second),
+                                               -400 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -351,25 +336,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({-16 * Metre / Second,
-                                   12 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
   EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
-              Eq(Displacement<ICRS>(
-                     {2 * Metre, 1 * Metre, 0 * Metre})));
+              Eq(Displacement<ICRS>({2 * Metre, 1 * Metre, 0 * Metre})));
   EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -391,10 +371,10 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             (-300 + 400) * Metre / Pow<2>(Second),
-                             (-400 - 300) * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+        .WillOnce(Return(
+            Vector<Acceleration, ICRS>({(-300 + 400) * Metre / Pow<2>(Second),
+                                        (-400 - 300) * Metre / Pow<2>(Second),
+                                        0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -419,25 +399,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({-16 * Metre / Second,
-                                   12 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
           {big_gravitational_parameter_, small_gravitational_parameter_});
   EXPECT_THAT(barycentre_dof.position() - ICRS::origin,
-              Eq(Displacement<ICRS>(
-                     {2 * Metre, 1 * Metre, 0 * Metre})));
+              Eq(Displacement<ICRS>({2 * Metre, 1 * Metre, 0 * Metre})));
   EXPECT_THAT(barycentre_dof.velocity(), Eq(Velocity<ICRS>()));
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -449,20 +424,20 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
   {
     // The acceleration is linear + centripetal.
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             (-160 + 120) * Metre / Pow<2>(Second),
-                             (120 + 160) * Metre / Pow<2>(Second),
-                             300 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(Return(
+            Vector<Acceleration, ICRS>({(-160 + 120) * Metre / Pow<2>(Second),
+                                        (120 + 160) * Metre / Pow<2>(Second),
+                                        300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             (-160 - 300) * Metre / Pow<2>(Second),
-                             (120 - 400) * Metre / Pow<2>(Second),
-                             300 * Metre / Pow<2>(Second)})));
+        .WillOnce(Return(
+            Vector<Acceleration, ICRS>({(-160 - 300) * Metre / Pow<2>(Second),
+                                        (120 - 400) * Metre / Pow<2>(Second),
+                                        300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -507,8 +482,8 @@ TEST_F(BarycentricRotatingDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.secondary());
 
   auto const read_big_small_frame =
-      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
-          message, ephemeris_.get());
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(message,
+                                                         ephemeris_.get());
   EXPECT_THAT(read_big_small_frame, Not(IsNull()));
 
   Instant const t = t0_ + period_;

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -214,14 +214,14 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({(80 - 30) * Metre / Second,
                             (-60 - 40) * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
@@ -275,14 +275,14 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = 
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
@@ -336,14 +336,14 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},
@@ -399,14 +399,14 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const barycentre_dof =
       Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
           {big_dof, small_dof},

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -215,7 +215,8 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CoriolisAcceleration) {
                             (-60 - 40) * Metre / Second,
                             0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+       ICRS::origin,
        Velocity<ICRS>(
            {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const small_dof =
@@ -276,10 +277,11 @@ TEST_F(BarycentricRotatingDynamicFrameTest, CentrifugalAcceleration) {
                             0 * Metre / Second,
                             0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+       ICRS::origin,
        Velocity<ICRS>(
            {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = 
+  DegreesOfFreedom<ICRS> const small_dof =
       {Displacement<ICRS>({5 * Metre, 5 * Metre, 0 * Metre}) + ICRS::origin,
        Velocity<ICRS>(
            {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
@@ -337,7 +339,8 @@ TEST_F(BarycentricRotatingDynamicFrameTest, EulerAcceleration) {
                             0 * Metre / Second,
                             0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+       ICRS::origin,
        Velocity<ICRS>(
            {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const small_dof =
@@ -400,7 +403,8 @@ TEST_F(BarycentricRotatingDynamicFrameTest, LinearAcceleration) {
                             0 * Metre / Second,
                             0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) + ICRS::origin,
+      {Displacement<ICRS>({0.8 * Metre, -0.6 * Metre, 0 * Metre}) +
+       ICRS::origin,
        Velocity<ICRS>(
            {-16 * Metre / Second, 12 * Metre / Second, 0 * Metre / Second})};
   DegreesOfFreedom<ICRS> const small_dof =

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -102,9 +102,9 @@ class BodyCentredBodyDirectionDynamicFrameTest : public ::testing::Test {
     EXPECT_CALL(mock_ephemeris_,
                 trajectory(solar_system_.massive_body(*ephemeris_, small)))
         .WillOnce(Return(&mock_small_trajectory_));
-    mock_frame_ = std::make_unique<
-        BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>(
-        &mock_ephemeris_, big_, small_);
+    mock_frame_ =
+        std::make_unique<BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>(
+            &mock_ephemeris_, big_, small_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_small_frame_ = std::make_unique<
@@ -206,12 +206,10 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CoriolisAcceleration) {
       {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
            ICRS::origin,
        Velocity<ICRS>()};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -221,20 +219,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CoriolisAcceleration) {
       .WillRepeatedly(Return(small_dof));
   {
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             -300 * Metre / Pow<2>(Second),
-                             -400 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({-300 * Metre / Pow<2>(Second),
+                                               -400 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -257,18 +255,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({0 * Metre / Second,
-                                   0 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -278,20 +272,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CentrifugalAcceleration) {
       .WillRepeatedly(Return(small_dof));
   {
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             -300 * Metre / Pow<2>(Second),
-                             -400 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({-300 * Metre / Pow<2>(Second),
+                                               -400 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -315,18 +309,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({0 * Metre / Second,
-                                   0 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
       .WillRepeatedly(Return(big_dof));
@@ -336,20 +326,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, EulerAcceleration) {
   {
     // The acceleration is centripetal + tangential.
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             (-300 + 400) * Metre / Pow<2>(Second),
-                             (-400 - 300) * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+        .WillOnce(Return(
+            Vector<Acceleration, ICRS>({(-300 + 400) * Metre / Pow<2>(Second),
+                                        (-400 - 300) * Metre / Pow<2>(Second),
+                                        0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -373,18 +363,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({0 * Metre / Second,
-                                   0 * Metre / Second,
-                                   0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof =
-      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({40 * Metre / Second,
-                                   -30 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof = {
+      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -395,20 +381,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, LinearAcceleration) {
   {
     // The acceleration is linear + centripetal.
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             -160 * Metre / Pow<2>(Second),
-                             120 * Metre / Pow<2>(Second),
-                             300 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(check_not_null(big_), t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({-160 * Metre / Pow<2>(Second),
+                                               120 * Metre / Pow<2>(Second),
+                                               300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             (-160 - 300) * Metre / Pow<2>(Second),
-                             (120 - 400) * Metre / Pow<2>(Second),
-                             300 * Metre / Pow<2>(Second)})));
+        .WillOnce(Return(
+            Vector<Acceleration, ICRS>({(-160 - 300) * Metre / Pow<2>(Second),
+                                        (120 - 400) * Metre / Pow<2>(Second),
+                                        300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -453,8 +439,8 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.secondary());
 
   auto const read_big_small_frame =
-      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
-          message, ephemeris_.get());
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(message,
+                                                         ephemeris_.get());
   EXPECT_THAT(read_big_small_frame, Not(IsNull()));
 
   Instant const t = t0_ + period_;
@@ -512,10 +498,9 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ConstructFromOneBody) {
     // geometric acceleration when this is not the case.
     auto const intrinsic_acceleration =
         ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(
-            ICRS::origin +
-                Displacement<ICRS>({0 * Kilo(Metre),
-                                                10.0 / 7.0 * Kilo(Metre),
-                                                0 * Kilo(Metre)}),
+            ICRS::origin + Displacement<ICRS>({0 * Kilo(Metre),
+                                               10.0 / 7.0 * Kilo(Metre),
+                                               0 * Kilo(Metre)}),
             t0_ + t);
     EXPECT_THAT(
         (barycentric_from_discrete.GeometricAcceleration(t0_ + t,

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -124,12 +124,10 @@ class BodyCentredBodyDirectionDynamicFrameTest : public ::testing::Test {
   GravitationalParameter small_gravitational_parameter_;
   StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
-  std::unique_ptr<
-      BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>
+  std::unique_ptr<BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>
       mock_frame_;
-  std::unique_ptr<
-      BodyCentredBodyDirectionDynamicFrame<ICRS, BigSmallFrame>>
-          big_small_frame_;
+  std::unique_ptr<BodyCentredBodyDirectionDynamicFrame<ICRS, BigSmallFrame>>
+      big_small_frame_;
   StrictMock<MockContinuousTrajectory<ICRS>> mock_big_trajectory_;
   StrictMock<MockContinuousTrajectory<ICRS>> mock_small_trajectory_;
 };

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -29,7 +29,7 @@ namespace principia {
 namespace physics {
 namespace internal_body_centred_body_direction_dynamic_frame {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::check_not_null;
 using geometry::Barycentre;
 using geometry::Bivector;
@@ -83,10 +83,10 @@ class BodyCentredBodyDirectionDynamicFrameTest : public ::testing::Test {
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
             /*fitting_tolerance=*/1 * Milli(Metre),
-            Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+            Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,
-                    Position<ICRFJ2000Equator>>(),
+                    Position<ICRS>>(),
                 /*step=*/10 * Milli(Second)))),
         big_(solar_system_.massive_body(*ephemeris_, big)),
         big_initial_state_(solar_system_.degrees_of_freedom(big)),
@@ -103,35 +103,35 @@ class BodyCentredBodyDirectionDynamicFrameTest : public ::testing::Test {
                 trajectory(solar_system_.massive_body(*ephemeris_, small)))
         .WillOnce(Return(&mock_small_trajectory_));
     mock_frame_ = std::make_unique<
-        BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, MockFrame>>(
+        BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>(
         &mock_ephemeris_, big_, small_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_small_frame_ = std::make_unique<
-        BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, BigSmallFrame>>(
+        BodyCentredBodyDirectionDynamicFrame<ICRS, BigSmallFrame>>(
         ephemeris_.get(), big_, small_);
   }
 
   Time const period_;
-  SolarSystem<ICRFJ2000Equator> solar_system_;
+  SolarSystem<ICRS> solar_system_;
   Instant const t0_;
-  std::unique_ptr<Ephemeris<ICRFJ2000Equator>> const ephemeris_;
+  std::unique_ptr<Ephemeris<ICRS>> const ephemeris_;
   MassiveBody const* big_;
-  DegreesOfFreedom<ICRFJ2000Equator> big_initial_state_;
+  DegreesOfFreedom<ICRS> big_initial_state_;
   GravitationalParameter big_gravitational_parameter_;
   MassiveBody const* small_;
-  DegreesOfFreedom<ICRFJ2000Equator> small_initial_state_;
+  DegreesOfFreedom<ICRS> small_initial_state_;
   GravitationalParameter small_gravitational_parameter_;
-  StrictMock<MockEphemeris<ICRFJ2000Equator>> mock_ephemeris_;
+  StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
   std::unique_ptr<
-      BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, MockFrame>>
+      BodyCentredBodyDirectionDynamicFrame<ICRS, MockFrame>>
       mock_frame_;
   std::unique_ptr<
-      BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, BigSmallFrame>>
+      BodyCentredBodyDirectionDynamicFrame<ICRS, BigSmallFrame>>
           big_small_frame_;
-  StrictMock<MockContinuousTrajectory<ICRFJ2000Equator>> mock_big_trajectory_;
-  StrictMock<MockContinuousTrajectory<ICRFJ2000Equator>> mock_small_trajectory_;
+  StrictMock<MockContinuousTrajectory<ICRS>> mock_big_trajectory_;
+  StrictMock<MockContinuousTrajectory<ICRS>> mock_small_trajectory_;
 };
 
 
@@ -142,10 +142,10 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ToBigSmallFrameAtTime) {
     auto const to_big_small_frame_at_t = big_small_frame_->ToThisFrameAtTime(t);
 
     // Check that the bodies don't move and are at the right locations.
-    DegreesOfFreedom<ICRFJ2000Equator> const big_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const big_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, big).
             EvaluateDegreesOfFreedom(t);
-    DegreesOfFreedom<ICRFJ2000Equator> const small_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const small_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, small).
             EvaluateDegreesOfFreedom(t);
 
@@ -202,14 +202,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({10 * Metre / Second,
                             20 * Metre / Second,
                             30 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>()};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>()};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
 
@@ -224,20 +224,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CoriolisAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -300 * Metre / Pow<2>(Second),
                              -400 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The Coriolis acceleration is towards the centre and opposed to the motion.
@@ -257,16 +257,16 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({0 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({0 * Metre / Second,
                                    0 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
 
@@ -281,20 +281,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CentrifugalAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -300 * Metre / Pow<2>(Second),
                              -400 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   EXPECT_THAT(mock_frame_->GeometricAcceleration(t, point_dof),
@@ -315,16 +315,16 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({0 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({0 * Metre / Second,
                                    0 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -339,20 +339,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, EulerAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (-300 + 400) * Metre / Pow<2>(Second),
                              (-400 - 300) * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The acceleration is centrifugal + Euler.
@@ -373,16 +373,16 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const big_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({0 * Metre / Second,
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({0 * Metre / Second,
                                    0 * Metre / Second,
                                    0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const small_dof =
-      {Displacement<ICRFJ2000Equator>({3 * Metre, 4 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({40 * Metre / Second,
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({40 * Metre / Second,
                                    -30 * Metre / Second,
                                    0 * Metre / Second})};
 
@@ -398,20 +398,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, LinearAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(big_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -160 * Metre / Pow<2>(Second),
                              120 * Metre / Pow<2>(Second),
                              300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     check_not_null(small_), t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              (-160 - 300) * Metre / Pow<2>(Second),
                              (120 - 400) * Metre / Pow<2>(Second),
                              300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The acceleration is linear + centrifugal.
@@ -453,7 +453,7 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.secondary());
 
   auto const read_big_small_frame =
-      DynamicFrame<ICRFJ2000Equator, BigSmallFrame>::ReadFromMessage(
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
           message, ephemeris_.get());
   EXPECT_THAT(read_big_small_frame, Not(IsNull()));
 
@@ -472,14 +472,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ConstructFromOneBody) {
   // A discrete trajectory that remains motionless at the barycentre.  Since
   // both bodies don't have the same mass, this means it has an intrinsic
   // acceleration.
-  DiscreteTrajectory<ICRFJ2000Equator> barycentre_trajectory;
+  DiscreteTrajectory<ICRS> barycentre_trajectory;
   for (Time t; t <= period_; t += period_ / 16) {
     auto const big_dof =
         ephemeris_->trajectory(big_)->EvaluateDegreesOfFreedom(t0_ + t);
     auto const small_dof =
         ephemeris_->trajectory(small_)->EvaluateDegreesOfFreedom(t0_ + t);
     auto const barycentre =
-        Barycentre<DegreesOfFreedom<ICRFJ2000Equator>, GravitationalParameter>(
+        Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
             {big_dof, small_dof},
             {big_->gravitational_parameter(),
              small_->gravitational_parameter()});
@@ -487,20 +487,20 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ConstructFromOneBody) {
                 VanishesBefore(1 * Kilo(Metre) / Second, 0, 45));
     barycentre_trajectory.Append(t0_ + t, barycentre);
   }
-  BodyCentredBodyDirectionDynamicFrame<ICRFJ2000Equator, BigSmallFrame>
+  BodyCentredBodyDirectionDynamicFrame<ICRS, BigSmallFrame>
       barycentric_from_discrete{
           ephemeris_.get(),
           [&t = barycentre_trajectory]() -> auto& { return t; },
           small_};
-  BarycentricRotatingDynamicFrame<ICRFJ2000Equator, BigSmallFrame>
+  BarycentricRotatingDynamicFrame<ICRS, BigSmallFrame>
       barycentric_from_both_bodies{ephemeris_.get(), big_, small_};
   for (Time t = period_ / 32; t <= period_ / 2; t += period_ / 32) {
     auto const dof_from_discrete =
         barycentric_from_discrete.ToThisFrameAtTime(t0_ + t)(
-            {ICRFJ2000Equator::origin, Velocity<ICRFJ2000Equator>{}});
+            {ICRS::origin, Velocity<ICRS>{}});
     auto const dof_from_both_bodies =
         barycentric_from_both_bodies.ToThisFrameAtTime(t0_ + t)(
-            {ICRFJ2000Equator::origin, Velocity<ICRFJ2000Equator>{}});
+            {ICRS::origin, Velocity<ICRS>{}});
     EXPECT_THAT(
         (dof_from_discrete.position() - dof_from_both_bodies.position()).Norm(),
         VanishesBefore(1 * Kilo(Metre), 0, 15));
@@ -512,8 +512,8 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, ConstructFromOneBody) {
     // geometric acceleration when this is not the case.
     auto const intrinsic_acceleration =
         ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(
-            ICRFJ2000Equator::origin +
-                Displacement<ICRFJ2000Equator>({0 * Kilo(Metre),
+            ICRS::origin +
+                Displacement<ICRS>({0 * Kilo(Metre),
                                                 10.0 / 7.0 * Kilo(Metre),
                                                 0 * Kilo(Metre)}),
             t0_ + t);

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -253,14 +253,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -307,14 +307,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, EulerAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
       .WillRepeatedly(Return(big_dof));
@@ -361,14 +361,14 @@ TEST_F(BodyCentredBodyDirectionDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const big_dof = {
-      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const small_dof = {
-      Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
-      Velocity<ICRS>(
-          {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const big_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const small_dof =
+      {Displacement<ICRS>({3 * Metre, 4 * Metre, 0 * Metre}) + ICRS::origin,
+       Velocity<ICRS>(
+           {40 * Metre / Second, -30 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_big_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)

--- a/physics/body_centred_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_test.cpp
@@ -26,7 +26,7 @@ namespace principia {
 namespace physics {
 namespace internal_body_centred_non_rotating_dynamic_frame {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::DefinesFrame;
@@ -78,10 +78,10 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
             /*fitting_tolerance=*/1 * Milli(Metre),
-            Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+            Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,
-                    Position<ICRFJ2000Equator>>(),
+                    Position<ICRS>>(),
                 /*step=*/10 * Milli(Second)))),
         big_initial_state_(solar_system_.degrees_of_freedom(big)),
         big_gravitational_parameter_(
@@ -91,28 +91,28 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
             solar_system_.gravitational_parameter(small)) {
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_frame_ = std::make_unique<
-                     BodyCentredNonRotatingDynamicFrame<ICRFJ2000Equator, Big>>(
+                     BodyCentredNonRotatingDynamicFrame<ICRS, Big>>(
                          ephemeris_.get(),
                          solar_system_.massive_body(*ephemeris_, big));
     small_frame_ = std::make_unique<
-                     BodyCentredNonRotatingDynamicFrame<ICRFJ2000Equator,
+                     BodyCentredNonRotatingDynamicFrame<ICRS,
                                                         Small>>(
                          ephemeris_.get(),
                          solar_system_.massive_body(*ephemeris_, small));
   }
 
   Time const period_;
-  SolarSystem<ICRFJ2000Equator> solar_system_;
+  SolarSystem<ICRS> solar_system_;
   Instant const t0_;
-  std::unique_ptr<Ephemeris<ICRFJ2000Equator>> const ephemeris_;
-  DegreesOfFreedom<ICRFJ2000Equator> const big_initial_state_;
+  std::unique_ptr<Ephemeris<ICRS>> const ephemeris_;
+  DegreesOfFreedom<ICRS> const big_initial_state_;
   GravitationalParameter const big_gravitational_parameter_;
-  DegreesOfFreedom<ICRFJ2000Equator> const small_initial_state_;
+  DegreesOfFreedom<ICRS> const small_initial_state_;
   GravitationalParameter const small_gravitational_parameter_;
   std::unique_ptr<
-      BodyCentredNonRotatingDynamicFrame<ICRFJ2000Equator, Big>> big_frame_;
+      BodyCentredNonRotatingDynamicFrame<ICRS, Big>> big_frame_;
   std::unique_ptr<
-      BodyCentredNonRotatingDynamicFrame<ICRFJ2000Equator, Small>> small_frame_;
+      BodyCentredNonRotatingDynamicFrame<ICRS, Small>> small_frame_;
 };
 
 
@@ -120,17 +120,17 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
 // the big body.
 TEST_F(BodyCentredNonRotatingDynamicFrameTest, SmallBodyInBigFrame) {
   int const steps = 100;
-  Bivector<double, ICRFJ2000Equator> const axis({0, 0, 1});
+  Bivector<double, ICRS> const axis({0, 0, 1});
 
-  RelativeDegreesOfFreedom<ICRFJ2000Equator> const initial_big_to_small =
+  RelativeDegreesOfFreedom<ICRS> const initial_big_to_small =
       small_initial_state_ - big_initial_state_;
   for (Instant t = t0_; t < t0_ + 1 * period_; t += period_ / steps) {
-    DegreesOfFreedom<ICRFJ2000Equator> const small_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const small_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, small).
             EvaluateDegreesOfFreedom(t);
 
     auto const rotation_in_big_frame_at_t =
-        Rotation<ICRFJ2000Equator, Big>(2 * π * (t - t0_) * Radian / period_,
+        Rotation<ICRS, Big>(2 * π * (t - t0_) * Radian / period_,
                                         axis,
                                         DefinesFrame<Big>{});
     DegreesOfFreedom<Big> const small_in_big_frame_at_t(
@@ -166,7 +166,7 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, Inverse) {
 
 TEST_F(BodyCentredNonRotatingDynamicFrameTest, GeometricAcceleration) {
   int const steps = 10;
-  RelativeDegreesOfFreedom<ICRFJ2000Equator> const initial_big_to_small =
+  RelativeDegreesOfFreedom<ICRS> const initial_big_to_small =
       small_initial_state_ - big_initial_state_;
   Length const big_to_small = initial_big_to_small.displacement().Norm();
   Acceleration const small_on_big =
@@ -208,7 +208,7 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.centre());
 
   auto const read_small_frame =
-      DynamicFrame<ICRFJ2000Equator, Small>::ReadFromMessage(
+      DynamicFrame<ICRS, Small>::ReadFromMessage(
           message, ephemeris_.get());
   EXPECT_THAT(read_small_frame, Not(IsNull()));
 

--- a/physics/body_centred_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_test.cpp
@@ -90,15 +90,12 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
         small_gravitational_parameter_(
             solar_system_.gravitational_parameter(small)) {
     ephemeris_->Prolong(t0_ + 2 * period_);
-    big_frame_ = std::make_unique<
-                     BodyCentredNonRotatingDynamicFrame<ICRS, Big>>(
-                         ephemeris_.get(),
-                         solar_system_.massive_body(*ephemeris_, big));
-    small_frame_ = std::make_unique<
-                     BodyCentredNonRotatingDynamicFrame<ICRS,
-                                                        Small>>(
-                         ephemeris_.get(),
-                         solar_system_.massive_body(*ephemeris_, small));
+    big_frame_ =
+        std::make_unique<BodyCentredNonRotatingDynamicFrame<ICRS, Big>>(
+            ephemeris_.get(), solar_system_.massive_body(*ephemeris_, big));
+    small_frame_ =
+        std::make_unique<BodyCentredNonRotatingDynamicFrame<ICRS, Small>>(
+            ephemeris_.get(), solar_system_.massive_body(*ephemeris_, small));
   }
 
   Time const period_;
@@ -109,10 +106,8 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
   GravitationalParameter const big_gravitational_parameter_;
   DegreesOfFreedom<ICRS> const small_initial_state_;
   GravitationalParameter const small_gravitational_parameter_;
-  std::unique_ptr<
-      BodyCentredNonRotatingDynamicFrame<ICRS, Big>> big_frame_;
-  std::unique_ptr<
-      BodyCentredNonRotatingDynamicFrame<ICRS, Small>> small_frame_;
+  std::unique_ptr<BodyCentredNonRotatingDynamicFrame<ICRS, Big>> big_frame_;
+  std::unique_ptr<BodyCentredNonRotatingDynamicFrame<ICRS, Small>> small_frame_;
 };
 
 
@@ -129,10 +124,8 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, SmallBodyInBigFrame) {
         solar_system_.trajectory(*ephemeris_, small).
             EvaluateDegreesOfFreedom(t);
 
-    auto const rotation_in_big_frame_at_t =
-        Rotation<ICRS, Big>(2 * π * (t - t0_) * Radian / period_,
-                                        axis,
-                                        DefinesFrame<Big>{});
+    auto const rotation_in_big_frame_at_t = Rotation<ICRS, Big>(
+        2 * π * (t - t0_) * Radian / period_, axis, DefinesFrame<Big>{});
     DegreesOfFreedom<Big> const small_in_big_frame_at_t(
         rotation_in_big_frame_at_t(initial_big_to_small.displacement()) +
             Big::origin,
@@ -208,8 +201,7 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, Serialization) {
   EXPECT_EQ(1, extension.centre());
 
   auto const read_small_frame =
-      DynamicFrame<ICRS, Small>::ReadFromMessage(
-          message, ephemeris_.get());
+      DynamicFrame<ICRS, Small>::ReadFromMessage(message, ephemeris_.get());
   EXPECT_THAT(read_small_frame, Not(IsNull()));
 
   Instant const t = t0_ + period_;

--- a/physics/body_surface_dynamic_frame_test.cpp
+++ b/physics/body_surface_dynamic_frame_test.cpp
@@ -30,7 +30,7 @@ namespace principia {
 namespace physics {
 namespace internal_body_surface_dynamic_frame {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::check_not_null;
 using base::dynamic_cast_not_null;
 using geometry::Bivector;
@@ -88,12 +88,12 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
             /*fitting_tolerance=*/1 * Milli(Metre),
-            Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+            Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,
-                    Position<ICRFJ2000Equator>>(),
+                    Position<ICRS>>(),
                 /*step=*/10 * Milli(Second)))),
-        big_(dynamic_cast_not_null<RotatingBody<ICRFJ2000Equator> const*>(
+        big_(dynamic_cast_not_null<RotatingBody<ICRS> const*>(
             solar_system_.massive_body(*ephemeris_, big))),
         big_initial_state_(solar_system_.degrees_of_freedom(big)),
         big_gravitational_parameter_(
@@ -105,7 +105,7 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
         // BodyCentredBodyDirectionDynamicFrameTest, so it produces the same
         // fictitious forces.
         centre_(MassiveBody::Parameters(1 * Kilogram),
-                RotatingBody<ICRFJ2000Equator>::Parameters(
+                RotatingBody<ICRS>::Parameters(
                     /*mean_radius=*/1 * Metre,
                     /*reference_angle=*/0 * Radian,
                     /*reference_instant=*/t0_,
@@ -116,33 +116,33 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
     EXPECT_CALL(mock_ephemeris_, trajectory(_))
         .WillOnce(Return(&mock_centre_trajectory_));
     mock_frame_ =
-        std::make_unique<BodySurfaceDynamicFrame<ICRFJ2000Equator, MockFrame>>(
+        std::make_unique<BodySurfaceDynamicFrame<ICRS, MockFrame>>(
             &mock_ephemeris_, &centre_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
     big_frame_ = std::make_unique<
-        BodySurfaceDynamicFrame<ICRFJ2000Equator, BigSmallFrame>>(
+        BodySurfaceDynamicFrame<ICRS, BigSmallFrame>>(
         ephemeris_.get(), big_);
   }
 
   Time const period_;
-  SolarSystem<ICRFJ2000Equator> solar_system_;
+  SolarSystem<ICRS> solar_system_;
   Instant const t0_;
-  std::unique_ptr<Ephemeris<ICRFJ2000Equator>> const ephemeris_;
-  RotatingBody<ICRFJ2000Equator> const* const big_;
-  DegreesOfFreedom<ICRFJ2000Equator> big_initial_state_;
+  std::unique_ptr<Ephemeris<ICRS>> const ephemeris_;
+  RotatingBody<ICRS> const* const big_;
+  DegreesOfFreedom<ICRS> big_initial_state_;
   GravitationalParameter big_gravitational_parameter_;
-  DegreesOfFreedom<ICRFJ2000Equator> small_initial_state_;
+  DegreesOfFreedom<ICRS> small_initial_state_;
   GravitationalParameter small_gravitational_parameter_;
-  RotatingBody<ICRFJ2000Equator> const centre_;
+  RotatingBody<ICRS> const centre_;
   not_null<MassiveBody const*> const massive_centre_;
-  StrictMock<MockEphemeris<ICRFJ2000Equator>> mock_ephemeris_;
+  StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
-  std::unique_ptr<BodySurfaceDynamicFrame<ICRFJ2000Equator, MockFrame>>
+  std::unique_ptr<BodySurfaceDynamicFrame<ICRS, MockFrame>>
       mock_frame_;
   std::unique_ptr<
-      BodySurfaceDynamicFrame<ICRFJ2000Equator, BigSmallFrame>> big_frame_;
-  StrictMock<MockContinuousTrajectory<ICRFJ2000Equator>>
+      BodySurfaceDynamicFrame<ICRS, BigSmallFrame>> big_frame_;
+  StrictMock<MockContinuousTrajectory<ICRS>>
       mock_centre_trajectory_;
 };
 
@@ -155,10 +155,10 @@ TEST_F(BodySurfaceDynamicFrameTest, ToBigSmallFrameAtTime) {
 
     // Check that the big body is at the origin and doesn't move.  Check that
     // the small body is at a fixed position in the sky.
-    DegreesOfFreedom<ICRFJ2000Equator> const big_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const big_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, big).
             EvaluateDegreesOfFreedom(t);
-    DegreesOfFreedom<ICRFJ2000Equator> const small_in_inertial_frame_at_t =
+    DegreesOfFreedom<ICRS> const small_in_inertial_frame_at_t =
         solar_system_.trajectory(*ephemeris_, small).
             EvaluateDegreesOfFreedom(t);
 
@@ -215,10 +215,10 @@ TEST_F(BodySurfaceDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({10 * Metre / Second,
                             20 * Metre / Second,
                             30 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const centre_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>()};
+  DegreesOfFreedom<ICRS> const centre_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>()};
 
   EXPECT_CALL(mock_centre_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -228,13 +228,13 @@ TEST_F(BodySurfaceDynamicFrameTest, CoriolisAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The Coriolis acceleration is towards the centre and opposed to the motion.
@@ -253,10 +253,10 @@ TEST_F(BodySurfaceDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const centre_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({0 * Metre / Second,
+  DegreesOfFreedom<ICRS> const centre_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({0 * Metre / Second,
                                    0 * Metre / Second,
                                    0 * Metre / Second})};
   EXPECT_CALL(mock_centre_trajectory_, EvaluateDegreesOfFreedom(t))
@@ -267,13 +267,13 @@ TEST_F(BodySurfaceDynamicFrameTest, CentrifugalAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second),
                              0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   EXPECT_THAT(mock_frame_->GeometricAcceleration(t, point_dof).coordinates(),
@@ -294,10 +294,10 @@ TEST_F(BodySurfaceDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRFJ2000Equator> const centre_dof =
-      {Displacement<ICRFJ2000Equator>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRFJ2000Equator::origin,
-       Velocity<ICRFJ2000Equator>({0 * Metre / Second,
+  DegreesOfFreedom<ICRS> const centre_dof =
+      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
+           ICRS::origin,
+       Velocity<ICRS>({0 * Metre / Second,
                                    0 * Metre / Second,
                                    0 * Metre / Second})};
 
@@ -310,13 +310,13 @@ TEST_F(BodySurfaceDynamicFrameTest, LinearAcceleration) {
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMassiveBody(
                     massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>({
+        .WillOnce(Return(Vector<Acceleration, ICRS>({
                              -160 * Metre / Pow<2>(Second),
                              120 * Metre / Pow<2>(Second),
                              300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRFJ2000Equator>()));
+        .WillOnce(Return(Vector<Acceleration, ICRS>()));
   }
 
   // The acceleration is linear + centrifugal.
@@ -356,7 +356,7 @@ TEST_F(BodySurfaceDynamicFrameTest, Serialization) {
   EXPECT_EQ(0, extension.centre());
 
   auto const read_big_frame =
-      DynamicFrame<ICRFJ2000Equator, BigSmallFrame>::ReadFromMessage(
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
           message, ephemeris_.get());
   EXPECT_THAT(read_big_frame, Not(IsNull()));
 

--- a/physics/body_surface_dynamic_frame_test.cpp
+++ b/physics/body_surface_dynamic_frame_test.cpp
@@ -115,13 +115,11 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
         massive_centre_(&centre_) {
     EXPECT_CALL(mock_ephemeris_, trajectory(_))
         .WillOnce(Return(&mock_centre_trajectory_));
-    mock_frame_ =
-        std::make_unique<BodySurfaceDynamicFrame<ICRS, MockFrame>>(
-            &mock_ephemeris_, &centre_);
+    mock_frame_ = std::make_unique<BodySurfaceDynamicFrame<ICRS, MockFrame>>(
+        &mock_ephemeris_, &centre_);
 
     ephemeris_->Prolong(t0_ + 2 * period_);
-    big_frame_ = std::make_unique<
-        BodySurfaceDynamicFrame<ICRS, BigSmallFrame>>(
+    big_frame_ = std::make_unique<BodySurfaceDynamicFrame<ICRS, BigSmallFrame>>(
         ephemeris_.get(), big_);
   }
 
@@ -138,12 +136,9 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
   not_null<MassiveBody const*> const massive_centre_;
   StrictMock<MockEphemeris<ICRS>> mock_ephemeris_;
 
-  std::unique_ptr<BodySurfaceDynamicFrame<ICRS, MockFrame>>
-      mock_frame_;
-  std::unique_ptr<
-      BodySurfaceDynamicFrame<ICRS, BigSmallFrame>> big_frame_;
-  StrictMock<MockContinuousTrajectory<ICRS>>
-      mock_centre_trajectory_;
+  std::unique_ptr<BodySurfaceDynamicFrame<ICRS, MockFrame>> mock_frame_;
+  std::unique_ptr<BodySurfaceDynamicFrame<ICRS, BigSmallFrame>> big_frame_;
+  StrictMock<MockContinuousTrajectory<ICRS>> mock_centre_trajectory_;
 };
 
 
@@ -215,23 +210,22 @@ TEST_F(BodySurfaceDynamicFrameTest, CoriolisAcceleration) {
        Velocity<MockFrame>({10 * Metre / Second,
                             20 * Metre / Second,
                             30 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const centre_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>()};
+  DegreesOfFreedom<ICRS> const centre_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>()};
 
   EXPECT_CALL(mock_centre_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
       .WillRepeatedly(Return(centre_dof));
   {
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(massive_centre_, t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -253,24 +247,22 @@ TEST_F(BodySurfaceDynamicFrameTest, CentrifugalAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const centre_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({0 * Metre / Second,
-                                   0 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const centre_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
   EXPECT_CALL(mock_centre_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
       .WillRepeatedly(Return(centre_dof));
   {
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second),
-                             0 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(massive_centre_, t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second),
+                                               0 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -294,12 +286,10 @@ TEST_F(BodySurfaceDynamicFrameTest, LinearAcceleration) {
        Velocity<MockFrame>({0 * Metre / Second,
                             0 * Metre / Second,
                             0 * Metre / Second})};
-  DegreesOfFreedom<ICRS> const centre_dof =
-      {Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) +
-           ICRS::origin,
-       Velocity<ICRS>({0 * Metre / Second,
-                                   0 * Metre / Second,
-                                   0 * Metre / Second})};
+  DegreesOfFreedom<ICRS> const centre_dof = {
+      Displacement<ICRS>({0 * Metre, 0 * Metre, 0 * Metre}) + ICRS::origin,
+      Velocity<ICRS>(
+          {0 * Metre / Second, 0 * Metre / Second, 0 * Metre / Second})};
 
   EXPECT_CALL(mock_centre_trajectory_, EvaluateDegreesOfFreedom(t))
       .Times(2)
@@ -307,13 +297,13 @@ TEST_F(BodySurfaceDynamicFrameTest, LinearAcceleration) {
   {
     // The acceleration is linear + centripetal.
     InSequence s;
-    EXPECT_CALL(mock_ephemeris_,
-                ComputeGravitationalAccelerationOnMassiveBody(
-                    massive_centre_, t))
-        .WillOnce(Return(Vector<Acceleration, ICRS>({
-                             -160 * Metre / Pow<2>(Second),
-                             120 * Metre / Pow<2>(Second),
-                             300 * Metre / Pow<2>(Second)})));
+    EXPECT_CALL(
+        mock_ephemeris_,
+        ComputeGravitationalAccelerationOnMassiveBody(massive_centre_, t))
+        .WillOnce(
+            Return(Vector<Acceleration, ICRS>({-160 * Metre / Pow<2>(Second),
+                                               120 * Metre / Pow<2>(Second),
+                                               300 * Metre / Pow<2>(Second)})));
     EXPECT_CALL(mock_ephemeris_,
                 ComputeGravitationalAccelerationOnMasslessBody(_, t))
         .WillOnce(Return(Vector<Acceleration, ICRS>()));
@@ -356,8 +346,8 @@ TEST_F(BodySurfaceDynamicFrameTest, Serialization) {
   EXPECT_EQ(0, extension.centre());
 
   auto const read_big_frame =
-      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(
-          message, ephemeris_.get());
+      DynamicFrame<ICRS, BigSmallFrame>::ReadFromMessage(message,
+                                                         ephemeris_.get());
   EXPECT_THAT(read_big_frame, Not(IsNull()));
 
   Instant const t = t0_ + period_;

--- a/physics/body_surface_frame_field_test.cpp
+++ b/physics/body_surface_frame_field_test.cpp
@@ -17,7 +17,7 @@ namespace principia {
 namespace physics {
 namespace internal_body_surface_dynamic_frame {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::J2000;
 using geometry::Displacement;
 using geometry::InnerProduct;
@@ -41,7 +41,7 @@ class BodySurfaceFrameFieldTest : public ::testing::Test {
 
   BodySurfaceFrameFieldTest()
       : body_(MassiveBody::Parameters(1 * Kilogram),
-              RotatingBody<ICRFJ2000Equator>::Parameters(
+              RotatingBody<ICRS>::Parameters(
                   /*mean_radius=*/1 * Metre,
                   /*reference_angle=*/0 * Radian,
                   /*reference_instant=*/J2000,
@@ -51,26 +51,26 @@ class BodySurfaceFrameFieldTest : public ::testing::Test {
     // The polar axis is {1/2, 1/2, 1/Sqrt[2]}.
     EXPECT_CALL(ephemeris_, trajectory(_)).WillOnce(Return(&trajectory_));
     EXPECT_CALL(trajectory_, EvaluatePosition(J2000))
-        .WillOnce(Return(ICRFJ2000Equator::origin));
+        .WillOnce(Return(ICRS::origin));
     field_ =
-        std::make_unique<BodySurfaceFrameField<ICRFJ2000Equator, TestFrame>>(
+        std::make_unique<BodySurfaceFrameField<ICRS, TestFrame>>(
             ephemeris_, J2000, &body_);
   }
 
-  MockEphemeris<ICRFJ2000Equator> const ephemeris_;
-  RotatingBody<ICRFJ2000Equator> const body_;
-  MockContinuousTrajectory<ICRFJ2000Equator> trajectory_;
-  std::unique_ptr<BodySurfaceFrameField<ICRFJ2000Equator, TestFrame>> field_;
+  MockEphemeris<ICRS> const ephemeris_;
+  RotatingBody<ICRS> const body_;
+  MockContinuousTrajectory<ICRS> trajectory_;
+  std::unique_ptr<BodySurfaceFrameField<ICRS, TestFrame>> field_;
 };
 
 TEST_F(BodySurfaceFrameFieldTest, FromThisFrame) {
-  Displacement<ICRFJ2000Equator> const displacement(
+  Displacement<ICRS> const displacement(
       {2 * Metre, 3 * Metre, 4 * Metre});
-  Rotation<TestFrame, ICRFJ2000Equator> const rotation =
-      field_->FromThisFrame(ICRFJ2000Equator::origin + displacement);
+  Rotation<TestFrame, ICRS> const rotation =
+      field_->FromThisFrame(ICRS::origin + displacement);
   {
     auto const actual = rotation(Vector<double, TestFrame>({1, 0, 0}));
-    auto const expected = Vector<double, ICRFJ2000Equator>(
+    auto const expected = Vector<double, ICRS>(
         {Sqrt((4531 + 1624 * Sqrt(2)) / 8149),
          -2 * Sqrt((419 - 116 * Sqrt(2)) / 8149),
          -Sqrt(((2 * (971 - 580 * Sqrt(2))) / 8149))});
@@ -80,7 +80,7 @@ TEST_F(BodySurfaceFrameFieldTest, FromThisFrame) {
   }
   {
     auto const actual = rotation(Vector<double, TestFrame>({0, 1, 0}));
-    auto const expected = Vector<double, ICRFJ2000Equator>(
+    auto const expected = Vector<double, ICRS>(
         {-Sqrt((86 - 56 * Sqrt(2)) / 281),
          -2 * Sqrt(2 * (17 + 2 * Sqrt(2)) / 281),
          Sqrt((59 + 40 * Sqrt(2)) / 281)});
@@ -92,7 +92,7 @@ TEST_F(BodySurfaceFrameFieldTest, FromThisFrame) {
   }
   {
     auto const actual = rotation(Vector<double, TestFrame>({0, 0, 1}));
-    auto const expected = Vector<double, ICRFJ2000Equator>(
+    auto const expected = Vector<double, ICRS>(
         {-2 / Sqrt(29), -3 / Sqrt(29), -4 / Sqrt(29)});
     EXPECT_THAT(actual, AlmostEquals(expected, 7, 76));
   }

--- a/physics/body_surface_frame_field_test.cpp
+++ b/physics/body_surface_frame_field_test.cpp
@@ -52,9 +52,8 @@ class BodySurfaceFrameFieldTest : public ::testing::Test {
     EXPECT_CALL(ephemeris_, trajectory(_)).WillOnce(Return(&trajectory_));
     EXPECT_CALL(trajectory_, EvaluatePosition(J2000))
         .WillOnce(Return(ICRS::origin));
-    field_ =
-        std::make_unique<BodySurfaceFrameField<ICRS, TestFrame>>(
-            ephemeris_, J2000, &body_);
+    field_ = std::make_unique<BodySurfaceFrameField<ICRS, TestFrame>>(
+        ephemeris_, J2000, &body_);
   }
 
   MockEphemeris<ICRS> const ephemeris_;
@@ -64,26 +63,25 @@ class BodySurfaceFrameFieldTest : public ::testing::Test {
 };
 
 TEST_F(BodySurfaceFrameFieldTest, FromThisFrame) {
-  Displacement<ICRS> const displacement(
-      {2 * Metre, 3 * Metre, 4 * Metre});
+  Displacement<ICRS> const displacement({2 * Metre, 3 * Metre, 4 * Metre});
   Rotation<TestFrame, ICRS> const rotation =
       field_->FromThisFrame(ICRS::origin + displacement);
   {
     auto const actual = rotation(Vector<double, TestFrame>({1, 0, 0}));
-    auto const expected = Vector<double, ICRS>(
-        {Sqrt((4531 + 1624 * Sqrt(2)) / 8149),
-         -2 * Sqrt((419 - 116 * Sqrt(2)) / 8149),
-         -Sqrt(((2 * (971 - 580 * Sqrt(2))) / 8149))});
+    auto const expected =
+        Vector<double, ICRS>({Sqrt((4531 + 1624 * Sqrt(2)) / 8149),
+                              -2 * Sqrt((419 - 116 * Sqrt(2)) / 8149),
+                              -Sqrt(((2 * (971 - 580 * Sqrt(2))) / 8149))});
     EXPECT_THAT(actual, AlmostEquals(expected, 9, 43));
     EXPECT_THAT(InnerProduct(actual, displacement),
                 VanishesBefore(displacement.Norm(), 2, 11));
   }
   {
     auto const actual = rotation(Vector<double, TestFrame>({0, 1, 0}));
-    auto const expected = Vector<double, ICRS>(
-        {-Sqrt((86 - 56 * Sqrt(2)) / 281),
-         -2 * Sqrt(2 * (17 + 2 * Sqrt(2)) / 281),
-         Sqrt((59 + 40 * Sqrt(2)) / 281)});
+    auto const expected =
+        Vector<double, ICRS>({-Sqrt((86 - 56 * Sqrt(2)) / 281),
+                              -2 * Sqrt(2 * (17 + 2 * Sqrt(2)) / 281),
+                              Sqrt((59 + 40 * Sqrt(2)) / 281)});
     EXPECT_THAT(actual, AlmostEquals(expected, 10, 74));
     EXPECT_THAT(InnerProduct(actual, displacement),
                 VanishesBefore(displacement.Norm(), 0, 17));
@@ -92,8 +90,8 @@ TEST_F(BodySurfaceFrameFieldTest, FromThisFrame) {
   }
   {
     auto const actual = rotation(Vector<double, TestFrame>({0, 0, 1}));
-    auto const expected = Vector<double, ICRS>(
-        {-2 / Sqrt(29), -3 / Sqrt(29), -4 / Sqrt(29)});
+    auto const expected =
+        Vector<double, ICRS>({-2 / Sqrt(29), -3 / Sqrt(29), -4 / Sqrt(29)});
     EXPECT_THAT(actual, AlmostEquals(expected, 7, 76));
   }
 }

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -258,31 +258,28 @@ TEST_F(BodyTest, AllFrames) {
   TestRotatingBody<serialization::Frame::PluginTag,
                    serialization::Frame::ALICE_WORLD>();
   TestRotatingBody<serialization::Frame::PluginTag,
-                  serialization::Frame::BARYCENTRIC>();
+                   serialization::Frame::BARYCENTRIC>();
   TestRotatingBody<serialization::Frame::PluginTag,
                    serialization::Frame::NAVIGATION>();
   TestRotatingBody<serialization::Frame::PluginTag,
-                  serialization::Frame::WORLD>();
+                   serialization::Frame::WORLD>();
   TestRotatingBody<serialization::Frame::PluginTag,
-                  serialization::Frame::WORLD_SUN>();
+                   serialization::Frame::WORLD_SUN>();
 
   TestRotatingBody<serialization::Frame::SolarSystemTag,
-                  serialization::Frame::ICRF_J2000_ECLIPTIC>();
+                   serialization::Frame::ICRF_J2000_ECLIPTIC>();
   TestRotatingBody<serialization::Frame::SolarSystemTag,
-                  serialization::Frame::ICRS>();
+                   serialization::Frame::ICRS>();
 
+  TestRotatingBody<serialization::Frame::TestTag, serialization::Frame::TEST>();
   TestRotatingBody<serialization::Frame::TestTag,
-                  serialization::Frame::TEST>();
-  TestRotatingBody<serialization::Frame::TestTag,
-                  serialization::Frame::TEST1>();
+                   serialization::Frame::TEST1>();
   TestRotatingBody<serialization::Frame::TestTag,
                    serialization::Frame::TEST2>();
-  TestRotatingBody<serialization::Frame::TestTag,
-                   serialization::Frame::FROM>();
+  TestRotatingBody<serialization::Frame::TestTag, serialization::Frame::FROM>();
   TestRotatingBody<serialization::Frame::TestTag,
                    serialization::Frame::THROUGH>();
-  TestRotatingBody<serialization::Frame::TestTag,
-                   serialization::Frame::TO>();
+  TestRotatingBody<serialization::Frame::TestTag, serialization::Frame::TO>();
 }
 
 }  // namespace internal_body

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -267,9 +267,11 @@ TEST_F(BodyTest, AllFrames) {
                    serialization::Frame::WORLD_SUN>();
 
   TestRotatingBody<serialization::Frame::SolarSystemTag,
-                   serialization::Frame::ICRF_J2000_ECLIPTIC>();
+                   serialization::Frame::GCRS>();
   TestRotatingBody<serialization::Frame::SolarSystemTag,
                    serialization::Frame::ICRS>();
+  TestRotatingBody<serialization::Frame::SolarSystemTag,
+                   serialization::Frame::ITRS>();
 
   TestRotatingBody<serialization::Frame::TestTag, serialization::Frame::TEST>();
   TestRotatingBody<serialization::Frame::TestTag,

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -269,7 +269,7 @@ TEST_F(BodyTest, AllFrames) {
   TestRotatingBody<serialization::Frame::SolarSystemTag,
                   serialization::Frame::ICRF_J2000_ECLIPTIC>();
   TestRotatingBody<serialization::Frame::SolarSystemTag,
-                  serialization::Frame::ICRF_J2000_EQUATOR>();
+                  serialization::Frame::ICRS>();
 
   TestRotatingBody<serialization::Frame::TestTag,
                   serialization::Frame::TEST>();

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -866,15 +866,12 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
   initial_state.emplace_back(q2, v);
   initial_state.emplace_back(q3, v);
 
-  Ephemeris<ICRS>
-      ephemeris(
-          std::move(bodies),
-          initial_state,
-          t0_,
-          5 * Milli(Metre),
-          Ephemeris<ICRS>::FixedStepParameters(
-              integrator(),
-              duration / 100));
+  Ephemeris<ICRS> ephemeris(
+      std::move(bodies),
+      initial_state,
+      t0_,
+      5 * Milli(Metre),
+      Ephemeris<ICRS>::FixedStepParameters(integrator(), duration / 100));
   ephemeris.Prolong(t0_ + duration);
 
   Vector<Acceleration, ICRS> actual_acceleration0 =

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -39,7 +39,6 @@ namespace physics {
 namespace internal_ephemeris {
 
 using astronomy::ICRS;
-using astronomy::SolarSystemBarycentreEquator;
 using base::not_null;
 using geometry::Barycentre;
 using geometry::AngularVelocity;

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -517,7 +517,6 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
 }
 
 #define CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(element1, element2, reference)       \
-                                                                               \
   [&]() {                                                                      \
     KeplerianElements<ICRS> elements;                                          \
     elements.element1 = (reference).element1;                                  \

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -15,7 +15,7 @@ namespace principia {
 namespace physics {
 namespace internal_kepler_orbit {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::J2000;
 using astronomy::operator""_TT;
 using quantities::astronomy::JulianYear;
@@ -71,8 +71,8 @@ using ::testing::Lt;
 
 class KeplerOrbitTest : public ::testing::Test {
  protected:
-  static KeplerianElements<ICRFJ2000Equator> MoonElements() {
-    KeplerianElements<ICRFJ2000Equator> elements;
+  static KeplerianElements<ICRS> MoonElements() {
+    KeplerianElements<ICRS> elements;
     elements.eccentricity                = 4.772161502830355e-02;
     elements.semimajor_axis              = 3.870051955415476e+05 * Kilo(Metre);
     elements.mean_motion                 = 1.511718576836574e-04 * (Degree /
@@ -88,8 +88,8 @@ class KeplerOrbitTest : public ::testing::Test {
     return elements;
   }
 
-  static KeplerianElements<ICRFJ2000Equator> VoyagerElements() {
-    KeplerianElements<ICRFJ2000Equator> elements;
+  static KeplerianElements<ICRS> VoyagerElements() {
+    KeplerianElements<ICRS> elements;
     elements.eccentricity                =  3.754904752975423e+00;
     elements.semimajor_axis              = -4.808470899553643e+08 * Kilo(Metre);
     elements.hyperbolic_mean_motion      =  1.979556771581467e-06 * (Degree /
@@ -103,8 +103,8 @@ class KeplerOrbitTest : public ::testing::Test {
     return elements;
   }
 
-  static KeplerianElements<ICRFJ2000Equator> SimpleEllipse() {
-    KeplerianElements<ICRFJ2000Equator> elements;
+  static KeplerianElements<ICRS> SimpleEllipse() {
+    KeplerianElements<ICRS> elements;
     elements.eccentricity = 0.5;
     elements.asymptotic_true_anomaly = -NaN<Angle>();
     elements.turning_angle = -NaN<Angle>();
@@ -136,8 +136,8 @@ class KeplerOrbitTest : public ::testing::Test {
     return elements;
   }
 
-  static KeplerianElements<ICRFJ2000Equator> SimpleHyperbola() {
-    KeplerianElements<ICRFJ2000Equator> elements;
+  static KeplerianElements<ICRS> SimpleHyperbola() {
+    KeplerianElements<ICRS> elements;
     elements.eccentricity = 1.5;
     elements.asymptotic_true_anomaly = ArcCos(-1 / 1.5);
     elements.turning_angle = 2 * ArcSin(1 / 1.5);
@@ -171,8 +171,8 @@ class KeplerOrbitTest : public ::testing::Test {
   }
 
   // An ellipse with a = 1 au, e very close to 1.
-  static KeplerianElements<ICRFJ2000Equator> NearlyParabolicEllipse() {
-    KeplerianElements<ICRFJ2000Equator> elements;
+  static KeplerianElements<ICRS> NearlyParabolicEllipse() {
+    KeplerianElements<ICRS> elements;
     // This is about half the bits at 1, which maximizes the error in the naïve
     // evaluation of 1 - (1 - ε)².  Note the 1 - (1 - x), to ensure that
     // (1 - ε) is exact.
@@ -215,8 +215,8 @@ class KeplerOrbitTest : public ::testing::Test {
   }
 
   static void ExpectConicParametersAlmostEqual(
-      KeplerianElements<ICRFJ2000Equator> const& actual,
-      KeplerianElements<ICRFJ2000Equator> const& expected,
+      KeplerianElements<ICRS> const& actual,
+      KeplerianElements<ICRS> const& expected,
       std::int64_t const eccentrity_ulps,
       std::int64_t const asymptotic_true_anomaly_ulps,
       std::int64_t const turning_angle_ulps,
@@ -279,13 +279,13 @@ class KeplerOrbitTest : public ::testing::Test {
 };
 
 TEST_F(KeplerOrbitTest, EarthMoon) {
-  SolarSystem<ICRFJ2000Equator> solar_system(
+  SolarSystem<ICRS> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");
-  auto const earth = SolarSystem<ICRFJ2000Equator>::MakeMassiveBody(
+  auto const earth = SolarSystem<ICRS>::MakeMassiveBody(
                          solar_system.gravity_model_message("Earth"));
-  auto const moon = SolarSystem<ICRFJ2000Equator>::MakeMassiveBody(
+  auto const moon = SolarSystem<ICRS>::MakeMassiveBody(
                         solar_system.gravity_model_message("Moon"));
   // The numbers in the gravity models and those from the query above both come
   // from DE431, so the sums are the same up to round-off.
@@ -295,11 +295,11 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
           4.0350323550225975e+05 * (Pow<3>(Kilo(Metre)) / Pow<2>(Second)), 1));
   constexpr Instant date = "JD2457397.500000000"_TT;
 
-  Displacement<ICRFJ2000Equator> const expected_displacement(
+  Displacement<ICRS> const expected_displacement(
       { 1.177367562036580e+05 * Kilo(Metre),
        -3.419908628150604e+05 * Kilo(Metre),
        -1.150659799281941e+05 * Kilo(Metre)});
-  Velocity<ICRFJ2000Equator> const expected_velocity(
+  Velocity<ICRS> const expected_velocity(
       {9.745048087261129e-01 * (Kilo(Metre) / Second),
        3.500672337210811e-01 * (Kilo(Metre) / Second),
        1.066306010215636e-01 * (Kilo(Metre) / Second)});
@@ -311,7 +311,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
   partial_elements.apoapsis_distance.reset();
   partial_elements.true_anomaly.reset();
   {
-    KeplerOrbit<ICRFJ2000Equator> moon_orbit(
+    KeplerOrbit<ICRS> moon_orbit(
         *earth, *moon, partial_elements, date);
     EXPECT_THAT(moon_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 15));
@@ -324,7 +324,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
   partial_elements.semimajor_axis.reset();
   partial_elements.periapsis_distance = MoonElements().periapsis_distance;
   {
-    KeplerOrbit<ICRFJ2000Equator> moon_orbit(
+    KeplerOrbit<ICRS> moon_orbit(
         *earth, *moon, partial_elements, date);
     EXPECT_THAT(moon_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 13, 15));
@@ -332,7 +332,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
                 AlmostEquals(expected_velocity, 23));
   }
 
-  KeplerOrbit<ICRFJ2000Equator> moon_orbit(
+  KeplerOrbit<ICRS> moon_orbit(
       *earth, *moon, {expected_displacement, expected_velocity}, date);
   EXPECT_THAT(*moon_orbit.elements_at_epoch().eccentricity,
               AlmostEquals(*MoonElements().eccentricity, 8));
@@ -359,20 +359,20 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
 }
 
 TEST_F(KeplerOrbitTest, Voyager1) {
-  SolarSystem<ICRFJ2000Equator> solar_system(
+  SolarSystem<ICRS> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");
-  auto const sun = SolarSystem<ICRFJ2000Equator>::MakeMassiveBody(
+  auto const sun = SolarSystem<ICRS>::MakeMassiveBody(
                          solar_system.gravity_model_message("Sun"));
   MasslessBody const voyager1{};
   constexpr Instant date = "2017-05-25T19:44:00,000"_TT;
 
-  Displacement<ICRFJ2000Equator> const expected_displacement(
+  Displacement<ICRS> const expected_displacement(
       {-4.202547896125371e+09 * Kilo(Metre),
        -1.982453908150731e+10 * Kilo(Metre),
         4.378406169173994e+09 * Kilo(Metre)});
-  Velocity<ICRFJ2000Equator> const expected_velocity(
+  Velocity<ICRS> const expected_velocity(
       {-2.067668772297011e+00 * (Kilo(Metre) / Second),
        -1.647515322877371e+01 * (Kilo(Metre) / Second),
         3.618493348898172e+00 * (Kilo(Metre) / Second)});
@@ -382,7 +382,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
   partial_elements.periapsis_distance.reset();
   partial_elements.true_anomaly.reset();
   {
-    KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
+    KeplerOrbit<ICRS> voyager_orbit(
         *sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 37, 49));
@@ -395,7 +395,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
   partial_elements.semimajor_axis.reset();
   partial_elements.periapsis_distance = VoyagerElements().periapsis_distance;
   {
-    KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
+    KeplerOrbit<ICRS> voyager_orbit(
         *sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 31, 44));
@@ -403,7 +403,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
                 AlmostEquals(expected_velocity, 27, 28));
   }
 
-  KeplerOrbit<ICRFJ2000Equator> voyager_orbit(
+  KeplerOrbit<ICRS> voyager_orbit(
       *sun, voyager1, {expected_displacement, expected_velocity}, date);
   EXPECT_THAT(*voyager_orbit.elements_at_epoch().eccentricity,
               AlmostEquals(*VoyagerElements().eccentricity, 2));
@@ -426,13 +426,13 @@ TEST_F(KeplerOrbitTest, Voyager1) {
 }
 
 TEST_F(KeplerOrbitTest, TrueAnomalyToEllipticMeanAnomaly) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.semilatus_rectum = SimpleEllipse().semilatus_rectum;
   elements.periapsis_distance = SimpleEllipse().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.true_anomaly = SimpleEllipse().true_anomaly;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.true_anomaly, Eq(*SimpleEllipse().true_anomaly));
   EXPECT_THAT(*elements.mean_anomaly,
@@ -442,13 +442,13 @@ TEST_F(KeplerOrbitTest, TrueAnomalyToEllipticMeanAnomaly) {
 }
 
 TEST_F(KeplerOrbitTest, TrueAnomalyToHyperbolicMeanAnomaly) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.semilatus_rectum = SimpleHyperbola().semilatus_rectum;
   elements.periapsis_distance = SimpleHyperbola().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.true_anomaly = SimpleHyperbola().true_anomaly;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.true_anomaly, Eq(*SimpleHyperbola().true_anomaly));
   EXPECT_THAT(*elements.mean_anomaly,
@@ -458,13 +458,13 @@ TEST_F(KeplerOrbitTest, TrueAnomalyToHyperbolicMeanAnomaly) {
 }
 
 TEST_F(KeplerOrbitTest, EllipticMeanAnomalyToTrueAnomaly) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.semilatus_rectum = SimpleEllipse().semilatus_rectum;
   elements.periapsis_distance = SimpleEllipse().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.mean_anomaly = SimpleEllipse().mean_anomaly;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.mean_anomaly, Eq(*SimpleEllipse().mean_anomaly));
   EXPECT_THAT(*elements.true_anomaly,
@@ -474,13 +474,13 @@ TEST_F(KeplerOrbitTest, EllipticMeanAnomalyToTrueAnomaly) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolicMeanAnomalyToTrueAnomaly) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.semilatus_rectum = SimpleHyperbola().semilatus_rectum;
   elements.periapsis_distance = SimpleHyperbola().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.hyperbolic_mean_anomaly = SimpleHyperbola().hyperbolic_mean_anomaly;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.hyperbolic_mean_anomaly,
               Eq(*SimpleHyperbola().hyperbolic_mean_anomaly));
@@ -491,7 +491,7 @@ TEST_F(KeplerOrbitTest, HyperbolicMeanAnomalyToTrueAnomaly) {
 }
 
 TEST_F(KeplerOrbitTest, OrientationFromLongitudeOfPeriapsis) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.eccentricity = 0;
   elements.semimajor_axis = 1 * Metre;
   elements.mean_anomaly.emplace();
@@ -500,7 +500,7 @@ TEST_F(KeplerOrbitTest, OrientationFromLongitudeOfPeriapsis) {
       SimpleEllipse().longitude_of_ascending_node;
   elements.longitude_of_periapsis = SimpleEllipse().longitude_of_periapsis;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.longitude_of_periapsis,
               Eq(*SimpleEllipse().longitude_of_periapsis));
@@ -509,7 +509,7 @@ TEST_F(KeplerOrbitTest, OrientationFromLongitudeOfPeriapsis) {
 }
 
 TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
-  KeplerianElements<ICRFJ2000Equator> elements;
+  KeplerianElements<ICRS> elements;
   elements.eccentricity = 0;
   elements.semimajor_axis = 1 * Metre;
   elements.mean_anomaly.emplace();
@@ -518,7 +518,7 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
       SimpleEllipse().longitude_of_ascending_node;
   elements.argument_of_periapsis = SimpleEllipse().argument_of_periapsis;
   elements =
-      KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)
+      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
           .elements_at_epoch();
   EXPECT_THAT(*elements.argument_of_periapsis,
               Eq(*SimpleEllipse().argument_of_periapsis));
@@ -529,7 +529,7 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
 #define CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(element1, element2, reference)       \
   \
 [&]() {                                                                        \
-    KeplerianElements<ICRFJ2000Equator> elements;                              \
+    KeplerianElements<ICRS> elements;                              \
     elements.element1 = (reference).element1;                                  \
     elements.element2 = (reference).element2;                                  \
     /* Leaving the orientation parameters and anomalies to their default    */ \
@@ -537,7 +537,7 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
     elements.argument_of_periapsis.emplace();                                  \
     elements.mean_anomaly.emplace();                                           \
     elements =                                                                 \
-        KeplerOrbit<ICRFJ2000Equator>(body_, MasslessBody{}, elements, J2000)  \
+        KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)  \
             .elements_at_epoch();                                              \
     /* The inputs must not change.                                          */ \
     EXPECT_THAT(*elements.element1, Eq(*(reference).element1));                \
@@ -551,7 +551,7 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
 // Test all choices of two categories of conic parameters.
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semimajor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -575,7 +575,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemimajorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemiminorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semiminor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -599,7 +599,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemiminorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -623,7 +623,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -647,7 +647,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -671,7 +671,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemiminorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, semiminor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -695,7 +695,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemiminorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -719,7 +719,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -743,7 +743,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -767,7 +767,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semiminor_axis, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -791,7 +791,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semiminor_axis, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -815,7 +815,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semiminor_axis, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -839,7 +839,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semilatus_rectum, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -863,7 +863,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semilatus_rectum, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -887,7 +887,7 @@ TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromPeriapsisDistanceAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           periapsis_distance, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -914,7 +914,7 @@ TEST_F(KeplerOrbitTest, EllipseFromPeriapsisDistanceAndApoapsisDistance) {
 // is already tested above).
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificEnergy) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, specific_energy, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -938,7 +938,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndCharacteristicEnergy) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, characteristic_energy, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -962,7 +962,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndCharacteristicEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndMeanMotion) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, mean_motion, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -986,7 +986,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndMeanMotion) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriod) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(eccentricity, period, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
@@ -1012,7 +1012,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriod) {
 // itself is already tested above).
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificAngularMomentum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, specific_angular_momentum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1040,7 +1040,7 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificAngularMomentum) {
 // Test all choices of two categories of conic parameters.
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semimajor_axis, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1064,7 +1064,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemimajorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndImpactParameter) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, impact_parameter, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1088,7 +1088,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndImpactParameter) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1112,7 +1112,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1136,7 +1136,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1160,7 +1160,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndImpactParameter) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, impact_parameter, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1184,7 +1184,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndImpactParameter) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1208,7 +1208,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1232,7 +1232,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semimajor_axis, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1256,7 +1256,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           impact_parameter, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1280,7 +1280,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           impact_parameter, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1304,7 +1304,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           impact_parameter, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1328,7 +1328,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semilatus_rectum, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1352,7 +1352,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           semilatus_rectum, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1376,7 +1376,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromPeriapsisDistanceAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           periapsis_distance, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1404,7 +1404,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromPeriapsisDistanceAndApoapsisDistance) {
 
 TEST_F(KeplerOrbitTest,
        HyperbolaFromAsymptoticTrueAnomalyAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           asymptotic_true_anomaly, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1428,7 +1428,7 @@ TEST_F(KeplerOrbitTest,
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromTurningAngleAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           turning_angle, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1455,7 +1455,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromTurningAngleAndPeriapsisDistance) {
 // is already tested above).
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificEnergy) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, specific_energy, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1479,7 +1479,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndCharacteristicEnergy) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, characteristic_energy, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1503,7 +1503,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndCharacteristicEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicMeanMotion) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, hyperbolic_mean_motion, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1527,7 +1527,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicMeanMotion) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicExcessVelocity) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, hyperbolic_excess_velocity, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1554,7 +1554,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicExcessVelocity) {
 // itself is already tested above).
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificAngularMomentum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, specific_angular_momentum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1581,7 +1581,7 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificAngularMomentum) {
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semimajor_axis, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1606,7 +1606,7 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemiminorAxis) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semiminor_axis, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1631,7 +1631,7 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, semilatus_rectum, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1656,7 +1656,7 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, periapsis_distance, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
@@ -1681,7 +1681,7 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRFJ2000Equator> const elements =
+  KeplerianElements<ICRS> const elements =
       CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
           eccentricity, apoapsis_distance, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,

--- a/physics/kepler_orbit_test.cpp
+++ b/physics/kepler_orbit_test.cpp
@@ -284,9 +284,9 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");
   auto const earth = SolarSystem<ICRS>::MakeMassiveBody(
-                         solar_system.gravity_model_message("Earth"));
+      solar_system.gravity_model_message("Earth"));
   auto const moon = SolarSystem<ICRS>::MakeMassiveBody(
-                        solar_system.gravity_model_message("Moon"));
+      solar_system.gravity_model_message("Moon"));
   // The numbers in the gravity models and those from the query above both come
   // from DE431, so the sums are the same up to round-off.
   EXPECT_THAT(
@@ -311,8 +311,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
   partial_elements.apoapsis_distance.reset();
   partial_elements.true_anomaly.reset();
   {
-    KeplerOrbit<ICRS> moon_orbit(
-        *earth, *moon, partial_elements, date);
+    KeplerOrbit<ICRS> moon_orbit(*earth, *moon, partial_elements, date);
     EXPECT_THAT(moon_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 15));
     EXPECT_THAT(moon_orbit.StateVectors(date).velocity(),
@@ -324,8 +323,7 @@ TEST_F(KeplerOrbitTest, EarthMoon) {
   partial_elements.semimajor_axis.reset();
   partial_elements.periapsis_distance = MoonElements().periapsis_distance;
   {
-    KeplerOrbit<ICRS> moon_orbit(
-        *earth, *moon, partial_elements, date);
+    KeplerOrbit<ICRS> moon_orbit(*earth, *moon, partial_elements, date);
     EXPECT_THAT(moon_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 13, 15));
     EXPECT_THAT(moon_orbit.StateVectors(date).velocity(),
@@ -364,7 +362,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");
   auto const sun = SolarSystem<ICRS>::MakeMassiveBody(
-                         solar_system.gravity_model_message("Sun"));
+      solar_system.gravity_model_message("Sun"));
   MasslessBody const voyager1{};
   constexpr Instant date = "2017-05-25T19:44:00,000"_TT;
 
@@ -382,8 +380,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
   partial_elements.periapsis_distance.reset();
   partial_elements.true_anomaly.reset();
   {
-    KeplerOrbit<ICRS> voyager_orbit(
-        *sun, voyager1, partial_elements, date);
+    KeplerOrbit<ICRS> voyager_orbit(*sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 37, 49));
     EXPECT_THAT(voyager_orbit.StateVectors(date).velocity(),
@@ -395,8 +392,7 @@ TEST_F(KeplerOrbitTest, Voyager1) {
   partial_elements.semimajor_axis.reset();
   partial_elements.periapsis_distance = VoyagerElements().periapsis_distance;
   {
-    KeplerOrbit<ICRS> voyager_orbit(
-        *sun, voyager1, partial_elements, date);
+    KeplerOrbit<ICRS> voyager_orbit(*sun, voyager1, partial_elements, date);
     EXPECT_THAT(voyager_orbit.StateVectors(date).displacement(),
                 AlmostEquals(expected_displacement, 31, 44));
     EXPECT_THAT(voyager_orbit.StateVectors(date).velocity(),
@@ -431,9 +427,8 @@ TEST_F(KeplerOrbitTest, TrueAnomalyToEllipticMeanAnomaly) {
   elements.periapsis_distance = SimpleEllipse().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.true_anomaly = SimpleEllipse().true_anomaly;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.true_anomaly, Eq(*SimpleEllipse().true_anomaly));
   EXPECT_THAT(*elements.mean_anomaly,
               AlmostEquals(*SimpleEllipse().mean_anomaly, 0));
@@ -447,9 +442,8 @@ TEST_F(KeplerOrbitTest, TrueAnomalyToHyperbolicMeanAnomaly) {
   elements.periapsis_distance = SimpleHyperbola().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.true_anomaly = SimpleHyperbola().true_anomaly;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.true_anomaly, Eq(*SimpleHyperbola().true_anomaly));
   EXPECT_THAT(*elements.mean_anomaly,
               AlmostEquals(*SimpleHyperbola().mean_anomaly, 0));
@@ -463,9 +457,8 @@ TEST_F(KeplerOrbitTest, EllipticMeanAnomalyToTrueAnomaly) {
   elements.periapsis_distance = SimpleEllipse().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.mean_anomaly = SimpleEllipse().mean_anomaly;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.mean_anomaly, Eq(*SimpleEllipse().mean_anomaly));
   EXPECT_THAT(*elements.true_anomaly,
               AlmostEquals(*SimpleEllipse().true_anomaly, 1));
@@ -479,9 +472,8 @@ TEST_F(KeplerOrbitTest, HyperbolicMeanAnomalyToTrueAnomaly) {
   elements.periapsis_distance = SimpleHyperbola().periapsis_distance;
   elements.argument_of_periapsis.emplace();
   elements.hyperbolic_mean_anomaly = SimpleHyperbola().hyperbolic_mean_anomaly;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.hyperbolic_mean_anomaly,
               Eq(*SimpleHyperbola().hyperbolic_mean_anomaly));
   EXPECT_THAT(*elements.true_anomaly,
@@ -499,9 +491,8 @@ TEST_F(KeplerOrbitTest, OrientationFromLongitudeOfPeriapsis) {
   elements.longitude_of_ascending_node =
       SimpleEllipse().longitude_of_ascending_node;
   elements.longitude_of_periapsis = SimpleEllipse().longitude_of_periapsis;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.longitude_of_periapsis,
               Eq(*SimpleEllipse().longitude_of_periapsis));
   EXPECT_THAT(*elements.argument_of_periapsis,
@@ -517,9 +508,8 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
   elements.longitude_of_ascending_node =
       SimpleEllipse().longitude_of_ascending_node;
   elements.argument_of_periapsis = SimpleEllipse().argument_of_periapsis;
-  elements =
-      KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
-          .elements_at_epoch();
+  elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)
+                 .elements_at_epoch();
   EXPECT_THAT(*elements.argument_of_periapsis,
               Eq(*SimpleEllipse().argument_of_periapsis));
   EXPECT_THAT(*elements.longitude_of_periapsis,
@@ -527,18 +517,17 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
 }
 
 #define CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(element1, element2, reference)       \
-  \
-[&]() {                                                                        \
-    KeplerianElements<ICRS> elements;                              \
+                                                                               \
+  [&]() {                                                                      \
+    KeplerianElements<ICRS> elements;                                          \
     elements.element1 = (reference).element1;                                  \
     elements.element2 = (reference).element2;                                  \
     /* Leaving the orientation parameters and anomalies to their default    */ \
     /* values.  This test does not exercise them.                           */ \
     elements.argument_of_periapsis.emplace();                                  \
     elements.mean_anomaly.emplace();                                           \
-    elements =                                                                 \
-        KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)  \
-            .elements_at_epoch();                                              \
+    elements = KeplerOrbit<ICRS>(body_, MasslessBody{}, elements, J2000)       \
+                   .elements_at_epoch();                                       \
     /* The inputs must not change.                                          */ \
     EXPECT_THAT(*elements.element1, Eq(*(reference).element1));                \
     EXPECT_THAT(*elements.element2, Eq(*(reference).element2));                \
@@ -551,9 +540,8 @@ TEST_F(KeplerOrbitTest, OrientationFromArgumentOfPeriapsis) {
 // Test all choices of two categories of conic parameters.
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semimajor_axis, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semimajor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -575,9 +563,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemimajorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemiminorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semiminor_axis, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semiminor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -599,9 +586,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemiminorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semilatus_rectum, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -623,9 +609,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, periapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -647,9 +632,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, apoapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -671,9 +655,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemiminorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, semiminor_axis, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, semiminor_axis, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/2,
@@ -695,9 +678,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemiminorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, semilatus_rectum, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -719,9 +701,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, periapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -743,9 +724,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, apoapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -767,9 +747,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemimajorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semiminor_axis, semilatus_rectum, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semiminor_axis, semilatus_rectum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/2,
@@ -791,9 +770,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semiminor_axis, periapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semiminor_axis, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/2,
@@ -815,9 +793,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semiminor_axis, apoapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semiminor_axis, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/1,
@@ -839,9 +816,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemiminorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semilatus_rectum, periapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semilatus_rectum, periapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -863,9 +839,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semilatus_rectum, apoapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semilatus_rectum, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -887,9 +862,8 @@ TEST_F(KeplerOrbitTest, EllipseFromSemilatusRectumAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromPeriapsisDistanceAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          periapsis_distance, apoapsis_distance, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      periapsis_distance, apoapsis_distance, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -914,9 +888,8 @@ TEST_F(KeplerOrbitTest, EllipseFromPeriapsisDistanceAndApoapsisDistance) {
 // is already tested above).
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificEnergy) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, specific_energy, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, specific_energy, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -938,9 +911,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndCharacteristicEnergy) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, characteristic_energy, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, characteristic_energy, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -962,9 +934,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndCharacteristicEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndMeanMotion) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, mean_motion, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, mean_motion, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1012,9 +983,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndPeriod) {
 // itself is already tested above).
 
 TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificAngularMomentum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, specific_angular_momentum, SimpleEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, specific_angular_momentum, SimpleEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1040,9 +1010,8 @@ TEST_F(KeplerOrbitTest, EllipseFromEccentricityAndSpecificAngularMomentum) {
 // Test all choices of two categories of conic parameters.
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semimajor_axis, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semimajor_axis, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1064,9 +1033,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemimajorAxis) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndImpactParameter) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, impact_parameter, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, impact_parameter, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1088,9 +1056,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndImpactParameter) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semilatus_rectum, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1112,9 +1079,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1136,9 +1102,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, apoapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1160,9 +1125,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndImpactParameter) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, impact_parameter, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, impact_parameter, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1184,9 +1148,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndImpactParameter) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, semilatus_rectum, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1208,9 +1171,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1232,9 +1194,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semimajor_axis, apoapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semimajor_axis, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1256,9 +1217,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemimajorAxisAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          impact_parameter, semilatus_rectum, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      impact_parameter, semilatus_rectum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1280,9 +1240,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndSemilatusRectum) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          impact_parameter, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      impact_parameter, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1304,9 +1263,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          impact_parameter, apoapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      impact_parameter, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1328,9 +1286,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromImpactParameterAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semilatus_rectum, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semilatus_rectum, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1352,9 +1309,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndPeriapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          semilatus_rectum, apoapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      semilatus_rectum, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1376,9 +1332,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromSemilatusRectumAndApoapsisDistance) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromPeriapsisDistanceAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          periapsis_distance, apoapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      periapsis_distance, apoapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1404,9 +1359,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromPeriapsisDistanceAndApoapsisDistance) {
 
 TEST_F(KeplerOrbitTest,
        HyperbolaFromAsymptoticTrueAnomalyAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          asymptotic_true_anomaly, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      asymptotic_true_anomaly, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/1,
@@ -1428,9 +1382,8 @@ TEST_F(KeplerOrbitTest,
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromTurningAngleAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          turning_angle, periapsis_distance, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      turning_angle, periapsis_distance, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1455,9 +1408,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromTurningAngleAndPeriapsisDistance) {
 // is already tested above).
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificEnergy) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, specific_energy, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, specific_energy, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1479,9 +1431,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndCharacteristicEnergy) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, characteristic_energy, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, characteristic_energy, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1503,9 +1454,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndCharacteristicEnergy) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicMeanMotion) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, hyperbolic_mean_motion, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, hyperbolic_mean_motion, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1527,9 +1477,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicMeanMotion) {
 }
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicExcessVelocity) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, hyperbolic_excess_velocity, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, hyperbolic_excess_velocity, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1554,9 +1503,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndHyperbolicExcessVelocity) {
 // itself is already tested above).
 
 TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificAngularMomentum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, specific_angular_momentum, SimpleHyperbola());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, specific_angular_momentum, SimpleHyperbola());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/SimpleHyperbola(),
                                    /*eccentrity_ulps=*/0,
@@ -1581,9 +1529,8 @@ TEST_F(KeplerOrbitTest, HyperbolaFromEccentricityAndSpecificAngularMomentum) {
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemimajorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semimajor_axis, NearlyParabolicEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semimajor_axis, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/NearlyParabolicEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1606,9 +1553,8 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemiminorAxis) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semiminor_axis, NearlyParabolicEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semiminor_axis, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/NearlyParabolicEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1631,9 +1577,8 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndSemilatusRectum) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, semilatus_rectum, NearlyParabolicEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, semilatus_rectum, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/NearlyParabolicEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1656,9 +1601,8 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndPeriapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, periapsis_distance, NearlyParabolicEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, periapsis_distance, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/NearlyParabolicEllipse(),
                                    /*eccentrity_ulps=*/0,
@@ -1681,9 +1625,8 @@ TEST_F(KeplerOrbitTest,
 
 TEST_F(KeplerOrbitTest,
        NearlyParabolicEllipseFromEccentricityAndApoapsisDistance) {
-  KeplerianElements<ICRS> const elements =
-      CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
-          eccentricity, apoapsis_distance, NearlyParabolicEllipse());
+  KeplerianElements<ICRS> const elements = CONSTRUCT_CONIC_FROM_TWO_ELEMENTS(
+      eccentricity, apoapsis_distance, NearlyParabolicEllipse());
   ExpectConicParametersAlmostEqual(/*actual=*/elements,
                                    /*expected=*/NearlyParabolicEllipse(),
                                    /*eccentrity_ulps=*/0,

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -156,7 +156,7 @@ inline not_null<std::unique_ptr<MassiveBody>> MassiveBody::ReadFromMessage(
       if (enum_descriptor == google::protobuf::GetEnumDescriptor<Tag>()) {
         switch (static_cast<Tag>(enum_value_descriptor->number())) {
           ROTATING_BODY_TAG_VALUE_CASE(ICRF_J2000_ECLIPTIC);
-          ROTATING_BODY_TAG_VALUE_CASE(ICRF_J2000_EQUATOR);
+          ROTATING_BODY_TAG_VALUE_CASE(ICRS);
         }
       }
     }

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -155,8 +155,10 @@ inline not_null<std::unique_ptr<MassiveBody>> MassiveBody::ReadFromMessage(
       using Tag = serialization::Frame::SolarSystemTag;
       if (enum_descriptor == google::protobuf::GetEnumDescriptor<Tag>()) {
         switch (static_cast<Tag>(enum_value_descriptor->number())) {
-          ROTATING_BODY_TAG_VALUE_CASE(ICRF_J2000_ECLIPTIC);
           ROTATING_BODY_TAG_VALUE_CASE(ICRS);
+          ROTATING_BODY_TAG_VALUE_CASE(SKY);
+          ROTATING_BODY_TAG_VALUE_CASE(ITRS);
+          ROTATING_BODY_TAG_VALUE_CASE(GCRS);
         }
       }
     }

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -155,10 +155,10 @@ inline not_null<std::unique_ptr<MassiveBody>> MassiveBody::ReadFromMessage(
       using Tag = serialization::Frame::SolarSystemTag;
       if (enum_descriptor == google::protobuf::GetEnumDescriptor<Tag>()) {
         switch (static_cast<Tag>(enum_value_descriptor->number())) {
-          ROTATING_BODY_TAG_VALUE_CASE(ICRS);
-          ROTATING_BODY_TAG_VALUE_CASE(SKY);
-          ROTATING_BODY_TAG_VALUE_CASE(ITRS);
           ROTATING_BODY_TAG_VALUE_CASE(GCRS);
+          ROTATING_BODY_TAG_VALUE_CASE(ICRS);
+          ROTATING_BODY_TAG_VALUE_CASE(ITRS);
+          ROTATING_BODY_TAG_VALUE_CASE(SKY);
         }
       }
     }

--- a/physics/solar_system_test.cpp
+++ b/physics/solar_system_test.cpp
@@ -16,7 +16,7 @@ namespace principia {
 namespace physics {
 namespace internal_solar_system {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::Fingerprint2011;
 using integrators::SymplecticRungeKuttaNyströmIntegrator;
 using integrators::methods::McLachlanAtela1992Order4Optimal;
@@ -34,7 +34,7 @@ using ::testing::ElementsAreArray;
 class SolarSystemTest : public ::testing::Test {};
 
 TEST_F(SolarSystemTest, RealSolarSystem) {
-  SolarSystem<ICRFJ2000Equator> solar_system(
+  SolarSystem<ICRS> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");
@@ -80,9 +80,9 @@ TEST_F(SolarSystemTest, RealSolarSystem) {
 
   auto const ephemeris = solar_system.MakeEphemeris(
       /*fitting_tolerance=*/1 * Metre,
-      Ephemeris<ICRFJ2000Equator>::FixedStepParameters(
+      Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order4Optimal,
-                                                Position<ICRFJ2000Equator>>(),
+                                                Position<ICRS>>(),
           /*step=*/1 * Second));
   auto const earth = solar_system.massive_body(*ephemeris, "Earth");
   EXPECT_LT(RelativeError(5.97258 * Yotta(Kilogram), earth->mass()), 6e-9);
@@ -156,7 +156,7 @@ TEST_F(SolarSystemTest, KSPSystem) {
 }
 
 TEST_F(SolarSystemTest, Clear) {
-  SolarSystem<ICRFJ2000Equator> solar_system(
+  SolarSystem<ICRS> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2433282_500000000.proto.txt");

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -163,7 +163,7 @@ message Frame {
   // The frame tags used in the astronomical simulations.
   enum SolarSystemTag {
     ICRF_J2000_ECLIPTIC = 1;
-    ICRF_J2000_EQUATOR = 2;
+    ICRS = 2;
     SKY = 3;
     ITRS = 4;
     GCRS = 5;

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -162,12 +162,12 @@ message Frame {
 
   // The frame tags used in the astronomical simulations.
   enum SolarSystemTag {
+    GCRS = 5;
+    ICRS = 2;
+    ITRS = 4;
+    SKY = 3;
     reserved 1;
     reserved "ICRF_J2000_ECLIPTIC";
-    ICRS = 2;
-    SKY = 3;
-    ITRS = 4;
-    GCRS = 5;
   }
 
   // The frame tags used in tests.

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -162,7 +162,8 @@ message Frame {
 
   // The frame tags used in the astronomical simulations.
   enum SolarSystemTag {
-    ICRF_J2000_ECLIPTIC = 1;
+    reserved 1;
+    reserved "ICRF_J2000_ECLIPTIC";
     ICRS = 2;
     SKY = 3;
     ITRS = 4;

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -165,6 +165,8 @@ message Frame {
     ICRF_J2000_ECLIPTIC = 1;
     ICRF_J2000_EQUATOR = 2;
     SKY = 3;
+    ITRS = 4;
+    GCRS = 5;
   }
 
   // The frame tags used in tests.

--- a/testing_utilities/solar_system_factory.hpp
+++ b/testing_utilities/solar_system_factory.hpp
@@ -22,7 +22,7 @@ namespace principia {
 namespace testing_utilities {
 namespace internal_solar_system_factory {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using base::not_constructible;
 using base::not_null;
 using physics::SolarSystem;
@@ -89,11 +89,11 @@ class SolarSystemFactory : not_constructible {
                              SolarSystem<Frame>& solar_system);
 
   // A solar system at the time of the launch of Простейший Спутник-1.
-  static not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>>
+  static not_null<std::unique_ptr<SolarSystem<ICRS>>>
   AtСпутник1Launch(Accuracy accuracy);
 
   // A solar system at the time of the launch of Простейший Спутник-2.
-  static not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>>
+  static not_null<std::unique_ptr<SolarSystem<ICRS>>>
   AtСпутник2Launch(Accuracy accuracy);
 
   // Returns the index of the parent of the body with the given |index|.

--- a/testing_utilities/solar_system_factory_body.hpp
+++ b/testing_utilities/solar_system_factory_body.hpp
@@ -89,10 +89,10 @@ void SolarSystemFactory::AdjustAccuracy(
   }
 }
 
-inline not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>>
+inline not_null<std::unique_ptr<SolarSystem<ICRS>>>
 SolarSystemFactory::AtСпутник1Launch(Accuracy const accuracy) {
   auto solar_system =
-      base::make_not_null_unique<SolarSystem<ICRFJ2000Equator>>(
+      base::make_not_null_unique<SolarSystem<ICRS>>(
           SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
           SOLUTION_DIR / "astronomy" /
               "sol_initial_state_jd_2436116_311504629.proto.txt");
@@ -100,10 +100,10 @@ SolarSystemFactory::AtСпутник1Launch(Accuracy const accuracy) {
   return solar_system;
 }
 
-inline not_null<std::unique_ptr<SolarSystem<ICRFJ2000Equator>>>
+inline not_null<std::unique_ptr<SolarSystem<ICRS>>>
 SolarSystemFactory::AtСпутник2Launch(Accuracy const accuracy) {
   auto solar_system =
-      base::make_not_null_unique<SolarSystem<ICRFJ2000Equator>>(
+      base::make_not_null_unique<SolarSystem<ICRS>>(
           SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
           SOLUTION_DIR / "astronomy" /
               "sol_initial_state_jd_2436145_604166667.proto.txt");

--- a/testing_utilities/solar_system_factory_body.hpp
+++ b/testing_utilities/solar_system_factory_body.hpp
@@ -91,22 +91,20 @@ void SolarSystemFactory::AdjustAccuracy(
 
 inline not_null<std::unique_ptr<SolarSystem<ICRS>>>
 SolarSystemFactory::AtСпутник1Launch(Accuracy const accuracy) {
-  auto solar_system =
-      base::make_not_null_unique<SolarSystem<ICRS>>(
-          SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
-          SOLUTION_DIR / "astronomy" /
-              "sol_initial_state_jd_2436116_311504629.proto.txt");
+  auto solar_system = base::make_not_null_unique<SolarSystem<ICRS>>(
+      SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+      SOLUTION_DIR / "astronomy" /
+          "sol_initial_state_jd_2436116_311504629.proto.txt");
   AdjustAccuracy(accuracy, *solar_system);
   return solar_system;
 }
 
 inline not_null<std::unique_ptr<SolarSystem<ICRS>>>
 SolarSystemFactory::AtСпутник2Launch(Accuracy const accuracy) {
-  auto solar_system =
-      base::make_not_null_unique<SolarSystem<ICRS>>(
-          SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
-          SOLUTION_DIR / "astronomy" /
-              "sol_initial_state_jd_2436145_604166667.proto.txt");
+  auto solar_system = base::make_not_null_unique<SolarSystem<ICRS>>(
+      SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+      SOLUTION_DIR / "astronomy" /
+          "sol_initial_state_jd_2436145_604166667.proto.txt");
   AdjustAccuracy(accuracy, *solar_system);
   return solar_system;
 }

--- a/testing_utilities/solar_system_factory_test.cpp
+++ b/testing_utilities/solar_system_factory_test.cpp
@@ -78,15 +78,14 @@ class SolarSystemFactoryTest : public testing::Test {
       DegreesOfFreedom<ICRS> const& secondary_dof,
       std::optional<std::reference_wrapper<MassiveBody const>> const&
           primary_body,
-      std::optional <std::reference_wrapper<
-          DegreesOfFreedom<ICRS> const>> const& primary_dof,
+      std::optional<std::reference_wrapper<DegreesOfFreedom<ICRS> const>> const&
+          primary_dof,
       std::string const& message) {
     RelativeDegreesOfFreedom<ICRS> const tertiary_secondary =
         tertiary_dof - secondary_dof;
     KeplerOrbit<ICRS> orbit{
         secondary_body, tertiary_body, tertiary_secondary, J2000};
-    Vector<Length, ICRS> const& r =
-        tertiary_secondary.displacement();
+    Vector<Length, ICRS> const& r = tertiary_secondary.displacement();
     EXPECT_THAT(
         RelativeError(eccentricity, *orbit.elements_at_epoch().eccentricity),
         Lt(relative_error))
@@ -106,14 +105,13 @@ class SolarSystemFactoryTest : public testing::Test {
     }
   }
 
-  void TestStronglyBoundOrbit(
-      double excentricity,
-      double relative_error,
-      MassiveBody const& tertiary_body,
-      DegreesOfFreedom<ICRS> const& tertiary_dof,
-      MassiveBody const& secondary_body,
-      DegreesOfFreedom<ICRS> const& secondary_dof,
-      std::string const& message) {
+  void TestStronglyBoundOrbit(double excentricity,
+                              double relative_error,
+                              MassiveBody const& tertiary_body,
+                              DegreesOfFreedom<ICRS> const& tertiary_dof,
+                              MassiveBody const& secondary_body,
+                              DegreesOfFreedom<ICRS> const& secondary_dof,
+                              std::string const& message) {
     TestStronglyBoundOrbit(excentricity,
                            relative_error,
                            tertiary_body,
@@ -138,14 +136,13 @@ class SolarSystemFactoryTest : public testing::Test {
   }
 
   std::vector<std::unique_ptr<MassiveBody>> GetMassiveBodies(
-    SolarSystem<ICRS> const& solar_system) {
+      SolarSystem<ICRS> const& solar_system) {
     std::vector<std::unique_ptr<MassiveBody>> massive_bodies;
     for (int i = SolarSystemFactory::Sun;
          i <= SolarSystemFactory::LastBody;
          ++i) {
-      massive_bodies.emplace_back(
-          SolarSystem<ICRS>::MakeMassiveBody(
-              solar_system.gravity_model_message(SolarSystemFactory::name(i))));
+      massive_bodies.emplace_back(SolarSystem<ICRS>::MakeMassiveBody(
+          solar_system.gravity_model_message(SolarSystemFactory::name(i))));
     }
     return massive_bodies;
   }

--- a/testing_utilities/solar_system_factory_test.cpp
+++ b/testing_utilities/solar_system_factory_test.cpp
@@ -15,7 +15,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::J2000;
 using geometry::Bivector;
 using geometry::Vector;
@@ -53,10 +53,10 @@ class SolarSystemFactoryTest : public testing::Test {
   // around the primary.
   Length LaplaceSphereRadiusRadius(
       MassiveBody const& primary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& primary_dof,
+      DegreesOfFreedom<ICRS> const& primary_dof,
       MassiveBody const& secondary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& secondary_dof) {
-    Length const a = *KeplerOrbit<ICRFJ2000Equator>{
+      DegreesOfFreedom<ICRS> const& secondary_dof) {
+    Length const a = *KeplerOrbit<ICRS>{
         primary_body,
         secondary_body,
         secondary_dof - primary_dof, J2000}.elements_at_epoch().semimajor_axis;
@@ -73,19 +73,19 @@ class SolarSystemFactoryTest : public testing::Test {
       double eccentricity,
       double relative_error,
       MassiveBody const& tertiary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& tertiary_dof,
+      DegreesOfFreedom<ICRS> const& tertiary_dof,
       MassiveBody const& secondary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& secondary_dof,
+      DegreesOfFreedom<ICRS> const& secondary_dof,
       std::optional<std::reference_wrapper<MassiveBody const>> const&
           primary_body,
       std::optional <std::reference_wrapper<
-          DegreesOfFreedom<ICRFJ2000Equator> const>> const& primary_dof,
+          DegreesOfFreedom<ICRS> const>> const& primary_dof,
       std::string const& message) {
-    RelativeDegreesOfFreedom<ICRFJ2000Equator> const tertiary_secondary =
+    RelativeDegreesOfFreedom<ICRS> const tertiary_secondary =
         tertiary_dof - secondary_dof;
-    KeplerOrbit<ICRFJ2000Equator> orbit{
+    KeplerOrbit<ICRS> orbit{
         secondary_body, tertiary_body, tertiary_secondary, J2000};
-    Vector<Length, ICRFJ2000Equator> const& r =
+    Vector<Length, ICRS> const& r =
         tertiary_secondary.displacement();
     EXPECT_THAT(
         RelativeError(eccentricity, *orbit.elements_at_epoch().eccentricity),
@@ -110,9 +110,9 @@ class SolarSystemFactoryTest : public testing::Test {
       double excentricity,
       double relative_error,
       MassiveBody const& tertiary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& tertiary_dof,
+      DegreesOfFreedom<ICRS> const& tertiary_dof,
       MassiveBody const& secondary_body,
-      DegreesOfFreedom<ICRFJ2000Equator> const& secondary_dof,
+      DegreesOfFreedom<ICRS> const& secondary_dof,
       std::string const& message) {
     TestStronglyBoundOrbit(excentricity,
                            relative_error,
@@ -125,9 +125,9 @@ class SolarSystemFactoryTest : public testing::Test {
                            message);
   }
 
-  std::vector<DegreesOfFreedom<ICRFJ2000Equator>> GetDegreesOfFreedom(
-      SolarSystem<ICRFJ2000Equator> const& solar_system) {
-    std::vector<DegreesOfFreedom<ICRFJ2000Equator>> degrees_of_freedom;
+  std::vector<DegreesOfFreedom<ICRS>> GetDegreesOfFreedom(
+      SolarSystem<ICRS> const& solar_system) {
+    std::vector<DegreesOfFreedom<ICRS>> degrees_of_freedom;
     for (int i = SolarSystemFactory::Sun;
          i <= SolarSystemFactory::LastBody;
          ++i) {
@@ -138,13 +138,13 @@ class SolarSystemFactoryTest : public testing::Test {
   }
 
   std::vector<std::unique_ptr<MassiveBody>> GetMassiveBodies(
-    SolarSystem<ICRFJ2000Equator> const& solar_system) {
+    SolarSystem<ICRS> const& solar_system) {
     std::vector<std::unique_ptr<MassiveBody>> massive_bodies;
     for (int i = SolarSystemFactory::Sun;
          i <= SolarSystemFactory::LastBody;
          ++i) {
       massive_bodies.emplace_back(
-          SolarSystem<ICRFJ2000Equator>::MakeMassiveBody(
+          SolarSystem<ICRS>::MakeMassiveBody(
               solar_system.gravity_model_message(SolarSystemFactory::name(i))));
     }
     return massive_bodies;

--- a/tools/generate_configuration.cpp
+++ b/tools/generate_configuration.cpp
@@ -21,7 +21,7 @@
 
 namespace principia {
 
-using astronomy::ICRFJ2000Equator;
+using astronomy::ICRS;
 using astronomy::J2000;
 using physics::DegreesOfFreedom;
 using physics::SolarSystem;
@@ -65,7 +65,7 @@ void GenerateConfiguration(std::string const& game_epoch,
                            std::string const& needs) {
   std::filesystem::path const directory =
       SOLUTION_DIR / "astronomy";
-  SolarSystem<ICRFJ2000Equator> solar_system(
+  SolarSystem<ICRS> solar_system(
       (directory / gravity_model_stem).replace_extension(proto_txt),
       (directory / initial_state_stem).replace_extension(proto_txt),
       /*ignore_frame=*/true);
@@ -169,10 +169,10 @@ void GenerateConfiguration(std::string const& game_epoch,
     auto const barycentric_system =
         hierarchical_system->ConsumeBarycentricSystem();
 
-    auto displacement = [](DegreesOfFreedom<ICRFJ2000Equator> const& dof) {
-      return (dof.position() - ICRFJ2000Equator::origin).coordinates();
+    auto displacement = [](DegreesOfFreedom<ICRS> const& dof) {
+      return (dof.position() - ICRS::origin).coordinates();
     };
-    auto velocity = [](DegreesOfFreedom<ICRFJ2000Equator> const& dof) {
+    auto velocity = [](DegreesOfFreedom<ICRS> const& dof) {
       return dof.velocity().coordinates();
     };
 


### PR DESCRIPTION
- Avoid the sloppy JPL explanation based on dynamical properties;
- the ICRS has coordinates consistent with FK5 J2000 equatorial coordinates, there is no ICRS ecliptic, see [Capitaine and Soffel 2015, On the definition and use of the ecliptic in modern astronomy](https://arxiv.org/pdf/1501.05534.pdf); rename `ICRFJ2000Equator` to `ICRS` and get rid of `ICRFJ2000Ecliptic`.
- introduce the ITRS in preparation for tests based on ILRS products;
- introduce the TIRS, CIRS, and GCRS to enable conversions from the ITRS to the ICRS;
- document the errors arising from not versioning the ITRFs; this is be fine for our purposes for the recent ones;
- document the errors arising from identifying the ITRS and TIRS, and the CIRS and GCRS; these are likely not tolerable. 