### PR TITLE
A benchmark for damping oblateness

### DIFF
--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -124,7 +124,7 @@ void BM_EphemerisKSPSystem(benchmark::State& state) {
     astronomy::StabilizeKSP(*at_origin);
     Instant const final_time = at_origin->epoch() + 100 * JulianYear;
     auto const ephemeris = at_origin->MakeEphemeris(
-        MakeAccuracyParameters(state.range_x()),
+        MakeAccuracyParameters(state.range(0)),
         Ephemeris<Barycentric>::FixedStepParameters(
             SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                   Position<Barycentric>>(),
@@ -147,8 +147,8 @@ void BM_EphemerisKSPSystem(benchmark::State& state) {
   state.SetLabel(quantities::DebugString(error / AstronomicalUnit) + " ua");
 }
 
-void EphemerisSolarSystemBenchmark(SolarSystemFactory::Accuracy const accuracy,
-                                   benchmark::State& state) {
+template<SolarSystemFactory::Accuracy accuracy>
+void BM_EphemerisSolarSystem(benchmark::State& state) {
   Length error;
   while (state.KeepRunning()) {
     state.PauseTiming();
@@ -156,7 +156,7 @@ void EphemerisSolarSystemBenchmark(SolarSystemFactory::Accuracy const accuracy,
     auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
     Instant const final_time = at_спутник_1_launch->epoch() + 100 * JulianYear;
     auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
-                               MakeAccuracyParameters(state.range_x()),
+                               MakeAccuracyParameters(state.range(0)),
                                EphemerisParameters());
 
     state.ResumeTiming();
@@ -176,9 +176,152 @@ void EphemerisSolarSystemBenchmark(SolarSystemFactory::Accuracy const accuracy,
   state.SetLabel(quantities::DebugString(error / AstronomicalUnit) + " ua");
 }
 
-template<Flow* flow>
-void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
-                               Time const integration_duration,
+template<SolarSystemFactory::Accuracy accuracy, Flow* flow>
+void BM_EphemerisLEOProbe(benchmark::State& state) {
+  Length sun_error;
+  Length earth_error;
+  int steps;
+
+  auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
+  Instant const final_time = at_спутник_1_launch->epoch() + 1 * JulianYear;
+
+  auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
+                             MakeAccuracyParameters(state.range(0)),
+                             EphemerisParameters());
+
+  ephemeris->Prolong(final_time);
+
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    // A probe in low earth orbit.
+    MasslessBody probe;
+    DiscreteTrajectory<Barycentric> trajectory;
+    DegreesOfFreedom<Barycentric> const earth_degrees_of_freedom =
+        at_спутник_1_launch->degrees_of_freedom(
+            SolarSystemFactory::name(SolarSystemFactory::Earth));
+    Displacement<Barycentric> const earth_probe_displacement(
+        {6371 * Kilo(Metre) + 100 * NauticalMile, 0 * Metre, 0 * Metre});
+    Speed const earth_probe_speed =
+        Sqrt(at_спутник_1_launch->gravitational_parameter(
+                 SolarSystemFactory::name(SolarSystemFactory::Earth)) /
+                     earth_probe_displacement.Norm());
+    Velocity<Barycentric> const earth_probe_velocity(
+        {0 * Metre / Second, earth_probe_speed, 0 * Metre / Second});
+    trajectory.Append(at_спутник_1_launch->epoch(),
+                      DegreesOfFreedom<Barycentric>(
+                          earth_degrees_of_freedom.position() +
+                              earth_probe_displacement,
+                          earth_degrees_of_freedom.velocity() +
+                              earth_probe_velocity));
+
+    state.ResumeTiming();
+    flow(&trajectory, final_time, *ephemeris);
+    state.PauseTiming();
+
+    sun_error = (at_спутник_1_launch->trajectory(
+                     *ephemeris,
+                     SolarSystemFactory::name(SolarSystemFactory::Sun)).
+                         EvaluatePosition(final_time) -
+                 trajectory.last().degrees_of_freedom().position()).
+                     Norm();
+    earth_error = (at_спутник_1_launch->trajectory(
+                       *ephemeris,
+                       SolarSystemFactory::name(SolarSystemFactory::Earth)).
+                           EvaluatePosition(final_time) -
+                   trajectory.last().degrees_of_freedom().position()).
+                       Norm();
+    steps = trajectory.Size();
+    state.ResumeTiming();
+  }
+  std::stringstream ss;
+  ss << steps;
+  state.SetLabel(ss.str() + " steps, " +
+                 quantities::DebugString(sun_error / AstronomicalUnit) +
+                 " ua, " +
+                 quantities::DebugString((earth_error - 6371 * Kilo(Metre)) /
+                                         NauticalMile) +
+                 " nmi");
+}
+
+void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
+  auto const at_спутник_1_launch =
+      SolarSystemAtСпутник1Launch(
+          SolarSystemFactory::Accuracy::AllBodiesAndOblateness);
+  Instant const epoch = at_спутник_1_launch->epoch();
+  auto const ephemeris =
+      at_спутник_1_launch->MakeEphemeris(1 * Milli(Metre),
+                                         EphemerisParameters());
+  std::string const& earth_name =
+      SolarSystemFactory::name(SolarSystemFactory::Earth);
+  auto const earth_massive_body =
+      at_спутник_1_launch->massive_body(*ephemeris, earth_name);
+  auto const earth_degrees_of_freedom =
+      at_спутник_1_launch->degrees_of_freedom(earth_name);
+
+  MasslessBody probe;
+  std::list<DiscreteTrajectory<Barycentric>> trajectories;
+  for (int i = 0; i < state.range(0); ++i) {
+    KeplerianElements<Barycentric> elements;
+    elements.eccentricity = 0;
+    elements.semimajor_axis = (i + 1) * 10'000 * Kilo(Metre);
+    elements.inclination = 0 * Radian;
+    elements.longitude_of_ascending_node = 0 * Radian;
+    elements.argument_of_periapsis = 0 * Radian;
+    elements.true_anomaly = 0 * Radian;
+    KeplerOrbit<Barycentric> const orbit(
+        *earth_massive_body, probe, elements, epoch);
+    trajectories.emplace_back();
+    auto& trajectory = trajectories.back();
+    trajectory.Append(epoch,
+                      earth_degrees_of_freedom + orbit.StateVectors(epoch));
+  }
+
+  ThreadPool<void> pool(/*pool_size=*/state.range(1));
+  static constexpr int warp_factor = 6E6;
+  static constexpr Frequency refresh_frequency = 50 * Hertz;
+  static constexpr Time step = warp_factor / refresh_frequency;
+  Instant final_time = epoch;
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    std::vector<not_null<std::unique_ptr<Integrator<Ephemeris<
+        Barycentric>::NewtonianMotionEquation>::Instance>>>
+        instances;
+    for (auto& trajectory : trajectories) {
+      instances.push_back(ephemeris->NewInstance(
+          {&trajectory},
+          Ephemeris<Barycentric>::NoIntrinsicAccelerations,
+          Ephemeris<Barycentric>::FixedStepParameters(
+              SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
+                                                 Position<Barycentric>>(),
+              /*step=*/10 * Second)));
+    }
+    final_time += step;
+    state.ResumeTiming();
+
+    std::vector<std::future<void>> futures;
+    for (auto& instance : instances) {
+      futures.push_back(pool.Add([&ephemeris, &instance, final_time]() {
+        ephemeris->FlowWithFixedStep(final_time, *instance);
+      }));
+    }
+    for (auto const& future : futures) {
+      future.wait();
+    }
+  }
+
+  std::stringstream ss;
+  for (auto const& trajectory : trajectories) {
+    Length const earth_distance =
+        (at_спутник_1_launch->trajectory(*ephemeris, earth_name).
+             EvaluatePosition(final_time) -
+         trajectory.last().degrees_of_freedom().position()).Norm();
+    ss << earth_distance << " ";
+  }
+  state.SetLabel(ss.str());
+}
+
+template<SolarSystemFactory::Accuracy accuracy, Flow* flow>
+void EphemerisL4ProbeBenchmark(Time const integration_duration,
                                benchmark::State& state) {
   Length sun_error;
   Length earth_error;
@@ -189,7 +332,7 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
                              integration_duration;
 
   auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
-                             MakeAccuracyParameters(state.range_x()),
+                             MakeAccuracyParameters(state.range(0)),
                              EphemerisParameters());
 
   ephemeris->Prolong(final_time);
@@ -282,222 +425,25 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
                  std::to_string(total_degree));
 }
 
-template<Flow* flow>
-void EphemerisLEOProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
-                                benchmark::State& state) {
-  Length sun_error;
-  Length earth_error;
-  int steps;
-
-  auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
-  Instant const final_time = at_спутник_1_launch->epoch() + 1 * JulianYear;
-
-  auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
-                             MakeAccuracyParameters(state.range_x()),
-                             EphemerisParameters());
-
-  ephemeris->Prolong(final_time);
-
-  while (state.KeepRunning()) {
-    state.PauseTiming();
-    // A probe in low earth orbit.
-    MasslessBody probe;
-    DiscreteTrajectory<Barycentric> trajectory;
-    DegreesOfFreedom<Barycentric> const earth_degrees_of_freedom =
-        at_спутник_1_launch->degrees_of_freedom(
-            SolarSystemFactory::name(SolarSystemFactory::Earth));
-    Displacement<Barycentric> const earth_probe_displacement(
-        {6371 * Kilo(Metre) + 100 * NauticalMile, 0 * Metre, 0 * Metre});
-    Speed const earth_probe_speed =
-        Sqrt(at_спутник_1_launch->gravitational_parameter(
-                 SolarSystemFactory::name(SolarSystemFactory::Earth)) /
-                     earth_probe_displacement.Norm());
-    Velocity<Barycentric> const earth_probe_velocity(
-        {0 * Metre / Second, earth_probe_speed, 0 * Metre / Second});
-    trajectory.Append(at_спутник_1_launch->epoch(),
-                      DegreesOfFreedom<Barycentric>(
-                          earth_degrees_of_freedom.position() +
-                              earth_probe_displacement,
-                          earth_degrees_of_freedom.velocity() +
-                              earth_probe_velocity));
-
-    state.ResumeTiming();
-    flow(&trajectory, final_time, *ephemeris);
-    state.PauseTiming();
-
-    sun_error = (at_спутник_1_launch->trajectory(
-                     *ephemeris,
-                     SolarSystemFactory::name(SolarSystemFactory::Sun)).
-                         EvaluatePosition(final_time) -
-                 trajectory.last().degrees_of_freedom().position()).
-                     Norm();
-    earth_error = (at_спутник_1_launch->trajectory(
-                       *ephemeris,
-                       SolarSystemFactory::name(SolarSystemFactory::Earth)).
-                           EvaluatePosition(final_time) -
-                   trajectory.last().degrees_of_freedom().position()).
-                       Norm();
-    steps = trajectory.Size();
-    state.ResumeTiming();
-  }
-  std::stringstream ss;
-  ss << steps;
-  state.SetLabel(ss.str() + " steps, " +
-                 quantities::DebugString(sun_error / AstronomicalUnit) +
-                 " ua, " +
-                 quantities::DebugString((earth_error - 6371 * Kilo(Metre)) /
-                                         NauticalMile) +
-                 " nmi");
-}
-
-void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
-  auto const at_спутник_1_launch =
-      SolarSystemAtСпутник1Launch(
-          SolarSystemFactory::Accuracy::AllBodiesAndOblateness);
-  Instant const epoch = at_спутник_1_launch->epoch();
-  auto const ephemeris =
-      at_спутник_1_launch->MakeEphemeris(1 * Milli(Metre),
-                                         EphemerisParameters());
-  std::string const& earth_name =
-      SolarSystemFactory::name(SolarSystemFactory::Earth);
-  auto const earth_massive_body =
-      at_спутник_1_launch->massive_body(*ephemeris, earth_name);
-  auto const earth_degrees_of_freedom =
-      at_спутник_1_launch->degrees_of_freedom(earth_name);
-
-  MasslessBody probe;
-  std::list<DiscreteTrajectory<Barycentric>> trajectories;
-  for (int i = 0; i < state.range_x(); ++i) {
-    KeplerianElements<Barycentric> elements;
-    elements.eccentricity = 0;
-    elements.semimajor_axis = (i + 1) * 10'000 * Kilo(Metre);
-    elements.inclination = 0 * Radian;
-    elements.longitude_of_ascending_node = 0 * Radian;
-    elements.argument_of_periapsis = 0 * Radian;
-    elements.true_anomaly = 0 * Radian;
-    KeplerOrbit<Barycentric> const orbit(
-        *earth_massive_body, probe, elements, epoch);
-    trajectories.emplace_back();
-    auto& trajectory = trajectories.back();
-    trajectory.Append(epoch,
-                      earth_degrees_of_freedom + orbit.StateVectors(epoch));
-  }
-
-  ThreadPool<void> pool(/*pool_size=*/state.range_y());
-  static constexpr int warp_factor = 6E6;
-  static constexpr Frequency refresh_frequency = 50 * Hertz;
-  static constexpr Time step = warp_factor / refresh_frequency;
-  Instant final_time = epoch;
-  while (state.KeepRunning()) {
-    state.PauseTiming();
-    std::vector<not_null<std::unique_ptr<Integrator<Ephemeris<
-        Barycentric>::NewtonianMotionEquation>::Instance>>>
-        instances;
-    for (auto& trajectory : trajectories) {
-      instances.push_back(ephemeris->NewInstance(
-          {&trajectory},
-          Ephemeris<Barycentric>::NoIntrinsicAccelerations,
-          Ephemeris<Barycentric>::FixedStepParameters(
-              SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
-                                                 Position<Barycentric>>(),
-              /*step=*/10 * Second)));
-    }
-    final_time += step;
-    state.ResumeTiming();
-
-    std::vector<std::future<void>> futures;
-    for (auto& instance : instances) {
-      futures.push_back(pool.Add([&ephemeris, &instance, final_time]() {
-        ephemeris->FlowWithFixedStep(final_time, *instance);
-      }));
-    }
-    for (auto const& future : futures) {
-      future.wait();
-    }
-  }
-
-  std::stringstream ss;
-  for (auto const& trajectory : trajectories) {
-    Length const earth_distance =
-        (at_спутник_1_launch->trajectory(*ephemeris, earth_name).
-             EvaluatePosition(final_time) -
-         trajectory.last().degrees_of_freedom().position()).Norm();
-    ss << earth_distance << " ";
-  }
-  state.SetLabel(ss.str());
-}
-
 }  // namespace
 
-void BM_EphemerisSolarSystemMajorBodiesOnly(benchmark::State& state) {
-  EphemerisSolarSystemBenchmark(SolarSystemFactory::Accuracy::MajorBodiesOnly,
-                                state);
-}
-
-void BM_EphemerisSolarSystemMinorAndMajorBodies(benchmark::State& state) {
-  EphemerisSolarSystemBenchmark(
-      SolarSystemFactory::Accuracy::MinorAndMajorBodies,
-      state);
-}
-
-void BM_EphemerisSolarSystemAllBodiesAndOblateness(benchmark::State& state) {
-  EphemerisSolarSystemBenchmark(
-      SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
-      state);
-}
-
-template<Flow* flow>
-void BM_EphemerisL4ProbeMajorBodiesOnly(benchmark::State& state) {
-  EphemerisL4ProbeBenchmark<flow>(SolarSystemFactory::Accuracy::MajorBodiesOnly,
-                                  /*integration_duration=*/100 * JulianYear,
-                                  state);
-}
-
-template<Flow* flow>
-void BM_EphemerisL4ProbeMinorAndMajorBodies(benchmark::State& state) {
-  EphemerisL4ProbeBenchmark<flow>(
-      SolarSystemFactory::Accuracy::MinorAndMajorBodies,
-      /*integration_duration=*/100 * JulianYear,
-      state);
-}
-
-template<Flow* flow>
-void BM_EphemerisL4ProbeAllBodiesAndOblateness(benchmark::State& state) {
-  EphemerisL4ProbeBenchmark<flow>(
-      SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
-      /*integration_duration=*/100 * JulianYear,
-      state);
-}
-
-template<Flow* flow>
-void BM_EphemerisLEOProbeMajorBodiesOnly(benchmark::State& state) {
-  EphemerisLEOProbeBenchmark<flow>(
-      SolarSystemFactory::Accuracy::MajorBodiesOnly, state);
-}
-
-template<Flow* flow>
-void BM_EphemerisLEOProbeMinorAndMajorBodies(benchmark::State& state) {
-  EphemerisLEOProbeBenchmark<flow>(
-      SolarSystemFactory::Accuracy::MinorAndMajorBodies, state);
-}
-
-template<Flow* flow>
-void BM_EphemerisLEOProbeAllBodiesAndOblateness(benchmark::State& state) {
-  EphemerisLEOProbeBenchmark<flow>(
-      SolarSystemFactory::Accuracy::AllBodiesAndOblateness, state);
+template<SolarSystemFactory::Accuracy accuracy, Flow* flow>
+void BM_EphemerisL4Probe(benchmark::State& state) {
+  EphemerisL4ProbeBenchmark<accuracy, flow>(
+      /*integration_duration=*/100 * JulianYear, state);
 }
 
 template<Flow* flow>
 void BM_EphemerisFittingTolerance(benchmark::State& state) {
-  EphemerisL4ProbeBenchmark<flow>(SolarSystemFactory::Accuracy::MajorBodiesOnly,
-                                  /*integration_duration=*/100 * JulianYear,
+  EphemerisL4ProbeBenchmark<SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                            flow>(/*integration_duration=*/100 * JulianYear,
                                   state);
 }
 
 template<Flow* flow>
 void BM_EphemerisStartup(benchmark::State& state) {
-  EphemerisL4ProbeBenchmark<flow>(SolarSystemFactory::Accuracy::MajorBodiesOnly,
-                                  /*integration_duration=*/100 * Second,
+  EphemerisL4ProbeBenchmark<SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                            flow>(/*integration_duration=*/100 * Second,
                                   state);
 }
 
@@ -555,41 +501,71 @@ BENCHMARK(BM_EphemerisMultithreadingBenchmark)
     ->ArgPair(3, 4)
     ->ArgPair(3, 5);
 BENCHMARK(BM_EphemerisKSPSystem)->Arg(-3);
-BENCHMARK(BM_EphemerisSolarSystemMajorBodiesOnly)->Arg(-3);
-BENCHMARK(BM_EphemerisSolarSystemMinorAndMajorBodies)->Arg(-3);
-BENCHMARK(BM_EphemerisSolarSystemAllBodiesAndOblateness)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisL4ProbeMajorBodiesOnly,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisL4ProbeMinorAndMajorBodies,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisL4ProbeAllBodiesAndOblateness,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMajorBodiesOnly,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMajorBodiesOnly,
-                    &FlowEphemerisWithFixedStepSLMS)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMajorBodiesOnly,
-                    &FlowEphemerisWithFixedStepSRKN)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMinorAndMajorBodies,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMinorAndMajorBodies,
-                    &FlowEphemerisWithFixedStepSLMS)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeMinorAndMajorBodies,
-                    &FlowEphemerisWithFixedStepSRKN)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeAllBodiesAndOblateness,
-                    &FlowEphemerisWithAdaptiveStep)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeAllBodiesAndOblateness,
-                    &FlowEphemerisWithFixedStepSLMS)->Arg(-3);
-BENCHMARK_TEMPLATE1(BM_EphemerisLEOProbeAllBodiesAndOblateness,
-                    &FlowEphemerisWithFixedStepSRKN)->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
+                   SolarSystemFactory::Accuracy::MajorBodiesOnly)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
+                   SolarSystemFactory::Accuracy::MinorAndMajorBodies)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
+                   SolarSystemFactory::Accuracy::AllBodiesAndOblateness)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
+                   SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
+                   SolarSystemFactory::Accuracy::MinorAndMajorBodies,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
+                   SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                   &FlowEphemerisWithFixedStepSLMS)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MajorBodiesOnly,
+                   &FlowEphemerisWithFixedStepSRKN)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MinorAndMajorBodies,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MinorAndMajorBodies,
+                   &FlowEphemerisWithFixedStepSLMS)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::MinorAndMajorBodies,
+                   &FlowEphemerisWithFixedStepSRKN)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
+                   &FlowEphemerisWithAdaptiveStep)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
+                   &FlowEphemerisWithFixedStepSLMS)
+    ->Arg(-3);
+BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
+                   SolarSystemFactory::Accuracy::AllBodiesAndOblateness,
+                   &FlowEphemerisWithFixedStepSRKN)
+    ->Arg(-3);
 
-BENCHMARK_TEMPLATE1(BM_EphemerisFittingTolerance,
-                    &FlowEphemerisWithAdaptiveStep)->DenseRange(-4, 4);
+BENCHMARK_TEMPLATE(BM_EphemerisFittingTolerance, &FlowEphemerisWithAdaptiveStep)
+    ->DenseRange(-4, 4);
 
-BENCHMARK_TEMPLATE1(BM_EphemerisStartup,
-                    &FlowEphemerisWithFixedStepSLMS)->Arg(3);
-BENCHMARK_TEMPLATE1(BM_EphemerisStartup,
-                    &FlowEphemerisWithFixedStepSRKN)->Arg(3);
+BENCHMARK_TEMPLATE(BM_EphemerisStartup, &FlowEphemerisWithFixedStepSLMS)
+    ->Arg(3);
+BENCHMARK_TEMPLATE(BM_EphemerisStartup, &FlowEphemerisWithFixedStepSRKN)
+    ->Arg(3);
 
 }  // namespace physics
 }  // namespace principia

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -88,7 +88,8 @@ using Flow = void(not_null<DiscreteTrajectory<Barycentric>*> const trajectory,
                   Instant const& t,
                   Ephemeris<Barycentric>& ephemeris);
 
-Length FittingTolerance(int const scale) {
+typename Ephemeris<Barycentric>::AccuracyParameters MakeAccuracyParameters(
+    int const scale) {
   return 5 * std::pow(10.0, scale) * Metre;
 }
 
@@ -123,7 +124,7 @@ void BM_EphemerisKSPSystem(benchmark::State& state) {
     astronomy::StabilizeKSP(*at_origin);
     Instant const final_time = at_origin->epoch() + 100 * JulianYear;
     auto const ephemeris = at_origin->MakeEphemeris(
-        FittingTolerance(state.range_x()),
+        MakeAccuracyParameters(state.range_x()),
         Ephemeris<Barycentric>::FixedStepParameters(
             SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                   Position<Barycentric>>(),
@@ -154,9 +155,9 @@ void EphemerisSolarSystemBenchmark(SolarSystemFactory::Accuracy const accuracy,
 
     auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
     Instant const final_time = at_спутник_1_launch->epoch() + 100 * JulianYear;
-    auto const ephemeris =
-        at_спутник_1_launch->MakeEphemeris(FittingTolerance(state.range_x()),
-                                           EphemerisParameters());
+    auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
+                               MakeAccuracyParameters(state.range_x()),
+                               EphemerisParameters());
 
     state.ResumeTiming();
     ephemeris->Prolong(final_time);
@@ -187,9 +188,9 @@ void EphemerisL4ProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
   Instant const final_time = at_спутник_1_launch->epoch() +
                              integration_duration;
 
-  auto const ephemeris =
-      at_спутник_1_launch->MakeEphemeris(FittingTolerance(state.range_x()),
-                                         EphemerisParameters());
+  auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
+                             MakeAccuracyParameters(state.range_x()),
+                             EphemerisParameters());
 
   ephemeris->Prolong(final_time);
 
@@ -291,9 +292,9 @@ void EphemerisLEOProbeBenchmark(SolarSystemFactory::Accuracy const accuracy,
   auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
   Instant const final_time = at_спутник_1_launch->epoch() + 1 * JulianYear;
 
-  auto const ephemeris =
-      at_спутник_1_launch->MakeEphemeris(FittingTolerance(state.range_x()),
-                                         EphemerisParameters());
+  auto const ephemeris = at_спутник_1_launch->MakeEphemeris(
+                             MakeAccuracyParameters(state.range_x()),
+                             EphemerisParameters());
 
   ephemeris->Prolong(final_time);
 

--- a/physics/solar_system.hpp
+++ b/physics/solar_system.hpp
@@ -49,8 +49,9 @@ class SolarSystem final {
   // The bodies and initial state are constructed from the data passed to
   // |Initialize|.
   not_null<std::unique_ptr<Ephemeris<Frame>>> MakeEphemeris(
-      Length const& fitting_tolerance,
-      typename Ephemeris<Frame>::FixedStepParameters const& parameters) const;
+      typename Ephemeris<Frame>::AccuracyParameters const& accuracy_parameters,
+      typename Ephemeris<Frame>::FixedStepParameters const&
+          fixed_step_parameters) const;
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>>
   MakeAllMassiveBodies() const;

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -185,13 +185,14 @@ SolarSystem<Frame>& SolarSystem<Frame>::operator=(const SolarSystem& other) {
 
 template<typename Frame>
 not_null<std::unique_ptr<Ephemeris<Frame>>> SolarSystem<Frame>::MakeEphemeris(
-    Length const& fitting_tolerance,
-    typename Ephemeris<Frame>::FixedStepParameters const& parameters) const {
+    typename Ephemeris<Frame>::AccuracyParameters const& accuracy_parameters,
+    typename Ephemeris<Frame>::FixedStepParameters const& fixed_step_parameters)
+    const {
   return make_not_null_unique<Ephemeris<Frame>>(MakeAllMassiveBodies(),
                                                 MakeAllDegreesOfFreedom(),
                                                 epoch_,
-                                                fitting_tolerance,
-                                                parameters);
+                                                accuracy_parameters,
+                                                fixed_step_parameters);
 }
 
 template<typename Frame>

--- a/testing_utilities/solar_system_factory.hpp
+++ b/testing_utilities/solar_system_factory.hpp
@@ -12,6 +12,7 @@
 #include "geometry/rotation.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/discrete_trajectory.hpp"
+#include "physics/ephemeris.hpp"
 #include "physics/massive_body.hpp"
 #include "physics/solar_system.hpp"
 #include "quantities/quantities.hpp"
@@ -25,7 +26,9 @@ namespace internal_solar_system_factory {
 using astronomy::ICRS;
 using base::not_constructible;
 using base::not_null;
+using physics::Ephemeris;
 using physics::SolarSystem;
+using quantities::Length;
 
 // A helper class for constructing physics::SolarSystem objects for testing.
 // TODO(egg): should this be a namespace instead?  It contains only static
@@ -80,13 +83,20 @@ class SolarSystemFactory : not_constructible {
     MajorBodiesOnly,
     // Same as above, with some smaller satellites of the main planets.
     MinorAndMajorBodies,
-    // Same as above, with oblateness.
-    AllBodiesAndOblateness,
+    // Same as above, with damped oblateness.
+    AllBodiesAndDampedOblateness,
+    // Same as above, without damping.
+    AllBodiesAndFullOblateness,
   };
 
   template<typename Frame>
   static void AdjustAccuracy(Accuracy const accuracy,
                              SolarSystem<Frame>& solar_system);
+
+  template<typename Frame>
+  static typename Ephemeris<Frame>::AccuracyParameters MakeAccuracyParameters(
+      Length const& fitting_tolerance,
+      Accuracy const accuracy);
 
   // A solar system at the time of the launch of Простейший Спутник-1.
   static not_null<std::unique_ptr<SolarSystem<ICRS>>>

--- a/testing_utilities/solar_system_factory_body.hpp
+++ b/testing_utilities/solar_system_factory_body.hpp
@@ -23,7 +23,8 @@ void SolarSystemFactory::AdjustAccuracy(
   std::set<std::string> existing;
   std::set<std::string> oblate;
   switch (accuracy) {
-    case SolarSystemFactory::Accuracy::AllBodiesAndOblateness:
+    case SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness:
+    case SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness:
       oblate.insert(SolarSystemFactory::name(SolarSystemFactory::Sun));
       oblate.insert(SolarSystemFactory::name(SolarSystemFactory::Jupiter));
       oblate.insert(SolarSystemFactory::name(SolarSystemFactory::Saturn));
@@ -87,6 +88,26 @@ void SolarSystemFactory::AdjustAccuracy(
   for (std::string const& body_to_spherify : bodies_to_spherify) {
     solar_system.LimitOblatenessToDegree(body_to_spherify, /*max_degree=*/0);
   }
+}
+
+template<typename Frame>
+typename Ephemeris<Frame>::AccuracyParameters
+SolarSystemFactory::MakeAccuracyParameters(Length const& fitting_tolerance,
+                                           Accuracy const accuracy) {
+  switch (accuracy) {
+    case Accuracy::MajorBodiesOnly:
+    case Accuracy::MinorAndMajorBodies:
+    case Accuracy::AllBodiesAndDampedOblateness:
+      return typename Ephemeris<Frame>::AccuracyParameters(
+          fitting_tolerance,
+          /*geopotential_tolerance=*/0x1.0p-24);
+    case Accuracy::AllBodiesAndFullOblateness:
+      return typename Ephemeris<Frame>::AccuracyParameters(
+          fitting_tolerance,
+          /*geopotential_tolerance=*/0.0);
+  }
+  LOG(FATAL) << "Bad accuracy";
+  base::noreturn();
 }
 
 inline not_null<std::unique_ptr<SolarSystem<ICRS>>>

--- a/testing_utilities/solar_system_factory_test.cpp
+++ b/testing_utilities/solar_system_factory_test.cpp
@@ -41,6 +41,7 @@ using quantities::si::Radian;
 using ::testing::ElementsAreArray;
 using ::testing::Lt;
 using ::testing::Ge;
+using ::testing::UnorderedElementsAreArray;
 
 namespace testing_utilities {
 
@@ -170,6 +171,11 @@ TEST_F(SolarSystemFactoryTest, Name) {
       "Charon", "Ariel", "Umbriel", "Dione", "Ceres", "Tethys", "Vesta",
       "Enceladus", "Miranda", "Mimas", "Phobos", "Deimos"};
   EXPECT_THAT(names, ElementsAreArray(expected_names));
+
+  // Check that the enum is complete.
+  auto const solar_system = SolarSystemFactory::AtСпутник1Launch(
+      SolarSystemFactory::Accuracy::MinorAndMajorBodies);
+  EXPECT_THAT(solar_system->names(), UnorderedElementsAreArray(expected_names));
 }
 
 TEST_F(SolarSystemFactoryTest, Parent) {


### PR DESCRIPTION
TL;DR: The new code is 2x slower for low-Earth orbit, comparable in the other cases.

Benchmarks with `PRINCIPIA_USE_EXTENDED_GEOPOTENTIAL` set to 0:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                     Time         CPU Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_EphemerisMultithreadingBenchmark/3/1                                                                               102495353 ns        0 ns        100 +9.98765338665172644e+06 m +1.99941207398748249e+07 m +2.99993670217528194e+07 m
BM_EphemerisMultithreadingBenchmark/3/2                                                                                77841192 ns   156001 ns        100 +9.98765338665172644e+06 m +1.99941207398748249e+07 m +2.99993670217528194e+07 m
BM_EphemerisMultithreadingBenchmark/3/3                                                                                49749029 ns        0 ns        100 +9.98765338665172644e+06 m +1.99941207398748249e+07 m +2.99993670217528194e+07 m
BM_EphemerisMultithreadingBenchmark/3/4                                                                                46776591 ns        0 ns        100 +9.98765338665172644e+06 m +1.99941207398748249e+07 m +2.99993670217528194e+07 m
BM_EphemerisMultithreadingBenchmark/3/5                                                                                46512723 ns   156001 ns        100 +9.98765338665172644e+06 m +1.99941207398748249e+07 m +2.99993670217528194e+07 m
BM_EphemerisKSPSystem/-3                                                                                             45582163971 ns 45365090800 ns          1 +5.19502291148908779e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::MajorBodiesOnly>/-3                                            44419417105 ns 44288683900 ns          1 +9.92179030813603147e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::MinorAndMajorBodies>/-3                                        107768180359 ns 107406688500 ns          1 +9.92179031500272979e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness>/-3                               137863528928 ns 136469674800 ns          1 +9.92178865021161704e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness>/-3                                 136361164738 ns 135861270900 ns          1 +9.92178865021161704e-01 ua
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithAdaptiveStep>/-3                1165673650 ns 1154407400 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 78.839016
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithAdaptiveStep>/-3            3289566942 ns 3276021000 ns          1 154375 steps, +9.91602312429100796e-01 ua, +1.07738938749615909e+00 ua, degree 177.897618
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithAdaptiveStep>/-3   3178620405 ns 3166820300 ns          1 154375 steps, +9.91602312327635960e-01 ua, +1.07738926882746555e+00 ua, degree 178.009061
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithAdaptiveStep>/-3     3227772928 ns 3213620600 ns          1 154375 steps, +9.91602312327635960e-01 ua, +1.07738926882746555e+00 ua, degree 178.009061
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithAdaptiveStep>/-3               2097585334 ns 2090413400 ns          1 750001 steps, +9.91871697508377559e-01 ua, +9.99471255698674810e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithFixedStepSLMS>/-3              4675509288 ns 4633229700 ns          1 3155761 steps, +9.91888191584786028e-01 ua, +9.99957028991727839e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithFixedStepSRKN>/-3              15809241621 ns 15756101000 ns          1 3155761 steps, +9.91888190770475076e-01 ua, +9.99957014032675744e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithAdaptiveStep>/-3           3844897165 ns 3822024500 ns          1 750001 steps, +9.91871699265742257e-01 ua, +9.99472218270988861e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithFixedStepSLMS>/-3          7649785880 ns 7644049000 ns          1 3155761 steps, +9.91888192034501626e-01 ua, +9.99957081922148916e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithFixedStepSRKN>/-3          31026406313 ns 30981798600 ns          1 3155761 steps, +9.91888191491747340e-01 ua, +9.99957068526476718e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithAdaptiveStep>/-3  4724257263 ns 4711230200 ns          1 752025 steps, +9.91855046394646833e-01 ua, +8.93222024420957155e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithFixedStepSLMS>/-3 8542391197 ns 8533254700 ns          1 3155761 steps, +9.91841998260718172e-01 ua, +8.91409686009186402e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithFixedStepSRKN>/-3 36433558330 ns 36317032800 ns          1 3155761 steps, +9.91841998751963438e-01 ua, +8.91409587823412721e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithAdaptiveStep>/-3    4635004741 ns 4586429400 ns          1 752025 steps, +9.91855046394646833e-01 ua, +8.93222024420957155e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithFixedStepSLMS>/-3   8381716246 ns 8392853800 ns          1 3155761 steps, +9.91841998260718172e-01 ua, +8.91409686009186402e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithFixedStepSRKN>/-3   37843208767 ns 37721041800 ns          1 3155761 steps, +9.91841998751963438e-01 ua, +8.91409587823412721e+01 nmi
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-4                                                      1152197391 ns 1138807300 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 82.853624
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-3                                                      1147761906 ns 1154407400 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 78.839016
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-2                                                      1111707073 ns 1123207200 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581448441e+00 ua, degree 75.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-1                                                      1090847513 ns 1076406900 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581448441e+00 ua, degree 70.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/0                                                       1078204477 ns 1060806800 ns          1 154375 steps, +9.91602312582898548e-01 ua, +1.07738936581444511e+00 ua, degree 63.205200
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/1                                                       1051870846 ns 1045206700 ns          1 154375 steps, +9.91602312582899548e-01 ua, +1.07738936581440425e+00 ua, degree 61.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/2                                                       1004814982 ns 1014006500 ns          1 154375 steps, +9.91602312582899992e-01 ua, +1.07738936581436162e+00 ua, degree 57.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/3                                                        990937580 ns  982806300 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581446598e+00 ua, degree 55.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/4                                                        973856580 ns  982806300 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581435807e+00 ua, degree 54.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSLMS>/3                                                                  1135293 ns    1119508 ns        641 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSRKN>/3                                                                    51212 ns      51453 ns      11218 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
```
Benchmarks with `PRINCIPIA_USE_EXTENDED_GEOPOTENTIAL` set to 1:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                     Time         CPU Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_EphemerisMultithreadingBenchmark/3/1                                                                               233040985 ns        0 ns        100 +9.98770532375670038e+06 m +1.99941582925424948e+07 m +2.99993769189726748e+07 m
BM_EphemerisMultithreadingBenchmark/3/2                                                                               163622618 ns        0 ns        100 +9.98770532375670038e+06 m +1.99941582925424948e+07 m +2.99993769189726748e+07 m
BM_EphemerisMultithreadingBenchmark/3/3                                                                                94941591 ns        0 ns        100 +9.98770532375670038e+06 m +1.99941582925424948e+07 m +2.99993769189726748e+07 m
BM_EphemerisMultithreadingBenchmark/3/4                                                                                95739635 ns   156001 ns        100 +9.98770532375670038e+06 m +1.99941582925424948e+07 m +2.99993769189726748e+07 m
BM_EphemerisMultithreadingBenchmark/3/5                                                                                95260429 ns        0 ns        100 +9.98770532375670038e+06 m +1.99941582925424948e+07 m +2.99993769189726748e+07 m
BM_EphemerisKSPSystem/-3                                                                                             43786495721 ns 43602279500 ns          1 +5.19502291148908779e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::MajorBodiesOnly>/-3                                            44138741857 ns 43976681900 ns          1 +9.92179030813603147e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::MinorAndMajorBodies>/-3                                        106484910502 ns 106080680000 ns          1 +9.92179031500272979e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness>/-3                               146759006596 ns 146001335900 ns          1 +9.92178865559089740e-01 ua
BM_EphemerisSolarSystem<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness>/-3                                 509818839727 ns 507471253000 ns          1 +9.92178864993057741e-01 ua
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithAdaptiveStep>/-3                1091791768 ns 1060806800 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 78.839016
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithAdaptiveStep>/-3            3078273757 ns 3042019500 ns          1 154375 steps, +9.91602312429100796e-01 ua, +1.07738938749615909e+00 ua, degree 177.897618
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithAdaptiveStep>/-3   3207070796 ns 3198020500 ns          1 154375 steps, +9.91602312423093712e-01 ua, +1.07738926998535067e+00 ua, degree 177.887628
BM_EphemerisL4Probe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithAdaptiveStep>/-3     4715380723 ns 4695630100 ns          1 154375 steps, +9.91602312327635738e-01 ua, +1.07738926880737629e+00 ua, degree 177.838299
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithAdaptiveStep>/-3               2123580914 ns 2121613600 ns          1 750001 steps, +9.91871697508377559e-01 ua, +9.99471255698674810e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithFixedStepSLMS>/-3              4602490318 ns 4602029500 ns          1 3155761 steps, +9.91888191584786028e-01 ua, +9.99957028991727839e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MajorBodiesOnly, &FlowEphemerisWithFixedStepSRKN>/-3              16627441744 ns 16582906300 ns          1 3155761 steps, +9.91888190770475076e-01 ua, +9.99957014032675744e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithAdaptiveStep>/-3           4094824329 ns 4087226200 ns          1 750001 steps, +9.91871699265742257e-01 ua, +9.99472218270988861e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithFixedStepSLMS>/-3          7352558205 ns 7347647100 ns          1 3155761 steps, +9.91888192034501626e-01 ua, +9.99957081922148916e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::MinorAndMajorBodies, &FlowEphemerisWithFixedStepSRKN>/-3          33133189845 ns 33009811600 ns          1 3155761 steps, +9.91888191491747340e-01 ua, +9.99957068526476718e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithAdaptiveStep>/-3  9947325317 ns 9890463400 ns          1 752034 steps, +9.91875930178298004e-01 ua, +8.97619706021554435e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithFixedStepSLMS>/-3 16481947532 ns 16395705100 ns          1 3155761 steps, +9.91859374230485091e-01 ua, +8.90992280327162831e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness, &FlowEphemerisWithFixedStepSRKN>/-3 80512102404 ns 80168913900 ns          1 3155761 steps, +9.91859374993099507e-01 ua, +8.90992417868622084e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithAdaptiveStep>/-3    10976244897 ns 10920070000 ns          1 752034 steps, +9.91875930729894772e-01 ua, +8.97619532501515067e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithFixedStepSLMS>/-3   18061093477 ns 18049315700 ns          1 3155761 steps, +9.91859374608220601e-01 ua, +8.90992346899588910e+01 nmi
BM_EphemerisLEOProbe<SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness, &FlowEphemerisWithFixedStepSRKN>/-3   88408275347 ns 88187365300 ns          1 3155761 steps, +9.91859375310073288e-01 ua, +8.90992473763314194e+01 nmi
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-4                                                      1062422484 ns 1060806800 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 82.853624
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-3                                                      1057943081 ns 1060806800 ns          1 154375 steps, +9.91602312582897105e-01 ua, +1.07738936581449729e+00 ua, degree 78.839016
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-2                                                      1013792347 ns 1014006500 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581448441e+00 ua, degree 75.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/-1                                                      1008302194 ns 1014006500 ns          1 154375 steps, +9.91602312582897549e-01 ua, +1.07738936581448441e+00 ua, degree 70.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/0                                                        980955647 ns  982806300 ns          1 154375 steps, +9.91602312582898548e-01 ua, +1.07738936581444511e+00 ua, degree 63.205200
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/1                                                        970172044 ns  967206200 ns          1 154375 steps, +9.91602312582899548e-01 ua, +1.07738936581440425e+00 ua, degree 61.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/2                                                        912012773 ns  904805800 ns          1 154375 steps, +9.91602312582899992e-01 ua, +1.07738936581436162e+00 ua, degree 57.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/3                                                        907915028 ns  904805800 ns          1 154375 steps, +9.91602312582898771e-01 ua, +1.07738936581446598e+00 ua, degree 55.000000
BM_EphemerisFittingTolerance<&FlowEphemerisWithAdaptiveStep>/4                                                        884230132 ns  889205700 ns          1 154375 steps, +9.91602312582899770e-01 ua, +1.07738936581435807e+00 ua, degree 54.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSLMS>/3                                                                  1127565 ns    1143845 ns        641 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
BM_EphemerisStartup<&FlowEphemerisWithFixedStepSRKN>/3                                                                    51238 ns      50065 ns      14022 11 steps, +9.91835233804689742e-01 ua, +9.91835231548724217e-01 ua, degree 55.000000
```