### PR TITLE
Try to make the SAS more reliable

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -21,11 +21,6 @@ public partial class PrincipiaPluginAdapter
   private DateTimeOffset next_release_date_ =
       new DateTimeOffset(2019, 02, 04, 21, 04, 00, TimeSpan.Zero);
 
-  // TODO(egg): Remove these traces.
-  private DateTimeOffset lastprepend;
-  private DateTimeOffset lastoverride;
-  private DateTimeOffset lasteffectiveoverride;
-
   // From https://forum.kerbalspaceprogram.com/index.php?/topic/84273--/,
   // edited 2017-03-09.  Where the name of the layer is not CamelCase, the
   // actual name is commented.
@@ -475,11 +470,7 @@ public partial class PrincipiaPluginAdapter
   }
 
   private void OverrideRSASTarget(FlightCtrlState state) {
-    Log.Info("[RSAS] Override RSAS target");
-    lastoverride = DateTimeOffset.UtcNow;
-    lasteffectiveoverride = DateTimeOffset.UtcNow;
     if (override_rsas_target_ && FlightGlobals.ActiveVessel.Autopilot.Enabled) {
-      Log.Info("[RSAS]> SetTargetOrientation");
       FlightGlobals.ActiveVessel.Autopilot.SAS.SetTargetOrientation(
           rsas_target_,
           reset_rsas_target_);
@@ -970,7 +961,6 @@ public partial class PrincipiaPluginAdapter
         // Make the autopilot target our Frenet trihedron.
         if (!active_vessel.OnPreAutopilotUpdate.GetInvocationList().Contains(
                 (FlightInputCallback)OverrideRSASTarget)) {
-          lastprepend = DateTime.Now;
           Log.Info("Prepending RSAS override");
           active_vessel.OnPreAutopilotUpdate += OverrideRSASTarget;
         }
@@ -2067,9 +2057,6 @@ public partial class PrincipiaPluginAdapter
       if (!PluginRunning()) {
         UnityEngine.GUILayout.TextArea(text : "Plugin is not started");
       }
-      UnityEngine.GUILayout.TextArea($"last prepend: {DateTimeOffset.UtcNow - lastprepend}");
-      UnityEngine.GUILayout.TextArea($"last override: {DateTimeOffset.UtcNow - lastoverride}");
-      UnityEngine.GUILayout.TextArea($"last effective override: {DateTimeOffset.UtcNow - lasteffectiveoverride}");
       if (DateTimeOffset.Now > next_release_date_) {
         UnityEngine.GUILayout.TextArea(
             "Announcement: the new moon of lunation number " +

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -973,6 +973,7 @@ public partial class PrincipiaPluginAdapter
           lastprepend = DateTime.Now;
           force_prepend_ = false;
           Log.Info("Prepending RSAS override");
+          active_vessel.OnPreAutopilotUpdate += OverrideRSASTarget;
           active_vessel.OnAutopilotUpdate =
               (FlightInputCallback)Delegate.Combine(
                   new FlightInputCallback(OverrideRSASTarget),

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -21,7 +21,7 @@ public partial class PrincipiaPluginAdapter
   private DateTimeOffset next_release_date_ =
       new DateTimeOffset(2019, 02, 04, 21, 04, 00, TimeSpan.Zero);
 
-  private bool force_prepend_;
+  // TODO(egg): Remove these traces.
   private DateTimeOffset lastprepend;
   private DateTimeOffset lastoverride;
   private DateTimeOffset lasteffectiveoverride;
@@ -968,17 +968,11 @@ public partial class PrincipiaPluginAdapter
         SetNavballVector(navball_.antiNormalVector, -normal);
 
         // Make the autopilot target our Frenet trihedron.
-        if (active_vessel.OnAutopilotUpdate.GetInvocationList()[0] !=
-            (Delegate)(FlightInputCallback)OverrideRSASTarget || force_prepend_) {
+        if (!active_vessel.OnPreAutopilotUpdate.GetInvocationList().Contains(
+                (FlightInputCallback)OverrideRSASTarget)) {
           lastprepend = DateTime.Now;
-          force_prepend_ = false;
           Log.Info("Prepending RSAS override");
           active_vessel.OnPreAutopilotUpdate += OverrideRSASTarget;
-          active_vessel.OnAutopilotUpdate =
-              (FlightInputCallback)Delegate.Combine(
-                  new FlightInputCallback(OverrideRSASTarget),
-                  active_vessel.OnAutopilotUpdate);
-          active_vessel.OnAutopilotUpdate(new FlightCtrlState());
         }
         if (active_vessel.Autopilot.Enabled) {
           override_rsas_target_ = true;
@@ -2072,13 +2066,6 @@ public partial class PrincipiaPluginAdapter
     using (new VerticalLayout()) {
       if (!PluginRunning()) {
         UnityEngine.GUILayout.TextArea(text : "Plugin is not started");
-      }
-      force_prepend_ = UnityEngine.GUILayout.Button("Force prepend RSAS override");
-      if (UnityEngine.GUILayout.Button("Force FeedInputFeed")) {
-        FlightGlobals.ActiveVessel.FeedInputFeed();
-      }
-      if (UnityEngine.GUILayout.Button("Force OnAutopilotUpdate")) {
-        FlightGlobals.ActiveVessel.OnAutopilotUpdate(new FlightCtrlState());
       }
       UnityEngine.GUILayout.TextArea($"last prepend: {DateTimeOffset.UtcNow - lastprepend}");
       UnityEngine.GUILayout.TextArea($"last override: {DateTimeOffset.UtcNow - lastoverride}");


### PR DESCRIPTION
Fix #1868, hopefully.

From traces, it seems that if https://github.com/mockingbirdnest/Principia/blob/f46184556565f10020d41125fd650a7066595798/ksp_plugin_adapter/ksp_plugin_adapter.cs#L657-L660 was called while the SAS was on (which happened, e.g., if the SAS was turned on before launch), it *would* change the invocation list as expected, i.e.,
```C#
active_vessel.OnAutopilotUpdate.GetInvocationList()[0] ==
    (Delegate)(FlightInputCallback)OverrideRSASTarget
```
would then hold, but invoking `active_vessel.OnAutopilotUpdate` would somehow not call `OverrideRSASTarget`, thus keeping the stock SAS behaviour (and resulting in #1868).
I have no explanation for this behaviour.

The invocation did have the expected effect, however, if the delegate combination occurred with the SAS *off*, e.g., if the SAS was off during liftoff and turned on later on.

Switching to `OnPreAutopilotUpdate` does not appear to have any unexpected behaviour (and appending to that one is more readable than prepending to the other anyway).