### PR TITLE
Better stacktrace decoding

### DIFF
--- a/stacktrace_decoder/App.config
+++ b/stacktrace_decoder/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/stacktrace_decoder/App.config
+++ b/stacktrace_decoder/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/stacktrace_decoder/dbghelp.cs
+++ b/stacktrace_decoder/dbghelp.cs
@@ -76,11 +76,6 @@ internal static class DbgHelp {
       out Int32 pdwDisplacement,
       [MarshalAs(UnmanagedType.LPStruct)] IMAGEHLP_LINEW64 Line);
 
-  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-  [return: MarshalAs(UnmanagedType.Bool)]
-  internal static extern bool SymCleanup(
-      IntPtr hProcess);
-
   [DllImport("dbghelp.dll", CharSet = CharSet.Unicode)]
   internal static extern UInt32 SymSetOptions(
       UInt32 SymOptions);

--- a/stacktrace_decoder/dbghelp.cs
+++ b/stacktrace_decoder/dbghelp.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace principia {
+namespace tools {
+
+internal static class DbgHelp {
+  [StructLayout(LayoutKind.Sequential)]
+  internal class IMAGEHLP_LINEW64 {
+    public Int32 SizeOfStruct = Marshal.SizeOf<IMAGEHLP_LINEW64>();
+    public IntPtr Key;
+    public Int32 LineNumber;
+    private IntPtr FileName_;
+    public Int64 Address;
+
+    public string FileName {
+      get {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0;; i += 2) {
+          char code_unit = (char)Marshal.ReadInt16(FileName_, i);
+          if (code_unit == 0) {
+            return result.ToString();
+          }
+          result.Append(code_unit);
+        }
+      }
+    }
+  }
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymInitializeW(
+      IntPtr hProcess,
+      [MarshalAs(UnmanagedType.LPWStr)] string UserSearchPath,
+      [MarshalAs(UnmanagedType.Bool)] bool fInvadeProcess);
+
+  [DllImport("dbghelp.dll", CharSet = CharSet.Unicode)]
+  internal static extern Int32 SymAddrIncludeInlineTrace(
+      IntPtr hProcess,
+      Int64 Address);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymQueryInlineTrace(
+      IntPtr hProcess,
+      Int64 StartAddress,
+      Int32 StartContext,
+      Int64 StartRetAddress,
+      Int64 CurAddress,
+      out Int32 CurContext,
+      out Int32 CurFrameIndex);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymGetLineFromInlineContextW(
+      IntPtr hProcess,
+      Int64 dwAddr,
+      Int32 InlineContext,
+      Int64 qwModuleBaseAddress,
+      out Int32 pdwDisplacement,
+      [MarshalAs(UnmanagedType.LPStruct)] IMAGEHLP_LINEW64 Line);
+
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymGetLineFromAddrW64(
+      IntPtr hProcess,
+      Int64 dwAddr,
+      out Int32 pdwDisplacement,
+      [MarshalAs(UnmanagedType.LPStruct)] IMAGEHLP_LINEW64 Line);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymCleanup(
+      IntPtr hProcess);
+
+  [DllImport("dbghelp.dll", CharSet = CharSet.Unicode)]
+  internal static extern UInt32 SymSetOptions(
+      UInt32 SymOptions);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  internal static extern Int64 SymLoadModuleExW(
+      IntPtr hProcess,
+      IntPtr hFile,
+      [MarshalAs(UnmanagedType.LPWStr)] string ImageName,
+      [MarshalAs(UnmanagedType.LPWStr)] string ModuleName,
+      Int64 BaseOfDll,
+      Int32 DllSize,
+      IntPtr Data,
+      UInt32 Flags);
+}
+
+} // namespace tools
+} // namespace principia

--- a/stacktrace_decoder/dbghelp.cs
+++ b/stacktrace_decoder/dbghelp.cs
@@ -10,6 +10,8 @@ namespace principia {
 namespace tools {
 
 internal static class DbgHelp {
+  const UInt32 SYMOPT_LOAD_LINES = 0x00000010;
+
   [StructLayout(LayoutKind.Sequential)]
   internal class IMAGEHLP_LINEW64 {
     public Int32 SizeOfStruct = Marshal.SizeOf<IMAGEHLP_LINEW64>();

--- a/stacktrace_decoder/dbghelp.cs
+++ b/stacktrace_decoder/dbghelp.cs
@@ -10,7 +10,7 @@ namespace principia {
 namespace tools {
 
 internal static class DbgHelp {
-  const UInt32 SYMOPT_LOAD_LINES = 0x00000010;
+  internal const UInt32 SYMOPT_LOAD_LINES = 0x00000010;
 
   [StructLayout(LayoutKind.Sequential)]
   internal class IMAGEHLP_LINEW64 {

--- a/stacktrace_decoder/dbghelp.cs
+++ b/stacktrace_decoder/dbghelp.cs
@@ -11,6 +11,32 @@ namespace tools {
 
 internal static class DbgHelp {
   internal const UInt32 SYMOPT_LOAD_LINES = 0x00000010;
+  internal const Int32 MAX_SYM_NAME = 2000;
+
+  [StructLayout(LayoutKind.Sequential,
+                Size = 88 + 2 * (MAX_SYM_NAME - 1),
+                CharSet = CharSet.Unicode)]
+  internal class SYMBOL_INFOW {
+    public Int32 SizeOfStruct = 88;
+    public Int32 TypeIndex;
+    public Int64 Reserved0;
+    public Int64 Reserved1;
+    public Int32 Index;
+    public Int32 Size;
+    public Int64 ModBase;
+    public Int32 Flags;
+    public Int64 Value;
+    public Int64 Address;
+    public Int32 Register;
+    public Int32 Scope;
+    public Int32 Tag;
+    public Int32 NameLen;
+    public Int32 MaxNameLen = MAX_SYM_NAME;
+    // The entire name goes here, but in order to access it we would need
+    // a fixed-size buffer, which would require making this an unsafe struct
+    // instead of a class.  We don't need the name at this point.
+    public char Name0;
+  }
 
   [StructLayout(LayoutKind.Sequential)]
   internal class IMAGEHLP_LINEW64 {
@@ -90,6 +116,23 @@ internal static class DbgHelp {
       Int32 DllSize,
       IntPtr Data,
       UInt32 Flags);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymFromAddrW(
+      IntPtr hProcess,
+      Int64 Address,
+      out Int64 Displacement,
+      [MarshalAs(UnmanagedType.LPStruct)] SYMBOL_INFOW Symbol);
+
+  [DllImport("dbghelp.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  internal static extern bool SymFromInlineContextW(
+      IntPtr hProcess,
+      Int64 Address,
+      Int32 InlineContext,
+      out Int64 Displacement,
+      [MarshalAs(UnmanagedType.LPStruct)] SYMBOL_INFOW Symbol);
 }
 
 } // namespace tools

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -41,8 +41,12 @@ class StackTraceDecoder {
       string file = $"{file_match.Groups[1]}/{file_match.Groups[2]}";
       string url = "https://github.com/mockingbirdnest/Principia/blob/" +
                    $"{commit}/{file}#L{line.LineNumber}";
-      Console.WriteLine(
-          snippets ? url : $"[`{file}:{line.LineNumber}`]({url})");
+      // Snippets should not be separated by new lines, as they are on their own
+      // line anyway, so that a new line spaces them more than necessary.  In
+      // order to keep the Markdown readable, hide a new line in a comment.
+      // `file:line` links need still to be separated by new lines.
+      Console.Write(snippets ? $"<!---\n--> {url} "
+                             : $"\n[`{file}:{line.LineNumber}`]({url})");
       return true;
     } else {
       return false;
@@ -61,7 +65,9 @@ class StackTraceDecoder {
   }
 
   private static void LogComment(string comment) {
-    Console.WriteLine($"<!--- {comment} -->");
+    // Put the new line in the comment in order to avoid introducing
+    // new lines in the Markdown.
+    Console.Write($"<!---\n {comment} -->");
   }
 
   private static void Main(string[] args) {

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -125,7 +125,6 @@ class StackTraceDecoder {
       stack_match = stack_regex.Match(stream.ReadLine());
     } while (!stack_match.Success);
     IntPtr handle = new IntPtr(1729);
-    UInt32 SYMOPT_LOAD_LINES = 0x00000010;
     SymSetOptions(SYMOPT_LOAD_LINES);
     Win32Check(SymInitializeW(handle, null, fInvadeProcess: false));
     Win32Check(SymLoadModuleExW(handle,

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -125,16 +125,25 @@ class StackTraceDecoder {
       stack_match = stack_regex.Match(stream.ReadLine());
     } while (!stack_match.Success);
     IntPtr handle = new IntPtr(1729);
-    SymSetOptions(0x80000000  // SYMOPT_DEBUG
-                 |0x00000010  // SYMOPT_LOAD_LINES
-                 );
+    UInt32 SYMOPT_LOAD_LINES = 0x00000010;
+    SymSetOptions(SYMOPT_LOAD_LINES);
     Win32Check(SymInitializeW(handle, null, fInvadeProcess: false));
-    Win32Check(SymLoadModuleExW(handle, IntPtr.Zero, principia_pdb_file.Replace(".pdb", ".dll"),
-        null, principia_base_address, 0,
-        IntPtr.Zero, 0) != 0);
-    Win32Check(SymLoadModuleExW(handle, IntPtr.Zero, physics_pdb_file.Replace(".pdb", ".dll"),
-        null, physics_base_address, 0,
-        IntPtr.Zero, 0) != 0);
+    Win32Check(SymLoadModuleExW(handle,
+                                IntPtr.Zero,
+                                principia_pdb_file.Replace(".pdb", ".dll"),
+                                null,
+                                principia_base_address,
+                                0,
+                                IntPtr.Zero,
+                                0) != 0);
+    Win32Check(SymLoadModuleExW(handle,
+                                IntPtr.Zero,
+                                physics_pdb_file.Replace(".pdb", ".dll"),
+                                null,
+                                physics_base_address,
+                                0,
+                                IntPtr.Zero,
+                                0) != 0);
 
     for (;
          stack_match.Success;

--- a/stacktrace_decoder/stacktrace_decoder.csproj
+++ b/stacktrace_decoder/stacktrace_decoder.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>stacktrace_decoder</RootNamespace>
     <AssemblyName>stacktrace_decoder</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/stacktrace_decoder/stacktrace_decoder.csproj
+++ b/stacktrace_decoder/stacktrace_decoder.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>stacktrace_decoder</RootNamespace>
     <AssemblyName>stacktrace_decoder</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/stacktrace_decoder/stacktrace_decoder.csproj
+++ b/stacktrace_decoder/stacktrace_decoder.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="dbghelp.cs" />
     <Compile Include="stacktrace_decoder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
The stacktrace provided in #2056 notably differs from the one we recover from the logs in that it includes inline frames.
In order to get those, we need to directly use dbghelp instead of going through dbh. This also solves a lot of clunkiness surrounding base addresses, as well as the issue that dbh did not appear to work with non-ASCII paths (what year is this).
Further, GitHub now [automatically renders code snippets](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/), so use that by default instead of ``[`file:line`](link)`` markdown.

In order to have more context in the snippet, make the snippet range from the start of the symbol to the line corresponding to the stack frame. Make the trace most-recent-call-last so that the sequence of snippets reads monotonically.

Note that since our stack does not include the line with the failing check, we miss any inline frames between the check and the next non-inline frame, and we do not get a snippet for the check itself.
We should probably omit one frame fewer.

Example with the stacktrace from #2056:
#### Old output:
```markdown
<!--- Using Principia base address 7ff9eab60000 -->
<!--- Using Physics base address 7ff9ff390000 -->
[`ksp_plugin/pile_up.cpp:131`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L131)
<!--- Nothing for @   00007FF9EAC4ABDD          principia__VesselVelocity [0x00007FF9EAC4ABDC+273788] -->
[`base/thread_pool_body.hpp:15`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L15)
[`base/thread_pool_body.hpp:80`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L80)
<!--- Nothing for @   00007FF9EAC4B96C          principia__VesselVelocity [0x00007FF9EAC4B96B+277259] -->
<!--- Nothing for @   00007FF9EABE1A79          (No symbol) [0x00007FF9EABE1A78] -->
<!--- Nothing for @   00007FFA3E36DAB5          iswascii [0x00007FFA3E36DAB4+164] -->
<!--- Nothing for @   00007FFA3F181FE4          BaseThreadInitThunk [0x00007FFA3F181FE3+19] -->
<!--- Nothing for @   00007FFA415FCB81          RtlUserThreadStart [0x00007FFA415FCB80+32] -->
```
#### Renders as:
<!--- Using Principia base address 7ff9eab60000 -->
<!--- Using Physics base address 7ff9ff390000 -->
[`ksp_plugin/pile_up.cpp:131`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L131)
<!--- Nothing for @   00007FF9EAC4ABDD          principia__VesselVelocity [0x00007FF9EAC4ABDC+273788] -->
[`base/thread_pool_body.hpp:15`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L15)
[`base/thread_pool_body.hpp:80`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L80)
<!--- Nothing for @   00007FF9EAC4B96C          principia__VesselVelocity [0x00007FF9EAC4B96B+277259] -->
<!--- Nothing for @   00007FF9EABE1A79          (No symbol) [0x00007FF9EABE1A78] -->
<!--- Nothing for @   00007FFA3E36DAB5          iswascii [0x00007FFA3E36DAB4+164] -->
<!--- Nothing for @   00007FFA3F181FE4          BaseThreadInitThunk [0x00007FFA3F181FE3+19] -->
<!--- Nothing for @   00007FFA415FCB81          RtlUserThreadStart [0x00007FFA415FCB80+32] -->

#### New output:

```markdown
<!---
 Using Principia base address 7FF9EAB60000 --><!---
 Using Physics base address 7FF9FF390000 --><!---
 Not in loaded modules: @   00007FFA415FCB81    RtlUserThreadStart [0x00007FFA415FCB80+32] --><!---
 Not in loaded modules: @   00007FFA3F181FE4    BaseThreadInitThunk [0x00007FFA3F181FE3+19] --><!---
 Not in loaded modules: @   00007FFA3E36DAB5    iswascii [0x00007FFA3E36DAB4+164] --><!---
 Not in Principia code: @   00007FF9EABE1A79    (No symbol) [0x00007FF9EABE1A78] --><!---
 Not in Principia code: @   00007FF9EAC4B96C    principia__VesselVelocity [0x00007FF9EAC4B96B+277259] --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L57-L80 <!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L14-L15 <!---
 Inline frame not in Principia code --><!---
 Not in Principia code: @   00007FF9EAC4ABDD    principia__VesselVelocity [0x00007FF9EAC4ABDC+273788] --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/plugin.cpp#L719-L719 <!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L126-L131
```
<h4 id="meow"> Renders as:</h4>

<!---
 Using Principia base address 7FF9EAB60000 --><!---
 Using Physics base address 7FF9FF390000 --><!---
 Not in loaded modules: @   00007FFA415FCB81    RtlUserThreadStart [0x00007FFA415FCB80+32] --><!---
 Not in loaded modules: @   00007FFA3F181FE4    BaseThreadInitThunk [0x00007FFA3F181FE3+19] --><!---
 Not in loaded modules: @   00007FFA3E36DAB5    iswascii [0x00007FFA3E36DAB4+164] --><!---
 Not in Principia code: @   00007FF9EABE1A79    (No symbol) [0x00007FF9EABE1A78] --><!---
 Not in Principia code: @   00007FF9EAC4B96C    principia__VesselVelocity [0x00007FF9EAC4B96B+277259] --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L57-L80 <!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L14-L15 <!---
 Inline frame not in Principia code --><!---
 Not in Principia code: @   00007FF9EAC4ABDD    principia__VesselVelocity [0x00007FF9EAC4ABDC+273788] --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
 Inline frame not in Principia code --><!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/plugin.cpp#L719-L719 <!---
--> https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L126-L131

#### New output with `--no-snippet --no-comment`:
```markdown
[`base/thread_pool_body.hpp:80`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L57-L80)
[`base/thread_pool_body.hpp:15`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L14-L15)
[`ksp_plugin/plugin.cpp:719`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/plugin.cpp#L719-L719)
[`ksp_plugin/pile_up.cpp:131`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L126-L131)
```
#### Renders as:
[`base/thread_pool_body.hpp:80`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L57-L80)
[`base/thread_pool_body.hpp:15`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/base/thread_pool_body.hpp#L14-L15)
[`ksp_plugin/plugin.cpp:719`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/plugin.cpp#L719-L719)
[`ksp_plugin/pile_up.cpp:131`](https://github.com/mockingbirdnest/Principia/blob/3e2334a95bcfc6869b5464ecda5ae48b5412dba0/ksp_plugin/pile_up.cpp#L126-L131)