### PR TITLE
RKNG

### DIFF
--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -131,10 +131,10 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
   static constexpr auto stages_ = Method::stages;
   static constexpr auto c_ = Method::c;
   static constexpr auto a_ = Method::a;
-  static constexpr auto b_hat_ = Method::b_hat;
-  static constexpr auto b_prime_hat_ = Method::b_prime_hat;
+  static constexpr auto b̂_ = Method::b̂;
+  static constexpr auto b̂ʹ_ = Method::b̂ʹ;
   static constexpr auto b_ = Method::b;
-  static constexpr auto b_prime_ = Method::b_prime;
+  static constexpr auto bʹ_ = Method::bʹ;
 };
 
 }  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -43,9 +43,13 @@ using quantities::Variation;
 //   b̂′ for the velocity weights of the high-order method;
 //   b for the position weights of the low-order method;
 //   b′ for the velocity weights of the low-order method.
-// This is a common notation, used, e.g., by Fine (1987), Low Order Practical
-// Runge-Kutta-Nyström Methods.  This notation is consistent with the one we use
-// for Runge-Kutta-Nyström methods (which have no a′).
+// This is similar to the notation used, e.g., by Fine (1987), Low Order
+// Practical Runge-Kutta-Nyström Methods.  This notation is consistent with the
+// one we use for Runge-Kutta-Nyström methods (which have no a′).
+// However, note that Fine uses ^ for the low order method, whereas we use it
+// for the high order method, consistently with the notation used by Dormand,
+// المكاوى, and Prince for RKN methods.
+
 // Alternative notations use a and b for the velocity Runge Kutta matrix and
 // weights: Murua (1998), Runge-Kutta-Nyström methods for general second Order
 // ODEs with application to multi-body Systems, uses (c, α, a, β̂, b̂, β, b),

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -65,9 +65,9 @@ using quantities::Variation;
 template<typename Method, typename Position>
 class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
     : public AdaptiveStepSizeIntegrator<
-                 SecondOrderDifferentialEquation<Position>> {
+                 ExplicitSecondOrderDifferentialEquation<Position>> {
  public:
-  using ODE = SecondOrderDifferentialEquation<Position>;
+  using ODE = ExplicitSecondOrderDifferentialEquation<Position>;
   using typename Integrator<ODE>::AppendState;
   using typename AdaptiveStepSizeIntegrator<ODE>::Parameters;
   using typename AdaptiveStepSizeIntegrator<ODE>::ToleranceToErrorRatio;
@@ -79,13 +79,13 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
   EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
 
   EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator(
-      EmbeddedExplicitRungeKuttaNyströmIntegrator const&) = delete;
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&) = delete;
   EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator(
-      EmbeddedExplicitRungeKuttaNyströmIntegrator&&) = delete;
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator&&) = delete;
   EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator& operator=(
-      EmbeddedExplicitRungeKuttaNyströmIntegrator const&) = delete;
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&) = delete;
   EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator& operator=(
-      EmbeddedExplicitRungeKuttaNyströmIntegrator&&) = delete;
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator&&) = delete;
 
   class Instance : public AdaptiveStepSizeIntegrator<ODE>::Instance {
    public:
@@ -103,7 +103,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
              AppendState const& append_state,
              ToleranceToErrorRatio const& tolerance_to_error_ratio,
              Parameters const& adaptive_step_size,
-             EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator);
+             EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const& integrator);
 
     EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const& integrator_;
     friend class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator;

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -141,8 +141,8 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
 
 template<typename Method, typename Position>
 internal_embedded_explicit_runge_kutta_nyström_integrator::
-    EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const&
-EmbeddedExplicitRungeKuttaNyströmIntegrator();
+    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
 
 }  // namespace integrators
 }  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -131,6 +131,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
   static constexpr auto stages_ = Method::stages;
   static constexpr auto c_ = Method::c;
   static constexpr auto a_ = Method::a;
+  static constexpr auto aʹ_ = Method::aʹ;
   static constexpr auto b̂_ = Method::b̂;
   static constexpr auto b̂ʹ_ = Method::b̂ʹ;
   static constexpr auto b_ = Method::b;

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -147,8 +147,9 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::
-    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
-EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
+    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method,
+                                                           Position> const&
+        EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
 
 }  // namespace integrators
 }  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -143,7 +143,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
   static constexpr auto bʹ_ = Method::bʹ;
 };
 
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -22,7 +22,7 @@
 
 namespace principia {
 namespace integrators {
-namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
+namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {  // NOLINT(whitespace/line_length)
 
 using base::not_null;
 using base::Status;
@@ -107,7 +107,8 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
              AppendState const& append_state,
              ToleranceToErrorRatio const& tolerance_to_error_ratio,
              Parameters const& adaptive_step_size,
-             EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const& integrator);
+             EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&
+                 integrator);
 
     EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const& integrator_;
     friend class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator;
@@ -142,7 +143,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
   static constexpr auto bʹ_ = Method::bʹ;
 };
 
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::
@@ -152,7 +153,7 @@ EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
 }  // namespace integrators
 }  // namespace principia
 
-#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp"
+#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp"  // NOLINT(whitespace/line_length)
 
 #endif  // PRINCIPIA_INTEGRATORS_EMBEDDED_EXPLICIT_GENERALIZED_RUNGE_KUTTA_NYSTRÖM_INTEGRATOR_HPP_  // NOLINT(whitespace/line_length)
 #endif  // PRINCIPIA_INTEGRATORS_INTEGRATORS_HPP_

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -69,9 +69,9 @@ using quantities::Variation;
 template<typename Method, typename Position>
 class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
     : public AdaptiveStepSizeIntegrator<
-                 ExplicitSecondOrderDifferentialEquation<Position>> {
+                 ExplicitSecondOrderOrdinaryDifferentialEquation<Position>> {
  public:
-  using ODE = ExplicitSecondOrderDifferentialEquation<Position>;
+  using ODE = ExplicitSecondOrderOrdinaryDifferentialEquation<Position>;
   using typename Integrator<ODE>::AppendState;
   using typename AdaptiveStepSizeIntegrator<ODE>::Parameters;
   using typename AdaptiveStepSizeIntegrator<ODE>::ToleranceToErrorRatio;
@@ -145,7 +145,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
 }  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
 
 template<typename Method, typename Position>
-internal_embedded_explicit_runge_kutta_nyström_integrator::
+internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::
     EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator();
 

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -169,7 +169,7 @@ Instance::Solve(Instant const& t_final) {
         }
       }
 
-      Time const h² = h * h;
+      auto const h² = h * h;
 
       // Runge-Kutta-Nyström iteration; fills |g|.
       for (int i = first_stage; i < stages_; ++i) {

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -349,14 +349,17 @@ ReadFromMessage(
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::
-    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
-EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
+    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method,
+                                                           Position> const&
+        EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
   static_assert(
       std::is_base_of<methods::EmbeddedExplicitGeneralizedRungeKuttaNyström,
                       Method>::value,
-      "Method must be derived from EmbeddedExplicitGeneralizedRungeKuttaNyström");
+      "Method must be derived from "
+      "EmbeddedExplicitGeneralizedRungeKuttaNyström");
   static internal_embedded_explicit_runge_kutta_nyström_integrator::
-      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method,
+                                                             Position> const
           integrator;
   return integrator;
 }

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -262,7 +262,7 @@ Instance::integrator() const {
 
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
-    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+    ExplicitSecondOrderOrdinaryDifferentialEquation<Position>>::Instance>>
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Clone() const {
   return std::unique_ptr<Instance>(new Instance(*this));
@@ -297,7 +297,7 @@ Instance::Instance(
 
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
-    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+    ExplicitSecondOrderOrdinaryDifferentialEquation<Position>>::Instance>>
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 NewInstance(IntegrationProblem<ODE> const& problem,
             AppendState const& append_state,
@@ -321,7 +321,7 @@ WriteToMessage(not_null<serialization::AdaptiveStepSizeIntegrator*> message)
 
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
-    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+    ExplicitSecondOrderOrdinaryDifferentialEquation<Position>>::Instance>>
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 ReadFromMessage(
     serialization::AdaptiveStepSizeIntegratorInstance const& message,
@@ -347,7 +347,7 @@ ReadFromMessage(
 }  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
 
 template<typename Method, typename Position>
-internal_embedded_explicit_runge_kutta_nyström_integrator::
+internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::
     EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
   static_assert(

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -247,8 +247,8 @@ Instance::Solve(Instant const& t_final) {
 }
 
 template<typename Method, typename Position>
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const&
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::integrator() const {
   return integrator_;
 }
@@ -256,13 +256,13 @@ Instance::integrator() const {
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
     SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Clone() const {
   return std::unique_ptr<Instance>(new Instance(*this));
 }
 
 template<typename Method, typename Position>
-void EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+void EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::WriteToMessage(
     not_null<serialization::IntegratorInstance*> message) const {
   AdaptiveStepSizeIntegrator<ODE>::Instance::WriteToMessage(message);
@@ -272,18 +272,18 @@ Instance::WriteToMessage(
               serialization::AdaptiveStepSizeIntegratorInstance::extension)
           ->MutableExtension(
               serialization::
-                  EmbeddedExplicitRungeKuttaNystromIntegratorInstance::
+                  EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::
                       extension);
 }
 
 template<typename Method, typename Position>
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Instance(
     IntegrationProblem<ODE> const& problem,
     AppendState const& append_state,
     ToleranceToErrorRatio const& tolerance_to_error_ratio,
     Parameters const& parameters,
-    EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator)
+    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const& integrator)
     : AdaptiveStepSizeIntegrator<ODE>::Instance(
           problem, append_state, tolerance_to_error_ratio, parameters),
       integrator_(integrator) {}
@@ -291,7 +291,7 @@ Instance::Instance(
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
     SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 NewInstance(IntegrationProblem<ODE> const& problem,
             AppendState const& append_state,
             ToleranceToErrorRatio const& tolerance_to_error_ratio,
@@ -306,7 +306,7 @@ NewInstance(IntegrationProblem<ODE> const& problem,
 }
 
 template<typename Method, typename Position>
-void EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+void EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 WriteToMessage(not_null<serialization::AdaptiveStepSizeIntegrator*> message)
     const {
   message->set_kind(Method::kind);
@@ -315,7 +315,7 @@ WriteToMessage(not_null<serialization::AdaptiveStepSizeIntegrator*> message)
 template<typename Method, typename Position>
 not_null<std::unique_ptr<typename Integrator<
     SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
-EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 ReadFromMessage(
     serialization::AdaptiveStepSizeIntegratorInstance const& message,
     IntegrationProblem<ODE> const& problem,
@@ -323,7 +323,7 @@ ReadFromMessage(
     ToleranceToErrorRatio const& tolerance_to_error_ratio,
     Parameters const& parameters) const {
   CHECK(message.HasExtension(
-      serialization::EmbeddedExplicitRungeKuttaNystromIntegratorInstance::
+      serialization::EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::
           extension))
       << message.DebugString();
 
@@ -341,14 +341,14 @@ ReadFromMessage(
 
 template<typename Method, typename Position>
 internal_embedded_explicit_runge_kutta_nyström_integrator::
-    EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const&
-EmbeddedExplicitRungeKuttaNyströmIntegrator() {
+    EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const&
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
   static_assert(
       std::is_base_of<methods::EmbeddedExplicitGeneralizedRungeKuttaNyström,
                       Method>::value,
       "Method must be derived from EmbeddedExplicitGeneralizedRungeKuttaNyström");
   static internal_embedded_explicit_runge_kutta_nyström_integrator::
-      EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position> const
           integrator;
   return integrator;
 }

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -15,7 +15,7 @@
 
 namespace principia {
 namespace integrators {
-namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
+namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {  // NOLINT(whitespace/line_length)
 
 using base::make_not_null_unique;
 using geometry::Sign;
@@ -42,8 +42,9 @@ EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
 }
 
 template<typename Method, typename Position>
-Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
-Instance::Solve(Instant const& t_final) {
+Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+    Method,
+    Position>::Instance::Solve(Instant const& t_final) {
   using Displacement = typename ODE::Displacement;
   using Velocity = typename ODE::Velocity;
   using Acceleration = typename ODE::Acceleration;
@@ -273,14 +274,13 @@ void EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::WriteToMessage(
     not_null<serialization::IntegratorInstance*> message) const {
   AdaptiveStepSizeIntegrator<ODE>::Instance::WriteToMessage(message);
+  auto const& rkng_extension = serialization::
+      EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::extension;
   auto* const extension =
       message
           ->MutableExtension(
               serialization::AdaptiveStepSizeIntegratorInstance::extension)
-          ->MutableExtension(
-              serialization::
-                  EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::
-                      extension);
+          ->MutableExtension(rkng_extension);
 }
 
 template<typename Method, typename Position>
@@ -330,8 +330,9 @@ ReadFromMessage(
     ToleranceToErrorRatio const& tolerance_to_error_ratio,
     Parameters const& parameters) const {
   CHECK(message.HasExtension(
-      serialization::EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::
-          extension))
+      serialization::
+          EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance::
+              extension))
       << message.DebugString();
 
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
@@ -344,7 +345,7 @@ ReadFromMessage(
                    *this));
 }
 
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -345,7 +345,7 @@ ReadFromMessage(
                    *this));
 }
 
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT
 
 template<typename Method, typename Position>
 internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -27,7 +27,7 @@ using quantities::Quotient;
 template<typename Method, typename Position>
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
-  // the first node is always 0 in an explicit method.
+  // The first node is always 0 in an explicit method.
   CHECK_EQ(0.0, c_[0]);
   if (first_same_as_last) {
     // Check that the conditions for the FSAL property are satisfied, see for
@@ -119,7 +119,7 @@ Instance::Solve(Instant const& t_final) {
 
   // The first stage of the Runge-Kutta-Nyström iteration.  In the FSAL case,
   // |first_stage == 1| after the first step, since the first RHS evaluation has
-  // already occured in the previous step.  In the non-FSAL case and in the
+  // already occurred in the previous step.  In the non-FSAL case and in the
   // first step of the FSAL case, |first_stage == 0|.
   int first_stage = 0;
 

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -169,6 +169,8 @@ Instance::Solve(Instant const& t_final) {
         }
       }
 
+      Time const h² = h * h;
+
       // Runge-Kutta-Nyström iteration; fills |g|.
       for (int i = first_stage; i < stages_; ++i) {
         Instant const t_stage =
@@ -182,8 +184,7 @@ Instance::Solve(Instant const& t_final) {
             Σj_a_ij_g_jk  += a[i][j] * g[j][k];
             Σj_aʹ_ij_g_jk += aʹ[i][j] * g[j][k];
           }
-          q_stage[k] = q̂[k].value +
-                           h * (c[i] * v̂[k].value + h * Σj_a_ij_g_jk);
+          q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σj_a_ij_g_jk;
           v_stage[k] = v̂[k].value + h * Σj_aʹ_ij_g_jk;
         }
         status.Update(
@@ -205,8 +206,8 @@ Instance::Solve(Instant const& t_final) {
           Σi_bʹ_i_g_ik += bʹ[i] * g[i][k];
         }
         // The hat-less Δq and Δv are the low-order increments.
-        Δq̂[k]                   = h * (h * (Σi_b̂_i_g_ik) + v̂[k].value);
-        Displacement const Δq_k = h * (h * (Σi_b_i_g_ik) + v̂[k].value);
+        Δq̂[k]                   = h * v̂[k].value + h² * Σi_b̂_i_g_ik;
+        Displacement const Δq_k = h * v̂[k].value + h² * Σi_b_i_g_ik;
         Δv̂[k]                   = h * Σi_b̂ʹ_i_g_ik;
         Velocity const Δv_k     = h * Σi_bʹ_i_g_ik;
 

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -1,0 +1,357 @@
+﻿
+#pragma once
+
+#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <ctime>
+#include <optional>
+#include <vector>
+
+#include "geometry/sign.hpp"
+#include "glog/logging.h"
+#include "quantities/quantities.hpp"
+
+namespace principia {
+namespace integrators {
+namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
+
+using base::make_not_null_unique;
+using geometry::Sign;
+using numerics::DoublePrecision;
+using quantities::DebugString;
+using quantities::Difference;
+using quantities::Quotient;
+
+template<typename Method, typename Position>
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
+EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
+  // the first node is always 0 in an explicit method.
+  CHECK_EQ(0.0, c_[0]);
+  if (first_same_as_last) {
+    // Check that the conditions for the FSAL property are satisfied, see for
+    // instance Dormand, El-Mikkawy and Prince (1986),
+    // Families of Runge-Kutta-Nyström formulae, equation 3.1.
+    CHECK_EQ(1.0, c_[stages_ - 1]);
+    CHECK_EQ(0.0, b_hat_[stages_ - 1]);
+    for (int j = 0; j < stages_ - 1; ++j) {
+      CHECK_EQ(b_hat_[j], a_[stages_ - 1][j]);
+    }
+  }
+}
+
+template<typename Method, typename Position>
+Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
+Instance::Solve(Instant const& t_final) {
+  using Displacement = typename ODE::Displacement;
+  using Velocity = typename ODE::Velocity;
+  using Acceleration = typename ODE::Acceleration;
+
+  auto const& a = integrator_.a_;
+  auto const& b_hat = integrator_.b_hat_;
+  auto const& b_prime_hat = integrator_.b_prime_hat_;
+  auto const& b = integrator_.b_;
+  auto const& b_prime = integrator_.b_prime_;
+  auto const& c = integrator_.c_;
+
+  auto& append_state = this->append_state_;
+  auto& current_state = this->current_state_;
+  auto& first_use = this->first_use_;
+  auto& parameters = this->parameters_;
+  auto const& equation = this->equation_;
+
+  // |current_state| gets updated as the integration progresses to allow
+  // restartability.
+
+  // State before the last, truncated step.
+  std::optional<typename ODE::SystemState> final_state;
+
+  // Argument checks.
+  int const dimension = current_state.positions.size();
+  Sign const integration_direction = Sign(parameters.first_time_step);
+  if (integration_direction.Positive()) {
+    // Integrating forward.
+    CHECK_LT(current_state.time.value, t_final);
+  } else {
+    // Integrating backward.
+    CHECK_GT(current_state.time.value, t_final);
+  }
+  CHECK(first_use || !parameters.last_step_is_exact)
+      << "Cannot reuse an instance where the last step is exact";
+  first_use = false;
+
+  // Time step.  Updated as the integration progresses to allow restartability.
+  Time& h = this->time_step_;
+  // Current time.  This is a non-const reference whose purpose is to make the
+  // equations more readable.
+  DoublePrecision<Instant>& t = current_state.time;
+
+  // Position increment (high-order).
+  std::vector<Displacement> Δq_hat(dimension);
+  // Velocity increment (high-order).
+  std::vector<Velocity> Δv_hat(dimension);
+  // Current position.  This is a non-const reference whose purpose is to make
+  // the equations more readable.
+  std::vector<DoublePrecision<Position>>& q_hat = current_state.positions;
+  // Current velocity.  This is a non-const reference whose purpose is to make
+  // the equations more readable.
+  std::vector<DoublePrecision<Velocity>>& v_hat = current_state.velocities;
+
+  // Difference between the low- and high-order approximations.
+  typename ODE::SystemStateError error_estimate;
+  error_estimate.position_error.resize(dimension);
+  error_estimate.velocity_error.resize(dimension);
+
+  // Current Runge-Kutta-Nyström stage.
+  std::vector<Position> q_stage(dimension);
+  // Accelerations at each stage.
+  // TODO(egg): this is a rectangular container, use something more appropriate.
+  std::vector<std::vector<Acceleration>> g(stages_);
+  for (auto& g_stage : g) {
+    g_stage.resize(dimension);
+  }
+
+  bool at_end = false;
+  double tolerance_to_error_ratio;
+
+  // The first stage of the Runge-Kutta-Nyström iteration.  In the FSAL case,
+  // |first_stage == 1| after the first step, since the first RHS evaluation has
+  // already occured in the previous step.  In the non-FSAL case and in the
+  // first step of the FSAL case, |first_stage == 0|.
+  int first_stage = 0;
+
+  // The number of steps already performed.
+  std::int64_t step_count = 0;
+
+  Status status;
+
+  // No step size control on the first step.  If this instance is being
+  // restarted we already have a value of |h| suitable for the next step, based
+  // on the computation of |tolerance_to_error_ratio_| during the last
+  // invocation.
+  goto runge_kutta_nyström_step;
+
+  while (!at_end) {
+    // Compute the next step with decreasing step sizes until the error is
+    // tolerable.
+    do {
+      // Adapt step size.
+      // TODO(egg): find out whether there's a smarter way to compute that root,
+      // especially since we make the order compile-time.
+      h *= parameters.safety_factor *
+               std::pow(tolerance_to_error_ratio, 1.0 / (lower_order + 1));
+      // TODO(egg): should we check whether it vanishes in double precision
+      // instead?
+      if (t.value + (t.error + h) == t.value) {
+        return Status(termination_condition::VanishingStepSize,
+                      "At time " + DebugString(t.value) +
+                          ", step size is effectively zero.  Singularity or "
+                          "stiff system suspected.");
+      }
+
+    runge_kutta_nyström_step:
+      // Termination condition.
+      if (parameters.last_step_is_exact) {
+        Time const time_to_end = (t_final - t.value) - t.error;
+        at_end = integration_direction * h >=
+                 integration_direction * time_to_end;
+        if (at_end) {
+          // The chosen step size will overshoot.  Clip it to just reach the
+          // end, and terminate if the step is accepted.  Note that while this
+          // step size is a good approximation, there is no guarantee that it
+          // won't over/undershoot, so we still need to special case the very
+          // last stage below.
+          h = time_to_end;
+          final_state = current_state;
+        }
+      }
+
+      // Runge-Kutta-Nyström iteration; fills |g|.
+      for (int i = first_stage; i < stages_; ++i) {
+        Instant const t_stage =
+            (parameters.last_step_is_exact && at_end && c[i] == 1.0)
+                ? t_final
+                : t.value + (t.error + c[i] * h);
+        for (int k = 0; k < dimension; ++k) {
+          Acceleration Σj_a_ij_g_jk{};
+          for (int j = 0; j < i; ++j) {
+            Σj_a_ij_g_jk += a[i][j] * g[j][k];
+          }
+          q_stage[k] = q_hat[k].value +
+                           h * (c[i] * v_hat[k].value + h * Σj_a_ij_g_jk);
+        }
+        status.Update(equation.compute_acceleration(t_stage, q_stage, g[i]));
+      }
+
+      // Increment computation and step size control.
+      for (int k = 0; k < dimension; ++k) {
+        Acceleration Σi_b_hat_i_g_ik{};
+        Acceleration Σi_b_i_g_ik{};
+        Acceleration Σi_b_prime_hat_i_g_ik{};
+        Acceleration Σi_b_prime_i_g_ik{};
+        // Please keep the eight assigments below aligned, they become illegible
+        // otherwise.
+        for (int i = 0; i < stages_; ++i) {
+          Σi_b_hat_i_g_ik       += b_hat[i] * g[i][k];
+          Σi_b_i_g_ik           += b[i] * g[i][k];
+          Σi_b_prime_hat_i_g_ik += b_prime_hat[i] * g[i][k];
+          Σi_b_prime_i_g_ik     += b_prime[i] * g[i][k];
+        }
+        // The hat-less Δq and Δv are the low-order increments.
+        Δq_hat[k]               = h * (h * (Σi_b_hat_i_g_ik) + v_hat[k].value);
+        Displacement const Δq_k = h * (h * (Σi_b_i_g_ik) + v_hat[k].value);
+        Δv_hat[k]               = h * Σi_b_prime_hat_i_g_ik;
+        Velocity const Δv_k     = h * Σi_b_prime_i_g_ik;
+
+        error_estimate.position_error[k] = Δq_k - Δq_hat[k];
+        error_estimate.velocity_error[k] = Δv_k - Δv_hat[k];
+      }
+      tolerance_to_error_ratio =
+          this->tolerance_to_error_ratio_(h, error_estimate);
+    } while (tolerance_to_error_ratio < 1.0);
+
+    if (!parameters.last_step_is_exact && t.value + (t.error + h) > t_final) {
+      // We did overshoot.  Drop the point that we just computed and exit.
+      final_state = current_state;
+      break;
+    }
+
+    if (first_same_as_last) {
+      using std::swap;
+      swap(g.front(), g.back());
+      first_stage = 1;
+    }
+
+    // Increment the solution with the high-order approximation.
+    t.Increment(h);
+    for (int k = 0; k < dimension; ++k) {
+      q_hat[k].Increment(Δq_hat[k]);
+      v_hat[k].Increment(Δv_hat[k]);
+    }
+    append_state(current_state);
+    ++step_count;
+    if (step_count == parameters.max_steps && !at_end) {
+      return Status(termination_condition::ReachedMaximalStepCount,
+                    "Reached maximum step count " +
+                        std::to_string(parameters.max_steps) +
+                        " at time " + DebugString(t.value) +
+                        "; requested t_final is " + DebugString(t_final) +
+                        ".");
+    }
+  }
+  // The resolution is restartable from the last non-truncated state.
+  CHECK(final_state);
+  current_state = *final_state;
+  return status;
+}
+
+template<typename Method, typename Position>
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const&
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+Instance::integrator() const {
+  return integrator_;
+}
+
+template<typename Method, typename Position>
+not_null<std::unique_ptr<typename Integrator<
+    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+Instance::Clone() const {
+  return std::unique_ptr<Instance>(new Instance(*this));
+}
+
+template<typename Method, typename Position>
+void EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+Instance::WriteToMessage(
+    not_null<serialization::IntegratorInstance*> message) const {
+  AdaptiveStepSizeIntegrator<ODE>::Instance::WriteToMessage(message);
+  auto* const extension =
+      message
+          ->MutableExtension(
+              serialization::AdaptiveStepSizeIntegratorInstance::extension)
+          ->MutableExtension(
+              serialization::
+                  EmbeddedExplicitRungeKuttaNystromIntegratorInstance::
+                      extension);
+}
+
+template<typename Method, typename Position>
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+Instance::Instance(
+    IntegrationProblem<ODE> const& problem,
+    AppendState const& append_state,
+    ToleranceToErrorRatio const& tolerance_to_error_ratio,
+    Parameters const& parameters,
+    EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator)
+    : AdaptiveStepSizeIntegrator<ODE>::Instance(
+          problem, append_state, tolerance_to_error_ratio, parameters),
+      integrator_(integrator) {}
+
+template<typename Method, typename Position>
+not_null<std::unique_ptr<typename Integrator<
+    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+NewInstance(IntegrationProblem<ODE> const& problem,
+            AppendState const& append_state,
+            ToleranceToErrorRatio const& tolerance_to_error_ratio,
+            Parameters const& parameters) const {
+  // Cannot use |make_not_null_unique| because the constructor of |Instance| is
+  // private.
+  return std::unique_ptr<Instance>(new Instance(problem,
+                                                append_state,
+                                                tolerance_to_error_ratio,
+                                                parameters,
+                                                *this));
+}
+
+template<typename Method, typename Position>
+void EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+WriteToMessage(not_null<serialization::AdaptiveStepSizeIntegrator*> message)
+    const {
+  message->set_kind(Method::kind);
+}
+
+template<typename Method, typename Position>
+not_null<std::unique_ptr<typename Integrator<
+    SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
+EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
+ReadFromMessage(
+    serialization::AdaptiveStepSizeIntegratorInstance const& message,
+    IntegrationProblem<ODE> const& problem,
+    AppendState const& append_state,
+    ToleranceToErrorRatio const& tolerance_to_error_ratio,
+    Parameters const& parameters) const {
+  CHECK(message.HasExtension(
+      serialization::EmbeddedExplicitRungeKuttaNystromIntegratorInstance::
+          extension))
+      << message.DebugString();
+
+  // Cannot use |make_not_null_unique| because the constructor of |Instance| is
+  // private.
+  return std::unique_ptr<typename AdaptiveStepSizeIntegrator<ODE>::Instance>(
+      new Instance(problem,
+                   append_state,
+                   tolerance_to_error_ratio,
+                   parameters,
+                   *this));
+}
+
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
+
+template<typename Method, typename Position>
+internal_embedded_explicit_runge_kutta_nyström_integrator::
+    EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const&
+EmbeddedExplicitRungeKuttaNyströmIntegrator() {
+  static_assert(
+      std::is_base_of<methods::EmbeddedExplicitGeneralizedRungeKuttaNyström,
+                      Method>::value,
+      "Method must be derived from EmbeddedExplicitGeneralizedRungeKuttaNyström");
+  static internal_embedded_explicit_runge_kutta_nyström_integrator::
+      EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position> const
+          integrator;
+  return integrator;
+}
+
+}  // namespace integrators
+}  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -1,4 +1,4 @@
-﻿#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
+﻿#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"  // NOLINT(whitespace/line_length)
 
 #include <algorithm>
 #include <limits>
@@ -19,7 +19,7 @@
 
 namespace principia {
 namespace integrators {
-namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
+namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {  // NOLINT(whitespace/line_length)
 
 using numerics::EstrinEvaluator;
 using numerics::LegendrePolynomial;
@@ -56,8 +56,9 @@ double ToleranceToErrorRatio(
     double const& tolerance,
     Variation<double> const& derivative_tolerance,
     std::function<void(bool tolerable)> callback) {
-  double const r = std::min(tolerance / Abs(error.position_error[0]),
-                            derivative_tolerance / Abs(error.velocity_error[0]));
+  double const r =
+      std::min(tolerance / Abs(error.position_error[0]),
+               derivative_tolerance / Abs(error.velocity_error[0]));
   callback(r > 1.0);
   return r;
 }
@@ -145,7 +146,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   }
   EXPECT_THAT(max_error, IsNear(172e-6));
   EXPECT_THAT(max_derivative_error, IsNear(4.54e-3 / Second));
-}
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
 
 }  // namespace internal_ordinary_differential_equations
 }  // namespace integrators

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -48,7 +48,7 @@ using ::std::placeholders::_3;
 using ::testing::ElementsAreArray;
 using ::testing::Lt;
 
-using ODE = SpecialSecondOrderDifferentialEquation<Length>;
+using ODE = ExplicitSecondOrderOrdinaryDifferentialEquation<Length>;
 
 namespace {
 
@@ -73,7 +73,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
        HarmonicOscillatorBackAndForth) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::DormandالمكاوىPrince1986RKN434FM,
+          methods::Fine1987RKNG34,
           Length>();
   Length const x_initial = 1 * Metre;
   Speed const v_initial = 0 * Metre / Second;
@@ -180,7 +180,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
 TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, MaxSteps) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::DormandالمكاوىPrince1986RKN434FM,
+          methods::Fine1987RKNG34,
           Length>();
   Length const x_initial = 1 * Metre;
   Speed const v_initial = 0 * Metre / Second;
@@ -312,7 +312,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Singularity)
 
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::DormandالمكاوىPrince1986RKN434FM,
+          methods::Fine1987RKNG34,
           Length>();
 
   auto const instance = integrator.NewInstance(problem,
@@ -332,7 +332,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Singularity)
 TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Restart) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::DormandالمكاوىPrince1986RKN434FM,
+          methods::Fine1987RKNG34,
           Length>();
   Length const x_initial = 1 * Metre;
   Speed const v_initial = 0 * Metre / Second;
@@ -437,7 +437,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Restart) {
 TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Serialization) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::DormandالمكاوىPrince1986RKN434FM,
+          methods::Fine1987RKNG34,
           Length>();
   Length const x_initial = 1 * Metre;
   Speed const v_initial = 0 * Metre / Second;

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -67,7 +67,6 @@ double ToleranceToErrorRatio(
 class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest
     : public ::testing::Test {};
 
-
 TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -9,6 +9,8 @@
 #include "glog/logging.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "numerics/legendre.hpp"
+#include "numerics/polynomial_evaluators.hpp"
 #include "quantities/si.hpp"
 #include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/integration.hpp"
@@ -20,6 +22,8 @@ namespace principia {
 namespace integrators {
 namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
 
+using numerics::EstrinEvaluator;
+using numerics::LegendrePolynomial;
 using quantities::Abs;
 using quantities::Time;
 using quantities::Variation;
@@ -64,12 +68,12 @@ double ToleranceToErrorRatio(
 class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest
     : public ::testing::Test {};
 
-TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
-       LegendreBackAndForth) {
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
           methods::Fine1987RKNG34,
           double>();
+  constexpr int degree = 15;
   double const x_initial = 1;
   Variation<double> const v_initial = -6435 / (2048 * Second);
   Instant const t_initial;
@@ -100,7 +104,7 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
   std::vector<ODE::SystemState> solution;
   ODE legendre_equation;
   legendre_equation.compute_acceleration =
-      std::bind(ComputeLegendrePolynomialSecondDerivative<15>,
+      std::bind(ComputeLegendrePolynomialSecondDerivative<degree>,
                 _1, _2, _3, _4, &evaluations);
   IntegrationProblem<ODE> problem;
   problem.equation = legendre_equation;
@@ -123,373 +127,22 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
   auto outcome = instance->Solve(t_final);
   EXPECT_EQ(termination_condition::Done, outcome.error());
 
-#if 0
-
-  evaluations = 0;
-  subsequent_rejections = 0;
-  initial_rejections = 0;
-  first_step = true;
-  problem.initial_state = solution.back();
-  {
-    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-        /*first_time_step=*/t_initial - t_final,
-        /*safety_factor=*/0.9);
-    auto const tolerance_to_error_ratio =
-        std::bind(HarmonicOscillatorToleranceRatio,
-                  _1, _2,
-                  2 * length_tolerance,
-                  2 * speed_tolerance,
-                  step_size_callback);
-    auto instance = integrator.NewInstance(
-        problem, append_state, tolerance_to_error_ratio, parameters);
-    auto outcome = instance->Solve(t_initial);
-    EXPECT_EQ(termination_condition::Done, outcome.error());
-  }
-  EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
-              IsNear(1.2e-3 * Metre));
-  EXPECT_THAT(AbsoluteError(v_initial, solution.back().velocities[0].value),
-              IsNear(2.5e-3 * Metre / Second));
-  EXPECT_EQ(t_initial, solution.back().time.value);
-  EXPECT_EQ(steps_backward, solution.size() - steps_forward);
-  EXPECT_EQ((1 + initial_rejections) * 4 +
-                (steps_backward - 1 + subsequent_rejections) * 3,
-            evaluations);
-  EXPECT_EQ(1, initial_rejections);
-  EXPECT_EQ(11, subsequent_rejections);
-#endif
-}
-#if 0
-TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, MaxSteps) {
-  AdaptiveStepSizeIntegrator<ODE> const& integrator =
-      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::Fine1987RKNG34,
-          Length>();
-  Length const x_initial = 1 * Metre;
-  Speed const v_initial = 0 * Metre / Second;
-  Speed const v_amplitude = 1 * Metre / Second;
-  Time const period = 2 * π * Second;
-  AngularFrequency const ω = 1 * Radian / Second;
-  Instant const t_initial;
-  Instant const t_final = t_initial + 10 * period;
-  Length const length_tolerance = 1 * Milli(Metre);
-  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
-  // The number of steps if no step limit is set.
-  std::int64_t const steps_forward = 132;
-
-  auto const step_size_callback = [](bool tolerable) {};
-
-  std::vector<ODE::SystemState> solution;
-  ODE harmonic_oscillator;
-  harmonic_oscillator.compute_acceleration =
-      std::bind(ComputeHarmonicOscillatorAcceleration1D,
-                _1, _2, _3, /*evaluations=*/nullptr);
-  IntegrationProblem<ODE> problem;
-  problem.equation = harmonic_oscillator;
-  problem.initial_state = {{x_initial}, {v_initial}, t_initial};
-  auto const append_state = [&solution](ODE::SystemState const& state) {
-    solution.push_back(state);
-  };
-  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-      /*first_time_step=*/t_final - t_initial,
-      /*safety_factor=*/0.9,
-      /*max_steps=*/100,
-      /*last_step_is_exact=*/true);
-  auto const tolerance_to_error_ratio =
-      std::bind(HarmonicOscillatorToleranceRatio,
-                _1, _2,
-                length_tolerance,
-                speed_tolerance,
-                step_size_callback);
-
-  auto const instance = integrator.NewInstance(problem,
-                                               append_state,
-                                               tolerance_to_error_ratio,
-                                               parameters);
-  auto const outcome = instance->Solve(t_final);
-
-  EXPECT_EQ(termination_condition::ReachedMaximalStepCount, outcome.error());
-  EXPECT_THAT(AbsoluteError(
-                  x_initial * Cos(ω * (solution.back().time.value - t_initial)),
-                      solution.back().positions[0].value),
-              IsNear(9.0e-4 * Metre));
-  EXPECT_THAT(AbsoluteError(
-                  -v_amplitude *
-                      Sin(ω * (solution.back().time.value - t_initial)),
-                  solution.back().velocities[0].value),
-              IsNear(1.9e-3 * Metre / Second));
-  EXPECT_THAT(solution.back().time.value, Lt(t_final));
-  EXPECT_EQ(100, solution.size());
-
-  // Check that a |max_steps| greater than or equal to the unconstrained number
-  // of steps has no effect.
-  for (std::int64_t const max_steps :
-       {steps_forward, steps_forward + 1234}) {
-    solution.clear();
-    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-        /*first_time_step=*/t_final - t_initial,
-        /*safety_factor=*/0.9,
-        /*max_steps=*/steps_forward,
-        /*last_step_is_exact=*/true);
-    auto const instance = integrator.NewInstance(problem,
-                                                 append_state,
-                                                 tolerance_to_error_ratio,
-                                                 parameters);
-    auto const outcome = instance->Solve(t_final);
-    EXPECT_EQ(termination_condition::Done, outcome.error());
-    EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
-                IsNear(3.6e-4 * Metre));
-    EXPECT_THAT(AbsoluteError(v_initial, solution.back().velocities[0].value),
-                IsNear(2.8e-3 * Metre / Second));
-    EXPECT_EQ(t_final, solution.back().time.value);
-    EXPECT_EQ(steps_forward, solution.size());
+  double max_error{};
+  Variation<double> max_derivative_error{};
+  for (ODE::SystemState const& state : solution) {
+    double const x = (state.time.value - t_initial) / (1 * Second);
+    double const error =
+        AbsoluteError(LegendrePolynomial<degree, EstrinEvaluator>().Evaluate(x),
+                      state.positions[0].value);
+    Variation<double> const derivative_error = AbsoluteError(
+        LegendrePolynomial<degree, EstrinEvaluator>().Derivative().Evaluate(x) /
+            (1 * Second),
+        state.velocities[0].value);
+    max_error = std::max(max_error, error);
+    max_derivative_error = std::max(max_derivative_error, derivative_error);
   }
 }
 
-TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Singularity) {
-  // Integrating the position of an ideal rocket,
-  //   x"(t) = m' I_sp / m(t),
-  //   x'(0) = 0, x(0) = 0,
-  // where m(t) = m₀ - t m'.
-  // The solution is
-  //   x(t)  = I_sp (t + (t - m₀ / m') log(m₀ / m(t))
-  //   x'(t) = I_sp log(m₀ / m(t)) (Циолко́вский's equation).
-  // There is a singularity at t = m₀ / m'.
-  Variation<Mass> const mass_flow = 1 * Kilogram / Second;
-  Mass const initial_mass = 1 * Kilogram;
-  SpecificImpulse const specific_impulse = 1 * Newton * Second / Kilogram;
-  Instant const t_initial;
-  Instant const t_singular = t_initial + initial_mass / mass_flow;
-  // After the singularity.
-  Instant const t_final = t_initial + 2 * initial_mass / mass_flow;
-  auto const mass = [initial_mass, t_initial, mass_flow](Instant const& t) {
-    return initial_mass - (t - t_initial) * mass_flow;
-  };
-
-  Length const length_tolerance = 1 * Milli(Metre);
-  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
-
-  std::vector<ODE::SystemState> solution;
-  ODE rocket_equation;
-  rocket_equation.compute_acceleration = [&mass, specific_impulse, mass_flow](
-      Instant const& t,
-      std::vector<Length> const& position,
-      std::vector<Acceleration>& acceleration) {
-    acceleration.back() = mass_flow * specific_impulse / mass(t);
-    return Status::OK;
-  };
-  IntegrationProblem<ODE> problem;
-  auto const append_state = [&solution](ODE::SystemState const& state) {
-    solution.push_back(state);
-  };
-  problem.equation = rocket_equation;
-  problem.initial_state = {{0 * Metre}, {0 * Metre / Second}, t_initial};
-  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-      /*first_time_step=*/t_final - t_initial,
-      /*safety_factor=*/0.9);
-  auto const tolerance_to_error_ratio = [length_tolerance, speed_tolerance](
-      Time const& h, ODE::SystemStateError const& error) {
-    return std::min(length_tolerance / Abs(error.position_error[0]),
-                    speed_tolerance / Abs(error.velocity_error[0]));
-  };
-
-  AdaptiveStepSizeIntegrator<ODE> const& integrator =
-      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::Fine1987RKNG34,
-          Length>();
-
-  auto const instance = integrator.NewInstance(problem,
-                                               append_state,
-                                               tolerance_to_error_ratio,
-                                               parameters);
-  auto const outcome = instance->Solve(t_final);
-
-  EXPECT_EQ(termination_condition::VanishingStepSize, outcome.error());
-  EXPECT_EQ(132, solution.size());
-  EXPECT_THAT(solution.back().time.value - t_initial,
-              AlmostEquals(t_singular - t_initial, 15));
-  EXPECT_THAT(solution.back().positions.back().value,
-              AlmostEquals(specific_impulse * initial_mass / mass_flow, 540));
-}
-
-TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Restart) {
-  AdaptiveStepSizeIntegrator<ODE> const& integrator =
-      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::Fine1987RKNG34,
-          Length>();
-  Length const x_initial = 1 * Metre;
-  Speed const v_initial = 0 * Metre / Second;
-  Speed const v_amplitude = 1 * Metre / Second;
-  Time const period = 2 * π * Second;
-  AngularFrequency const ω = 1 * Radian / Second;
-  Instant const t_initial;
-  Time const duration = 10 * period;
-  Length const length_tolerance = 1 * Milli(Metre);
-  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
-  // The number of steps if no step limit is set.
-  std::int64_t const steps_forward = 132;
-
-  auto const step_size_callback = [](bool tolerable) {};
-
-  std::vector<ODE::SystemState> solution1;
-  {
-    ODE harmonic_oscillator;
-    harmonic_oscillator.compute_acceleration =
-        std::bind(ComputeHarmonicOscillatorAcceleration1D,
-                  _1, _2, _3, /*evaluations=*/nullptr);
-    IntegrationProblem<ODE> problem;
-    problem.equation = harmonic_oscillator;
-    problem.initial_state = {{x_initial}, {v_initial}, t_initial};
-    auto const append_state = [&solution1](ODE::SystemState const& state) {
-      solution1.push_back(state);
-    };
-
-    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-        /*first_time_step=*/duration,
-        /*safety_factor=*/0.9,
-        /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
-        /*last_step_is_exact=*/false);
-    auto const tolerance_to_error_ratio =
-        std::bind(HarmonicOscillatorToleranceRatio,
-                  _1, _2,
-                  length_tolerance,
-                  speed_tolerance,
-                  step_size_callback);
-
-    auto const instance = integrator.NewInstance(problem,
-                                                 append_state,
-                                                 tolerance_to_error_ratio,
-                                                 parameters);
-    auto outcome = instance->Solve(t_initial + duration);
-    EXPECT_EQ(termination_condition::Done, outcome.error());
-
-    // Check that the time step has been updated.
-    EXPECT_EQ(131, solution1.size());
-    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
-                solution1[solution1.size() - 2].time.value,
-                AlmostEquals(0.00810677945075361400 * duration, 0));
-
-    // Restart the integration.
-    outcome = instance->Solve(t_initial + 2.0 * duration);
-    EXPECT_EQ(termination_condition::Done, outcome.error());
-
-    // Check that the time step has been updated again.
-    EXPECT_EQ(261, solution1.size());
-    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
-                solution1[solution1.size() - 2].time.value,
-                AlmostEquals(0.00805976959833537384 * duration, 0, 128));
-  }
-
-  // Do it again in one call to |Solve| and check associativity.
-  std::vector<ODE::SystemState> solution2;
-  {
-    ODE harmonic_oscillator;
-    harmonic_oscillator.compute_acceleration =
-        std::bind(ComputeHarmonicOscillatorAcceleration1D,
-                  _1, _2, _3, /*evaluations=*/nullptr);
-    IntegrationProblem<ODE> problem;
-    problem.equation = harmonic_oscillator;
-    problem.initial_state = {{x_initial}, {v_initial}, t_initial};
-    auto const append_state = [&solution2](ODE::SystemState const& state) {
-      solution2.push_back(state);
-    };
-
-    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-        /*first_time_step=*/duration,
-        /*safety_factor=*/0.9,
-        /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
-        /*last_step_is_exact=*/false);
-    auto const tolerance_to_error_ratio =
-        std::bind(HarmonicOscillatorToleranceRatio,
-                  _1, _2,
-                  length_tolerance,
-                  speed_tolerance,
-                  step_size_callback);
-
-    auto const instance = integrator.NewInstance(problem,
-                                                 append_state,
-                                                 tolerance_to_error_ratio,
-                                                 parameters);
-    auto outcome = instance->Solve(t_initial + 2.0 * duration);
-    EXPECT_EQ(termination_condition::Done, outcome.error());
-  }
-
-  EXPECT_THAT(solution2, ElementsAreArray(solution1));
-}
-
-TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Serialization) {
-  AdaptiveStepSizeIntegrator<ODE> const& integrator =
-      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
-          methods::Fine1987RKNG34,
-          Length>();
-  Length const x_initial = 1 * Metre;
-  Speed const v_initial = 0 * Metre / Second;
-  Time const period = 2 * π * Second;
-  Instant const t_initial;
-  Instant const t_final = t_initial + 10 * period;
-  Length const length_tolerance = 1 * Milli(Metre);
-  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
-
-  auto const step_size_callback = [](bool tolerable) {};
-
-  std::vector<ODE::SystemState> solution;
-  ODE harmonic_oscillator;
-  harmonic_oscillator.compute_acceleration =
-      std::bind(ComputeHarmonicOscillatorAcceleration1D,
-                _1, _2, _3, /*evaluations=*/nullptr);
-  IntegrationProblem<ODE> problem;
-  problem.equation = harmonic_oscillator;
-  problem.initial_state = {{x_initial}, {v_initial}, t_initial};
-  auto const append_state = [&solution](ODE::SystemState const& state) {
-    solution.push_back(state);
-  };
-  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
-      /*first_time_step=*/t_final - t_initial,
-      /*safety_factor=*/0.9);
-  auto const tolerance_to_error_ratio =
-      std::bind(HarmonicOscillatorToleranceRatio,
-                _1, _2,
-                length_tolerance,
-                speed_tolerance,
-                step_size_callback);
-
-  auto const instance1 = integrator.NewInstance(problem,
-                                                append_state,
-                                                tolerance_to_error_ratio,
-                                                parameters);
-  serialization::IntegratorInstance message1;
-  instance1->WriteToMessage(&message1);
-  auto const instance2 =
-      AdaptiveStepSizeIntegrator<ODE>::Instance::ReadFromMessage(
-          message1,
-          harmonic_oscillator,
-          append_state,
-          tolerance_to_error_ratio);
-  serialization::IntegratorInstance message2;
-  instance2->WriteToMessage(&message2);
-  EXPECT_THAT(message1, EqualsProto(message2));
-}
-
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
-
-// Reopen this namespace to allow printing out the system state.
-namespace internal_ordinary_differential_equations {
-
-void PrintTo(
-    typename internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::ODE::
-        SystemState const& system_state,
-    std::ostream* const out) {
-  *out << "\nTime: " << system_state.time << "\n";
-  *out << "Positions:\n";
-  for (int i = 0; i < system_state.positions.size(); ++i) {
-    *out << "  " << i << ": " << system_state.positions[i] << "\n";
-  }
-  *out << "Velocities:\n";
-  for (int i = 0; i < system_state.velocities.size(); ++i) {
-    *out << "  " << i << ": " << system_state.velocities[i] << "\n";
-  }
-}
-#endif 0
 }  // namespace internal_ordinary_differential_equations
-
 }  // namespace integrators
 }  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -146,8 +146,8 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   }
   EXPECT_THAT(max_error, IsNear(172e-6));
   EXPECT_THAT(max_derivative_error, IsNear(4.54e-3 / Second));
-}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT(whitespace/line_length)
+}
 
-}  // namespace internal_ordinary_differential_equations
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator  // NOLINT
 }  // namespace integrators
 }  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -1,0 +1,513 @@
+﻿
+#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include "base/macros.hpp"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "quantities/si.hpp"
+#include "testing_utilities/almost_equals.hpp"
+#include "testing_utilities/integration.hpp"
+#include "testing_utilities/is_near.hpp"
+#include "testing_utilities/matchers.hpp"
+#include "testing_utilities/numerics.hpp"
+
+namespace principia {
+namespace integrators {
+namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {
+
+using quantities::Abs;
+using quantities::Acceleration;
+using quantities::AngularFrequency;
+using quantities::Cos;
+using quantities::Length;
+using quantities::Mass;
+using quantities::Sin;
+using quantities::SpecificImpulse;
+using quantities::Speed;
+using quantities::Time;
+using quantities::si::Centi;
+using quantities::si::Kilogram;
+using quantities::si::Metre;
+using quantities::si::Milli;
+using quantities::si::Newton;
+using quantities::si::Radian;
+using quantities::si::Second;
+using testing_utilities::AbsoluteError;
+using testing_utilities::AlmostEquals;
+using testing_utilities::ComputeHarmonicOscillatorAcceleration1D;
+using testing_utilities::EqualsProto;
+using testing_utilities::IsNear;
+using ::std::placeholders::_1;
+using ::std::placeholders::_2;
+using ::std::placeholders::_3;
+using ::testing::ElementsAreArray;
+using ::testing::Lt;
+
+using ODE = SpecialSecondOrderDifferentialEquation<Length>;
+
+namespace {
+
+double HarmonicOscillatorToleranceRatio(
+    Time const& h,
+    ODE::SystemStateError const& error,
+    Length const& q_tolerance,
+    Speed const& v_tolerance,
+    std::function<void(bool tolerable)> callback) {
+  double const r = std::min(q_tolerance / Abs(error.position_error[0]),
+                            v_tolerance / Abs(error.velocity_error[0]));
+  callback(r > 1.0);
+  return r;
+}
+
+}  // namespace
+
+class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest
+    : public ::testing::Test {};
+
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest,
+       HarmonicOscillatorBackAndForth) {
+  AdaptiveStepSizeIntegrator<ODE> const& integrator =
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+          methods::DormandالمكاوىPrince1986RKN434FM,
+          Length>();
+  Length const x_initial = 1 * Metre;
+  Speed const v_initial = 0 * Metre / Second;
+  Time const period = 2 * π * Second;
+  Instant const t_initial;
+  Instant const t_final = t_initial + 10 * period;
+  Length const length_tolerance = 1 * Milli(Metre);
+  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
+  int const steps_forward = 132;
+  // We integrate backward with double the tolerance.
+  int const steps_backward = 112;
+
+  int evaluations = 0;
+  int initial_rejections = 0;
+  int subsequent_rejections = 0;
+  bool first_step = true;
+  auto const step_size_callback = [&initial_rejections, &subsequent_rejections,
+                                   &first_step](bool tolerable) {
+    if (!tolerable) {
+      if (first_step) {
+        ++initial_rejections;
+      } else {
+        ++subsequent_rejections;
+      }
+    } else if (first_step) {
+      first_step = false;
+    }
+  };
+
+  std::vector<ODE::SystemState> solution;
+  ODE harmonic_oscillator;
+  harmonic_oscillator.compute_acceleration =
+      std::bind(ComputeHarmonicOscillatorAcceleration1D,
+                _1, _2, _3, &evaluations);
+  IntegrationProblem<ODE> problem;
+  problem.equation = harmonic_oscillator;
+  problem.initial_state = {{x_initial}, {v_initial}, t_initial};
+  auto const append_state = [&solution](ODE::SystemState const& state) {
+    solution.push_back(state);
+  };
+
+  {
+    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+        /*first_time_step=*/t_final - t_initial,
+        /*safety_factor=*/0.9);
+    auto const tolerance_to_error_ratio =
+        std::bind(HarmonicOscillatorToleranceRatio,
+                  _1, _2,
+                  length_tolerance,
+                  speed_tolerance,
+                  step_size_callback);
+    auto instance = integrator.NewInstance(problem,
+                                           append_state,
+                                           tolerance_to_error_ratio,
+                                           parameters);
+    auto outcome = instance->Solve(t_final);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+  }
+  EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
+              IsNear(3.5e-4 * Metre));
+  EXPECT_THAT(AbsoluteError(v_initial, solution.back().velocities[0].value),
+              IsNear(2.8e-3 * Metre / Second));
+  EXPECT_EQ(t_final, solution.back().time.value);
+  EXPECT_EQ(steps_forward, solution.size());
+  EXPECT_EQ((1 + initial_rejections) * 4 +
+                (steps_forward - 1 + subsequent_rejections) * 3,
+            evaluations);
+  EXPECT_EQ(1, initial_rejections);
+  EXPECT_EQ(3, subsequent_rejections);
+
+  evaluations = 0;
+  subsequent_rejections = 0;
+  initial_rejections = 0;
+  first_step = true;
+  problem.initial_state = solution.back();
+  {
+    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+        /*first_time_step=*/t_initial - t_final,
+        /*safety_factor=*/0.9);
+    auto const tolerance_to_error_ratio =
+        std::bind(HarmonicOscillatorToleranceRatio,
+                  _1, _2,
+                  2 * length_tolerance,
+                  2 * speed_tolerance,
+                  step_size_callback);
+    auto instance = integrator.NewInstance(
+        problem, append_state, tolerance_to_error_ratio, parameters);
+    auto outcome = instance->Solve(t_initial);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+  }
+  EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
+              IsNear(1.2e-3 * Metre));
+  EXPECT_THAT(AbsoluteError(v_initial, solution.back().velocities[0].value),
+              IsNear(2.5e-3 * Metre / Second));
+  EXPECT_EQ(t_initial, solution.back().time.value);
+  EXPECT_EQ(steps_backward, solution.size() - steps_forward);
+  EXPECT_EQ((1 + initial_rejections) * 4 +
+                (steps_backward - 1 + subsequent_rejections) * 3,
+            evaluations);
+  EXPECT_EQ(1, initial_rejections);
+  EXPECT_EQ(11, subsequent_rejections);
+}
+
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, MaxSteps) {
+  AdaptiveStepSizeIntegrator<ODE> const& integrator =
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+          methods::DormandالمكاوىPrince1986RKN434FM,
+          Length>();
+  Length const x_initial = 1 * Metre;
+  Speed const v_initial = 0 * Metre / Second;
+  Speed const v_amplitude = 1 * Metre / Second;
+  Time const period = 2 * π * Second;
+  AngularFrequency const ω = 1 * Radian / Second;
+  Instant const t_initial;
+  Instant const t_final = t_initial + 10 * period;
+  Length const length_tolerance = 1 * Milli(Metre);
+  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
+  // The number of steps if no step limit is set.
+  std::int64_t const steps_forward = 132;
+
+  auto const step_size_callback = [](bool tolerable) {};
+
+  std::vector<ODE::SystemState> solution;
+  ODE harmonic_oscillator;
+  harmonic_oscillator.compute_acceleration =
+      std::bind(ComputeHarmonicOscillatorAcceleration1D,
+                _1, _2, _3, /*evaluations=*/nullptr);
+  IntegrationProblem<ODE> problem;
+  problem.equation = harmonic_oscillator;
+  problem.initial_state = {{x_initial}, {v_initial}, t_initial};
+  auto const append_state = [&solution](ODE::SystemState const& state) {
+    solution.push_back(state);
+  };
+  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+      /*first_time_step=*/t_final - t_initial,
+      /*safety_factor=*/0.9,
+      /*max_steps=*/100,
+      /*last_step_is_exact=*/true);
+  auto const tolerance_to_error_ratio =
+      std::bind(HarmonicOscillatorToleranceRatio,
+                _1, _2,
+                length_tolerance,
+                speed_tolerance,
+                step_size_callback);
+
+  auto const instance = integrator.NewInstance(problem,
+                                               append_state,
+                                               tolerance_to_error_ratio,
+                                               parameters);
+  auto const outcome = instance->Solve(t_final);
+
+  EXPECT_EQ(termination_condition::ReachedMaximalStepCount, outcome.error());
+  EXPECT_THAT(AbsoluteError(
+                  x_initial * Cos(ω * (solution.back().time.value - t_initial)),
+                      solution.back().positions[0].value),
+              IsNear(9.0e-4 * Metre));
+  EXPECT_THAT(AbsoluteError(
+                  -v_amplitude *
+                      Sin(ω * (solution.back().time.value - t_initial)),
+                  solution.back().velocities[0].value),
+              IsNear(1.9e-3 * Metre / Second));
+  EXPECT_THAT(solution.back().time.value, Lt(t_final));
+  EXPECT_EQ(100, solution.size());
+
+  // Check that a |max_steps| greater than or equal to the unconstrained number
+  // of steps has no effect.
+  for (std::int64_t const max_steps :
+       {steps_forward, steps_forward + 1234}) {
+    solution.clear();
+    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+        /*first_time_step=*/t_final - t_initial,
+        /*safety_factor=*/0.9,
+        /*max_steps=*/steps_forward,
+        /*last_step_is_exact=*/true);
+    auto const instance = integrator.NewInstance(problem,
+                                                 append_state,
+                                                 tolerance_to_error_ratio,
+                                                 parameters);
+    auto const outcome = instance->Solve(t_final);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+    EXPECT_THAT(AbsoluteError(x_initial, solution.back().positions[0].value),
+                IsNear(3.6e-4 * Metre));
+    EXPECT_THAT(AbsoluteError(v_initial, solution.back().velocities[0].value),
+                IsNear(2.8e-3 * Metre / Second));
+    EXPECT_EQ(t_final, solution.back().time.value);
+    EXPECT_EQ(steps_forward, solution.size());
+  }
+}
+
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Singularity) {
+  // Integrating the position of an ideal rocket,
+  //   x"(t) = m' I_sp / m(t),
+  //   x'(0) = 0, x(0) = 0,
+  // where m(t) = m₀ - t m'.
+  // The solution is
+  //   x(t)  = I_sp (t + (t - m₀ / m') log(m₀ / m(t))
+  //   x'(t) = I_sp log(m₀ / m(t)) (Циолко́вский's equation).
+  // There is a singularity at t = m₀ / m'.
+  Variation<Mass> const mass_flow = 1 * Kilogram / Second;
+  Mass const initial_mass = 1 * Kilogram;
+  SpecificImpulse const specific_impulse = 1 * Newton * Second / Kilogram;
+  Instant const t_initial;
+  Instant const t_singular = t_initial + initial_mass / mass_flow;
+  // After the singularity.
+  Instant const t_final = t_initial + 2 * initial_mass / mass_flow;
+  auto const mass = [initial_mass, t_initial, mass_flow](Instant const& t) {
+    return initial_mass - (t - t_initial) * mass_flow;
+  };
+
+  Length const length_tolerance = 1 * Milli(Metre);
+  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
+
+  std::vector<ODE::SystemState> solution;
+  ODE rocket_equation;
+  rocket_equation.compute_acceleration = [&mass, specific_impulse, mass_flow](
+      Instant const& t,
+      std::vector<Length> const& position,
+      std::vector<Acceleration>& acceleration) {
+    acceleration.back() = mass_flow * specific_impulse / mass(t);
+    return Status::OK;
+  };
+  IntegrationProblem<ODE> problem;
+  auto const append_state = [&solution](ODE::SystemState const& state) {
+    solution.push_back(state);
+  };
+  problem.equation = rocket_equation;
+  problem.initial_state = {{0 * Metre}, {0 * Metre / Second}, t_initial};
+  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+      /*first_time_step=*/t_final - t_initial,
+      /*safety_factor=*/0.9);
+  auto const tolerance_to_error_ratio = [length_tolerance, speed_tolerance](
+      Time const& h, ODE::SystemStateError const& error) {
+    return std::min(length_tolerance / Abs(error.position_error[0]),
+                    speed_tolerance / Abs(error.velocity_error[0]));
+  };
+
+  AdaptiveStepSizeIntegrator<ODE> const& integrator =
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+          methods::DormandالمكاوىPrince1986RKN434FM,
+          Length>();
+
+  auto const instance = integrator.NewInstance(problem,
+                                               append_state,
+                                               tolerance_to_error_ratio,
+                                               parameters);
+  auto const outcome = instance->Solve(t_final);
+
+  EXPECT_EQ(termination_condition::VanishingStepSize, outcome.error());
+  EXPECT_EQ(132, solution.size());
+  EXPECT_THAT(solution.back().time.value - t_initial,
+              AlmostEquals(t_singular - t_initial, 15));
+  EXPECT_THAT(solution.back().positions.back().value,
+              AlmostEquals(specific_impulse * initial_mass / mass_flow, 540));
+}
+
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Restart) {
+  AdaptiveStepSizeIntegrator<ODE> const& integrator =
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+          methods::DormandالمكاوىPrince1986RKN434FM,
+          Length>();
+  Length const x_initial = 1 * Metre;
+  Speed const v_initial = 0 * Metre / Second;
+  Speed const v_amplitude = 1 * Metre / Second;
+  Time const period = 2 * π * Second;
+  AngularFrequency const ω = 1 * Radian / Second;
+  Instant const t_initial;
+  Time const duration = 10 * period;
+  Length const length_tolerance = 1 * Milli(Metre);
+  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
+  // The number of steps if no step limit is set.
+  std::int64_t const steps_forward = 132;
+
+  auto const step_size_callback = [](bool tolerable) {};
+
+  std::vector<ODE::SystemState> solution1;
+  {
+    ODE harmonic_oscillator;
+    harmonic_oscillator.compute_acceleration =
+        std::bind(ComputeHarmonicOscillatorAcceleration1D,
+                  _1, _2, _3, /*evaluations=*/nullptr);
+    IntegrationProblem<ODE> problem;
+    problem.equation = harmonic_oscillator;
+    problem.initial_state = {{x_initial}, {v_initial}, t_initial};
+    auto const append_state = [&solution1](ODE::SystemState const& state) {
+      solution1.push_back(state);
+    };
+
+    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+        /*first_time_step=*/duration,
+        /*safety_factor=*/0.9,
+        /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
+        /*last_step_is_exact=*/false);
+    auto const tolerance_to_error_ratio =
+        std::bind(HarmonicOscillatorToleranceRatio,
+                  _1, _2,
+                  length_tolerance,
+                  speed_tolerance,
+                  step_size_callback);
+
+    auto const instance = integrator.NewInstance(problem,
+                                                 append_state,
+                                                 tolerance_to_error_ratio,
+                                                 parameters);
+    auto outcome = instance->Solve(t_initial + duration);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+
+    // Check that the time step has been updated.
+    EXPECT_EQ(131, solution1.size());
+    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
+                solution1[solution1.size() - 2].time.value,
+                AlmostEquals(0.00810677945075361400 * duration, 0));
+
+    // Restart the integration.
+    outcome = instance->Solve(t_initial + 2.0 * duration);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+
+    // Check that the time step has been updated again.
+    EXPECT_EQ(261, solution1.size());
+    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
+                solution1[solution1.size() - 2].time.value,
+                AlmostEquals(0.00805976959833537384 * duration, 0, 128));
+  }
+
+  // Do it again in one call to |Solve| and check associativity.
+  std::vector<ODE::SystemState> solution2;
+  {
+    ODE harmonic_oscillator;
+    harmonic_oscillator.compute_acceleration =
+        std::bind(ComputeHarmonicOscillatorAcceleration1D,
+                  _1, _2, _3, /*evaluations=*/nullptr);
+    IntegrationProblem<ODE> problem;
+    problem.equation = harmonic_oscillator;
+    problem.initial_state = {{x_initial}, {v_initial}, t_initial};
+    auto const append_state = [&solution2](ODE::SystemState const& state) {
+      solution2.push_back(state);
+    };
+
+    AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+        /*first_time_step=*/duration,
+        /*safety_factor=*/0.9,
+        /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
+        /*last_step_is_exact=*/false);
+    auto const tolerance_to_error_ratio =
+        std::bind(HarmonicOscillatorToleranceRatio,
+                  _1, _2,
+                  length_tolerance,
+                  speed_tolerance,
+                  step_size_callback);
+
+    auto const instance = integrator.NewInstance(problem,
+                                                 append_state,
+                                                 tolerance_to_error_ratio,
+                                                 parameters);
+    auto outcome = instance->Solve(t_initial + 2.0 * duration);
+    EXPECT_EQ(termination_condition::Done, outcome.error());
+  }
+
+  EXPECT_THAT(solution2, ElementsAreArray(solution1));
+}
+
+TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Serialization) {
+  AdaptiveStepSizeIntegrator<ODE> const& integrator =
+      EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
+          methods::DormandالمكاوىPrince1986RKN434FM,
+          Length>();
+  Length const x_initial = 1 * Metre;
+  Speed const v_initial = 0 * Metre / Second;
+  Time const period = 2 * π * Second;
+  Instant const t_initial;
+  Instant const t_final = t_initial + 10 * period;
+  Length const length_tolerance = 1 * Milli(Metre);
+  Speed const speed_tolerance = 1 * Milli(Metre) / Second;
+
+  auto const step_size_callback = [](bool tolerable) {};
+
+  std::vector<ODE::SystemState> solution;
+  ODE harmonic_oscillator;
+  harmonic_oscillator.compute_acceleration =
+      std::bind(ComputeHarmonicOscillatorAcceleration1D,
+                _1, _2, _3, /*evaluations=*/nullptr);
+  IntegrationProblem<ODE> problem;
+  problem.equation = harmonic_oscillator;
+  problem.initial_state = {{x_initial}, {v_initial}, t_initial};
+  auto const append_state = [&solution](ODE::SystemState const& state) {
+    solution.push_back(state);
+  };
+  AdaptiveStepSizeIntegrator<ODE>::Parameters const parameters(
+      /*first_time_step=*/t_final - t_initial,
+      /*safety_factor=*/0.9);
+  auto const tolerance_to_error_ratio =
+      std::bind(HarmonicOscillatorToleranceRatio,
+                _1, _2,
+                length_tolerance,
+                speed_tolerance,
+                step_size_callback);
+
+  auto const instance1 = integrator.NewInstance(problem,
+                                                append_state,
+                                                tolerance_to_error_ratio,
+                                                parameters);
+  serialization::IntegratorInstance message1;
+  instance1->WriteToMessage(&message1);
+  auto const instance2 =
+      AdaptiveStepSizeIntegrator<ODE>::Instance::ReadFromMessage(
+          message1,
+          harmonic_oscillator,
+          append_state,
+          tolerance_to_error_ratio);
+  serialization::IntegratorInstance message2;
+  instance2->WriteToMessage(&message2);
+  EXPECT_THAT(message1, EqualsProto(message2));
+}
+
+}  // namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator
+
+// Reopen this namespace to allow printing out the system state.
+namespace internal_ordinary_differential_equations {
+
+void PrintTo(
+    typename internal_embedded_explicit_generalized_runge_kutta_nyström_integrator::ODE::
+        SystemState const& system_state,
+    std::ostream* const out) {
+  *out << "\nTime: " << system_state.time << "\n";
+  *out << "Positions:\n";
+  for (int i = 0; i < system_state.positions.size(); ++i) {
+    *out << "  " << i << ": " << system_state.positions[i] << "\n";
+  }
+  *out << "Velocities:\n";
+  for (int i = 0; i < system_state.velocities.size(); ++i) {
+    *out << "  " << i << ": " << system_state.velocities[i] << "\n";
+  }
+}
+
+}  // namespace internal_ordinary_differential_equations
+
+}  // namespace integrators
+}  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -1,5 +1,4 @@
-﻿
-#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
+﻿#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -68,16 +67,20 @@ double ToleranceToErrorRatio(
 class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest
     : public ::testing::Test {};
 
+
 TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   AdaptiveStepSizeIntegrator<ODE> const& integrator =
       EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
           methods::Fine1987RKNG34,
           double>();
-  constexpr int degree = 15;
-  double const x_initial = 1;
-  Variation<double> const v_initial = -6435 / (2048 * Second);
+  // TODO(egg): Change that back to 15 once compiling LegendrePolynomial<15>
+  // becomes tractable.
+  constexpr int degree = 3;
+  double const x_initial = 0;
+  Variation<double> const v_initial =
+      -3 / (2 * Second);  // -6435 / (2048 * Second);
   Instant const t_initial;
-  Instant const t_final = t_initial + 1 * Second;
+  Instant const t_final = t_initial + 0.99 * Second;
   double const tolerance = 1e-6;
   Variation<double> const derivative_tolerance = 1e-6 / Second;
   int const steps_forward = 132;
@@ -141,6 +144,8 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
     max_error = std::max(max_error, error);
     max_derivative_error = std::max(max_derivative_error, derivative_error);
   }
+  EXPECT_THAT(max_error, IsNear(172e-6));
+  EXPECT_THAT(max_derivative_error, IsNear(4.54e-3 / Second));
 }
 
 }  // namespace internal_ordinary_differential_equations

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -44,7 +44,7 @@ using quantities::Variation;
 // See Dormand, El-Mikkawy and Prince (1986),
 // Families of Runge-Kutta-Nyström formulae, for an example.
 // Note that other notations exist for the weights:
-// المكاوى and رحمو‎ (2003), A new optimized non-FSAL embedded
+// El-Mikkawy and Rahmo (2003), A new optimized non-FSAL embedded
 // Runge–Kutta–Nystrom algorithm of orders 6 and 4 in six stages, and
 // Sommeijer (1993), Explicit, high-order Runge-Kutta-Nyström methods for
 // parallel computers, call the the velocity weights d instead of b′,

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -133,10 +133,10 @@ class EmbeddedExplicitRungeKuttaNyströmIntegrator
   static constexpr auto stages_ = Method::stages;
   static constexpr auto c_ = Method::c;
   static constexpr auto a_ = Method::a;
-  static constexpr auto b_hat_ = Method::b_hat;
-  static constexpr auto b_prime_hat_ = Method::b_prime_hat;
+  static constexpr auto b̂_ = Method::b̂;
+  static constexpr auto b̂ʹ_ = Method::b̂ʹ;
   static constexpr auto b_ = Method::b;
-  static constexpr auto b_prime_ = Method::b_prime;
+  static constexpr auto bʹ_ = Method::bʹ;
 };
 
 }  // namespace internal_embedded_explicit_runge_kutta_nyström_integrator

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -56,7 +56,7 @@ using quantities::Variation;
 
 // In the implementation, we follow Dormand, El-Mikkawy and Prince in calling
 // the results of the right-hand-side evaluations gᵢ.  The notations kᵢ or fᵢ
-// also appear in the litterature.
+// also appear in the literature.
 // Since we are interested in physical applications, we call the solution q and
 // its derivative v, rather than the more common y and y′ found in the
 // literature on Runge-Kutta-Nyström methods.

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -43,6 +43,11 @@ using quantities::Variation;
 //   b′ for the velocity weights of the low-order method.
 // See Dormand, El-Mikkawy and Prince (1986),
 // Families of Runge-Kutta-Nyström formulae, for an example.
+// Note that the velocity weights b′ are sometimes called d instead, e.g.,
+// المكاوى and رحمو‎ (2003), A new optimized non-FSAL embedded
+// Runge–Kutta–Nystrom algorithm of orders 6 and 4 in six stages, or
+// Sommeijer (1993), Explicit, high-order Runge-Kutta-Nyström methods for
+// parallel computers.
 // In the implementation, we follow Dormand, El-Mikkawy and Prince in calling
 // the results of the right-hand-side evaluations gᵢ.  The notations kᵢ or fᵢ
 // also appear in the litterature.

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -167,6 +167,8 @@ Instance::Solve(Instant const& t_final) {
         }
       }
 
+      Time const h² = h * h;
+
       // Runge-Kutta-Nyström iteration; fills |g|.
       for (int i = first_stage; i < stages_; ++i) {
         Instant const t_stage =
@@ -178,8 +180,7 @@ Instance::Solve(Instant const& t_final) {
           for (int j = 0; j < i; ++j) {
             Σj_a_ij_g_jk += a[i][j] * g[j][k];
           }
-          q_stage[k] =
-              q̂[k].value + h * (c[i] * v̂[k].value + h * Σj_a_ij_g_jk);
+          q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σj_a_ij_g_jk;
         }
         status.Update(equation.compute_acceleration(t_stage, q_stage, g[i]));
       }
@@ -199,8 +200,8 @@ Instance::Solve(Instant const& t_final) {
           Σi_bʹ_i_g_ik += bʹ[i] * g[i][k];
         }
         // The hat-less Δq and Δv are the low-order increments.
-        Δq̂[k]                   = h * (h * (Σi_b̂_i_g_ik) + v̂[k].value);
-        Displacement const Δq_k = h * (h * (Σi_b_i_g_ik) + v̂[k].value);
+        Δq̂[k]                   = h * v̂[k].value + h² * Σi_b̂_i_g_ik;
+        Displacement const Δq_k = h * v̂[k].value + h² * Σi_b_i_g_ik;
         Δv̂[k]                   = h * Σi_b̂ʹ_i_g_ik;
         Velocity const Δv_k     = h * Σi_bʹ_i_g_ik;
 

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -27,7 +27,7 @@ using quantities::Quotient;
 template<typename Method, typename Position>
 EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
 EmbeddedExplicitRungeKuttaNyströmIntegrator() {
-  // the first node is always 0 in an explicit method.
+  // The first node is always 0 in an explicit method.
   CHECK_EQ(0.0, c_[0]);
   if (first_same_as_last) {
     // Check that the conditions for the FSAL property are satisfied, see for
@@ -117,7 +117,7 @@ Instance::Solve(Instant const& t_final) {
 
   // The first stage of the Runge-Kutta-Nyström iteration.  In the FSAL case,
   // |first_stage == 1| after the first step, since the first RHS evaluation has
-  // already occured in the previous step.  In the non-FSAL case and in the
+  // already occurred in the previous step.  In the non-FSAL case and in the
   // first step of the FSAL case, |first_stage == 0|.
   int first_stage = 0;
 

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -167,7 +167,7 @@ Instance::Solve(Instant const& t_final) {
         }
       }
 
-      Time const h² = h * h;
+      auto const h² = h * h;
 
       // Runge-Kutta-Nyström iteration; fills |g|.
       for (int i = first_stage; i < stages_; ++i) {

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -34,9 +34,9 @@ EmbeddedExplicitRungeKuttaNyströmIntegrator() {
     // instance Dormand, El-Mikkawy and Prince (1986),
     // Families of Runge-Kutta-Nyström formulae, equation 3.1.
     CHECK_EQ(1.0, c_[stages_ - 1]);
-    CHECK_EQ(0.0, b_hat_[stages_ - 1]);
+    CHECK_EQ(0.0, b̂_[stages_ - 1]);
     for (int j = 0; j < stages_ - 1; ++j) {
-      CHECK_EQ(b_hat_[j], a_[stages_ - 1][j]);
+      CHECK_EQ(b̂_[j], a_[stages_ - 1][j]);
     }
   }
 }
@@ -49,10 +49,10 @@ Instance::Solve(Instant const& t_final) {
   using Acceleration = typename ODE::Acceleration;
 
   auto const& a = integrator_.a_;
-  auto const& b_hat = integrator_.b_hat_;
-  auto const& b_prime_hat = integrator_.b_prime_hat_;
+  auto const& b̂ = integrator_.b̂_;
+  auto const& b̂ʹ = integrator_.b̂ʹ_;
   auto const& b = integrator_.b_;
-  auto const& b_prime = integrator_.b_prime_;
+  auto const& bʹ = integrator_.bʹ_;
   auto const& c = integrator_.c_;
 
   auto& append_state = this->append_state_;
@@ -88,15 +88,15 @@ Instance::Solve(Instant const& t_final) {
   DoublePrecision<Instant>& t = current_state.time;
 
   // Position increment (high-order).
-  std::vector<Displacement> Δq_hat(dimension);
+  std::vector<Displacement> Δq̂(dimension);
   // Velocity increment (high-order).
-  std::vector<Velocity> Δv_hat(dimension);
+  std::vector<Velocity> Δv̂(dimension);
   // Current position.  This is a non-const reference whose purpose is to make
   // the equations more readable.
-  std::vector<DoublePrecision<Position>>& q_hat = current_state.positions;
+  std::vector<DoublePrecision<Position>>& q̂ = current_state.positions;
   // Current velocity.  This is a non-const reference whose purpose is to make
   // the equations more readable.
-  std::vector<DoublePrecision<Velocity>>& v_hat = current_state.velocities;
+  std::vector<DoublePrecision<Velocity>>& v̂ = current_state.velocities;
 
   // Difference between the low- and high-order approximations.
   typename ODE::SystemStateError error_estimate;
@@ -178,34 +178,34 @@ Instance::Solve(Instant const& t_final) {
           for (int j = 0; j < i; ++j) {
             Σj_a_ij_g_jk += a[i][j] * g[j][k];
           }
-          q_stage[k] = q_hat[k].value +
-                           h * (c[i] * v_hat[k].value + h * Σj_a_ij_g_jk);
+          q_stage[k] =
+              q̂[k].value + h * (c[i] * v̂[k].value + h * Σj_a_ij_g_jk);
         }
         status.Update(equation.compute_acceleration(t_stage, q_stage, g[i]));
       }
 
       // Increment computation and step size control.
       for (int k = 0; k < dimension; ++k) {
-        Acceleration Σi_b_hat_i_g_ik{};
+        Acceleration Σi_b̂_i_g_ik{};
         Acceleration Σi_b_i_g_ik{};
-        Acceleration Σi_b_prime_hat_i_g_ik{};
-        Acceleration Σi_b_prime_i_g_ik{};
+        Acceleration Σi_b̂ʹ_i_g_ik{};
+        Acceleration Σi_bʹ_i_g_ik{};
         // Please keep the eight assigments below aligned, they become illegible
         // otherwise.
         for (int i = 0; i < stages_; ++i) {
-          Σi_b_hat_i_g_ik       += b_hat[i] * g[i][k];
-          Σi_b_i_g_ik           += b[i] * g[i][k];
-          Σi_b_prime_hat_i_g_ik += b_prime_hat[i] * g[i][k];
-          Σi_b_prime_i_g_ik     += b_prime[i] * g[i][k];
+          Σi_b̂_i_g_ik  += b̂[i] * g[i][k];
+          Σi_b_i_g_ik  += b[i] * g[i][k];
+          Σi_b̂ʹ_i_g_ik += b̂ʹ[i] * g[i][k];
+          Σi_bʹ_i_g_ik += bʹ[i] * g[i][k];
         }
         // The hat-less Δq and Δv are the low-order increments.
-        Δq_hat[k]               = h * (h * (Σi_b_hat_i_g_ik) + v_hat[k].value);
-        Displacement const Δq_k = h * (h * (Σi_b_i_g_ik) + v_hat[k].value);
-        Δv_hat[k]               = h * Σi_b_prime_hat_i_g_ik;
-        Velocity const Δv_k     = h * Σi_b_prime_i_g_ik;
+        Δq̂[k]                   = h * (h * (Σi_b̂_i_g_ik) + v̂[k].value);
+        Displacement const Δq_k = h * (h * (Σi_b_i_g_ik) + v̂[k].value);
+        Δv̂[k]                   = h * Σi_b̂ʹ_i_g_ik;
+        Velocity const Δv_k     = h * Σi_bʹ_i_g_ik;
 
-        error_estimate.position_error[k] = Δq_k - Δq_hat[k];
-        error_estimate.velocity_error[k] = Δv_k - Δv_hat[k];
+        error_estimate.position_error[k] = Δq_k - Δq̂[k];
+        error_estimate.velocity_error[k] = Δv_k - Δv̂[k];
       }
       tolerance_to_error_ratio =
           this->tolerance_to_error_ratio_(h, error_estimate);
@@ -226,8 +226,8 @@ Instance::Solve(Instant const& t_final) {
     // Increment the solution with the high-order approximation.
     t.Increment(h);
     for (int k = 0; k < dimension; ++k) {
-      q_hat[k].Increment(Δq_hat[k]);
-      v_hat[k].Increment(Δv_hat[k]);
+      q̂[k].Increment(Δq̂[k]);
+      v̂[k].Increment(Δv̂[k]);
     }
     append_state(current_state);
     ++step_count;

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_test.cpp
@@ -382,9 +382,10 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest, Restart) {
 
     // Check that the time step has been updated.
     EXPECT_EQ(131, solution1.size());
-    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
-                solution1[solution1.size() - 2].time.value,
-                AlmostEquals(0.00810677945075361400 * duration, 0));
+    EXPECT_THAT(
+        solution1[solution1.size() - 1].time.value -
+            solution1[solution1.size() - 2].time.value,
+        AlmostEquals(0.509'363'975'335'290'320 * Second, 0));
 
     // Restart the integration.
     outcome = instance->Solve(t_initial + 2.0 * duration);
@@ -392,9 +393,10 @@ TEST_F(EmbeddedExplicitRungeKuttaNyströmIntegratorTest, Restart) {
 
     // Check that the time step has been updated again.
     EXPECT_EQ(261, solution1.size());
-    EXPECT_THAT(solution1[solution1.size() - 1].time.value -
-                solution1[solution1.size() - 2].time.value,
-                AlmostEquals(0.00805976959833537384 * duration, 0, 128));
+    EXPECT_THAT(
+        solution1[solution1.size() - 1].time.value -
+            solution1[solution1.size() - 2].time.value,
+        AlmostEquals(0.506'410'259'195'249'068 * Second, 0));
   }
 
   // Do it again in one call to |Solve| and check associativity.

--- a/integrators/integrators.hpp
+++ b/integrators/integrators.hpp
@@ -146,9 +146,8 @@ class AdaptiveStepSizeIntegrator : public Integrator<ODE_> {
   // In both cases, the new step size is chosen so as to try and make the
   // result of the next call to this functor close to |safety_factor|.
   using ToleranceToErrorRatio =
-      std::function<
-          double(Time const& current_step_size,
-                  typename ODE::SystemStateError const& error)>;
+      std::function<double(Time const& current_step_size,
+                           typename ODE::SystemStateError const& error)>;
 
   struct Parameters final {
     Parameters(Time first_time_step,

--- a/integrators/integrators.vcxproj
+++ b/integrators/integrators.vcxproj
@@ -14,6 +14,7 @@
     <ClInclude Include="cohen_hubbard_oesterwinter.hpp" />
     <ClInclude Include="cohen_hubbard_oesterwinter_body.hpp" />
     <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp" />
+    <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp" />
     <ClInclude Include="embedded_explicit_runge_kutta_nyström_integrator.hpp" />
     <ClInclude Include="embedded_explicit_runge_kutta_nyström_integrator_body.hpp" />
     <ClInclude Include="backward_difference.hpp" />

--- a/integrators/integrators.vcxproj
+++ b/integrators/integrators.vcxproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\base\status.cpp" />
+    <ClCompile Include="embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp" />
     <ClCompile Include="embedded_explicit_runge_kutta_nyström_integrator_test.cpp" />
     <ClCompile Include="symmetric_linear_multistep_integrator_test.cpp" />
     <ClCompile Include="symplectic_runge_kutta_nyström_integrator_test.cpp" />

--- a/integrators/integrators.vcxproj
+++ b/integrators/integrators.vcxproj
@@ -13,6 +13,7 @@
     <ClInclude Include="backward_difference_body.hpp" />
     <ClInclude Include="cohen_hubbard_oesterwinter.hpp" />
     <ClInclude Include="cohen_hubbard_oesterwinter_body.hpp" />
+    <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp" />
     <ClInclude Include="embedded_explicit_runge_kutta_nyström_integrator.hpp" />
     <ClInclude Include="embedded_explicit_runge_kutta_nyström_integrator_body.hpp" />
     <ClInclude Include="backward_difference.hpp" />

--- a/integrators/integrators.vcxproj.filters
+++ b/integrators/integrators.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClInclude Include="methods.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="embedded_explicit_runge_kutta_nyström_integrator_test.cpp">

--- a/integrators/integrators.vcxproj.filters
+++ b/integrators/integrators.vcxproj.filters
@@ -77,6 +77,9 @@
     <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="embedded_explicit_runge_kutta_nyström_integrator_test.cpp">

--- a/integrators/integrators.vcxproj.filters
+++ b/integrators/integrators.vcxproj.filters
@@ -94,5 +94,8 @@
     <ClCompile Include="symmetric_linear_multistep_integrator_test.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/integrators/integrators_body.hpp
+++ b/integrators/integrators_body.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/macros.hpp"
+#include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
 #include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/methods.hpp"
 #include "integrators/symmetric_linear_multistep_integrator.hpp"

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -374,7 +374,7 @@ struct Fine1987RKNG34 : EmbeddedExplicitGeneralizedRungeKuttaNyström {
       {  2 /   125.0,    0        , -27 /   625.0, 32 /   625.0,  -3 / 125.0}}};
 };
 
-// Coefficients from Dormand, المكاوى (El-Mikkawy), and Prince (1986),
+// Coefficients from Dormand, El-Mikkawy, and Prince (1986),
 // Families of Runge-Kutta-Nyström formulae, table 3 (the RK4(3)4FM).
 // Minimizes the 4th order truncation error.
 struct DormandالمكاوىPrince1986RKN434FM :
@@ -714,7 +714,7 @@ struct McLachlanAtela1992Order5Optimal : SymplecticRungeKuttaNyström {
 //   construction des tables astronomiques, in Mémoires de l'Académie Royale des
 //   Sciences de Turin, vol. V, Mémoires présentés à l'Académie, p. 143-180.
 //   http://www.biodiversitylibrary.org/item/32318#page/698/mode/1up.
-// - Størmer (1907), Sur les trajectoires des corpuscules électrisés dans
+// - Störmer (1907), Sur les trajectoires des corpuscules électrisés dans
 //   l'espace, avec application aux aurores boréales.
 //   https://hal.archives-ouvertes.fr/jpa-00242574/document.
 // - Verlet (1967) Computer "Experiments" on classical fluids. I.
@@ -866,10 +866,10 @@ struct Ruth1983 : SymplecticPartitionedRungeKutta {
       {{7.0 / 24.0, 3.0 / 4.0, -1.0 / 24.0}}};
 };
 
-// Coefficients from 鈴木 (Suzuki, 1990), Fractal decomposition of exponential
+// Coefficients from Suzuki (1990), Fractal decomposition of exponential
 // operators with applications to many-body theories and Monte Carlo
-// simulations; see also the Japanese version,
-// 量子系のフラクタル経路積分法 と量子コヒーレンス,
+// simulations; see also the Japanese version:
+// 鈴木 (1990), 量子系のフラクタル経路積分法 と量子コヒーレンス,
 // https://www.jstage.jst.go.jp/article/soken/82/3/82_KJ00004703731/_pdf.
 struct 鈴木1990 : SymplecticPartitionedRungeKutta {
   static constexpr int order = 4;
@@ -893,7 +893,7 @@ struct 鈴木1990 : SymplecticPartitionedRungeKutta {
                                                    +0.20724538589718786857}}};
 };
 
-// The following methods have coefficients from 吉田 (Yoshida, 1990),
+// The following methods have coefficients from Yoshida (1990),
 // Construction of higher order symplectic integrators
 // http://sixtrack.web.cern.ch/SixTrack/doc/yoshida00.pdf.
 // NOTE(egg): The coefficients were derived from equations 5.4 through 5.17

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -29,6 +29,9 @@ struct EmbeddedExplicitRungeKuttaNyström : not_constructible {
   // static constexpr FixedVector<double, stages> bʹ = ...;
 };
 
+// Every RKNG method is an RKN method by simply ignoring aʹ, hence the
+// inheritance.  Every RK method can be turned into an RKNG method, however this
+// requires a computation, so it is done explicitly.
 struct EmbeddedExplicitGeneralizedRungeKuttaNyström : EmbeddedExplicitRungeKuttaNyström {
   // static constexpr int higher_order = ...;
   // static constexpr int lower_order = ...;
@@ -42,6 +45,18 @@ struct EmbeddedExplicitGeneralizedRungeKuttaNyström : EmbeddedExplicitRungeKutt
   // static constexpr FixedVector<double, stages> b̂ʹ = ...;
   // static constexpr FixedVector<double, stages> b = ...;
   // static constexpr FixedVector<double, stages> bʹ = ...;
+};
+
+struct EmbeddedExplicitRungeKutta : not_constructible {
+  // static constexpr int higher_order = ...;
+  // static constexpr int lower_order = ...;
+  // static constexpr int stages = ...;
+  // static constexpr bool first_same_as_last = ...;
+  // static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind = ..;
+  // static constexpr FixedVector<double, stages> c = ...;
+  // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> a = ..;
+  // static constexpr FixedVector<double, stages> b̂ = ...;
+  // static constexpr FixedVector<double, stages> b = ...;
 };
 
 struct SymmetricLinearMultistep : not_constructible {

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -343,6 +343,37 @@ struct CandyRozmus1991ForestRuth1990 : SymplecticPartitionedRungeKutta {
                                                    +0.6756035959798288170}}};
 };
 
+// Coefficients from Fine (1987), Low order practical Methods.
+struct Fine1987RKNG34 : EmbeddedExplicitGeneralizedRungeKuttaNyström {
+  static constexpr int higher_order = 4;
+  static constexpr int lower_order = 3;
+  static constexpr int stages = 5;
+  static constexpr bool first_same_as_last = true;
+  static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind =
+      serialization::AdaptiveStepSizeIntegrator::
+          DORMAND_ELMIKKAWY_PRINCE_1986_RKN_434FM;
+  static constexpr FixedVector<double, stages> c{{
+      { 0           ,    2 /   9.0,   1 /     3.0,  3 /     4.0,  1.0}}};
+  static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> a{{
+      {  2 /    81.0,
+         1 /    36.0,    1 /  36.0,
+         9 /   128.0,    0        ,  27 /   128.0,
+        11 /    60.0,   -3 /  20.0,   9 /    25.0,  8 /    75.0}}};
+  static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> aʹ{{
+      {  2 /     9.0,
+         1 /    12.0,    1 /   4.0,
+        69 /   128.0, -234 / 128.0, 135 /    64.0,
+       -17 /    12.0,   27 /   4.0, -27 /     5.0, 16 /    15.0}}};
+  static constexpr FixedVector<double, stages> b̂{{
+      { 19 /   180.0,    0        ,  63 /   200.0, 16 /   225.0,   1 / 120.0}}};
+  static constexpr FixedVector<double, stages> b̂ʹ{{
+      {  1 /     9.0,    0        ,   9 /    20.0, 16 /    45.0,   1 /  12.0}}};
+  static constexpr auto b = b̂ - FixedVector<double, stages>{{
+      { 25 / 1'116.0,    0        , -63 / 1'240.0, 64 / 1'395.0, -13 / 744.0}}};
+  static constexpr auto bʹ = b̂ʹ - FixedVector<double, stages>{{
+      {  2 /   125.0,    0        , -27 /   625.0, 32 /   625.0,  -3 / 125.0}}};
+};
+
 // Coefficients from Dormand, المكاوى (El-Mikkawy), and Prince (1986),
 // Families of Runge-Kutta-Nyström formulae, table 3 (the RK4(3)4FM).
 // Minimizes the 4th order truncation error.

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -29,6 +29,21 @@ struct EmbeddedExplicitRungeKuttaNyström : not_constructible {
   // static constexpr FixedVector<double, stages> bʹ = ...;
 };
 
+struct EmbeddedExplicitGeneralizedRungeKuttaNyström : EmbeddedExplicitRungeKuttaNyström {
+  // static constexpr int higher_order = ...;
+  // static constexpr int lower_order = ...;
+  // static constexpr int stages = ...;
+  // static constexpr bool first_same_as_last = ...;
+  // static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind = ..;
+  // static constexpr FixedVector<double, stages> c = ...;
+  // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> a = ..;
+  // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> aʹ = ..;
+  // static constexpr FixedVector<double, stages> b̂ = ...;
+  // static constexpr FixedVector<double, stages> b̂ʹ = ...;
+  // static constexpr FixedVector<double, stages> b = ...;
+  // static constexpr FixedVector<double, stages> bʹ = ...;
+};
+
 struct SymmetricLinearMultistep : not_constructible {
   static constexpr int Half(int const order) {
     return order / 2 + 1;

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -23,10 +23,10 @@ struct EmbeddedExplicitRungeKuttaNyström : not_constructible {
   // static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind = ..;
   // static constexpr FixedVector<double, stages> c = ...;
   // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> a = ..;
-  // static constexpr FixedVector<double, stages> b_hat = ...;
-  // static constexpr FixedVector<double, stages> b_prime_hat = ...;
+  // static constexpr FixedVector<double, stages> b̂ = ...;
+  // static constexpr FixedVector<double, stages> b̂ʹ = ...;
   // static constexpr FixedVector<double, stages> b = ...;
-  // static constexpr FixedVector<double, stages> b_prime = ...;
+  // static constexpr FixedVector<double, stages> bʹ = ...;
 };
 
 struct SymmetricLinearMultistep : not_constructible {
@@ -331,13 +331,13 @@ struct DormandالمكاوىPrince1986RKN434FM :
       { 1.0 /   32.0,
         7.0 / 1000.0, 119.0 / 500.0,
         1.0 /   14.0,   8.0 /  27.0,  25.0 / 189.0}}};
-  static constexpr FixedVector<double, stages> b_hat{{
+  static constexpr FixedVector<double, stages> b̂{{
       { 1.0 /   14.0,   8.0 /  27.0,  25.0 / 189.0,  0.0}}};
-  static constexpr FixedVector<double, stages> b_prime_hat{{
+  static constexpr FixedVector<double, stages> b̂ʹ{{
       { 1.0 /   14.0,  32.0 /  81.0, 250.0 / 567.0,  5.0 / 54.0}}};
   static constexpr FixedVector<double, stages> b{{
       {-7.0 /  150.0,  67.0 / 150.0,   3.0 /  20.0, -1.0 / 20.0}}};
-  static constexpr FixedVector<double, stages> b_prime{{
+  static constexpr FixedVector<double, stages> bʹ{{
       {13.0 /   21.0, -20.0 /  27.0, 275.0 / 189.0, -1.0 /  3.0}}};
 };
 

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -32,7 +32,8 @@ struct EmbeddedExplicitRungeKuttaNyström : not_constructible {
 // Every RKNG method is an RKN method by simply ignoring aʹ, hence the
 // inheritance.  Every RK method can be turned into an RKNG method, however this
 // requires a computation, so it is done explicitly.
-struct EmbeddedExplicitGeneralizedRungeKuttaNyström : EmbeddedExplicitRungeKuttaNyström {
+struct EmbeddedExplicitGeneralizedRungeKuttaNyström
+    : EmbeddedExplicitRungeKuttaNyström {
   // static constexpr int higher_order = ...;
   // static constexpr int lower_order = ...;
   // static constexpr int stages = ...;
@@ -40,7 +41,7 @@ struct EmbeddedExplicitGeneralizedRungeKuttaNyström : EmbeddedExplicitRungeKutt
   // static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind = ..;
   // static constexpr FixedVector<double, stages> c = ...;
   // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> a = ..;
-  // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> aʹ = ..;
+  // static constexpr FixedStrictlyLowerTriangularMatrix<double, stages> aʹ = .;
   // static constexpr FixedVector<double, stages> b̂ = ...;
   // static constexpr FixedVector<double, stages> b̂ʹ = ...;
   // static constexpr FixedVector<double, stages> b = ...;

--- a/integrators/methods.hpp
+++ b/integrators/methods.hpp
@@ -348,7 +348,7 @@ struct Fine1987RKNG34 : EmbeddedExplicitGeneralizedRungeKuttaNyström {
   static constexpr int higher_order = 4;
   static constexpr int lower_order = 3;
   static constexpr int stages = 5;
-  static constexpr bool first_same_as_last = true;
+  static constexpr bool first_same_as_last = false;
   static constexpr serialization::AdaptiveStepSizeIntegrator::Kind kind =
       serialization::AdaptiveStepSizeIntegrator::
           DORMAND_ELMIKKAWY_PRINCE_1986_RKN_434FM;

--- a/integrators/ordinary_differential_equations.hpp
+++ b/integrators/ordinary_differential_equations.hpp
@@ -151,10 +151,10 @@ struct ExplicitSecondOrderOrdinaryDifferentialEquation final {
     std::vector<Velocity> velocity_error;
   };
 
-  // A functor that computes f(q, t) and stores it in |accelerations|.
+  // A functor that computes f(q, q′, t) and stores it in |accelerations|.
   // This functor must be called with |accelerations.size()| equal to
-  // |positions.size()|, but there is no requirement on the values in
-  // |accelerations|.
+  // |positions.size()| and |velocities.size()| but there is no requirement on
+  // the values in |accelerations|.
   RightHandSideComputation compute_acceleration;
 };
 

--- a/integrators/ordinary_differential_equations.hpp
+++ b/integrators/ordinary_differential_equations.hpp
@@ -219,6 +219,8 @@ struct IntegrationProblem final {
 
 using internal_ordinary_differential_equations::
     DecomposableFirstOrderDifferentialEquation;
+using internal_ordinary_differential_equations::
+    ExplicitSecondOrderOrdinaryDifferentialEquation;
 using internal_ordinary_differential_equations::IntegrationProblem;
 using internal_ordinary_differential_equations::
     SpecialSecondOrderDifferentialEquation;

--- a/integrators/ordinary_differential_equations.hpp
+++ b/integrators/ordinary_differential_equations.hpp
@@ -175,31 +175,11 @@ struct SpecialSecondOrderDifferentialEquation final {
                  std::vector<Position> const& positions,
                  std::vector<Acceleration>& accelerations)>;
 
-  struct SystemState final {
-    SystemState() = default;
-    SystemState(std::vector<Position> const& q,
-                std::vector<Velocity> const& v,
-                Instant const& t);
-
-    std::vector<DoublePrecision<Position>> positions;
-    std::vector<DoublePrecision<Velocity>> velocities;
-    DoublePrecision<Instant> time;
-
-    friend bool operator==(SystemState const& lhs, SystemState const& rhs) {
-      return lhs.positions == rhs.positions &&
-             lhs.velocities == rhs.velocities &&
-             lhs.time == rhs.time;
-    }
-
-    void WriteToMessage(not_null<serialization::SystemState*> message) const;
-    static SystemState ReadFromMessage(
-        serialization::SystemState const& message);
-  };
-
-  struct SystemStateError final {
-    std::vector<Displacement> position_error;
-    std::vector<Velocity> velocity_error;
-  };
+  using SystemState = typename ExplicitSecondOrderOrdinaryDifferentialEquation<
+      Position>::SystemState;
+  using SystemStateError =
+      typename ExplicitSecondOrderOrdinaryDifferentialEquation<
+          Position>::SystemStateError;
 
   // A functor that computes f(q, t) and stores it in |accelerations|.
   // This functor must be called with |accelerations.size()| equal to

--- a/integrators/ordinary_differential_equations_body.hpp
+++ b/integrators/ordinary_differential_equations_body.hpp
@@ -25,13 +25,6 @@ ExplicitSecondOrderOrdinaryDifferentialEquation<
     Position_>::SystemState::SystemState(std::vector<Position> const& q,
                                          std::vector<Velocity> const& v,
                                          Instant const& t)
-    : positions(q), velocities(v), time(t) {}
-
-template<typename Position_>
-SpecialSecondOrderDifferentialEquation<Position_>::SystemState::SystemState(
-    std::vector<Position> const& q,
-    std::vector<Velocity> const& v,
-    Instant const& t)
     : time(t) {
   for (int i = 0; i < q.size(); ++i) {
     positions.emplace_back(q[i]);
@@ -40,9 +33,8 @@ SpecialSecondOrderDifferentialEquation<Position_>::SystemState::SystemState(
 }
 
 template<typename Position>
-void
-SpecialSecondOrderDifferentialEquation<Position>::SystemState::WriteToMessage(
-        not_null<serialization::SystemState*> const message) const {
+void ExplicitSecondOrderOrdinaryDifferentialEquation<Position>::SystemState::
+    WriteToMessage(not_null<serialization::SystemState*> const message) const {
   for (auto const& position : positions) {
     position.WriteToMessage(message->add_position());
   }
@@ -53,9 +45,9 @@ SpecialSecondOrderDifferentialEquation<Position>::SystemState::WriteToMessage(
 }
 
 template<typename Position>
-typename SpecialSecondOrderDifferentialEquation<Position>::SystemState
-SpecialSecondOrderDifferentialEquation<Position>::SystemState::ReadFromMessage(
-        serialization::SystemState const& message) {
+typename ExplicitSecondOrderOrdinaryDifferentialEquation<Position>::SystemState
+ExplicitSecondOrderOrdinaryDifferentialEquation<Position>::SystemState::
+    ReadFromMessage(serialization::SystemState const& message) {
   SystemState system_state;
   for (auto const& p : message.position()) {
     system_state.positions.push_back(

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -11,6 +11,7 @@ namespace principia {
 namespace numerics {
 namespace internal_fixed_arrays {
 
+using quantities::Difference;
 using quantities::Product;
 
 template<typename Scalar, int rows, int columns>
@@ -86,6 +87,11 @@ class FixedMatrix final {
       FixedMatrix<L, r, c> const& left,
       FixedVector<R, c> const& right);
 };
+
+template<typename ScalarLeft, typename ScalarRight, int size>
+constexpr FixedVector<Difference<ScalarLeft, ScalarRight>, size> operator-(
+    FixedVector<ScalarLeft, size> const& left,
+    FixedVector<ScalarRight, size> const& right);
 
 template<typename ScalarLeft, typename ScalarRight, int rows, int columns>
 FixedVector<Product<ScalarLeft, ScalarRight>, rows> operator*(

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -150,6 +150,18 @@ FixedMatrix<Scalar, rows, columns>::row() const {
   return Row<r>(this);
 }
 
+template<typename ScalarLeft, typename ScalarRight, int size>
+constexpr FixedVector<Difference<ScalarLeft, ScalarRight>, size> operator-(
+    FixedVector<ScalarLeft, size> const& left,
+    FixedVector<ScalarRight, size> const& right) {
+  std::array<Difference<ScalarLeft, ScalarRight>, size> result{};
+  for (int i = 0; i < size; ++i) {
+    result[i] = left[i] - right[i];
+  }
+  return FixedVector<Difference<ScalarLeft, ScalarRight>, size>(
+      std::move(result));
+}
+
 template<typename ScalarLeft, typename ScalarRight, int rows, int columns>
 FixedVector<Product<ScalarLeft, ScalarRight>, rows> operator*(
     FixedMatrix<ScalarLeft, rows, columns> const& left,

--- a/numerics/legendre.hpp
+++ b/numerics/legendre.hpp
@@ -12,6 +12,9 @@ constexpr PolynomialInMonomialBasis<double, double, degree_, Evaluator>
 LegendrePolynomial();
 
 }  // namespace internal_legendre
+
+using internal_legendre::LegendrePolynomial;
+
 }  // namespace numerics
 }  // namespace principia
 

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -77,7 +77,7 @@ class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
 
   constexpr int degree() const override;
 
-  template<int order>
+  template<int order = 1>
   PolynomialInMonomialBasis<
       Derivative<Value, Argument, order>, Argument, degree_ - order, Evaluator>
   Derivative() const;

--- a/numerics/polynomial_evaluators_body.hpp
+++ b/numerics/polynomial_evaluators_body.hpp
@@ -16,9 +16,9 @@ constexpr int FloorOfPowerOf2(int const n) {
   return n == 0 ? 0 : n == 1 ? 1 : FloorOfPowerOf2(n >> 1) << 1;
 }
 
-// Ceiling log2 of n.  8 -> 3, 7 -> 2.
+// Ceiling log2 of n, or 0 for n = 0.  8 -> 3, 7 -> 2.
 constexpr int CeilingLog2(int const n) {
-  return n == 1 ? 0 : CeilingLog2(n >> 1) + 1;
+  return n == 0 ? 0 : n == 1 ? 0 : CeilingLog2(n >> 1) + 1;
 }
 
 }  // namespace
@@ -228,15 +228,19 @@ Derivative<Value, Argument>
 EstrinEvaluator<Value, Argument, degree>::EvaluateDerivative(
     Coefficients const& coefficients,
     Argument const& argument) {
-  using InternalEvaluator = InternalEstrinEvaluator<Value,
-                                                    Argument,
-                                                    degree,
-                                                    /*low=*/1,
-                                                    /*subdegree=*/degree - 1>;
-  return InternalEvaluator::EvaluateDerivative(
-      coefficients,
-      argument,
-      InternalEvaluator::ArgumentSquaresGenerator::Evaluate(argument));
+  if constexpr (degree == 0) {
+    return Derivative<Value, Argument>{};
+  } else {
+    using InternalEvaluator = InternalEstrinEvaluator<Value,
+                                                      Argument,
+                                                      degree,
+                                                      /*low=*/1,
+                                                      /*subdegree=*/degree - 1>;
+    return InternalEvaluator::EvaluateDerivative(
+        coefficients,
+        argument,
+        InternalEvaluator::ArgumentSquaresGenerator::Evaluate(argument));
+  }
 }
 
 // Internal helper for Horner evaluation.  |degree| is the degree of the overall

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ApsidesTest, ComputeNodes) {
                     .coordinates()
                     .ToSpherical()
                     .longitude,
-                AlmostEquals(elements.longitude_of_ascending_node, 2, 100));
+                AlmostEquals(elements.longitude_of_ascending_node, 1, 100));
     if (previous_time) {
       EXPECT_THAT(time - *previous_time, AlmostEquals(*elements.period, 0, 20));
     }
@@ -232,7 +232,7 @@ TEST_F(ApsidesTest, ComputeNodes) {
                 .coordinates()
                 .ToSpherical()
                 .longitude,
-        AlmostEquals(elements.longitude_of_ascending_node - π * Radian, 0, 25));
+        AlmostEquals(elements.longitude_of_ascending_node - π * Radian, 0, 26));
     if (previous_time) {
       EXPECT_THAT(time - *previous_time, AlmostEquals(*elements.period, 0, 29));
     }

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -482,7 +482,7 @@ TEST_P(EphemerisTest, EarthProbe) {
               AnyOf(Eq(410),    // MSVC Release
                     Eq(421)));  // MSVC Debug
   EXPECT_THAT(probe_positions.back().coordinates().x,
-              AlmostEquals(1.00 * period * v_probe, 230, 259));
+              AlmostEquals(1.00 * period * v_probe, 222, 259));
   EXPECT_THAT(probe_positions.back().coordinates().y,
               Eq(q_probe));
 

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -479,7 +479,8 @@ TEST_P(EphemerisTest, EarthProbe) {
   // The solution is a line, so the rounding errors dominate.  Different
   // libms result in different errors and thus different numbers of steps.
   EXPECT_THAT(probe_positions.size(),
-              AnyOf(Eq(395), Eq(414), Eq(434), Eq(438), Eq(450)));
+              AnyOf(Eq(410),    // MSVC Release
+                    Eq(421)));  // MSVC Debug
   EXPECT_THAT(probe_positions.back().coordinates().x,
               AlmostEquals(1.00 * period * v_probe, 230, 259));
   EXPECT_THAT(probe_positions.back().coordinates().y,

--- a/serialization/integrators.proto
+++ b/serialization/integrators.proto
@@ -84,7 +84,7 @@ message AdaptiveStepSizeIntegratorInstance {
   extend IntegratorInstance {
     optional AdaptiveStepSizeIntegratorInstance extension = 7001;
   }
-  extensions 9000 to 9999;  // Last used: 9000
+  extensions 9000 to 9999;  // Last used: 9001
   message Parameters {
     required Quantity first_time_step = 1;
     required double safety_factor = 2;
@@ -103,6 +103,13 @@ message EmbeddedExplicitRungeKuttaNystromIntegratorInstance {
   extend AdaptiveStepSizeIntegratorInstance {
     optional EmbeddedExplicitRungeKuttaNystromIntegratorInstance
         extension = 9000;
+  }
+}
+
+message EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance {
+  extend AdaptiveStepSizeIntegratorInstance {
+    optional EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance
+        extension = 9001;
   }
 }
 

--- a/testing_utilities/integration.hpp
+++ b/testing_utilities/integration.hpp
@@ -25,25 +25,13 @@ using quantities::Length;
 using quantities::Momentum;
 using quantities::Speed;
 using quantities::Time;
+using quantities::Variation;
 
 // Right-hand sides for various differential equations frequently used to test
 // the properties of integrators.
 
-// The one-dimensional unit harmonic oscillator,
-//   q' = p / m,  |ComputeHarmonicOscillatorVelocity|,
-//   p' = -k q, |ComputeHarmonicOscillatorForce|,
-// where m = 1 kg, k = 1 N / m.
-
-void ComputeHarmonicOscillatorForce(Time const& t,
-                                    std::vector<Length> const& q,
-                                    std::vector<Force>& result);
-
-void ComputeHarmonicOscillatorVelocity(
-    std::vector<Momentum> const& p,
-    std::vector<Speed>& result);
-
 // The Runge-Kutta-Nyström formulation
-//   q" = -q k / m.
+//   qʺ = -q k / m.
 Status ComputeHarmonicOscillatorAcceleration1D(
     Instant const& t,
     std::vector<Length> const& q,
@@ -67,21 +55,37 @@ Status ComputeKeplerAcceleration(Instant const& t,
                                  std::vector<Acceleration>& result,
                                  int* evaluations);
 
-template<typename Frame>
-void ComputeGravitationalAcceleration(
-    Time const& t,
-    std::vector<Position<Frame>> const& q,
-    std::vector<Vector<Acceleration, Frame>>& result,
-    std::vector<MassiveBody> const& bodies);
+// The right-hand side of the Чебышёв differential equation, with the
+// independent variable scaled so that the interval [-1, 1] maps to
+// [J2000 - 1 s, J2000 + 1 s].
+// ч, чʹ, and чʺ must have size 1.
+template<int degree>
+Status ComputeЧебышёвPolynomialSecondDerivative(
+    Instant const& t,
+    std::vector<double> const& ч,
+    std::vector<Variation<double>> const& чʹ,
+    std::vector<Variation<Variation<double>>>& чʺ,
+    int* evaluations);
+
+// The right-hand side of the Legendre differential equation, with the
+// independent variable scaled so that the interval [-1, 1] maps to
+// [J2000 - 1 s, J2000 + 1 s].
+// p, pʹ, and pʺ must have size 1.
+template<int degree>
+Status ComputeLegendrePolynomialSecondDerivative(
+    Instant const& t,
+    std::vector<double> const& p,
+    std::vector<Variation<double>> const& pʹ,
+    std::vector<Variation<Variation<double>>>& pʺ,
+    int* evaluations);
 
 }  // namespace internal_integration
 
-using internal_integration::ComputeGravitationalAcceleration;
+using internal_integration::ComputeЧебышёвPolynomialSecondDerivative;
 using internal_integration::ComputeHarmonicOscillatorAcceleration1D;
 using internal_integration::ComputeHarmonicOscillatorAcceleration3D;
-using internal_integration::ComputeHarmonicOscillatorForce;
-using internal_integration::ComputeHarmonicOscillatorVelocity;
 using internal_integration::ComputeKeplerAcceleration;
+using internal_integration::ComputeLegendrePolynomialSecondDerivative;
 
 }  // namespace testing_utilities
 }  // namespace principia

--- a/testing_utilities/integration_body.hpp
+++ b/testing_utilities/integration_body.hpp
@@ -82,9 +82,9 @@ Status ComputeЧебышёвPolynomialSecondDerivative(
     std::vector<Variation<Variation<double>>>& чʺ,
     int* evaluations) {
   constexpr int n² = degree * degree;
-  constexpr Time s² = Pow<2>(Second);
+  constexpr auto s² = Pow<2>(Second);
   Time const x = (t - J2000);
-  Time const x² = x * x;
+  auto const x² = x * x;
   чʺ[0] = (x * чʹ[0] - n² * ч[0]) / (1 * s² - x²);
   if (evaluations != nullptr) {
     ++*evaluations;
@@ -100,7 +100,9 @@ Status ComputeLegendrePolynomialSecondDerivative(
     std::vector<Variation<Variation<double>>>& pʺ,
     int* evaluations) {
   constexpr int n = degree;
+  constexpr auto s² = Pow<2>(Second);
   Time const x = (t - J2000);
+  auto const x² = x * x;
   pʺ[0] = (2 * x * pʹ[0] - n * (n + 1) * p[0]) / (1 * s² - x²);
   if (evaluations != nullptr) {
     ++*evaluations;

--- a/testing_utilities/integration_body.hpp
+++ b/testing_utilities/integration_body.hpp
@@ -5,6 +5,7 @@
 
 #include "testing_utilities/integration.hpp"
 
+#include "astronomy/epoch.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/named_quantities.hpp"
@@ -13,6 +14,7 @@ namespace principia {
 namespace testing_utilities {
 namespace internal_integration {
 
+using astronomy::J2000;
 using geometry::Displacement;
 using geometry::InnerProduct;
 using quantities::Exponentiation;
@@ -28,19 +30,7 @@ using quantities::Sqrt;
 using quantities::Square;
 using quantities::Stiffness;
 using quantities::Time;
-
-inline void ComputeHarmonicOscillatorForce(
-    Time const& t,
-    std::vector<Length> const& q,
-    std::vector<Force>& result) {
-  result[0] = -q[0] * SIUnit<Stiffness>();
-}
-
-inline void ComputeHarmonicOscillatorVelocity(
-    std::vector<Momentum> const& p,
-    std::vector<Speed>& result) {
-  result[0] = p[0] / SIUnit<Mass>();
-}
+using quantities::si::Second;
 
 inline Status ComputeHarmonicOscillatorAcceleration1D(
     Instant const& t,
@@ -83,33 +73,39 @@ inline Status ComputeKeplerAcceleration(
   return Status::OK;
 }
 
-template<typename Frame>
-void ComputeGravitationalAcceleration(
-    Time const& t,
-    std::vector<Position<Frame>> const& q,
-    std::vector<Vector<Acceleration, Frame>>& result,
-    std::vector<MassiveBody> const& bodies) {
-  result.assign(result.size(), Vector<Acceleration, Frame>());
-  for (int b1 = 1; b1 < q.size(); ++b1) {
-    GravitationalParameter const& μ1 = bodies[b1].gravitational_parameter();
-    for (int b2 = 0; b2 < b1; ++b2) {
-      Displacement<Frame> const Δq = q[b1] - q[b2];
-      Square<Length> const r² = Δq.Norm²();
-      Exponentiation<Length, -3> const one_over_r³ = Sqrt(r²) / (r² * r²);
-      {
-        auto const μ1_over_r³ = μ1 * one_over_r³;
-        result[b2] += Δq * μ1_over_r³;
-      }
-      // Lex. III. Actioni contrariam semper & æqualem esse reactionem:
-      // sive corporum duorum actiones in se mutuo semper esse æquales &
-      // in partes contrarias dirigi.
-      {
-        GravitationalParameter const& μ2 = bodies[b2].gravitational_parameter();
-        auto const μ2_over_r³ = μ2 * one_over_r³;
-        result[b1] -= Δq * μ2_over_r³;
-      }
-    }
+
+template<int degree>
+Status ComputeЧебышёвPolynomialSecondDerivative(
+    Instant const& t,
+    std::vector<double> const& ч,
+    std::vector<Variation<double>> const& чʹ,
+    std::vector<Variation<Variation<double>>>& чʺ,
+    int* evaluations) {
+  constexpr int n² = degree * degree;
+  constexpr Time s² = Pow<2>(Second);
+  Time const x = (t - J2000);
+  Time const x² = x * x;
+  чʺ[0] = (x * чʹ[0] - n² * ч[0]) / (1 * s² - x²);
+  if (evaluations != nullptr) {
+    ++*evaluations;
   }
+  return Status::OK;
+}
+
+template<int degree>
+Status ComputeLegendrePolynomialSecondDerivative(
+    Instant const& t,
+    std::vector<double> const& p,
+    std::vector<Variation<double>> const& pʹ,
+    std::vector<Variation<Variation<double>>>& pʺ,
+    int* evaluations) {
+  constexpr int n = degree;
+  Time const x = (t - J2000);
+  pʺ[0] = (2 * x * pʹ[0] - n * (n + 1) * p[0]) / (1 * s² - x²);
+  if (evaluations != nullptr) {
+    ++*evaluations;
+  }
+  return Status::OK;
 }
 
 }  // namespace internal_integration


### PR DESCRIPTION
First cut, more tests to come (probably for the RKN too, the existing tests don't check the order).

Fix a bug in EstrinEvaluator (could not evaluate constants).

It may make sense to factor the implementations of the RKN and RKNG method with some template magic to ignore the a′ in the former.