### PR TITLE
Remove the implicit constructor for AccuracyParameters

### DIFF
--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -269,8 +269,8 @@ TEST_F(GeodesyTest, LAGEOS2) {
   // Absolute error in position.
   EXPECT_THAT(AbsoluteError(secondary_actual_final_dof.position(),
                             primary_actual_final_dof.position()),
-              AnyOf(IsNear(237 * Metre),   // Linux.
-                    IsNear(28 * Metre),    // No FMA.
+              AnyOf(IsNear(237 * Metre),    // Linux.
+                    IsNear(28 * Metre),     // No FMA.
                     IsNear(8.9 * Metre)));  // FMA.
   // Angular error at the geocentre.
   EXPECT_THAT(AngleBetween(secondary_actual_final_dof.position() - ITRS::origin,
@@ -284,7 +284,7 @@ TEST_F(GeodesyTest, LAGEOS2) {
                   (primary_actual_final_dof.position() - ITRS::origin).Norm()),
               AnyOf(IsNear(99 * Centi(Metre)),     // Linux.
                     IsNear(11 * Centi(Metre)),     // No FMA.
-                    IsNear(1.6 * Centi(Metre))));  // FMA.
+                    IsNear(3.3 * Centi(Metre))));  // FMA.
 }
 
 #endif

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -271,20 +271,20 @@ TEST_F(GeodesyTest, LAGEOS2) {
                             primary_actual_final_dof.position()),
               AnyOf(IsNear(237 * Metre),   // Linux.
                     IsNear(28 * Metre),    // No FMA.
-                    IsNear(10 * Metre)));  // FMA.
+                    IsNear(8.9 * Metre)));  // FMA.
   // Angular error at the geocentre.
   EXPECT_THAT(AngleBetween(secondary_actual_final_dof.position() - ITRS::origin,
                            primary_actual_final_dof.position() - ITRS::origin),
               AnyOf(IsNear(4.0 * ArcSecond),     // Linux.
                     IsNear(0.47 * ArcSecond),    // No FMA.
-                    IsNear(0.17 * ArcSecond)));  // FMA.
+                    IsNear(0.15 * ArcSecond)));  // FMA.
   // Radial error at the geocentre.
   EXPECT_THAT(AbsoluteError(
                   (secondary_actual_final_dof.position() - ITRS::origin).Norm(),
                   (primary_actual_final_dof.position() - ITRS::origin).Norm()),
               AnyOf(IsNear(99 * Centi(Metre)),     // Linux.
                     IsNear(11 * Centi(Metre)),     // No FMA.
-                    IsNear(1.7 * Centi(Metre))));  // FMA.
+                    IsNear(1.6 * Centi(Metre))));  // FMA.
 }
 
 #endif

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -61,7 +61,8 @@ class GeodesyTest : public ::testing::Test {
             SOLUTION_DIR / "astronomy" /
                 "sol_initial_state_jd_2455200_500000000.proto.txt"),
         ephemeris_(solar_system_2010_.MakeEphemeris(
-            /*fitting_tolerance=*/5 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<ICRS>::FixedStepParameters(
                 SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                                    Position<ICRS>>(),

--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -86,7 +86,8 @@ class KSPResonanceTest : public ::testing::Test {
 
   not_null<std::unique_ptr<Ephemeris<KSP>>> MakeEphemeris() {
     auto ephemeris = solar_system_.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<KSP>::FixedStepParameters(
             SymplecticRungeKuttaNyströmIntegrator<
                 McLachlanAtela1992Order5Optimal, Position<KSP>>(),

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -85,7 +85,9 @@ class KSPSystemTest : public ::testing::Test, protected KSPSystem {
  protected:
   KSPSystemTest()
       : ephemeris_(solar_system_.MakeEphemeris(
-            /*fitting_tolerance=*/1 * Milli(Metre),
+            Ephemeris<KSP>::AccuracyParameters(
+                /*fitting_tolerance=*/1 * Milli(Metre),
+                /*geopotential_tolerance=*/0x1p-24),
             Ephemeris<KSP>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order5Optimal,
@@ -418,7 +420,8 @@ TEST_P(KSPSystemConvergenceTest, DISABLED_Convergence) {
 
     auto const start = std::chrono::system_clock::now();
     auto const ephemeris = solar_system_.MakeEphemeris(
-        /*fitting_tolerance=*/1 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<KSP>::FixedStepParameters(integrator(), step));
     ephemeris->Prolong(solar_system_.epoch() + integration_duration);
     auto const end = std::chrono::system_clock::now();

--- a/astronomy/lunar_eclipse_test.cpp
+++ b/astronomy/lunar_eclipse_test.cpp
@@ -62,7 +62,8 @@ class LunarEclipseTest : public ::testing::Test {
   static void SetUpTestCase() {
     google::LogToStderr();
     ephemeris_ = solar_system_1950_.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                                Position<ICRS>>(),

--- a/astronomy/mercury_perihelion_test.cpp
+++ b/astronomy/mercury_perihelion_test.cpp
@@ -147,26 +147,26 @@ TEST_F(MercuryPerihelionTest, Year1950) {
 
   EXPECT_THAT(RelativeError(*keplerian_elements.eccentricity,
                              *keplerian_elements_1950_.eccentricity),
-              IsNear(9.3e-13));
+              IsNear(3.6e-13));
   EXPECT_THAT(RelativeError(*keplerian_elements.semimajor_axis,
                             *keplerian_elements_1950_.semimajor_axis),
-              IsNear(2.1e-13));
+              IsNear(7.7e-14));
   EXPECT_THAT(RelativeError(*keplerian_elements.mean_motion,
                           *keplerian_elements_1950_.mean_motion),
-              IsNear(3.1e-13));
+              IsNear(1.2e-13));
   EXPECT_THAT(RelativeError(keplerian_elements.inclination,
                           keplerian_elements_1950_.inclination),
-              IsNear(5.6e-14));
+              IsNear(1.7e-14));
   EXPECT_THAT(RelativeError(keplerian_elements.longitude_of_ascending_node,
                            keplerian_elements_1950_.
                                longitude_of_ascending_node),
-              IsNear(3.8e-14));
+              IsNear(1.2e-14));
   EXPECT_THAT(RelativeError(*keplerian_elements_1950_.argument_of_periapsis,
                           *keplerian_elements.argument_of_periapsis),
-              IsNear(2.0e-13));
+              IsNear(6.6e-14));
   EXPECT_THAT(RelativeError(*keplerian_elements.mean_anomaly,
                           *keplerian_elements_1950_.mean_anomaly),
-              IsNear(8.4e-14));
+              IsNear(3.0e-14));
 }
 
 #if !defined(_DEBUG)
@@ -185,23 +185,28 @@ TEST_F(MercuryPerihelionTest, Year1960) {
       *sun_, *mercury_, relative_degrees_of_freedom, t_1960_);
   KeplerianElements<ICRS> const keplerian_elements = orbit.elements_at_epoch();
 
-  EXPECT_LT(RelativeError(*keplerian_elements.eccentricity,
-                          *keplerian_elements_1960_.eccentricity), 5.3e-7);
-  EXPECT_LT(RelativeError(*keplerian_elements.semimajor_axis,
-                          *keplerian_elements_1960_.semimajor_axis), 1.1e-7);
-  EXPECT_LT(RelativeError(*keplerian_elements.mean_motion,
-                          *keplerian_elements_1960_.mean_motion), 1.7e-7);
-  EXPECT_LT(RelativeError(keplerian_elements.inclination,
-                          keplerian_elements_1960_.inclination), 1.1e-10);
-  EXPECT_LT(RelativeError(keplerian_elements.longitude_of_ascending_node,
-                          keplerian_elements_1960_.
-                              longitude_of_ascending_node), 1.3e-9);
+  EXPECT_THAT(RelativeError(*keplerian_elements.eccentricity,
+                            *keplerian_elements_1960_.eccentricity),
+              IsNear(5.3e-7));
+  EXPECT_THAT(RelativeError(*keplerian_elements.semimajor_axis,
+                            *keplerian_elements_1960_.semimajor_axis),
+              IsNear(1.1e-7));
+  EXPECT_THAT(RelativeError(*keplerian_elements.mean_motion,
+                            *keplerian_elements_1960_.mean_motion),
+              IsNear(1.6e-7));
+  EXPECT_THAT(RelativeError(keplerian_elements.inclination,
+                            keplerian_elements_1960_.inclination),
+              IsNear(9.3e-10));
+  EXPECT_THAT(
+      RelativeError(keplerian_elements.longitude_of_ascending_node,
+                    keplerian_elements_1960_.longitude_of_ascending_node),
+      IsNear(7.5e-9));
   EXPECT_THAT(*keplerian_elements_1960_.argument_of_periapsis -
                   *keplerian_elements.argument_of_periapsis,
-              IsNear(4.203 * ArcSecond, 1.0002));
+              IsNear(4.206 * ArcSecond, 1.0002));
   EXPECT_THAT(*keplerian_elements.mean_anomaly -
                   *keplerian_elements_1960_.mean_anomaly,
-              IsNear(17.03 * ArcSecond, 1.0002));
+              IsNear(17.03 * ArcSecond, 1.0003));
 }
 
 TEST_F(MercuryPerihelionTest, DISABLED_Year2050) {
@@ -219,26 +224,31 @@ TEST_F(MercuryPerihelionTest, DISABLED_Year2050) {
       *sun_, *mercury_, relative_degrees_of_freedom, t_2050_);
   KeplerianElements<ICRS> const keplerian_elements = orbit.elements_at_epoch();
 
-  EXPECT_LT(RelativeError(*keplerian_elements.eccentricity,
-                          *keplerian_elements_2050_.eccentricity), 9.8e-8);
-  EXPECT_LT(RelativeError(*keplerian_elements.semimajor_axis,
-                          *keplerian_elements_2050_.semimajor_axis), 1.9e-8);
-  EXPECT_LT(RelativeError(*keplerian_elements.mean_motion,
-                          *keplerian_elements_2050_.mean_motion), 2.8e-8);
-  EXPECT_LT(RelativeError(keplerian_elements.inclination,
-                          keplerian_elements_2050_.inclination), 6.3e-9);
-  EXPECT_LT(RelativeError(keplerian_elements.longitude_of_ascending_node,
-                          keplerian_elements_2050_.
-                              longitude_of_ascending_node), 9.1e-8);
+  EXPECT_THAT(RelativeError(*keplerian_elements.eccentricity,
+                            *keplerian_elements_2050_.eccentricity),
+              IsNear(9.8e-8));
+  EXPECT_THAT(RelativeError(*keplerian_elements.semimajor_axis,
+                            *keplerian_elements_2050_.semimajor_axis),
+              IsNear(1.8e-8));
+  EXPECT_THAT(RelativeError(*keplerian_elements.mean_motion,
+                            *keplerian_elements_2050_.mean_motion),
+              IsNear(2.7e-8));
+  EXPECT_THAT(RelativeError(keplerian_elements.inclination,
+                            keplerian_elements_2050_.inclination),
+              IsNear(4.0e-9));
+  EXPECT_THAT(
+      RelativeError(keplerian_elements.longitude_of_ascending_node,
+                    keplerian_elements_2050_.longitude_of_ascending_node),
+      IsNear(1.5e-7));
   // The actual number is 42.98" on average, but there are other periodic
   // effects so your mileage will vary.  See Nobili and Will, The real value of
   // Mercury's perihelion advance.
   EXPECT_THAT(*keplerian_elements_2050_.argument_of_periapsis -
                   *keplerian_elements.argument_of_periapsis,
-              IsNear(42.84 * ArcSecond, 1.0001));
+              IsNear(42.87 * ArcSecond, 1.0001));
   EXPECT_THAT(*keplerian_elements.mean_anomaly -
                   *keplerian_elements_2050_.mean_anomaly,
-              IsNear(171.3 * ArcSecond, 1.0006));
+              IsNear(171.2 * ArcSecond, 1.0006));
 }
 
 #endif

--- a/astronomy/mercury_perihelion_test.cpp
+++ b/astronomy/mercury_perihelion_test.cpp
@@ -60,7 +60,8 @@ class MercuryPerihelionTest : public testing::Test {
   static void SetUpTestCase() {
     google::LogToStderr();
     ephemeris_ = solar_system_1950_.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                                Position<ICRS>>(),

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -264,7 +264,8 @@ TEST_F(SolarSystemDynamicsTest, DISABLED_TenYearsFromJ2000) {
           "sol_initial_state_jd_2455200_500000000.proto.txt");
 
   auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
-      /*fitting_tolerance=*/5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                 Position<ICRS>>(),
@@ -379,7 +380,8 @@ TEST(MarsTest, Phobos) {
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2451545_000000000.proto.txt");
   auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
-      /*fitting_tolerance=*/5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                 Position<ICRS>>(),
@@ -480,7 +482,8 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
 
     auto const start = std::chrono::system_clock::now();
     auto const ephemeris = solar_system_at_j2000.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<ICRS>::FixedStepParameters(integrator(), step));
     ephemeris->Prolong(solar_system_at_j2000.epoch() + integration_duration);
     auto const end = std::chrono::system_clock::now();

--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -960,7 +960,8 @@ class TrappistDynamicsTest : public ::testing::Test {
                 SOLUTION_DIR / "astronomy" /
                     "trappist_initial_state_jd_2457000_000000000.proto.txt"),
         ephemeris_(system_.MakeEphemeris(
-            /*fitting_tolerance=*/5 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<Sky>::FixedStepParameters(
                 SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
                                                    Position<Sky>>(),
@@ -1075,7 +1076,8 @@ class TrappistDynamicsTest : public ::testing::Test {
         new Graveyard(std::thread::hardware_concurrency());
 
     auto ephemeris = system.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<Sky>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<Quinlan1999Order8A,
                                                Position<Sky>>(),

--- a/astronomy/молния_orbit_test.cpp
+++ b/astronomy/молния_orbit_test.cpp
@@ -73,7 +73,8 @@ class МолнияOrbitTest : public ::testing::Test {
   static void SetUpTestCase() {
     google::LogToStderr();
     ephemeris_ = solar_system_2000_.MakeEphemeris(
-        /*fitting_tolerance=*/5 * Milli(Metre),
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<ICRS>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                                Position<ICRS>>(),

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -134,7 +134,8 @@ void BM_BodyCentredNonRotatingDynamicFrame(benchmark::State& state) {
           "sol_initial_state_jd_2433282_500000000.proto.txt",
       /*ignore_frame=*/true);
   auto const ephemeris = solar_system.MakeEphemeris(
-      /*fitting_tolerance=*/5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<Barycentric>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order5Optimal,
                                                 Position<Barycentric>>(),
@@ -182,7 +183,8 @@ void BM_BarycentricRotatingDynamicFrame(benchmark::State& state) {
           "sol_initial_state_jd_2433282_500000000.proto.txt",
       /*ignore_frame=*/true);
   auto const ephemeris = solar_system.MakeEphemeris(
-      /*fitting_tolerance=*/5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<Barycentric>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order5Optimal,
                                                 Position<Barycentric>>(),

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -123,7 +123,8 @@ void BM_EphemerisKSPSystem(benchmark::State& state) {
     astronomy::StabilizeKSP(*at_origin);
     Instant const final_time = at_origin->epoch() + 100 * JulianYear;
     auto const ephemeris = at_origin->MakeEphemeris(
-        FittingTolerance(state.range(0)),
+        /*accuracy_parameters=*/{FittingTolerance(state.range(0)),
+                                 /*geopotential_tolerance=*/0x1p-24},
         Ephemeris<Barycentric>::FixedStepParameters(
             SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                   Position<Barycentric>>(),
@@ -324,8 +325,10 @@ void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
           SolarSystemFactory::Accuracy::AllBodiesAndFullOblateness);
   Instant const epoch = at_спутник_1_launch->epoch();
   auto const ephemeris =
-      at_спутник_1_launch->MakeEphemeris(1 * Milli(Metre),
-                                         EphemerisParameters());
+      at_спутник_1_launch->MakeEphemeris(
+          /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                   /*geopotential_tolerance=*/0x1p-24},
+          EphemerisParameters());
   std::string const& earth_name =
       SolarSystemFactory::name(SolarSystemFactory::Earth);
   auto const earth_massive_body =

--- a/benchmarks/planetarium_plot_methods.cpp
+++ b/benchmarks/planetarium_plot_methods.cpp
@@ -100,9 +100,10 @@ class Satellites {
             SOLUTION_DIR / "astronomy" /
                 "sol_initial_state_jd_2451545_000000000.proto.txt",
             /*ignore_frame=*/true)),
-        ephemeris_(
-            solar_system_->MakeEphemeris(/*fitting_tolerance=*/1 * Milli(Metre),
-                                         EphemerisParameters())),
+        ephemeris_(solar_system_->MakeEphemeris(
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
+            EphemerisParameters())),
         earth_(solar_system_->massive_body(
             *ephemeris_,
             SolarSystemFactory::name(SolarSystemFactory::Earth))),

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -72,7 +72,9 @@ class FlightPlanTest : public testing::Test {
         std::move(bodies),
         initial_state,
         /*initial_time=*/t0_ - 2 * π * Second,
-        /*fitting_tolerance=*/1 * Milli(Metre),
+        Ephemeris<Barycentric>::AccuracyParameters(
+            /*fitting_tolerance=*/1 * Milli(Metre),
+            /*geopotential_tolerance=*/0x1p-24),
         Ephemeris<Barycentric>::FixedStepParameters(
             SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                                Position<Barycentric>>(),

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -544,7 +544,8 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
       std::move(bodies),
       initial_state,
       /*initial_time=*/astronomy::J2000,
-      /*fitting_tolerance=*/1 * Metre,
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Metre,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<Barycentric>::FixedStepParameters{
           SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN6B,
                                                 Position<Barycentric>>(),

--- a/mathematica/local_error_analysis.cpp
+++ b/mathematica/local_error_analysis.cpp
@@ -53,7 +53,8 @@ void LocalErrorAnalyser::WriteLocalErrors(
     Time const& granularity,
     Time const& duration) const {
   auto const reference_ephemeris = solar_system_->MakeEphemeris(
-      fitting_tolerance,
+      /*accuracy_parameters=*/{fitting_tolerance,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator_, step_));
   reference_ephemeris->Prolong(solar_system_->epoch());
   std::vector<std::vector<Length>> errors;
@@ -100,7 +101,8 @@ not_null<std::unique_ptr<Ephemeris<ICRS>>> LocalErrorAnalyser::ForkEphemeris(
       solar_system_->MakeAllMassiveBodies(),
       degrees_of_freedom,
       t,
-      fitting_tolerance,
+      Ephemeris<ICRS>::AccuracyParameters(fitting_tolerance,
+                                          /*geopotential_tolerance=*/0x1p-24),
       Ephemeris<ICRS>::FixedStepParameters(integrator, step));
 }
 

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -191,7 +191,9 @@ not_null<std::unique_ptr<Ephemeris<Barycentric>>> MakeEphemeris(
       std::move(system.bodies),
       system.degrees_of_freedom,
       ksp_epoch,
-      /*fitting_tolerance=*/1 * Milli(Metre),
+      Ephemeris<Barycentric>::AccuracyParameters(
+          /*fitting_tolerance=*/1 * Milli(Metre),
+          /*geopotential_tolerance=*/0x1p-24),
       Ephemeris<Barycentric>::FixedStepParameters(integrator, step));
 }
 

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -586,7 +586,8 @@ void StatisticallyAnalyseStability() {
             std::move(system.bodies),
             system.degrees_of_freedom,
             ephemeris->t_min(),
-            1 * Milli(Metre),
+            /*accuracy_parameters=*/{1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<Barycentric>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<BlanesMoan2002SRKN14A,
                                                       Position<Barycentric>>(),

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -69,7 +69,8 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
       std::move(bodies),
       initial_state,
       t0,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Metre,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<World>::FixedStepParameters(
           SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                              Position<World>>(),
@@ -165,7 +166,8 @@ TEST_F(ApsidesTest, ComputeNodes) {
       std::move(bodies),
       initial_state,
       t0,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Metre,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<World>::FixedStepParameters(
           SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                              Position<World>>(),

--- a/physics/barycentric_rotating_dynamic_frame_test.cpp
+++ b/physics/barycentric_rotating_dynamic_frame_test.cpp
@@ -79,7 +79,8 @@ class BarycentricRotatingDynamicFrameTest : public ::testing::Test {
                           "test_initial_state_two_bodies_circular.proto.txt"),
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
-            /*fitting_tolerance=*/1 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,

--- a/physics/body_centred_body_direction_dynamic_frame_test.cpp
+++ b/physics/body_centred_body_direction_dynamic_frame_test.cpp
@@ -82,7 +82,8 @@ class BodyCentredBodyDirectionDynamicFrameTest : public ::testing::Test {
                           "test_initial_state_two_bodies_circular.proto.txt"),
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
-            /*fitting_tolerance=*/1 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,

--- a/physics/body_centred_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_test.cpp
@@ -77,7 +77,8 @@ class BodyCentredNonRotatingDynamicFrameTest : public ::testing::Test {
                           "test_initial_state_two_bodies_circular.proto.txt"),
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
-            /*fitting_tolerance=*/1 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,

--- a/physics/body_surface_dynamic_frame_test.cpp
+++ b/physics/body_surface_dynamic_frame_test.cpp
@@ -87,7 +87,8 @@ class BodySurfaceDynamicFrameTest : public ::testing::Test {
                           "test_initial_state_two_bodies_circular.proto.txt"),
         t0_(solar_system_.epoch()),
         ephemeris_(solar_system_.MakeEphemeris(
-            /*fitting_tolerance=*/1 * Milli(Metre),
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
             Ephemeris<ICRS>::FixedStepParameters(
                 SymplecticRungeKuttaNyströmIntegrator<
                     McLachlanAtela1992Order4Optimal,

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -357,7 +357,8 @@ TEST_F(BodyTest, SolarNoon) {
       SOLUTION_DIR / "astronomy" /
           "sol_initial_state_jd_2451545_000000000.proto.txt");
   auto const ephemeris = solar_system_j2000.MakeEphemeris(
-      /*fitting_tolerance=*/5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(
           SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
                                              Position<ICRS>>(),

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -117,8 +117,6 @@ class Ephemeris {
 
   class PHYSICS_DLL AccuracyParameters final {
    public:
-    // Implicit for compatibility.
-    AccuracyParameters(Length const& fitting_tolerance);  // NOLINT
     AccuracyParameters(Length const& fitting_tolerance,
                        double geopotential_tolerance);
 

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -162,11 +162,6 @@ Ephemeris<Frame>::ODEAdaptiveStepParameters<ODE>::ReadFromMessage(
 
 template<typename Frame>
 Ephemeris<Frame>::AccuracyParameters::AccuracyParameters(
-    Length const& fitting_tolerance)
-    : fitting_tolerance_(fitting_tolerance) {}
-
-template<typename Frame>
-Ephemeris<Frame>::AccuracyParameters::AccuracyParameters(
     Length const& fitting_tolerance,
     double const geopotential_tolerance)
     : fitting_tolerance_(fitting_tolerance),
@@ -755,7 +750,8 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
   }
 
   AccuracyParameters accuracy_parameters(
-      pre_ἐρατοσθένης_default_ephemeris_fitting_tolerance);
+      pre_ἐρατοσθένης_default_ephemeris_fitting_tolerance,
+      /*geopotential_tolerance=*/0);
   if (!is_pre_ἐρατοσθένης) {
     accuracy_parameters =
         AccuracyParameters::ReadFromMessage(message.accuracy_parameters());
@@ -818,7 +814,8 @@ template<typename Frame>
 Ephemeris<Frame>::Ephemeris(
     FixedStepSizeIntegrator<
         typename Ephemeris<Frame>::NewtonianMotionEquation> const& integrator)
-    : accuracy_parameters_(pre_ἐρατοσθένης_default_ephemeris_fitting_tolerance),
+    : accuracy_parameters_(pre_ἐρατοσθένης_default_ephemeris_fitting_tolerance,
+                           /*geopotential_tolerance=*/0),
       fixed_step_parameters_(integrator, 1 * Second) {}
 
 template<typename Frame>

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -167,7 +167,8 @@ TEST_P(EphemerisTest, ProlongSpecialCases) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
   EXPECT_THAT(ephemeris.planetary_integrator(), Ref(integrator()));
 
@@ -205,7 +206,8 @@ TEST_P(EphemerisTest, FlowWithAdaptiveStepSpecialCase) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
 
   MasslessBody probe;
@@ -259,7 +261,8 @@ TEST_P(EphemerisTest, EarthMoon) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
 
   ephemeris.Prolong(t0_ + period);
@@ -309,7 +312,8 @@ TEST_P(EphemerisTest, ForgetBefore) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 10));
 
   ephemeris.Prolong(t0_ + 16 * period);
@@ -347,7 +351,8 @@ TEST_P(EphemerisTest, Moon) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
 
   ephemeris.Prolong(t0_ + period);
@@ -404,7 +409,8 @@ TEST_P(EphemerisTest, EarthProbe) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
 
   MasslessBody probe;
@@ -529,7 +535,8 @@ TEST_P(EphemerisTest, EarthTwoProbes) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
 
   MasslessBody probe1;
@@ -643,7 +650,8 @@ TEST_P(EphemerisTest, Serialization) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), period / 100));
   ephemeris.Prolong(t0_ + period);
 
@@ -705,7 +713,8 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), duration / 100));
 
   // The elephant's initial position and velocity.
@@ -790,7 +799,8 @@ TEST_P(EphemerisTest, CollisionDetection) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), short_duration / 100));
 
   // The apple's initial position and velocity
@@ -873,7 +883,8 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
       std::move(bodies),
       initial_state,
       t0_,
-      5 * Milli(Metre),
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), duration / 100));
   ephemeris.Prolong(t0_ + duration);
 
@@ -949,7 +960,8 @@ TEST_P(EphemerisTest, ComputeApsidesContinuousTrajectory) {
   Speed v_periapsis = Sqrt(7 * (87 + 8 * Sqrt(35))) / 20 * Kilo(Metre) / Second;
 
   auto ephemeris = solar_system.MakeEphemeris(
-      fitting_tolerance,
+      /*accuracy_parameters=*/{fitting_tolerance,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order4Optimal,
                                                 Position<ICRS>>(),

--- a/physics/solar_system_test.cpp
+++ b/physics/solar_system_test.cpp
@@ -79,7 +79,8 @@ TEST_F(SolarSystemTest, RealSolarSystem) {
   EXPECT_EQ(32, solar_system.index("Venus"));
 
   auto const ephemeris = solar_system.MakeEphemeris(
-      /*fitting_tolerance=*/1 * Metre,
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Metre,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order4Optimal,
                                                 Position<ICRS>>(),
@@ -131,7 +132,8 @@ TEST_F(SolarSystemTest, KSPSystem) {
   EXPECT_EQ(8, solar_system.index("Kerbin"));
 
   auto const ephemeris = solar_system.MakeEphemeris(
-      /*fitting_tolerance=*/1 * Metre,
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Metre,
+                               /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<KSP>::FixedStepParameters(
           SymplecticRungeKuttaNyströmIntegrator<McLachlanAtela1992Order4Optimal,
                                                 Position<KSP>>(),


### PR DESCRIPTION
Use `0x1p-24` in most places; this should make the tests (and benchmarks, etc.) a bit faster, and most importantly prevent them from becoming massively slower with #2032.