### PR TITLE
Benchmark the effect of #1987

### DIFF
--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -249,7 +249,7 @@ void BM_ComputeGeopotentialF90(benchmark::State& state) {
 BENCHMARK(BM_ComputeGeopotentialCpp)->Arg(2)->Arg(3)->Arg(5)->Arg(10);
 BENCHMARK(BM_ComputeGeopotentialF90)->Arg(2)->Arg(3)->Arg(5)->Arg(10);
 BENCHMARK(BM_ComputeGeopotentialDistance)
-    ->Arg(80'000)      // C₂₂, S₂₂, J₂.
+    ->Arg(150'000)     // C₂₂, S₂₂, J₂.
     ->Arg(500'000)     // J₂.
     ->Arg(5'000'000);  // Central
 


### PR DESCRIPTION
Before:
```
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2                209881 ns     203362 ns       3452
BM_ComputeGeopotentialCpp/3                247661 ns     244795 ns       2804
BM_ComputeGeopotentialCpp/5                389660 ns     391089 ns       1795
BM_ComputeGeopotentialCpp/10              1229934 ns    1223537 ns        561
BM_ComputeGeopotentialF90/2                187493 ns     187752 ns       3739
BM_ComputeGeopotentialF90/3                233889 ns     229490 ns       2991
BM_ComputeGeopotentialF90/5                311598 ns     305884 ns       2244
BM_ComputeGeopotentialF90/10               783007 ns     782614 ns        897
BM_ComputeGeopotentialDistance/150000      206895 ns     207881 ns       3452
BM_ComputeGeopotentialDistance/500000      206158 ns     207881 ns       3452
BM_ComputeGeopotentialDistance/5000000      15791 ns      15645 ns      44872
```
After:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2                204456 ns     203362 ns       3452
BM_ComputeGeopotentialCpp/3                256037 ns     255922 ns       2804
BM_ComputeGeopotentialCpp/5                391698 ns     391089 ns       1795
BM_ComputeGeopotentialCpp/10              1159027 ns    1140114 ns        561
BM_ComputeGeopotentialF90/2                191895 ns     185285 ns       3452
BM_ComputeGeopotentialF90/3                237902 ns     233668 ns       2804
BM_ComputeGeopotentialF90/5                317587 ns     312836 ns       2244
BM_ComputeGeopotentialF90/10               801924 ns     817397 ns        897
BM_ComputeGeopotentialDistance/150000      209373 ns     207881 ns       3452
BM_ComputeGeopotentialDistance/500000       75461 ns      74750 ns       8974
BM_ComputeGeopotentialDistance/5000000      16079 ns      15992 ns      44872
```