### PR TITLE
Micro-optimizations of the geopotential computations

### DIFF
--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -55,9 +55,7 @@ GeneralSphericalHarmonicsAccelerationCpp(
     Instant const& t,
     Displacement<Frame> const& r) {
   auto const r² = r.Norm²();
-  auto const one_over_r³ = 1.0 / (r² * r.Norm());
-  return geopotential.GeneralSphericalHarmonicsAcceleration(
-              t, r, r², one_over_r³);
+  return geopotential.GeneralSphericalHarmonicsAcceleration(t, r, r²);
 }
 
 // For fairness, the Fortran implementation is wrapped to have the same API as

--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -73,7 +73,8 @@ GeneralSphericalHarmonicsAccelerationF90(
     Instant const& t,
     Displacement<Frame> const& r) {
   struct SurfaceFrame;
-  auto const to_surface_frame = body->ToSurfaceFrame<SurfaceFrame>(t);
+  auto const from_surface_frame = body->FromSurfaceFrame<SurfaceFrame>(t);
+  auto const to_surface_frame = from_surface_frame.Inverse();
 
   Displacement<SurfaceFrame> const r_surface = to_surface_frame(r);
   auto const acceleration_surface =
@@ -82,7 +83,7 @@ GeneralSphericalHarmonicsAccelerationF90(
           astronomy::fortran_astrodynamics_toolkit::
               ComputeGravityAccelerationLear<degree, order>(
                   r_surface.coordinates() / Metre, mu, rbar, cnm, snm));
-  return to_surface_frame.Inverse()(acceleration_surface);
+  return from_surface_frame(acceleration_surface);
 }
 
 OblateBody<ICRS> MakeEarthBody(SolarSystem<ICRS> const& solar_system,

--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -45,15 +45,17 @@ class Geopotential {
  private:
   // The frame of the surface of the celestial.
   struct SurfaceFrame;
-  static const Vector<double, SurfaceFrame> x_;
-  static const Vector<double, SurfaceFrame> y_;
 
-  using UnitVector = Vector<double, Frame>;
+  // This is the type that we return, so better have a name for it.
+  using ReducedAcceleration = Quotient<Acceleration, GravitationalParameter>;
 
+  // List of reduced accelerations computed for all degrees or orders.
   template<int size>
   using Accelerations =
-      std::array<Vector<Quotient<Acceleration, GravitationalParameter>, Frame>,
-                 size>;
+      std::array<Vector<ReducedAcceleration, SurfaceFrame>, size>;
+
+  template<typename F>
+  using UnitVector = Vector<double, F>;
 
   // Holds precomputed data for one evaluation of the acceleration.
   template<int size>
@@ -81,7 +83,7 @@ class Geopotential {
   // https://en.wikipedia.org/wiki/Geopotential_model which seems to want J̃₂ to
   // be negative.
   Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
-  Degree2ZonalAcceleration(UnitVector const& axis,
+  Degree2ZonalAcceleration(UnitVector<Frame> const& axis,
                            Displacement<Frame> const& r,
                            Exponentiation<Length, -2> const& one_over_r²,
                            Exponentiation<Length, -3> const& one_over_r³) const;

--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -39,8 +39,7 @@ class Geopotential {
   GeneralSphericalHarmonicsAcceleration(
       Instant const& t,
       Displacement<Frame> const& r,
-      Square<Length> const& r²,
-      Exponentiation<Length, -3> const& one_over_r³) const;
+      Square<Length> const& r²) const;
 
  private:
   // The frame of the surface of the celestial.

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -300,16 +300,13 @@ Acceleration(OblateBody<Frame> const& body,
 
   auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
 
-  cos = &body.cos();
-  sin = &body.sin();
-
   R3Element<Length> r_surface_coordinates = r_surface.coordinates();
   Length const x = r_surface_coordinates.x;
   Length const y = r_surface_coordinates.y;
   Length const z = r_surface_coordinates.z;
 
-  Length const r_norm = Sqrt(r²);
   auto const r_over_r² = r_surface / r²;
+  Length const r_norm = Sqrt(r²);
   Inverse<Length> const one_over_r_norm = 1 / r_norm;
 
   Square<Length> const x²_plus_y² = x * x + y * y;
@@ -323,8 +320,11 @@ Acceleration(OblateBody<Frame> const& body,
     sin_λ = y * one_over_r_equatorial;
   }
 
-  sin_β = z * one_over_r_norm;
+  cos = &body.cos();
+  sin = &body.sin();
+
   cos_β = r_equatorial * one_over_r_norm;
+  sin_β = z * one_over_r_norm;
 
   grad_𝔅_vector = UnitVector<SurfaceFrame>({-sin_β * cos_λ,
                                             -sin_β * sin_λ,

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -70,7 +70,8 @@ struct Geopotential<Frame>::Precomputations {
 template<typename Frame>
 template<int size, int degree, int order>
 struct Geopotential<Frame>::DegreeNOrderM {
-  static Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
+  FORCE_INLINE(static)
+  Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
   Acceleration(OblateBody<Frame> const& body,
                Displacement<Frame> const& r,
                Precomputations<size>& precomputations);

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -74,8 +74,7 @@ template<int size, int degree, int order>
 struct Geopotential<Frame>::DegreeNOrderM {
   FORCE_INLINE(static)
   Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
-  Acceleration(OblateBody<Frame> const& body,
-               Displacement<Frame> const& r,
+  Acceleration(Displacement<Frame> const& r,
                Precomputations<size>& precomputations);
 };
 
@@ -84,8 +83,7 @@ template<int size, int degree, int... orders>
 struct Geopotential<Frame>::
 DegreeNAllOrders<size, degree, std::integer_sequence<int, orders...>> {
   static Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
-  Acceleration(OblateBody<Frame> const& body,
-               Displacement<Frame> const& r,
+  Acceleration(Displacement<Frame> const& r,
                Precomputations<size>& precomputations);
 };
 
@@ -104,7 +102,6 @@ template<typename Frame>
 template<int size, int degree, int order>
 Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
 Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
-    OblateBody<Frame> const& body,
     Displacement<Frame> const& r,
     Precomputations<size>& precomputations) {
   if constexpr (degree == 2 && order == 1) {
@@ -253,9 +250,8 @@ template<int size, int degree, int... orders>
 Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
 Geopotential<Frame>::
 DegreeNAllOrders<size, degree, std::integer_sequence<int, orders...>>::
-Acceleration(OblateBody<Frame> const& body,
-              Displacement<Frame> const& r,
-              Precomputations<size>& precomputations) {
+Acceleration(Displacement<Frame> const& r,
+             Precomputations<size>& precomputations) {
   if constexpr (degree < 2) {
     return {};
   } else {
@@ -285,8 +281,8 @@ Acceleration(OblateBody<Frame> const& body,
 
     // Force the evaluation by increasing order using an initializer list.
     Accelerations<size> const accelerations = {
-        DegreeNOrderM<size, degree, orders>::Acceleration(
-            body, r, precomputations)...};
+        DegreeNOrderM<size, degree, orders>::
+            Acceleration(r, precomputations)...};
 
     return (accelerations[orders] + ...);
   }
@@ -383,7 +379,7 @@ Geopotential<Frame>::AllDegrees<std::integer_sequence<int, degrees...>>::
       DegreeNAllOrders<size,
                        degrees,
                        std::make_integer_sequence<int, degrees + 1>>::
-          Acceleration(body, r, precomputations)...};
+          Acceleration(r, precomputations)...};
 
   return (accelerations[degrees] + ...);
 }

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -65,6 +65,8 @@ struct Geopotential<Frame>::Precomputations {
   // These quantities depend on both n and m.  Note that the zeros for m > n are
   // not stored.
   FixedLowerTriangularMatrix<double, size> DmPn_of_sin_β;
+  typename OblateBody<Frame>::GeopotentialCoefficients const* cos;
+  typename OblateBody<Frame>::GeopotentialCoefficients const* sin;
 };
 
 template<typename Frame>
@@ -143,6 +145,8 @@ Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
     auto& cos_β_to_the_m = precomputations.cos_β_to_the_m[m];
 
     auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
+    auto const& cos = precomputations.cos;
+    auto const& sin = precomputations.sin;
 
     // The fold expressions in the caller ensures that we process n and m by
     // increasing values.  Thus, only the last value of m needs to be
@@ -225,8 +229,8 @@ Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
     Vector<Inverse<Length>, Frame> const grad_𝔅 =
         grad_𝔅_polynomials * grad_𝔅_vector;
 
-    double const Cnm = body.cos()[n][m];
-    double const Snm = body.sin()[n][m];
+    double const Cnm = (*cos)[n][m];
+    double const Snm = (*sin)[n][m];
     double const 𝔏 = Cnm * cos_mλ + Snm * sin_mλ;
 
     Vector<Inverse<Length>, Frame> 𝔅_grad_𝔏;
@@ -328,6 +332,8 @@ Geopotential<Frame>::AllDegrees<std::integer_sequence<int, degrees...>>::
   auto& cos_β_to_the_1 = precomputations.cos_β_to_the_m[1];
 
   auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
+  auto& cos = precomputations.cos;
+  auto& sin = precomputations.sin;
 
   x̂ = from_surface_frame(x_);
   ŷ = from_surface_frame(y_);
@@ -369,6 +375,8 @@ Geopotential<Frame>::AllDegrees<std::integer_sequence<int, degrees...>>::
   DmPn_of_sin_β[0][0] = 1;
   DmPn_of_sin_β[1][0] = sin_β;
   DmPn_of_sin_β[1][1] = 1;
+  cos = &body.cos();
+  sin = &body.sin();
 
   // Force the evaluation by increasing degree using an initializer list.
   Accelerations<size> const accelerations = {

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -74,8 +74,7 @@ template<int size, int degree, int order>
 struct Geopotential<Frame>::DegreeNOrderM {
   FORCE_INLINE(static)
   Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
-  Acceleration(Displacement<Frame> const& r,
-               Precomputations<size>& precomputations);
+  Acceleration(Precomputations<size>& precomputations);
 };
 
 template<typename Frame>
@@ -102,7 +101,6 @@ template<typename Frame>
 template<int size, int degree, int order>
 Vector<Quotient<Acceleration, GravitationalParameter>, Frame>
 Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
-    Displacement<Frame> const& r,
     Precomputations<size>& precomputations) {
   if constexpr (degree == 2 && order == 1) {
     // Let's not forget the Legendre derivative that we would compute if we did
@@ -281,8 +279,7 @@ Acceleration(Displacement<Frame> const& r,
 
     // Force the evaluation by increasing order using an initializer list.
     Accelerations<size> const accelerations = {
-        DegreeNOrderM<size, degree, orders>::
-            Acceleration(r, precomputations)...};
+        DegreeNOrderM<size, degree, orders>::Acceleration(precomputations)...};
 
     return (accelerations[orders] + ...);
   }

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -278,8 +278,8 @@ Acceleration(OblateBody<Frame> const& body,
               Square<Length> const& r²,
               Exponentiation<Length, -3> const& one_over_r³) {
   constexpr int size = sizeof...(degrees);
-  auto const to_surface_frame = body.ToSurfaceFrame<SurfaceFrame>(t);
-  auto const from_surface_frame = to_surface_frame.Inverse();
+  auto const from_surface_frame = body.FromSurfaceFrame<SurfaceFrame>(t);
+  auto const to_surface_frame = from_surface_frame.Inverse();
   Displacement<SurfaceFrame> const r_surface = to_surface_frame(r);
 
   Precomputations<size> precomputations;

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -108,13 +108,13 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
     static double const normalization_factor =
         LegendreNormalizationFactor(n, m);
 
-    auto const& cos_β = precomputations.cos_β;
-    auto const& sin_β = precomputations.sin_β;
+    double const cos_β = precomputations.cos_β;
+    double const sin_β = precomputations.sin_β;
 
     auto const& grad_𝔅_vector = precomputations.grad_𝔅_vector;
     auto const& grad_𝔏_vector = precomputations.grad_𝔏_vector;
 
-    auto const& ℜ = precomputations.ℜ[n];
+    Inverse<Length> const ℜ = precomputations.ℜ[n];
     auto const& grad_ℜ = precomputations.grad_ℜ;
 
     auto& cos_mλ = precomputations.cos_mλ[m];
@@ -123,8 +123,8 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
     auto& cos_β_to_the_m = precomputations.cos_β_to_the_m[m];
 
     auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
-    auto const& cos = precomputations.cos;
-    auto const& sin = precomputations.sin;
+    auto const& cos = *precomputations.cos;
+    auto const& sin = *precomputations.sin;
 
     // The caller ensures that we process n and m by increasing values.  Thus,
     // only the last value of m needs to be initialized for a given value of n.
@@ -204,8 +204,8 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
           m * sin_β * cos_β_to_the_m_minus_1 * DmPn_of_sin_β[n][m];
     }
 
-    double const Cnm = (*cos)[n][m];
-    double const Snm = (*sin)[n][m];
+    double const Cnm = cos[n][m];
+    double const Snm = sin[n][m];
     double const 𝔏 = Cnm * cos_mλ + Snm * sin_mλ;
 
     Vector<ReducedAcceleration, SurfaceFrame> const 𝔅𝔏_grad_ℜ =

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -36,10 +36,6 @@ template<typename Frame>
 template<int size>
 struct Geopotential<Frame>::Precomputations {
   // These quantities are independent from n and m.
-  Length x;
-  Length y;
-  Length z;
-
   Square<Length> r²;
   Length r_norm;
 
@@ -109,10 +105,6 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
     static_assert(0 <= m && m <= n);
     static double const normalization_factor =
         LegendreNormalizationFactor(n, m);
-
-    auto const& x = precomputations.x;
-    auto const& y = precomputations.y;
-    auto const& z = precomputations.z;
 
     auto const& r² = precomputations.r²;
     auto const& r_norm = precomputations.r_norm;
@@ -291,10 +283,6 @@ Acceleration(OblateBody<Frame> const& body,
 
   Precomputations<size> precomputations;
 
-  auto& x = precomputations.x;
-  auto& y = precomputations.y;
-  auto& z = precomputations.z;
-
   auto& r_norm = precomputations.r_norm;
 
   auto& cos_β = precomputations.cos_β;
@@ -317,9 +305,9 @@ Acceleration(OblateBody<Frame> const& body,
   auto& cos = precomputations.cos;
   auto& sin = precomputations.sin;
 
-  x = r_surface.coordinates().x;
-  y = r_surface.coordinates().y;
-  z = r_surface.coordinates().z;
+  Length const x = r_surface.coordinates().x;
+  Length const y = r_surface.coordinates().y;
+  Length const z = r_surface.coordinates().z;
 
   precomputations.r² = r²;
   r_norm = Sqrt(r²);

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -203,25 +203,27 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
       grad_𝔅_polynomials -=
           m * sin_β * cos_β_to_the_m_minus_1 * DmPn_of_sin_β[n][m];
     }
-    Vector<Inverse<Length>, SurfaceFrame> const grad_𝔅 =
-        grad_𝔅_polynomials * grad_𝔅_vector;
 
     double const Cnm = (*cos)[n][m];
     double const Snm = (*sin)[n][m];
     double const 𝔏 = Cnm * cos_mλ + Snm * sin_mλ;
 
-    Vector<Inverse<Length>, SurfaceFrame> 𝔅_grad_𝔏;
+    Vector<ReducedAcceleration, SurfaceFrame> const 𝔅𝔏_grad_ℜ =
+        (𝔅 * 𝔏) * grad_ℜ;
+    Vector<ReducedAcceleration, SurfaceFrame> const ℜ𝔏_grad_𝔅 =
+        (ℜ * 𝔏 * grad_𝔅_polynomials) * grad_𝔅_vector;
+    Vector<ReducedAcceleration, SurfaceFrame> grad_ℜ𝔅𝔏 =
+        𝔅𝔏_grad_ℜ + ℜ𝔏_grad_𝔅;
     if constexpr (m > 0) {
-      // This is not exactly grad_𝔏: we omit the cos_β numerator to remove a
-      // singularity.
-      Vector<Inverse<Length>, SurfaceFrame> const grad_𝔏 =
-          m * (Snm * cos_mλ - Cnm * sin_mλ) * grad_𝔏_vector;
       // Compensate a cos_β to remove a singularity when cos_β == 0.
-      𝔅_grad_𝔏 += cos_β_to_the_m_minus_1 * DmPn_of_sin_β[n][m] * grad_𝔏;
+      Vector<ReducedAcceleration, SurfaceFrame> const ℜ𝔅_grad_𝔏 =
+          (ℜ *
+           cos_β_to_the_m_minus_1 * DmPn_of_sin_β[n][m] *  // 𝔅/cos_β
+           m * (Snm * cos_mλ - Cnm * sin_mλ)) * grad_𝔏_vector;  // grad_𝔏*cos_β
+      grad_ℜ𝔅𝔏 += ℜ𝔅_grad_𝔏;
     }
 
-    return normalization_factor *
-           (grad_ℜ * 𝔅 * 𝔏 + ℜ * grad_𝔅 * 𝔏 + ℜ * 𝔅_grad_𝔏);
+    return normalization_factor * grad_ℜ𝔅𝔏;
   }
 }
 
@@ -254,7 +256,7 @@ Acceleration(Vector<Inverse<Length>, SurfaceFrame> const& r_over_r²,
       auto const& ℜh2 = precomputations.ℜ[h2];
       ℜ = ℜh1 * ℜh2 * r_norm;
     }
-    grad_ℜ = -(n + 1) * ℜ * r_over_r²;
+    grad_ℜ = (-(n + 1) * ℜ) * r_over_r²;
 
     // Force the evaluation by increasing order using an initializer list.
     Accelerations<size> const accelerations = {

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -77,9 +77,7 @@ class GeopotentialTest : public ::testing::Test {
                                         Instant const& t,
                                         Displacement<Frame> const& r) {
     auto const r² = r.Norm²();
-    auto const one_over_r³ = 1.0 / (r² * r.Norm());
-    return geopotential.GeneralSphericalHarmonicsAcceleration(
-               t, r, r², one_over_r³);
+    return geopotential.GeneralSphericalHarmonicsAcceleration(t, r, r²);
   }
 
   // The axis of rotation is along the z axis for ease of testing.


### PR DESCRIPTION
Benchmark (note that the Fortran code has become slower due to the benchmark being now fair):
```
Run on (4 X 3310 MHz CPU s)
09/30/18 16:32:13
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2      193212 ns     193208 ns      13807
BM_ComputeGeopotentialCpp/3      249143 ns     248923 ns      11218
BM_ComputeGeopotentialCpp/5      380883 ns     380278 ns       7179
BM_ComputeGeopotentialCpp/10    1065107 ns    1061599 ns       2601
BM_ComputeGeopotentialF90/2      186733 ns     186696 ns      14957
BM_ComputeGeopotentialF90/3      237447 ns     235970 ns      11966
BM_ComputeGeopotentialF90/5      320568 ns     319412 ns       8547
BM_ComputeGeopotentialF90/10     826904 ns     821305 ns       3324
```
C++ fit: `165282 - 2179.71 n + 9177.35 n²`
Fortran fit: `175488 - 4669.92 n + 6919.05 n²`

So the inner loop is about 30% more expensive in C++.