### PR TITLE
Transformation between the TIRS and the CIRS

### DIFF
--- a/astronomy/time_scales.hpp
+++ b/astronomy/time_scales.hpp
@@ -10,6 +10,7 @@ namespace astronomy {
 namespace internal_time_scales {
 
 using geometry::Instant;
+using quantities::Angle;
 
 // NOTE(egg): We cannot use literal operator templates for strings, so if an
 // invalid date is given and the result does not need to be constexpr the
@@ -19,6 +20,8 @@ using geometry::Instant;
 // http://wg21.cmeerw.net/ewg/issue66.
 // FWIW it seems that clang supports this proposal with
 // -Wno-gnu-string-literal-operator-template.
+
+constexpr Angle EarthRotationAngle (Instant const tt);
 
 constexpr Instant operator""_TAI(char const* str, std::size_t size);
 constexpr Instant operator""_TT(char const* str, std::size_t size);
@@ -32,6 +35,7 @@ Instant ParseUT1(std::string const& s);
 
 }  // namespace internal_time_scales
 
+using internal_time_scales::EarthRotationAngle;
 using internal_time_scales::operator""_TAI;
 using internal_time_scales::operator""_TT;
 using internal_time_scales::operator""_UTC;

--- a/astronomy/time_scales.hpp
+++ b/astronomy/time_scales.hpp
@@ -21,7 +21,7 @@ using quantities::Angle;
 // FWIW it seems that clang supports this proposal with
 // -Wno-gnu-string-literal-operator-template.
 
-constexpr Angle EarthRotationAngle (Instant const tt);
+constexpr Angle EarthRotationAngle(Instant const tt);
 
 constexpr Instant operator""_TAI(char const* str, std::size_t size);
 constexpr Instant operator""_TT(char const* str, std::size_t size);

--- a/astronomy/time_scales_body.hpp
+++ b/astronomy/time_scales_body.hpp
@@ -444,10 +444,10 @@ constexpr Angle EarthRotationAngle (Instant const tt) {
       LookupInEOPC04(tt), tt, ut1_julian_day_number_minus_2451545);
   double const Tu =
       ut1_julian_day_number_minus_2451545 + ut1_julian_day_fraction;
-  // IERS Conventions (2010), equation (5.15), with 1 subtracted from the
-  // constant term to keep things closer to 0.
+  // IERS Conventions (2010), equation (5.15).
+  // TODO(egg): We should probably have a modulo 1 on the last term.
   return 2 * π * Radian *
-         (ut1_julian_day_fraction + (0.7790572732640 - 1) +
+         (ut1_julian_day_fraction + 0.7790572732640 +
           0.00273781191135448 * Tu);
 }
 

--- a/astronomy/time_scales_body.hpp
+++ b/astronomy/time_scales_body.hpp
@@ -334,7 +334,7 @@ constexpr EOPC04Entry const* LookupUT1(quantities::Time const& ut1,
 }
 
 constexpr EOPC04Entry const* LookupTT(Instant const& tt,
-                                      EOPC04Entry const* begin,
+                                      EOPC04Entry const* const begin,
                                       std::ptrdiff_t const size) {
   CONSTEXPR_CHECK(size > 0);
   if (size == 1) {
@@ -357,8 +357,7 @@ constexpr EOPC04Entry const* LookupInEOPC04(
   return LookupUT1(ut1, &eop_c04[0], eop_c04.size());
 }
 
-constexpr EOPC04Entry const* LookupInEOPC04(
-    Instant const& tt) {
+constexpr EOPC04Entry const* LookupInEOPC04(Instant const& tt) {
   return LookupTT(tt, &eop_c04[0], eop_c04.size());
 }
 

--- a/astronomy/time_scales_body.hpp
+++ b/astronomy/time_scales_body.hpp
@@ -435,7 +435,7 @@ constexpr Instant FromUT1(quantities::Time const ut1) {
   }
 }
 
-constexpr Angle EarthRotationAngle (Instant const tt) {
+constexpr Angle EarthRotationAngle(Instant const tt) {
   CONSTEXPR_CHECK(tt >= eop_c04.front().tt())
       << "EarthRotationAngle is not implemented before 1962.";
 

--- a/astronomy/time_scales_test.cpp
+++ b/astronomy/time_scales_test.cpp
@@ -416,6 +416,23 @@ TEST_F(TimeScalesDeathTest, JulianDateUTC) {
   EXPECT_DEATH("MJD55200.123"_UTC, "size > 0");
 }
 
+TEST_F(TimeScalesTest, EarthRotationAngle) {
+  static_assert(EarthRotationAngle("JD2451545.0"_UT1) ==
+                    2 * π * Radian * (0.7790572732640 - 1),
+                "Angles differ");
+  EXPECT_THAT((EarthRotationAngle("JD2455200.0"_UT1)),
+              AlmostEquals(2 * π * Radian *
+                               (0.7790572732640 +
+                                0.00273781191135448 * (2455200 - 2451545) - 1),
+                           284));
+  EXPECT_THAT(
+      (EarthRotationAngle("JD2455200.623456701388"_UT1)),
+      AlmostEquals(2 * π * Radian *
+                       (0.623456701388 + 0.7790572732640 +
+                        0.00273781191135448 * (5200.623456701388 - 1545) - 2),
+                   269));
+}
+
 }  // namespace internal_time_scales
 }  // namespace astronomy
 }  // namespace principia

--- a/astronomy/time_scales_test.cpp
+++ b/astronomy/time_scales_test.cpp
@@ -422,24 +422,24 @@ TEST_F(TimeScalesDeathTest, JulianDateUTC) {
 
 TEST_F(TimeScalesTest, EarthRotationAngle) {
   // Round-trip from UT1, comparing with the direct computation from UT1.
-  static_assert(EarthRotationAngle("JD2451545.0"_UT1) ==
-                    2 * π * Radian * (0.7790572732640 - 1),
-                "Angles differ");
+  static_assert(
+      EarthRotationAngle("JD2451545.0"_UT1) == 2 * π * Radian * 0.7790572732640,
+      "Angles differ");
   EXPECT_THAT(EarthRotationAngle("JD2455200.0"_UT1),
               AlmostEquals(2 * π * Radian *
                                (0.7790572732640 +
-                                0.00273781191135448 * (2455200 - 2451545) - 1),
-                           284));
+                                0.00273781191135448 * (2455200 - 2451545)),
+                           142));
   EXPECT_THAT(
       EarthRotationAngle("JD2455200.623456701388"_UT1),
       AlmostEquals(2 * π * Radian *
                        (0.623456701388 + 0.7790572732640 +
-                        0.00273781191135448 * (5200.623456701388 - 1545) - 2),
-                   269));
+                        0.00273781191135448 * (5200.623456701388 - 1545) - 1),
+                   134));
 
   // Compare with the WGCCRE 2009 elements.
   EXPECT_THAT(
-      (EarthRotationAngle(J2000) + 3 * π / 2 * Radian) - 190.147 * Degree,
+      (EarthRotationAngle(J2000) - π / 2 * Radian) - 190.147 * Degree,
       IsNear(0.0469 * Degree));
   EXPECT_THAT((EarthRotationAngle("2000-01-01T23:00:00"_TT) -
                EarthRotationAngle("2000-01-01T01:00:00"_TT)) /

--- a/astronomy/time_scales_test.cpp
+++ b/astronomy/time_scales_test.cpp
@@ -421,21 +421,26 @@ TEST_F(TimeScalesDeathTest, JulianDateUTC) {
 }
 
 TEST_F(TimeScalesTest, EarthRotationAngle) {
+  double const revolutions_at_j2000_ut1 = 0.7790572732640;
+  double const excess_revolutions_per_ut1_day = 0.00273781191135448;
+
   // Round-trip from UT1, comparing with the direct computation from UT1.
-  static_assert(
-      EarthRotationAngle("JD2451545.0"_UT1) == 2 * π * Radian * 0.7790572732640,
-      "Angles differ");
-  EXPECT_THAT(EarthRotationAngle("JD2455200.0"_UT1),
-              AlmostEquals(2 * π * Radian *
-                               (0.7790572732640 +
-                                0.00273781191135448 * (2455200 - 2451545)),
-                           142));
+  static_assert(EarthRotationAngle("JD2451545.0"_UT1) ==
+                    2 * π * Radian * revolutions_at_j2000_ut1,
+                "Angles differ");
+  EXPECT_THAT(
+      EarthRotationAngle("JD2455200.0"_UT1),
+      AlmostEquals(2 * π * Radian *
+                       (revolutions_at_j2000_ut1 +
+                        excess_revolutions_per_ut1_day * (2455200 - 2451545)),
+                   142));
   EXPECT_THAT(
       EarthRotationAngle("JD2455200.623456701388"_UT1),
-      AlmostEquals(2 * π * Radian *
-                       (0.623456701388 + 0.7790572732640 +
-                        0.00273781191135448 * (5200.623456701388 - 1545) - 1),
-                   134));
+      AlmostEquals(
+          2 * π * Radian *
+              (0.623456701388 + revolutions_at_j2000_ut1 +
+               excess_revolutions_per_ut1_day * (5200.623456701388 - 1545) - 1),
+          134));
 
   // Compare with the WGCCRE 2009 elements.
   EXPECT_THAT(

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -62,17 +62,17 @@ class Point final {
   friend Point<V> operator+(V const& translation, Point<V> const& point);
 
   template<typename V>
-  friend typename std::enable_if_t<is_quantity<V>::value, bool> operator<(
-      Point<V> const& left, Point<V> const& right);
+  friend constexpr typename std::enable_if_t<is_quantity<V>::value, bool>
+  operator<(Point<V> const& left, Point<V> const& right);
   template<typename V>
-  friend typename std::enable_if_t<is_quantity<V>::value, bool> operator<=(
-      Point<V> const& left, Point<V> const& right);
+  friend constexpr typename std::enable_if_t<is_quantity<V>::value, bool>
+  operator<=(Point<V> const& left, Point<V> const& right);
   template<typename V>
-  friend typename std::enable_if_t<is_quantity<V>::value, bool> operator>=(
-      Point<V> const& left, Point<V> const& right);
+  friend constexpr typename std::enable_if_t<is_quantity<V>::value, bool>
+  operator>=(Point<V> const& left, Point<V> const& right);
   template<typename V>
-  friend typename std::enable_if_t<is_quantity<V>::value, bool> operator>(
-      Point<V> const& left, Point<V> const& right);
+  friend constexpr typename std::enable_if_t<is_quantity<V>::value, bool>
+  operator>(Point<V> const& left, Point<V> const& right);
 
   template<typename V>
   friend std::string DebugString(Point<V> const& point);
@@ -87,20 +87,20 @@ Point<Vector> operator+(Vector const& translation,
                         Point<Vector> const& point);
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator<(
-    Point<Vector> const& left, Point<Vector> const& right);
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator<(Point<Vector> const& left, Point<Vector> const& right);
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator<=(
-    Point<Vector> const& left, Point<Vector> const& right);
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator<=(Point<Vector> const& left, Point<Vector> const& right);
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator>=(
-    Point<Vector> const& left, Point<Vector> const& right);
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator>=(Point<Vector> const& left, Point<Vector> const& right);
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator>(
-    Point<Vector> const& left, Point<Vector> const& right);
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator>(Point<Vector> const& left, Point<Vector> const& right);
 
 template<typename Vector>
 std::string DebugString(Point<Vector> const& point);

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -129,26 +129,28 @@ Point<Vector> operator+(Vector const& translation,
 }
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator<(
-    Point<Vector> const& left, Point<Vector> const& right) {
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool> operator<(
+    Point<Vector> const& left,
+    Point<Vector> const& right) {
   return left.coordinates_ < right.coordinates_;
 }
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator<=(
-    Point<Vector> const& left, Point<Vector> const& right) {
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator<=(Point<Vector> const& left, Point<Vector> const& right) {
   return left.coordinates_ <= right.coordinates_;
 }
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator>=(
-    Point<Vector> const& left, Point<Vector> const& right) {
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool>
+operator>=(Point<Vector> const& left, Point<Vector> const& right) {
   return left.coordinates_ >= right.coordinates_;
 }
 
 template<typename Vector>
-typename std::enable_if_t<is_quantity<Vector>::value, bool> operator>(
-    Point<Vector> const& left, Point<Vector> const& right) {
+constexpr typename std::enable_if_t<is_quantity<Vector>::value, bool> operator>(
+    Point<Vector> const& left,
+    Point<Vector> const& right) {
   return left.coordinates_ > right.coordinates_;
 }
 


### PR DESCRIPTION
Earth Rotation Angle.

Note that this only incorporates the UT1 values reported by the IERS, and not the subdaily variations due to tides or libration; these have amplitudes bounded by 20 μs in UT1, resulting in sub-milliarcsecond changes in the ERA.