### PR TITLE
A benchmark for ThreadPool

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="polynomial.cpp" />
     <ClCompile Include="quantities.cpp" />
     <ClCompile Include="symplectic_runge_kutta_nyström_integrator.cpp" />
+    <ClCompile Include="thread_pool.cpp" />
     <ClCompile Include="чебышёв_series.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="geopotential.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="thread_pool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp">

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -1,4 +1,6 @@
 
+// .\Release\x64\benchmarks.exe --benchmark_min_time=2 --benchmark_repetitions=10 --benchmark_filter=ThreadPool  // NOLINT(whitespace/line_length)
+
 #include <cstdint>
 #include <mutex>
 #include <random>

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -1,0 +1,127 @@
+
+#include <cstdint>
+#include <mutex>
+#include <random>
+
+#include "base/shared_lock_guard.hpp"
+#include "base/thread_pool.hpp"
+#include "benchmark/benchmark.h"
+
+namespace principia {
+namespace base {
+
+std::shared_mutex lock;
+std::mt19937_64 random(42);
+std::uniform_int_distribution<int> distribution(0, 1e5);
+
+double ComsumeCpuNoLock(std::int64_t const n) {
+  double result;
+  {
+    base::shared_lock_guard l(lock);
+    result = distribution(random);
+  }
+  for (int i = 0; i < n; ++i) {
+    result += std::sqrt(i);
+  }
+  return result;
+}
+
+double ComsumeCpuSharedLock(std::int64_t const n) {
+  base::shared_lock_guard l(lock);
+  double result = distribution(random);
+  for (int i = 0; i < n; ++i) {
+    result += std::sqrt(i);
+  }
+  return result;
+}
+
+double ComsumeCpuExclusiveLock(std::int64_t const n) {
+  std::lock_guard l(lock);
+  double result = distribution(random);
+  for (int i = 0; i < n; ++i) {
+    result += std::sqrt(i);
+  }
+  return result;
+}
+
+void BM_ThreadPoolNoLock(benchmark::State& state) {
+  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  std::vector<std::int64_t> results;
+  while (state.KeepRunning()) {
+    std::vector<std::future<void>> futures;
+    for (int i = 0; i < 1000; ++i) {
+      futures.push_back(pool.Add([]() {
+        double const result = ComsumeCpuNoLock(1e5);
+        benchmark::DoNotOptimize(result);
+      }));
+    }
+    for (auto const& future : futures) {
+      future.wait();
+    }
+  }
+}
+
+void BM_ThreadPoolSharedLock(benchmark::State& state) {
+  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  std::vector<std::int64_t> results;
+  while (state.KeepRunning()) {
+    std::vector<std::future<void>> futures;
+    for (int i = 0; i < 1000; ++i) {
+      futures.push_back(pool.Add([]() {
+        double const result = ComsumeCpuSharedLock(1e5);
+        benchmark::DoNotOptimize(result);
+      }));
+    }
+    for (auto const& future : futures) {
+      future.wait();
+    }
+  }
+}
+
+void BM_ThreadPoolExclusiveLock(benchmark::State& state) {
+  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  std::vector<std::int64_t> results;
+  while (state.KeepRunning()) {
+    std::vector<std::future<void>> futures;
+    for (int i = 0; i < 1000; ++i) {
+      futures.push_back(pool.Add([]() {
+        double const result = ComsumeCpuExclusiveLock(1e5);
+        benchmark::DoNotOptimize(result);
+      }));
+    }
+    for (auto const& future : futures) {
+      future.wait();
+    }
+  }
+}
+
+BENCHMARK(BM_ThreadPoolNoLock)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(4)
+    ->Arg(5)
+    ->Arg(6)
+    ->Arg(7)
+    ->Arg(8);
+BENCHMARK(BM_ThreadPoolSharedLock)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(4)
+    ->Arg(5)
+    ->Arg(6)
+    ->Arg(7)
+    ->Arg(8);
+BENCHMARK(BM_ThreadPoolExclusiveLock)
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(4)
+    ->Arg(5)
+    ->Arg(6)
+    ->Arg(7)
+    ->Arg(8);
+
+}  // namespace base
+}  // namespace principia

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <mutex>
 #include <random>
+#include <vector>
 
 #include "base/shared_lock_guard.hpp"
 #include "base/thread_pool.hpp"

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -19,7 +19,7 @@ std::uniform_int_distribution<int> distribution(0, 1e5);
 double ComsumeCpuNoLock(std::int64_t const n) {
   double result;
   {
-    base::shared_lock_guard l(lock);
+    base::shared_lock_guard<std::shared_mutex> l(lock);
     result = distribution(random);
   }
   for (int i = 0; i < n; ++i) {
@@ -29,7 +29,7 @@ double ComsumeCpuNoLock(std::int64_t const n) {
 }
 
 double ComsumeCpuSharedLock(std::int64_t const n) {
-  base::shared_lock_guard l(lock);
+  base::shared_lock_guard<std::shared_mutex> l(lock);
   double result = distribution(random);
   for (int i = 0; i < n; ++i) {
     result += std::sqrt(i);
@@ -38,7 +38,7 @@ double ComsumeCpuSharedLock(std::int64_t const n) {
 }
 
 double ComsumeCpuExclusiveLock(std::int64_t const n) {
-  std::lock_guard l(lock);
+  std::lock_guard<std::shared_mutex> l(lock);
   double result = distribution(random);
   for (int i = 0; i < n; ++i) {
     result += std::sqrt(i);


### PR DESCRIPTION
To try to figure what's happening in #1955.  On Windows and Linux the results are what we expect, on macOS not so much.
On Windows:
```
Run on (4 X 3310 MHz CPU s)
10/14/18 17:50:12
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         622826191 ns   10920070 ns         10
BM_ThreadPoolNoLock/2         315923306 ns   14040090 ns         10
BM_ThreadPoolNoLock/3         209626186 ns    5546702 ns         90
BM_ThreadPoolNoLock/4         160130553 ns    5153604 ns        112
BM_ThreadPoolNoLock/5         158063773 ns     624004 ns        100
BM_ThreadPoolNoLock/6         158421306 ns     312002 ns        100
BM_ThreadPoolNoLock/7         159369923 ns     468003 ns        100
BM_ThreadPoolNoLock/8         159100837 ns          0 ns        100
BM_ThreadPoolSharedLock/1     623501396 ns    6240040 ns         10
BM_ThreadPoolSharedLock/2     312739040 ns    1560010 ns         10
BM_ThreadPoolSharedLock/3     208782389 ns    6933378 ns         90
BM_ThreadPoolSharedLock/4     159575955 ns    3588023 ns        100
BM_ThreadPoolSharedLock/5     157920654 ns    1560010 ns        100
BM_ThreadPoolSharedLock/6     157538956 ns     312002 ns        100
BM_ThreadPoolSharedLock/7     158004025 ns     312002 ns        100
BM_ThreadPoolSharedLock/8     157310211 ns     468003 ns        100
BM_ThreadPoolExclusiveLock/1  621480359 ns    9360060 ns         10
BM_ThreadPoolExclusiveLock/2  620139631 ns          0 ns         10
BM_ThreadPoolExclusiveLock/3  620300275 ns    1560010 ns         10
BM_ThreadPoolExclusiveLock/4  624718441 ns          0 ns         10
BM_ThreadPoolExclusiveLock/5  624766627 ns          0 ns         10
BM_ThreadPoolExclusiveLock/6  621439657 ns          0 ns         10
BM_ThreadPoolExclusiveLock/7  621080111 ns          0 ns         10
BM_ThreadPoolExclusiveLock/8  620067350 ns          0 ns         10
```
On Linux:
```
Run on (4 X 3361.62 MHz CPU s)
2018-10-14 15:52:36
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         631655773 ns   11130008 ns         10
BM_ThreadPoolNoLock/2         320515315 ns    9629434 ns         10
BM_ThreadPoolNoLock/3         221445537 ns    7186347 ns        122
BM_ThreadPoolNoLock/4         169096418 ns    5119246 ns        100
BM_ThreadPoolNoLock/5         188142073 ns     874420 ns        100
BM_ThreadPoolNoLock/6         168875878 ns     740710 ns        100
BM_ThreadPoolNoLock/7         163660424 ns     709844 ns        100
BM_ThreadPoolNoLock/8         162359400 ns     668211 ns        100
BM_ThreadPoolSharedLock/1     632980424 ns   10297849 ns         10
BM_ThreadPoolSharedLock/2     318876120 ns    8885829 ns         10
BM_ThreadPoolSharedLock/3     218699393 ns    7379492 ns        115
BM_ThreadPoolSharedLock/4     169374575 ns    5616464 ns        138
BM_ThreadPoolSharedLock/5     168409398 ns     752055 ns        100
BM_ThreadPoolSharedLock/6     163937210 ns    1009493 ns        100
BM_ThreadPoolSharedLock/7     161341600 ns     686104 ns        100
BM_ThreadPoolSharedLock/8     160607806 ns     628263 ns        100
BM_ThreadPoolExclusiveLock/1  631778521 ns   10876909 ns         10
BM_ThreadPoolExclusiveLock/2  631340952 ns     387928 ns         10
BM_ThreadPoolExclusiveLock/3  633617745 ns     319574 ns         10
BM_ThreadPoolExclusiveLock/4  632607607 ns     308393 ns         10
BM_ThreadPoolExclusiveLock/5  648738979 ns     307415 ns         10
BM_ThreadPoolExclusiveLock/6  639514665 ns     311579 ns         10
BM_ThreadPoolExclusiveLock/7  633756973 ns     330653 ns         10
BM_ThreadPoolExclusiveLock/8  641922431 ns     324636 ns         10
```
On macOS:
```
Run on (4 X 2500 MHz CPU s)
2018-10-14 18:13:55
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         174306568 ns    4182540 ns        100
BM_ThreadPoolNoLock/2          91726946 ns    3616470 ns        100
BM_ThreadPoolNoLock/3          87456398 ns    2394870 ns        100
BM_ThreadPoolNoLock/4          86410846 ns    2776730 ns        100
BM_ThreadPoolNoLock/5          84506540 ns    1297930 ns        100
BM_ThreadPoolNoLock/6          86481675 ns    1393100 ns        100
BM_ThreadPoolNoLock/7          91612452 ns    1378770 ns        100
BM_ThreadPoolNoLock/8          94560420 ns    1284660 ns        100
BM_ThreadPoolSharedLock/1     175671216 ns    5034632 ns        133
BM_ThreadPoolSharedLock/2      95299969 ns    3468120 ns        100
BM_ThreadPoolSharedLock/3      86168255 ns    2395490 ns        100
BM_ThreadPoolSharedLock/4      85811419 ns    2871370 ns        100
BM_ThreadPoolSharedLock/5      84450961 ns     997430 ns        100
BM_ThreadPoolSharedLock/6      84894455 ns    1525880 ns        100
BM_ThreadPoolSharedLock/7      92981024 ns    1295980 ns        100
BM_ThreadPoolSharedLock/8     111819097 ns    1100310 ns        100
BM_ThreadPoolExclusiveLock/1  361501650 ns    6557000 ns         10
BM_ThreadPoolExclusiveLock/2  264692260 ns     830900 ns         10
BM_ThreadPoolExclusiveLock/3  216135749 ns     646960 ns        100
BM_ThreadPoolExclusiveLock/4  195835180 ns     705000 ns        100
BM_ThreadPoolExclusiveLock/5  193870727 ns     573870 ns        100
BM_ThreadPoolExclusiveLock/6  194958273 ns     525220 ns        100
BM_ThreadPoolExclusiveLock/7  196944990 ns     514290 ns        100
BM_ThreadPoolExclusiveLock/8  197908922 ns     553090 ns        100
```