### PR TITLE
Remove the size parameter from Precomputations

### DIFF
--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -115,13 +115,12 @@ class Geopotential {
   using UnitVector = Vector<double, Frame>;
 
   // Holds precomputed data for one evaluation of the acceleration.
-  template<int size>
   struct Precomputations;
 
   // Helper templates for iterating over the degrees/orders of the geopotential.
-  template<int size, int degree, int order>
+  template<int degree, int order>
   struct DegreeNOrderM;
-  template<int size, int degree, typename>
+  template<int degree, typename>
   struct DegreeNAllOrders;
   template<typename>
   struct AllDegrees;

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -92,8 +92,12 @@ void HarmonicDamping::ComputeDampedRadialQuantities(
 }
 
 template<typename Frame>
-template<int size>
 struct Geopotential<Frame>::Precomputations {
+  // Allocate the maximum size to cover all possible degrees.  Making |size| a
+  // template parameters of this class would be possible, but it would greatly
+  // increase the number of instances of DegreeNOrderM and friends.
+  static constexpr int size = OblateBody<Frame>::max_geopotential_degree + 1;
+
   // These quantities are independent from n and m.
   typename OblateBody<Frame>::GeopotentialCoefficients const* cos;
   typename OblateBody<Frame>::GeopotentialCoefficients const* sin;
@@ -124,21 +128,21 @@ struct Geopotential<Frame>::Precomputations {
 };
 
 template<typename Frame>
-template<int size, int degree, int order>
+template<int degree, int order>
 struct Geopotential<Frame>::DegreeNOrderM {
-  FORCE_INLINE(static) auto Acceleration(Precomputations<size>& precomputations)
+  FORCE_INLINE(static) auto Acceleration(Precomputations& precomputations)
       -> Vector<ReducedAcceleration, Frame>;
 };
 
 template<typename Frame>
-template<int size, int degree, int... orders>
+template<int degree, int... orders>
 struct Geopotential<Frame>::
-DegreeNAllOrders<size, degree, std::integer_sequence<int, orders...>> {
+DegreeNAllOrders<degree, std::integer_sequence<int, orders...>> {
   static inline auto Acceleration(Geopotential<Frame> const& geopotential,
                                   Vector<double, Frame> const& r_normalized,
                                   Length const& r_norm,
                                   Square<Length> const& r²,
-                                  Precomputations<size>& precomputations)
+                                  Precomputations& precomputations)
       -> Vector<ReducedAcceleration, Frame>;
 };
 
@@ -155,9 +159,9 @@ struct Geopotential<Frame>::AllDegrees<std::integer_sequence<int, degrees...>> {
 };
 
 template<typename Frame>
-template<int size, int degree, int order>
-auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
-    Precomputations<size>& precomputations)
+template<int degree, int order>
+auto Geopotential<Frame>::DegreeNOrderM<degree, order>::Acceleration(
+    Precomputations& precomputations)
     -> Vector<ReducedAcceleration, Frame> {
   if constexpr (degree == 2 && order == 1) {
     // Let's not forget the Legendre derivative that we would compute if we did
@@ -295,19 +299,20 @@ auto Geopotential<Frame>::DegreeNOrderM<size, degree, order>::Acceleration(
 }
 
 template<typename Frame>
-template<int size, int degree, int... orders>
+template<int degree, int... orders>
 auto Geopotential<Frame>::
-DegreeNAllOrders<size, degree, std::integer_sequence<int, orders...>>::
+DegreeNAllOrders<degree, std::integer_sequence<int, orders...>>::
 Acceleration(Geopotential<Frame> const& geopotential,
              Vector<double, Frame> const& r_normalized,
              Length const& r_norm,
              Square<Length> const& r²,
-             Precomputations<size>& precomputations)
+             Precomputations& precomputations)
     -> Vector<ReducedAcceleration, Frame> {
   if constexpr (degree < 2) {
     return {};
   } else {
     constexpr int n = degree;
+    constexpr int size = sizeof...(orders);
 
     auto& ℜ_over_r = precomputations.ℜ_over_r[n];
 
@@ -339,13 +344,13 @@ Acceleration(Geopotential<Frame> const& geopotential,
     // (σ = 0).
     DCHECK_LT(r_norm, geopotential.degree_damping_[n].outer_threshold());
 
-    if (sizeof...(orders) == 1 || n >= geopotential.first_tesseral_degree_) {
+    if (size == 1 || n >= geopotential.first_tesseral_degree_) {
       // All orders came into effect at the same threshold, so we apply the same
       // σ to everything.
 
       // Force the evaluation by increasing order using an initializer list.
       ReducedAccelerations<size> const accelerations = {
-          DegreeNOrderM<size, degree, orders>::Acceleration(
+          DegreeNOrderM<degree, orders>::Acceleration(
               precomputations)...};
 
       return (accelerations[orders] + ...);
@@ -354,7 +359,7 @@ Acceleration(Geopotential<Frame> const& geopotential,
     // The degree-specific sigmoid computed above applies to the zonal term.
 
     Vector<ReducedAcceleration, Frame> const zonal_acceleration =
-        DegreeNOrderM<size, degree, 0>::Acceleration(precomputations);
+        DegreeNOrderM<degree, 0>::Acceleration(precomputations);
 
     // If we are above the outer threshold, we should have been called with
     // (orders...) = (0), since σ = 0.
@@ -370,7 +375,7 @@ Acceleration(Geopotential<Frame> const& geopotential,
 
     ReducedAccelerations<size> const accelerations = {
         (orders == 0 ? zonal_acceleration
-                     : DegreeNOrderM<size, degree, orders>::Acceleration(
+                     : DegreeNOrderM<degree, orders>::Acceleration(
                            precomputations))...};
 
     return (accelerations[orders] + ...);
@@ -393,7 +398,7 @@ Acceleration(Geopotential<Frame> const& geopotential,
       body.is_zonal() ||
       r_norm > geopotential.tesseral_damping_.outer_threshold();
 
-  Precomputations<size> precomputations;
+  Precomputations precomputations;
 
   auto& cos = precomputations.cos;
   auto& sin = precomputations.sin;
@@ -475,13 +480,12 @@ Acceleration(Geopotential<Frame> const& geopotential,
   ReducedAccelerations<size> accelerations;
   if (is_zonal) {
     accelerations = {
-        DegreeNAllOrders<size, degrees, std::make_integer_sequence<int, 1>>::
+        DegreeNAllOrders<degrees, std::make_integer_sequence<int, 1>>::
             Acceleration(
                 geopotential, r_normalized, r_norm, r², precomputations)...};
   } else {
     accelerations = {
-        DegreeNAllOrders<size,
-                         degrees,
+        DegreeNAllOrders<degrees,
                          std::make_integer_sequence<int, degrees + 1>>::
             Acceleration(
                 geopotential, r_normalized, r_norm, r², precomputations)...};

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -344,7 +344,7 @@ Acceleration(Geopotential<Frame> const& geopotential,
       // (σ = 0).
       DCHECK_LT(r_norm, geopotential.degree_damping_[2].outer_threshold());
       Vector<ReducedAcceleration, Frame> const j2_acceleration =
-          DegreeNOrderM<size, 2, 0>::Acceleration(precomputations);
+          DegreeNOrderM<2, 0>::Acceleration(precomputations);
       geopotential.sectoral_damping_.ComputeDampedRadialQuantities(
           r_norm,
           r²,
@@ -358,9 +358,9 @@ Acceleration(Geopotential<Frame> const& geopotential,
       DCHECK_LT(r_norm, geopotential.sectoral_damping_.outer_threshold());
       // Perform the precomputations for order 1 (but the result is known to be
       // 0, so don't bother adding it).
-      DegreeNOrderM<size, 2, 1>::Acceleration(precomputations);
+      DegreeNOrderM<2, 1>::Acceleration(precomputations);
       Vector<ReducedAcceleration, Frame> const c22_s22_acceleration =
-          DegreeNOrderM<size, 2, 2>::Acceleration(precomputations);
+          DegreeNOrderM<2, 2>::Acceleration(precomputations);
       return j2_acceleration + c22_s22_acceleration;
     } else {
       geopotential.degree_damping_[n].ComputeDampedRadialQuantities(
@@ -375,8 +375,7 @@ Acceleration(Geopotential<Frame> const& geopotential,
 
       // Force the evaluation by increasing order using an initializer list.
       ReducedAccelerations<size> const accelerations = {
-          DegreeNOrderM<size, degree, orders>::Acceleration(
-              precomputations)...};
+          DegreeNOrderM<degree, orders>::Acceleration(precomputations)...};
 
       return (accelerations[orders] + ...);
     }

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -94,7 +94,7 @@ void HarmonicDamping::ComputeDampedRadialQuantities(
 template<typename Frame>
 struct Geopotential<Frame>::Precomputations {
   // Allocate the maximum size to cover all possible degrees.  Making |size| a
-  // template parameters of this class would be possible, but it would greatly
+  // template parameter of this class would be possible, but it would greatly
   // increase the number of instances of DegreeNOrderM and friends.
   static constexpr int size = OblateBody<Frame>::max_geopotential_degree + 1;
 
@@ -120,10 +120,6 @@ struct Geopotential<Frame>::Precomputations {
   // These quantities depend on both n and m.  Note that the zeros for m > n are
   // not stored.
   FixedLowerTriangularMatrix<double, size> DmPn_of_sin_β{uninitialized};
-
-  // These quantities depend on n, and, for n = 2, on m.
-  Exponentiation<Length, -2> σℜ_over_r;
-  Vector<Exponentiation<Length, -2>, Frame> grad_σℜ;
 };
 
 template<typename Frame>


### PR DESCRIPTION
Also move some parameters out of Precomputations.

Before:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2                185057 ns     183580 ns       3739
BM_ComputeGeopotentialCpp/3                262468 ns     267049 ns       2804
BM_ComputeGeopotentialCpp/5                361499 ns     359818 ns       1951
BM_ComputeGeopotentialCpp/10              1113582 ns    1112307 ns        561
BM_ComputeGeopotentialF90/2                189437 ns     189804 ns       3452
BM_ComputeGeopotentialF90/3                231198 ns     229490 ns       2991
BM_ComputeGeopotentialF90/5                314695 ns     312836 ns       2244
BM_ComputeGeopotentialF90/10               797973 ns     792518 ns        748
BM_ComputeGeopotentialDistance/150000      190063 ns     191924 ns       3739
BM_ComputeGeopotentialDistance/500000       71952 ns      72313 ns      11218
BM_ComputeGeopotentialDistance/5000000      15912 ns      15992 ns      44872
```
After:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2                182962 ns     183580 ns       3739
BM_ComputeGeopotentialCpp/3                233103 ns     233668 ns       2804
BM_ComputeGeopotentialCpp/5                359574 ns     359818 ns       1951
BM_ComputeGeopotentialCpp/10               975638 ns     980220 ns        748
BM_ComputeGeopotentialF90/2                191297 ns     187752 ns       3739
BM_ComputeGeopotentialF90/3                252026 ns     250358 ns       2804
BM_ComputeGeopotentialF90/5                313378 ns     312836 ns       2244
BM_ComputeGeopotentialF90/10               794720 ns     800005 ns        897
BM_ComputeGeopotentialDistance/150000      186832 ns     187752 ns       3739
BM_ComputeGeopotentialDistance/500000       71877 ns      70922 ns      11218
BM_ComputeGeopotentialDistance/5000000      15804 ns      15645 ns      44872
```