### PR TITLE
Optimize the geopotential computations by removing Pow and trig functions

### DIFF
--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -43,9 +43,6 @@ class Geopotential {
       Exponentiation<Length, -3> const& one_over_r³) const;
 
  private:
-  // Holds precomputed data for one evaluation of the acceleration.
-  struct Precomputations;
-
   // The frame of the surface of the celestial.
   struct SurfaceFrame;
   static const Vector<double, SurfaceFrame> x_;
@@ -53,13 +50,15 @@ class Geopotential {
 
   using UnitVector = Vector<double, Frame>;
 
+  // Holds precomputed data for one evaluation of the acceleration.
+  template<int size>
+  struct Precomputations;
+
   // Helper templates for iterating over the degrees/orders of the geopotential.
-  template<int degree, int order>
+  template<int size, int degree, int order>
   struct DegreeNOrderM;
-
-  template<int degree, typename>
+  template<int size, int degree, typename>
   struct DegreeNAllOrders;
-
   template<typename>
   struct AllDegrees;
 

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -301,13 +301,19 @@ Geopotential<Frame>::AllDegrees<std::integer_sequence<int, degrees...>>::
 
   precomputations.r² = r²;
   r_norm = Sqrt(r²);
-  Angle const λ = ArcTan(y, x);
-  double const cos_λ = Cos(λ);
-  double const sin_λ = Sin(λ);
 
   Square<Length> const x²_plus_y² = x * x + y * y;
+  Length const r_equatorial = Sqrt(x²_plus_y²);
+
+  double cos_λ = 1;
+  double sin_λ = 0;
+  if (r_equatorial > Length{}) {
+    cos_λ = x / r_equatorial;
+    sin_λ = y / r_equatorial;
+  }
+
   sin_β = z / r_norm;
-  cos_β = Sqrt(x²_plus_y²) / r_norm;
+  cos_β = r_equatorial / r_norm;
 
   grad_𝔅_vector = (-sin_β * cos_λ * x̂ - sin_β * sin_λ * ŷ + cos_β * ẑ) / r_norm;
   grad_𝔏_vector = (-sin_λ * x̂ + cos_λ * ŷ) / r_norm;

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -250,7 +250,7 @@ TEST_F(GeopotentialTest, VerifyJ2) {
         geopotential1, Instant(), displacement);
     auto const acceleration2 = GeneralSphericalHarmonicsAcceleration(
         geopotential2, Instant(), displacement);
-    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 182019));
+    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 182020));
   }
   {
     Displacement<World> const displacement(
@@ -411,7 +411,7 @@ TEST_F(GeopotentialTest, VerifyJ3) {
         geopotential1, Instant(), displacement);
     auto const acceleration2 = GeneralSphericalHarmonicsAcceleration(
         geopotential2, Instant(), displacement);
-    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 264755));
+    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 264756));
   }
   {
     Displacement<World> const displacement(

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -352,7 +352,7 @@ TEST_F(GeopotentialTest, VerifyS22) {
         geopotential1, Instant(), displacement);
     auto const acceleration2 = GeneralSphericalHarmonicsAcceleration(
         geopotential2, Instant(), displacement);
-    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 14));
+    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 17));
   }
   {
     Displacement<World> const displacement(
@@ -361,7 +361,7 @@ TEST_F(GeopotentialTest, VerifyS22) {
         geopotential1, Instant(), displacement);
     auto const acceleration2 = GeneralSphericalHarmonicsAcceleration(
         geopotential2, Instant(), displacement);
-    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 5, 6));
+    EXPECT_THAT(acceleration2, AlmostEquals(acceleration1, 0, 1));
   }
 }
 


### PR DESCRIPTION
New benchmark:
```
Run on (4 X 3310 MHz CPU s)
09/29/18 00:24:58
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2      241652 ns     242489 ns      11966
BM_ComputeGeopotentialCpp/3      310604 ns     309429 ns       8974
BM_ComputeGeopotentialCpp/5      616819 ns     615382 ns       4487
BM_ComputeGeopotentialCpp/10    3579013 ns    3580023 ns        780
BM_ComputeGeopotentialF90/2       72471 ns      72365 ns      39019
BM_ComputeGeopotentialF90/3      111243 ns     111694 ns      25280
BM_ComputeGeopotentialF90/5      200372 ns     201117 ns      13807
BM_ComputeGeopotentialF90/10     690917 ns     692233 ns       4079
```
which fits `601929 - 285083 n + 58270 n²`.