### PR TITLE
Use absl::Mutex in the ThreadPool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,20 @@ ifeq ($(UNAME_S),Darwin)
     PLUGIN_DIRECTORY      := $(FINAL_PRODUCTS_DIR)GameData/Principia/MacOS64/
 endif
 
-TEST_LIBS     := $(DEP_DIR)benchmark/src/libbenchmark.a $(DEP_DIR)/protobuf/src/.libs/libprotobuf.a
-LIBS          := $(DEP_DIR)/protobuf/src/.libs/libprotobuf.a \
-	$(DEP_DIR)/gipfeli/libgipfeli.a \
-	$(DEP_DIR)/glog/.libs/libglog.a -lpthread -lc++ -lc++abi
+TEST_LIBS     := $(DEP_DIR)benchmark/src/libbenchmark.a $(DEP_DIR)protobuf/src/.libs/libprotobuf.a
+LIBS          := $(DEP_DIR)protobuf/src/.libs/libprotobuf.a \
+	$(DEP_DIR)gipfeli/libgipfeli.a \
+	$(DEP_DIR)abseil-cpp/absl/synchronization/libabsl_synchronization.a \
+	$(DEP_DIR)abseil-cpp/absl/time/libabsl_*.a \
+	$(DEP_DIR)abseil-cpp/absl/debugging/libabsl_*.a \
+	$(DEP_DIR)abseil-cpp/absl/numeric/libabsl_*.a \
+	$(DEP_DIR)abseil-cpp/absl/base/libabsl_*.a \
+	$(DEP_DIR)glog/.libs/libglog.a -lpthread -lc++ -lc++abi
 TEST_INCLUDES := \
 	-I$(DEP_DIR)googletest/googlemock/include -I$(DEP_DIR)googletest/googletest/include \
 	-I$(DEP_DIR)googletest/googlemock/ -I$(DEP_DIR)googletest/googletest/ -I$(DEP_DIR)benchmark/include
-INCLUDES      := -I. -I$(DEP_DIR)glog/src -I$(DEP_DIR)protobuf/src -I$(DEP_DIR)compatibility/filesystem -I$(DEP_DIR)gipfeli/include
+INCLUDES      := -I. -I$(DEP_DIR)glog/src -I$(DEP_DIR)protobuf/src -I$(DEP_DIR)compatibility/filesystem \
+	-I$(DEP_DIR)gipfeli/include -I$(DEP_DIR)abseil-cpp
 SHARED_ARGS   := \
 	-std=c++1z -stdlib=libc++ -O3 -g                           \
 	-fPIC -fexceptions -ferror-limit=1 -fno-omit-frame-pointer \

--- a/base/bundle.hpp
+++ b/base/bundle.hpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
 #include "base/macros.hpp"
 #include "base/monostable.hpp"
 #include "base/not_null.hpp"

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -70,26 +70,22 @@ char const* const Architecture = "x86-64";
 #error "Have you tried a Cray-1?"
 #endif
 
-#if defined(CDECL)
-#  error "CDECL already defined"
-#else
 // Architecture macros from http://goo.gl/ZypnO8.
 // We use cdecl on x86, the calling convention is unambiguous on x86-64.
-#  if ARCH_CPU_X86
-#    if PRINCIPIA_COMPILER_CLANG ||  \
-        PRINCIPIA_COMPILER_MSVC ||   \
-        PRINCIPIA_COMPILER_CLANG_CL
-#      define CDECL __cdecl
-#    elif PRINCIPIA_COMPILER_ICC || PRINCIPIA_COMPILER_GCC
-#      define CDECL __attribute__((cdecl))
-#    else
-#      error "Get a real compiler!"
-#    endif
-#  elif ARCH_CPU_X86_64
-#    define CDECL
+#if ARCH_CPU_X86
+#  if PRINCIPIA_COMPILER_CLANG ||  \
+      PRINCIPIA_COMPILER_MSVC ||   \
+      PRINCIPIA_COMPILER_CLANG_CL
+#    define CDECL __cdecl
+#  elif PRINCIPIA_COMPILER_ICC || PRINCIPIA_COMPILER_GCC
+#    define CDECL __attribute__((cdecl))
 #  else
-#    error "Have you tried a Cray-1?"
+#    error "Get a real compiler!"
 #  endif
+#elif ARCH_CPU_X86_64
+#  define CDECL
+#else
+#  error "Have you tried a Cray-1?"
 #endif
 
 // DLL-exported functions for interfacing with Platform Invocation Services.

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -172,15 +172,12 @@ inline void noreturn() { std::exit(0); }
 #  define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
 #  define EXCLUDES(...) \
        THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
-#  define GUARDED_BY(...) \
-       THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(__VA_ARGS__))
 #  define REQUIRES(...) \
        THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 #  define REQUIRES_SHARED(...) \
        THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
 #else
 #  define EXCLUDES(x)
-#  define GUARDED_BY(x)
 #  define REQUIRES(x)
 #  define REQUIRES_SHARED(x)
 #endif

--- a/base/pull_serializer.hpp
+++ b/base/pull_serializer.hpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <thread>
 
+#include "absl/base/thread_annotations.h"
 #include "base/array.hpp"
 #include "base/macros.hpp"
 #include "base/not_null.hpp"

--- a/base/push_deserializer.hpp
+++ b/base/push_deserializer.hpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <thread>
 
+#include "absl/base/thread_annotations.h"
 #include "base/array.hpp"
 #include "base/macros.hpp"
 #include "base/not_null.hpp"

--- a/base/thread_pool.hpp
+++ b/base/thread_pool.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <future>
 #include <list>
-#include <mutex>
 #include <thread>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 
 namespace principia {
 namespace base {
@@ -38,10 +39,9 @@ class ThreadPool final {
   // execute it, and set its result in the promise.
   void DequeueCallAndExecute();
 
-  std::mutex lock_;
-  bool shutdown_ = false;
-  std::deque<Call> calls_;
-  std::condition_variable has_calls_or_shutdown_;
+  absl::Mutex lock_;
+  bool shutdown_ GUARDED_BY(lock_) = false;
+  std::deque<Call> calls_ GUARDED_BY(lock_);
 
   std::list<std::thread> threads_;
 };

--- a/google_abseil-cpp.props
+++ b/google_abseil-cpp.props
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\Google\abseil-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\Google\abseil-cpp\msvc\$(PrincipiaDependencyConfiguration)\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>base.lib;container.lib;debugging.lib;hash.lib;numeric.lib;strings.lib;synchronization.lib;time.lib;types.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -72,6 +72,16 @@ git pull
 make
 popd
 
+if [ ! -d "abseil-cpp" ]; then
+  git clone "https://github.com/mockingbirdnest/abseil-cpp"
+fi
+pushd abseil-cpp
+git checkout master
+git pull
+cmake -DCMAKE_C_COMPILER:FILEPATH=`which clang` -DCMAKE_CXX_COMPILER:FILEPATH=`which clang++` -DCMAKE_C_FLAGS="${C_FLAGS}" -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_LD_FLAGS="${LD_FLAGS}" -DBUILD_TESTING=OFF
+make -j8
+popd
+
 if [ ! -d "compatibility" ]; then
   git clone "https://github.com/mockingbirdnest/compatibility"
 fi

--- a/ksp_physics/ksp_physics_lib.cpp
+++ b/ksp_physics/ksp_physics_lib.cpp
@@ -5,7 +5,6 @@
 
 #include "ksp_physics/ksp_physics_lib.hpp"
 
-#define NOGDI
 #include <windows.h>
 #include <psapi.h>
 

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -13,8 +13,6 @@
 #include <utility>
 #include <vector>
 #if OS_WIN
-#define NOGDI
-#define NOMINMAX
 #include <windows.h>
 #include <psapi.h>
 #endif

--- a/principia.props
+++ b/principia.props
@@ -99,7 +99,7 @@
         -Xclang --system-header-prefix=gmock/
       </AdditionalOptions>
       <PreprocessorDefinitions Condition="!$(PrincipiaCompilerClangLLVM)">
-        _ENABLE_EXTENDED_ALIGNED_STORAGE;%(PreprocessorDefinitions)
+        _ENABLE_EXTENDED_ALIGNED_STORAGE;NOGDI;%(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <TreatWarningAsError Condition="!$(PrincipiaCompilerClangLLVM)">true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>
@@ -146,6 +146,8 @@
   <Import Project="$(SolutionDir)google_glog.props" />
   <Import Project="$(SolutionDir)..\Google\gipfeli\msvc\portability_macros.props" />
   <Import Project="$(SolutionDir)google_gipfeli.props" />
+  <Import Project="$(SolutionDir)..\Google\abseil-cpp\msvc\portability_macros.props" />
+  <Import Project="$(SolutionDir)google_abseil-cpp.props" />
   <Import Project="$(SolutionDir)generate_version_translation_unit.props" />
 
   <ImportGroup Condition="$(ProjectName) == benchmarks or

--- a/principia.props
+++ b/principia.props
@@ -99,7 +99,7 @@
         -Xclang --system-header-prefix=gmock/
       </AdditionalOptions>
       <PreprocessorDefinitions Condition="!$(PrincipiaCompilerClangLLVM)">
-        _ENABLE_EXTENDED_ALIGNED_STORAGE;NOGDI;%(PreprocessorDefinitions)
+        _ENABLE_EXTENDED_ALIGNED_STORAGE;NOGDI;NOMINMAX;%(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <TreatWarningAsError Condition="!$(PrincipiaCompilerClangLLVM)">true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>

--- a/rebuild_all_solutions.ps1
+++ b/rebuild_all_solutions.ps1
@@ -4,7 +4,8 @@ $dependencies = @(".\Google\glog\google-glog.sln",
                   ".\Google\googletest\googlemock\msvc\2017\gmock.sln",
                   ".\Google\protobuf\vsprojects\protobuf.sln",
                   ".\Google\benchmark\msvc\google-benchmark.sln",
-                  ".\Google\gipfeli\msvc\gipfeli.sln")
+                  ".\Google\gipfeli\msvc\gipfeli.sln",
+                  ".\Google\abseil-cpp\msvc\abseil-cpp.sln")
 
 function build_solutions($solutions) {
   foreach ($configuration in "Debug", "Release") {


### PR DESCRIPTION
The benchmarks below are to be compared with those in #1962.  TL;DR: the performance is unchanged on Windows and Linux; on macOS however the numbers are quite different (1) for shared locks, the performance doesn't degrade with the number of threads in the pool, i.e, there is no contention (2) for exclusive locks the performance is not degraded when there are only few threads in the pool, presumably because there is no attempt to be fair.
On Windows:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         629866462 ns   21840140 ns         10
BM_ThreadPoolNoLock/2         323812446 ns    9360060 ns         10
BM_ThreadPoolNoLock/3         220171006 ns    4457171 ns         56
BM_ThreadPoolNoLock/4         167180891 ns    7103617 ns        112
BM_ThreadPoolNoLock/5         162273820 ns     156001 ns        100
BM_ThreadPoolNoLock/6         162013385 ns     468003 ns        100
BM_ThreadPoolNoLock/7         162998223 ns     468003 ns        100
BM_ThreadPoolNoLock/8         170731922 ns          0 ns        100
BM_ThreadPoolSharedLock/1     619784167 ns   24960160 ns         10
BM_ThreadPoolSharedLock/2     313771224 ns   10920070 ns         10
BM_ThreadPoolSharedLock/3     212478009 ns    5432178 ns        112
BM_ThreadPoolSharedLock/4     165817529 ns    5928038 ns        100
BM_ThreadPoolSharedLock/5     162222723 ns     312002 ns        100
BM_ThreadPoolSharedLock/6     161499684 ns     312002 ns        100
BM_ThreadPoolSharedLock/7     161811250 ns          0 ns        100
BM_ThreadPoolSharedLock/8     162515475 ns     468003 ns        100
BM_ThreadPoolExclusiveLock/1  620166817 ns    4680030 ns         10
BM_ThreadPoolExclusiveLock/2  620142569 ns          0 ns         10
BM_ThreadPoolExclusiveLock/3  620329069 ns          0 ns         10
BM_ThreadPoolExclusiveLock/4  622216927 ns    3120020 ns         10
BM_ThreadPoolExclusiveLock/5  623563284 ns          0 ns         10
BM_ThreadPoolExclusiveLock/6  620985531 ns          0 ns         10
BM_ThreadPoolExclusiveLock/7  623369021 ns          0 ns         10
BM_ThreadPoolExclusiveLock/8  621523691 ns          0 ns         10
```
On Linux:
```
Run on (4 X 3361.62 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 256K (x4)
  L3 Unified 6144K (x4)
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         634812123 ns   11155119 ns         10
BM_ThreadPoolNoLock/2         318681256 ns    8603277 ns         10
BM_ThreadPoolNoLock/3         218355212 ns    8042158 ns         99
BM_ThreadPoolNoLock/4         173784357 ns    5368604 ns        135
BM_ThreadPoolNoLock/5         163099873 ns     707125 ns        100
BM_ThreadPoolNoLock/6         162640237 ns     638854 ns        100
BM_ThreadPoolNoLock/7         164833795 ns     675132 ns        100
BM_ThreadPoolNoLock/8         163411559 ns     675566 ns        100
BM_ThreadPoolSharedLock/1     632776698 ns   10689567 ns         10
BM_ThreadPoolSharedLock/2     319962730 ns    8888000 ns         10
BM_ThreadPoolSharedLock/3     214524427 ns    7498344 ns        107
BM_ThreadPoolSharedLock/4     167766549 ns    5186854 ns        100
BM_ThreadPoolSharedLock/5     162478060 ns     770649 ns        100
BM_ThreadPoolSharedLock/6     162689813 ns     665079 ns        100
BM_ThreadPoolSharedLock/7     165458606 ns     684099 ns        100
BM_ThreadPoolSharedLock/8     163383126 ns     661848 ns        100
BM_ThreadPoolExclusiveLock/1  633899656 ns   10754440 ns         10
BM_ThreadPoolExclusiveLock/2  633524847 ns     283452 ns         10
BM_ThreadPoolExclusiveLock/3  636050825 ns     306411 ns         10
BM_ThreadPoolExclusiveLock/4  638742375 ns     277763 ns         10
BM_ThreadPoolExclusiveLock/5  639470201 ns     293376 ns         10
BM_ThreadPoolExclusiveLock/6  643042079 ns     288782 ns         10
BM_ThreadPoolExclusiveLock/7  638383528 ns     266692 ns         10
BM_ThreadPoolExclusiveLock/8  641937738 ns     283715 ns         10
```
On macOS:
```
Running bin/benchmark
Run on (4 X 2500 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 262K (x2)
  L3 Unified 4194K (x1)
--------------------------------------------------------------------
Benchmark                             Time           CPU Iterations
--------------------------------------------------------------------
BM_ThreadPoolNoLock/1         173036840 ns    3886310 ns        100
BM_ThreadPoolNoLock/2          90208778 ns    3425880 ns        100
BM_ThreadPoolNoLock/3          86008101 ns    2342660 ns        100
BM_ThreadPoolNoLock/4          86445185 ns    2786060 ns        100
BM_ThreadPoolNoLock/5          84467080 ns     575080 ns        100
BM_ThreadPoolNoLock/6          83074026 ns     501060 ns        100
BM_ThreadPoolNoLock/7          82593763 ns     489900 ns        100
BM_ThreadPoolNoLock/8          82948791 ns     519410 ns        100
BM_ThreadPoolSharedLock/1     172833389 ns    3889640 ns        100
BM_ThreadPoolSharedLock/2      88987543 ns    3501780 ns        100
BM_ThreadPoolSharedLock/3      86007174 ns    2361470 ns        100
BM_ThreadPoolSharedLock/4      85745776 ns    2692380 ns        100
BM_ThreadPoolSharedLock/5      84556017 ns     586620 ns        100
BM_ThreadPoolSharedLock/6      83475477 ns     556520 ns        100
BM_ThreadPoolSharedLock/7      83149281 ns     517860 ns        100
BM_ThreadPoolSharedLock/8      82749462 ns     536070 ns        100
BM_ThreadPoolExclusiveLock/1  172525262 ns    3847580 ns        100
BM_ThreadPoolExclusiveLock/2  173028851 ns     411570 ns        100
BM_ThreadPoolExclusiveLock/3  174003091 ns     397290 ns        100
BM_ThreadPoolExclusiveLock/4  178971899 ns     429390 ns        100
BM_ThreadPoolExclusiveLock/5  188714472 ns     402790 ns        100
BM_ThreadPoolExclusiveLock/6  191180197 ns     393390 ns        100
BM_ThreadPoolExclusiveLock/7  191670365 ns     397690 ns        100
BM_ThreadPoolExclusiveLock/8  186608532 ns     401890 ns        100
```