### PR TITLE
Actually implement IAU 29 resolution B3

### DIFF
--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -1172,7 +1172,7 @@ TEST_F(TrappistDynamicsTest, MathematicaTransits) {
 
   std::string info;
   double const χ² = Transitsχ²(observations, computations, info);
-  CHECK_LT(χ², 480.0);
+  CHECK_LT(χ², 482.0);
   CHECK_GT(χ², 470.0);
   LOG(ERROR) << u8"χ²: " << χ² << " " << info;
 }

--- a/astronomy/trappist_gravity_model.proto.txt
+++ b/astronomy/trappist_gravity_model.proto.txt
@@ -1,5 +1,5 @@
 gravity_model {
-  solar_system_frame : SKY
+  solar_system_frame    : SKY
   # Right ascensions from a normal distribution with μ=-90, σ=0.05.
   # Declinations from a normal distribution with μ=0, σ=0.05.
 
@@ -9,109 +9,109 @@ gravity_model {
   # Angular frequency from "Frequent flaring in the TRAPPIST-1 system — unsuited
   # for life?", Vida et al., 2017.
   body {
-    name                 : "Trappist-1"
-    mass                 : "0.0890 GM☉"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "0.1210 R☉"
-    axis_right_ascension : "-89.9408 deg"
-    axis_declination     : "0.0497342 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "109.256 deg / d"
+    name                    : "Trappist-1"
+    gravitational_parameter : "0.0890 GM☉"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "0.1210 R☉"
+    axis_right_ascension    : "-89.9408 deg"
+    axis_declination        : "0.0497342 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "109.256 deg / d"
   }
 
   # Planets.
   # Masses and radii from "The nature of the TRAPPIST-1 exoplanets", Grimm et
   # al., 2018.
-  # For planets b and c, the radius used is the radius of the core from table 4;
+  # For planets b and c, the mean radius is the radius of the core from table 4;
   # We model envelope of volatiles as liquid water and ice on d through h, so
-  # the transit radius from table 2 is used there instead.  All masses are from
-  # table 2.
+  # the transit radius from table 2 is used there instead.  All masses and
+  # reference radii are from table 2.
   # Angular frequencies from a linear fit of the transits over 100 years,
   # assuming tidal locking.
   # J2 from a log-normal distribution with median 0.001 (rougthly the J2 of
   # Earth) and σ = 1.
   body {
-    name                 : "Trappist-1b"
-    mass                 : "1.017 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "1.01 R🜨"
-    axis_right_ascension : "-89.9077 deg"
-    axis_declination     : "0.0561637 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "238.280381526399 deg / d"
-    j2                   : 0.000625831
-    reference_radius     : "1.121 R🜨"
+    name                    : "Trappist-1b"
+    gravitational_parameter : "1.017 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "1.01 R🜨"
+    axis_right_ascension    : "-89.9077 deg"
+    axis_declination        : "0.0561637 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "238.280381526399 deg / d"
+    j2                      : 0.000625831
+    reference_radius        : "1.121 R🜨"
   }
   body {
-    name                 : "Trappist-1c"
-    mass                 : "1.156 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "1.06 R🜨"
-    axis_right_ascension : "-89.9829 deg"
-    axis_declination     : "0.0787536 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "148.649662442390 deg / d"
-    j2                   : 0.000937274
-    reference_radius     : "1.095 R🜨"
+    name                    : "Trappist-1c"
+    gravitational_parameter : "1.156 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "1.06 R🜨"
+    axis_right_ascension    : "-89.9829 deg"
+    axis_declination        : "0.0787536 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "148.649662442390 deg / d"
+    j2                      : 0.000937274
+    reference_radius        : "1.095 R🜨"
   }
   body {
-    name                 : "Trappist-1d"
-    mass                 : "0.297 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "0.784 R🜨"
-    axis_right_ascension : "-90.0387 deg"
-    axis_declination     : "0.0106394 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "88.8958290050067 deg / d"
-    j2                   : 0.00189136
-    reference_radius     : "0.784 R🜨"
+    name                    : "Trappist-1d"
+    gravitational_parameter : "0.297 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "0.784 R🜨"
+    axis_right_ascension    : "-90.0387 deg"
+    axis_declination        : "0.0106394 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "88.8958290050067 deg / d"
+    j2                      : 0.00189136
+    reference_radius        : "0.784 R🜨"
   }
   body {
-    name                 : "Trappist-1e"
-    mass                 : "0.772 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "0.910 R🜨"
-    axis_right_ascension : "-89.9999 deg"
-    axis_declination     : "-0.0949119 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "59.0190202231139 deg / d"
-    j2                   : 0.000475803
-    reference_radius     : "0.910 R🜨"
+    name                    : "Trappist-1e"
+    gravitational_parameter : "0.772 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "0.910 R🜨"
+    axis_right_ascension    : "-89.9999 deg"
+    axis_declination        : "-0.0949119 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "59.0190202231139 deg / d"
+    j2                      : 0.000475803
+    reference_radius        : "0.910 R🜨"
   }
   body {
-    name                 : "Trappist-1f"
-    mass                 : "0.934 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "1.046 R🜨"
-    axis_right_ascension : "-89.9582 deg"
-    axis_declination     : "0.0404001 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "39.1011616849564 deg / d"
-    j2                   : 0.00264731
-    reference_radius     : "1.046 R🜨"
+    name                    : "Trappist-1f"
+    gravitational_parameter : "0.934 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "1.046 R🜨"
+    axis_right_ascension    : "-89.9582 deg"
+    axis_declination        : "0.0404001 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "39.1011616849564 deg / d"
+    j2                      : 0.00264731
+    reference_radius        : "1.046 R🜨"
   }
   body {
-    name                 : "Trappist-1g"
-    mass                 : "1.148 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "1.148 R🜨"
-    axis_right_ascension : "-89.9896 deg"
-    axis_declination     : "0.0367975 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "29.1422346007618 deg / d"
-    j2                   : 0.0000873713
-    reference_radius     : "1.148 R🜨"
+    name                    : "Trappist-1g"
+    gravitational_parameter : "1.148 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "1.148 R🜨"
+    axis_right_ascension    : "-89.9896 deg"
+    axis_declination        : "0.0367975 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "29.1422346007618 deg / d"
+    j2                      : 0.0000873713
+    reference_radius        : "1.148 R🜨"
   }
   body {
-    name                 : "Trappist-1h"
-    mass                 : "0.331 GM🜨"
-    reference_instant    : "JD2457000.000000000"
-    mean_radius          : "0.773 R🜨"
-    axis_right_ascension : "-89.8993 deg"
-    axis_declination     : "0.0130609 deg"
-    reference_angle      : "0 deg"
-    angular_frequency    : "19.1833342568893 deg / d"
-    j2                   : 0.00166162
-    reference_radius     : "0.773 R🜨"
+    name                    : "Trappist-1h"
+    gravitational_parameter : "0.331 GM🜨"
+    reference_instant       : "JD2457000.000000000"
+    mean_radius             : "0.773 R🜨"
+    axis_right_ascension    : "-89.8993 deg"
+    axis_declination        : "0.0130609 deg"
+    reference_angle         : "0 deg"
+    angular_frequency       : "19.1833342568893 deg / d"
+    j2                      : 0.00166162
+    reference_radius        : "0.773 R🜨"
   }
 }

--- a/astronomy/trappist_gravity_model.proto.txt
+++ b/astronomy/trappist_gravity_model.proto.txt
@@ -10,7 +10,7 @@ gravity_model {
   # for life?", Vida et al., 2017.
   body {
     name                 : "Trappist-1"
-    mass                 : "0.0890 M☉"
+    mass                 : "0.0890 GM☉"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "0.1210 R☉"
     axis_right_ascension : "-89.9408 deg"
@@ -32,7 +32,7 @@ gravity_model {
   # Earth) and σ = 1.
   body {
     name                 : "Trappist-1b"
-    mass                 : "1.017 M🜨"
+    mass                 : "1.017 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "1.01 R🜨"
     axis_right_ascension : "-89.9077 deg"
@@ -44,7 +44,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1c"
-    mass                 : "1.156 M🜨"
+    mass                 : "1.156 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "1.06 R🜨"
     axis_right_ascension : "-89.9829 deg"
@@ -56,7 +56,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1d"
-    mass                 : "0.297 M🜨"
+    mass                 : "0.297 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "0.784 R🜨"
     axis_right_ascension : "-90.0387 deg"
@@ -68,7 +68,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1e"
-    mass                 : "0.772 M🜨"
+    mass                 : "0.772 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "0.910 R🜨"
     axis_right_ascension : "-89.9999 deg"
@@ -80,7 +80,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1f"
-    mass                 : "0.934 M🜨"
+    mass                 : "0.934 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "1.046 R🜨"
     axis_right_ascension : "-89.9582 deg"
@@ -92,7 +92,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1g"
-    mass                 : "1.148 M🜨"
+    mass                 : "1.148 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "1.148 R🜨"
     axis_right_ascension : "-89.9896 deg"
@@ -104,7 +104,7 @@ gravity_model {
   }
   body {
     name                 : "Trappist-1h"
-    mass                 : "0.331 M🜨"
+    mass                 : "0.331 GM🜨"
     reference_instant    : "JD2457000.000000000"
     mean_radius          : "0.773 R🜨"
     axis_right_ascension : "-89.8993 deg"

--- a/astronomy/trappist_gravity_model.proto.txt
+++ b/astronomy/trappist_gravity_model.proto.txt
@@ -1,7 +1,10 @@
 gravity_model {
   solar_system_frame    : SKY
-  # Right ascensions from a normal distribution with μ=-90, σ=0.05.
-  # Declinations from a normal distribution with μ=0, σ=0.05.
+  # Right ascensions from a normal distribution with μ=-90, σ=0.05°.
+  # Declinations from a normal distribution with μ=0, σ=0.05°.
+  # This standard deviation is the mode of the polar angle scatter distribution
+  # in figure 7 of Luger, Lustig-Yaeger, and Agol (2017), Planet-Planet
+  # Occultations in TRAPPIST-1 and Other Exoplanet Systems.
 
   # Star.
   # Mass and radius from "Early 2017 observations of TRAPPIST-1 with Spitzer",

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -52,7 +52,6 @@ using quantities::SIUnit;
 using quantities::Speed;
 using quantities::Time;
 using quantities::astronomy::AstronomicalUnit;
-using quantities::astronomy::EarthMass;
 using quantities::astronomy::JulianYear;
 using quantities::si::Kilo;
 using quantities::si::Metre;

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -36,8 +36,7 @@ using quantities::Sqrt;
 using quantities::Time;
 using quantities::astronomy::AstronomicalUnit;
 using quantities::astronomy::JulianYear;
-using quantities::astronomy::SolarMass;
-using quantities::constants::GravitationalConstant;
+using quantities::astronomy::SolarGravitationalParameter;
 using quantities::si::Degree;
 using quantities::si::Kilo;
 using quantities::si::Milli;
@@ -58,7 +57,7 @@ class ApsidesTest : public ::testing::Test {
 
 TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
   Instant const t0;
-  GravitationalParameter const μ = GravitationalConstant * SolarMass;
+  GravitationalParameter const μ = SolarGravitationalParameter;
   auto const b = new MassiveBody(μ);
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
@@ -154,7 +153,7 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
 
 TEST_F(ApsidesTest, ComputeNodes) {
   Instant const t0;
-  GravitationalParameter const μ = GravitationalConstant * SolarMass;
+  GravitationalParameter const μ = SolarGravitationalParameter;
   auto const b = new MassiveBody(μ);
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -142,7 +142,7 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
     Position<World> const position = pair.second.position();
     if (previous_time) {
       EXPECT_THAT(time - *previous_time,
-                  AlmostEquals(0.5 * T, 103, 3820));
+                  AlmostEquals(0.5 * T, 103, 4936));
       EXPECT_THAT((position - *previous_position).Norm(),
                   AlmostEquals(2.0 * a, 0, 176));
     }
@@ -216,7 +216,7 @@ TEST_F(ApsidesTest, ComputeNodes) {
                     .coordinates()
                     .ToSpherical()
                     .longitude,
-                AlmostEquals(elements.longitude_of_ascending_node, 0, 100));
+                AlmostEquals(elements.longitude_of_ascending_node, 0, 104));
     if (previous_time) {
       EXPECT_THAT(time - *previous_time, AlmostEquals(*elements.period, 0, 20));
     }

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -754,7 +754,7 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
   EXPECT_THAT(elephant_positions.back().coordinates().y,
               AnyOf(IsNear(-2.3e-31 * Metre), Eq(0 * Metre)));
   EXPECT_LT(RelativeError(elephant_positions.back().coordinates().z,
-                          earth_polar_radius), 8e-7);
+                          TerrestrialPolarRadius), 8e-7);
 
   EXPECT_THAT(elephant_accelerations.size(), AnyOf(Eq(8), Eq(9)));
   EXPECT_THAT(elephant_accelerations.back().coordinates().x,

--- a/quantities/astronomy.hpp
+++ b/quantities/astronomy.hpp
@@ -34,7 +34,7 @@ constexpr Irradiance  TotalSolarIrradiance      = 1361 * (si::Watt /
 constexpr Power       SolarLuminosity           = 3.828e26 * si::Watt;
 constexpr Temperature SolarEffectiveTemperature = 5772 * si::Kelvin;
 constexpr GravitationalParameter SolarGravitationalParameter =
-    1.327'124'4e20 * (Pow<3>(Metre) / Pow<2>(Second));
+    1.327'124'4e20 * (Pow<3>(si::Metre) / Pow<2>(si::Second));
 
 // Planetary conversion constants.
 // “If equatorial vs. polar radius is not explicitly specified, it should be

--- a/quantities/astronomy.hpp
+++ b/quantities/astronomy.hpp
@@ -15,25 +15,43 @@ namespace astronomy {
 
 // Résolution B2 "Re-définition de l’unité astronomique de longueur" adopted
 // at the XXVIIIth General Assembly of the IAU in 2012.
-constexpr Length AstronomicalUnit      = 149597870700 * si::Metre;
+constexpr Length AstronomicalUnit = 149597870700 * si::Metre;
 
 // See note 4 of Résolution B2 "Sur la recommandation du "point zéro" des
 // échelles de magnitude bolométrique absolue et apparente" adopted at the
 // XXIXth General Assembly of the IAU in 2015.
-constexpr Length Parsec                = 648000 / π * AstronomicalUnit;
+constexpr Length Parsec = 648000 / π * AstronomicalUnit;
 
 // System of nominal solar and planetary conversion constants, Résolution B3
 // "Sur les valeurs  recommandées de constantes de conversion pour une sélection
 // de propriétés solaires et planétaires" adopted at the XXIXth General Assembly
 // of the IAU in 2015.
-constexpr Mass   SolarMass             = 1.98855e30 * si::Kilogram;
-constexpr Mass   JupiterMass           = 1.8986e27 * si::Kilogram;
-constexpr Mass   EarthMass             = 5.9742e24 * si::Kilogram;
-constexpr Length EarthEquatorialRadius = 6.3781e6 * si::Metre;
-constexpr Length SolarRadius           = 6.957e8 * si::Metre;
 
-constexpr Time   JulianYear            = 365.25 * si::Day;
-constexpr Length LightYear             = constants::SpeedOfLight * JulianYear;
+constexpr Length      SolarRadius               = 6.957e8 * si::Metre;
+constexpr Irradiance  TotalSolarIrradiance      = 1361 * (si::Watt /
+                                                          Pow<2>(si::Metre));
+constexpr Power       SolarLuminosity           = 3.828e26 * si::Watt;
+constexpr Temperature SolarEffectiveTemperature = 5772 * si::Kelvin;
+
+constexpr GravitationalParameter SolarGravitationalParameter =
+    1.327'124'4e20 * (Pow<3>(Metre) / Pow<2>(Second));
+
+// “If equatorial vs. polar radius is not explicitly specified, it should be
+// understood that nominal terrestrial [or jovian] radius refers specifically to
+// [the nominal equatorial radius], following common usage.”
+
+constexpr Length TerrestrialEquatorialRadius = 6.3781e6 * si::Metre;
+constexpr Length TerrestrialPolarRadius      = 6.3568e6 * si::Metre;
+constexpr Length JovianEquatorialRadius      = 7.1492e7 * si::Metre;
+constexpr Length JovianPolarRadius           = 6.6854e7 * si::Metre;
+
+constexpr GravitationalParameter TerrestrialGravitationalParameter =
+    3.986'004e14 * (Pow<3>(si::Metre) / Pow<2>(si::Second));
+constexpr GravitationalParameter JovianGravitationalParameter      =
+    1.266'865'3e17 * (Pow<3>(si::Metre) / Pow<2>(si::Second));
+
+constexpr Time   JulianYear = 365.25 * si::Day;
+constexpr Length LightYear  = constants::SpeedOfLight * JulianYear;
 
 }  // namespace astronomy
 }  // namespace quantities

--- a/quantities/astronomy.hpp
+++ b/quantities/astronomy.hpp
@@ -27,24 +27,23 @@ constexpr Length Parsec = 648000 / π * AstronomicalUnit;
 // de propriétés solaires et planétaires" adopted at the XXIXth General Assembly
 // of the IAU in 2015.
 
+// Solar conversion constants.
 constexpr Length      SolarRadius               = 6.957e8 * si::Metre;
 constexpr Irradiance  TotalSolarIrradiance      = 1361 * (si::Watt /
                                                           Pow<2>(si::Metre));
 constexpr Power       SolarLuminosity           = 3.828e26 * si::Watt;
 constexpr Temperature SolarEffectiveTemperature = 5772 * si::Kelvin;
-
 constexpr GravitationalParameter SolarGravitationalParameter =
     1.327'124'4e20 * (Pow<3>(Metre) / Pow<2>(Second));
 
+// Planetary conversion constants.
 // “If equatorial vs. polar radius is not explicitly specified, it should be
 // understood that nominal terrestrial [or jovian] radius refers specifically to
 // [the nominal equatorial radius], following common usage.”
-
 constexpr Length TerrestrialEquatorialRadius = 6.3781e6 * si::Metre;
 constexpr Length TerrestrialPolarRadius      = 6.3568e6 * si::Metre;
 constexpr Length JovianEquatorialRadius      = 7.1492e7 * si::Metre;
 constexpr Length JovianPolarRadius           = 6.6854e7 * si::Metre;
-
 constexpr GravitationalParameter TerrestrialGravitationalParameter =
     3.986'004e14 * (Pow<3>(si::Metre) / Pow<2>(si::Second));
 constexpr GravitationalParameter JovianGravitationalParameter      =

--- a/quantities/elementary_functions_test.cpp
+++ b/quantities/elementary_functions_test.cpp
@@ -114,7 +114,7 @@ TEST_F(ElementaryFunctionsTest, PhysicalConstants) {
               Lt(1e-2));
   EXPECT_THAT(RelativeError(1 * SolarGravitationalParameter,
                             1047 * JovianGravitationalParameter),
-              Lt(4e-4));
+              Lt(6e-4));
   // Delambre & Méchain.
   EXPECT_THAT(RelativeError(TerrestrialGravitationalParameter /
                                 Pow<2>(40 * Mega(Metre) / (2 * π)),

--- a/quantities/elementary_functions_test.cpp
+++ b/quantities/elementary_functions_test.cpp
@@ -20,12 +20,12 @@ namespace principia {
 namespace quantities {
 
 using astronomy::AstronomicalUnit;
-using astronomy::EarthMass;
 using astronomy::JulianYear;
-using astronomy::JupiterMass;
 using astronomy::LightYear;
 using astronomy::Parsec;
-using astronomy::SolarMass;
+using astronomy::JovianGravitationalParameter;
+using astronomy::SolarGravitationalParameter;
+using astronomy::TerrestrialGravitationalParameter;
 using constants::GravitationalConstant;
 using constants::SpeedOfLight;
 using constants::StandardGravity;
@@ -102,24 +102,23 @@ TEST_F(ElementaryFunctionsTest, PhysicalConstants) {
   // The Keplerian approximation for the mass of the Sun
   // is fairly accurate.
   EXPECT_THAT(RelativeError(
-                  4 * Pow<2>(π) * Pow<3>(AstronomicalUnit) /
-                      (GravitationalConstant * Pow<2>(JulianYear)),
-                  SolarMass),
+                  4 * Pow<2>(π) * Pow<3>(AstronomicalUnit) / Pow<2>(JulianYear),
+                  SolarGravitationalParameter),
               Lt(4e-5));
   EXPECT_THAT(RelativeError(1 * Parsec, 3.26156 * LightYear), Lt(2e-6));
   // The Keplerian approximation for the mass of the Earth
   // is pretty bad, but the error is still only 1%.
-  EXPECT_THAT(RelativeError(
-                  4 * Pow<2>(π) * Pow<3>(lunar_distance) /
-                      (GravitationalConstant * Pow<2>(27.321582 * Day)),
-                  EarthMass),
+  EXPECT_THAT(RelativeError(4 * Pow<2>(π) * Pow<3>(lunar_distance) /
+                                Pow<2>(27.321582 * Day),
+                            TerrestrialGravitationalParameter),
               Lt(1e-2));
-  EXPECT_THAT(RelativeError(1 * SolarMass, 1047 * JupiterMass), Lt(4e-4));
+  EXPECT_THAT(RelativeError(1 * SolarGravitationalParameter,
+                            1047 * JovianGravitationalParameter),
+              Lt(4e-4));
   // Delambre & Méchain.
-  EXPECT_THAT(RelativeError(
-                  GravitationalConstant * EarthMass /
-                      Pow<2>(40 * Mega(Metre) / (2 * π)),
-                  StandardGravity),
+  EXPECT_THAT(RelativeError(TerrestrialGravitationalParameter /
+                                Pow<2>(40 * Mega(Metre) / (2 * π)),
+                            StandardGravity),
               Lt(4e-3));
   // Talleyrand.
   EXPECT_THAT(RelativeError(π * Sqrt(1 * Metre / StandardGravity), 1 * Second),

--- a/quantities/parser_body.hpp
+++ b/quantities/parser_body.hpp
@@ -116,7 +116,7 @@ inline Unit ParseUnit(std::string const& s) {
   } else if (s == "km") {
     return Unit(si::Kilo(si::Metre));
   } else if (s == u8"R🜨") {
-    return Unit(astronomy::EarthEquatorialRadius);
+    return Unit(astronomy::TerrestrialEquatorialRadius);
   } else if (s == u8"R☉") {
     return Unit(astronomy::SolarRadius);
   } else if (s == "au") {
@@ -124,10 +124,6 @@ inline Unit ParseUnit(std::string const& s) {
   // Units of mass.
   } else if (s == "kg") {
     return Unit(si::Kilogram);
-  } else if (s == u8"M🜨") {
-    return Unit(astronomy::EarthMass);
-  } else if (s == u8"M☉") {
-    return Unit(astronomy::SolarMass);
   // Units of time.
   } else if (s == "ms") {
     return Unit(si::Milli(si::Second));
@@ -139,6 +135,11 @@ inline Unit ParseUnit(std::string const& s) {
     return Unit(si::Hour);
   } else if (s == "d") {
     return Unit(si::Day);
+  // Units of gravitational parameter.
+  } else if (s == u8"GM🜨") {
+    return Unit(astronomy::TerrestrialGravitationalParameter);
+  } else if (s == u8"GM☉") {
+    return Unit(astronomy::SolarGravitationalParameter);
   // Units of power.
   } else if (s == "W") {
     return Unit(si::Watt);

--- a/quantities/parser_body.hpp
+++ b/quantities/parser_body.hpp
@@ -136,9 +136,9 @@ inline Unit ParseUnit(std::string const& s) {
   } else if (s == "d") {
     return Unit(si::Day);
   // Units of gravitational parameter.
-  } else if (s == u8"GGM🜨") {
+  } else if (s == u8"GM🜨") {
     return Unit(astronomy::TerrestrialGravitationalParameter);
-  } else if (s == u8"GGM☉") {
+  } else if (s == u8"GM☉") {
     return Unit(astronomy::SolarGravitationalParameter);
   // Units of power.
   } else if (s == "W") {

--- a/quantities/parser_body.hpp
+++ b/quantities/parser_body.hpp
@@ -136,9 +136,9 @@ inline Unit ParseUnit(std::string const& s) {
   } else if (s == "d") {
     return Unit(si::Day);
   // Units of gravitational parameter.
-  } else if (s == u8"GM🜨") {
+  } else if (s == u8"GGM🜨") {
     return Unit(astronomy::TerrestrialGravitationalParameter);
-  } else if (s == u8"GM☉") {
+  } else if (s == u8"GGM☉") {
     return Unit(astronomy::SolarGravitationalParameter);
   // Units of power.
   } else if (s == "W") {

--- a/quantities/quantities_test.cpp
+++ b/quantities/quantities_test.cpp
@@ -16,13 +16,13 @@
 namespace principia {
 namespace quantities {
 
-using astronomy::EarthMass;
+using astronomy::JovianGravitationalParameter;
 using astronomy::JulianYear;
-using astronomy::JupiterMass;
 using astronomy::LightYear;
 using astronomy::Parsec;
-using astronomy::SolarMass;
+using astronomy::TerrestrialGravitationalParameter;
 using constants::ElectronMass;
+using constants::ProtonMass;
 using constants::SpeedOfLight;
 using si::Ampere;
 using si::Candela;
@@ -49,7 +49,8 @@ class QuantitiesTest : public testing::Test {};
 using QuantitiesDeathTest = QuantitiesTest;
 
 TEST_F(QuantitiesTest, DimensionfulComparisons) {
-  testing_utilities::TestOrder(EarthMass, JupiterMass);
+  testing_utilities::TestOrder(TerrestrialGravitationalParameter,
+                               JovianGravitationalParameter);
   testing_utilities::TestOrder(LightYear, Parsec);
   testing_utilities::TestOrder(-SpeedOfLight, SpeedOfLight);
   testing_utilities::TestOrder(SpeedOfLight * Day, LightYear);
@@ -61,8 +62,8 @@ TEST_F(QuantitiesTest, DimensionlfulOperations) {
       -340.29 * Metre / Second, 0.0, 1.0, -2 * π, 1729.0, 0, 2);
   // Dimensionful multiplication is a tensor product, see [Tao 2012].
   testing_utilities::TestBilinearMap(
-      std::multiplies<>(), SolarMass,
-      ElectronMass, SpeedOfLight, 1 * Furlong / JulianYear, -e, 0, 2);
+      std::multiplies<>(), ProtonMass, ElectronMass, SpeedOfLight,
+      1 * Furlong / JulianYear, -e, 0, 2);
 }
 
 // The Greek letters cause a warning when stringified by the macros, because


### PR DESCRIPTION
While #1846 introduced a reference to the IAU resolution, it kept the existing constants.

These are ancient, introduced by https://github.com/mockingbirdnest/Principia/commit/3084f819b5bd3a88c2ddbbf0fb37ccddd846b620 in March 2014, predating the relevant IAU resolution by more than a year; being masses, they are fundamentally unsuitable as nominal values, as gravitational parameters are known with much greater accuracy than 𝐺 is.

Switch to the system of nominal solar and planetary conversion constants.