### PR TITLE
Get rid of the "disposable" pattern for windows

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -46,11 +46,11 @@ class BurnEditor {
                                     adapter,
                                     ReferenceFrameChanged,
                                     "Manœuvring frame");
-    reference_frame_selector_.Reset(plugin);
+    reference_frame_selector_.Initialize(plugin);
     plugin_ = plugin;
     vessel_ = vessel;
     adapter_ = adapter;
-    reference_frame_selector_.Reset(
+    reference_frame_selector_.SetFrameParameters(
         adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();
   }
@@ -136,7 +136,7 @@ class BurnEditor {
     Δv_normal_.value = burn.delta_v.y;
     Δv_binormal_.value = burn.delta_v.z;
     initial_time_.value = burn.initial_time;
-    reference_frame_selector_.Reset(burn.frame);
+    reference_frame_selector_.SetFrameParameters(burn.frame);
     is_inertially_fixed_ = burn.is_inertially_fixed;
     duration_ = manoeuvre.duration;
     initial_mass_in_tonnes_ = manoeuvre.initial_mass_in_tonnes;

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -159,7 +159,7 @@ class BurnEditor {
   }
 
   public void Close() {
-    reference_frame_selector_.Dispose();
+    reference_frame_selector_.DisposeWindow();
   }
 
   private void ComputeEngineCharacteristics() {

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -44,14 +44,14 @@ class BurnEditor {
     initial_time_.value = initial_time;
     reference_frame_selector_ = new ReferenceFrameSelector(
                                     adapter,
-                                    plugin,
                                     ReferenceFrameChanged,
                                     "Manœuvring frame");
+    reference_frame_selector_.Reset(plugin);
     plugin_ = plugin;
     vessel_ = vessel;
     adapter_ = adapter;
     reference_frame_selector_.Reset(
-        adapter_.plotting_frame_selector_.get().FrameParameters());
+        adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();
   }
 
@@ -96,7 +96,7 @@ class BurnEditor {
       }
       string frame_warning = "";
       if (!reference_frame_selector_.FrameParameters().Equals(
-              adapter_.plotting_frame_selector_.get().FrameParameters())) {
+              adapter_.plotting_frame_selector_.FrameParameters())) {
         frame_warning = "Manœuvre frame differs from plotting frame";
       }
       UnityEngine.GUILayout.TextArea(frame_warning, warning_style);

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -11,6 +11,9 @@ class BurnEditor {
                     IntPtr plugin,
                     Vessel vessel,
                     double initial_time) {
+    adapter_ = adapter;
+    plugin_ = plugin;
+    vessel_ = vessel;
     Δv_tangent_ =
         new DifferentialSlider(label            : "Δv tangent",
                                unit             : "m / s",
@@ -43,13 +46,10 @@ class BurnEditor {
                             Planetarium.GetUniversalTime() - value)));
     initial_time_.value = initial_time;
     reference_frame_selector_ = new ReferenceFrameSelector(
-                                    adapter,
+                                    adapter_,
                                     ReferenceFrameChanged,
                                     "Manœuvring frame");
-    reference_frame_selector_.Initialize(plugin);
-    plugin_ = plugin;
-    vessel_ = vessel;
-    adapter_ = adapter;
+    reference_frame_selector_.Initialize(plugin_);
     reference_frame_selector_.SetFrameParameters(
         adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -8,9 +8,11 @@ namespace principia {
 namespace ksp_plugin_adapter {
 
 class FlightPlanner : SupervisedWindowRenderer {
-  public FlightPlanner(PrincipiaPluginAdapter adapter,
-                       IntPtr plugin) : base(adapter) {
+  public FlightPlanner(PrincipiaPluginAdapter adapter) : base(adapter) {
     adapter_ = adapter;
+  }
+
+  public void Reset(IntPtr plugin) {
     plugin_ = plugin;
     final_time_ = new DifferentialSlider(
                 label            : "Plan length",
@@ -24,7 +26,6 @@ class FlightPlanner : SupervisedWindowRenderer {
                         TimeSpan.FromSeconds(
                             value - plugin_.FlightPlanGetInitialTime(
                                         vessel_.id.ToString()))));
-
   }
 
   protected override void RenderWindow() {
@@ -352,8 +353,8 @@ class FlightPlanner : SupervisedWindowRenderer {
   }
 
   // Not owned.
-  private readonly IntPtr plugin_;
   private readonly PrincipiaPluginAdapter adapter_;
+  private IntPtr plugin_;
   private Vessel vessel_;
   private List<BurnEditor> burn_editors_;
 

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -12,7 +12,7 @@ class FlightPlanner : SupervisedWindowRenderer {
     adapter_ = adapter;
   }
 
-  public void Reset(IntPtr plugin) {
+  public void Initialize(IntPtr plugin) {
     plugin_ = plugin;
     final_time_ = new DifferentialSlider(
                 label            : "Plan length",

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -236,6 +236,7 @@ public partial class PrincipiaPluginAdapter
   private FlightPlanner flight_planner_;
   private MapNodePool map_node_pool_;
 
+  public event Action dispose_windows;
   public event Action render_windows;
 
   PrincipiaPluginAdapter() {
@@ -272,10 +273,6 @@ public partial class PrincipiaPluginAdapter
         new ReferenceFrameSelector(this,
                                    UpdateRenderingFrame,
                                    "Plotting frame");
-  }
-
-  ~PrincipiaPluginAdapter() {
-    Cleanup();
   }
 
   private bool PluginRunning() {
@@ -1018,7 +1015,6 @@ public partial class PrincipiaPluginAdapter
       KSP.UI.Screens.ApplicationLauncher.Instance.RemoveModApplication(
           toolbar_button_);
     }
-    WindowUtilities.ClearLock(this);
     Cleanup();
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.ObscenelyEarly,
                                     ObscenelyEarly);
@@ -2008,8 +2004,10 @@ public partial class PrincipiaPluginAdapter
 
   private void Cleanup() {
     UnityEngine.Object.Destroy(map_renderer_);
-    map_node_pool_.Clear();
     map_renderer_ = null;
+    map_node_pool_.Clear();
+    WindowUtilities.ClearLock(this);
+    dispose_windows();
     Interface.DeletePlugin(ref plugin_);
     previous_display_mode_ = null;
     navball_changed_ = true;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -276,6 +276,11 @@ public partial class PrincipiaPluginAdapter
                                    "Plotting frame");
   }
 
+  ~PrincipiaPluginAdapter() {
+    // We should not get here without deleting the plugin, but just for safety.
+    Interface.DeletePlugin(ref plugin_);
+  }
+
   private bool PluginRunning() {
     return plugin_ != IntPtr.Zero;
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -655,10 +655,10 @@ public partial class PrincipiaPluginAdapter
         serialization_encoding_ = "base64";
       }
 
-      plotting_frame_selector_.Reset(plugin_);
+      plotting_frame_selector_.Initialize(plugin_);
       previous_display_mode_ = null;
       must_set_plotting_frame_ = true;
-      flight_planner_.Reset(plugin_);
+      flight_planner_.Initialize(plugin_);
 
       plugin_construction_ = DateTime.Now;
     } else {
@@ -987,7 +987,7 @@ public partial class PrincipiaPluginAdapter
     }
     if (must_set_plotting_frame_ && FlightGlobals.currentMainBody != null) {
       must_set_plotting_frame_ = false;
-      plotting_frame_selector_.Reset(plugin_);
+      plotting_frame_selector_.UpdateMainBody();
       previous_display_mode_ = null;
     }
 
@@ -2497,9 +2497,9 @@ public partial class PrincipiaPluginAdapter
       plugin_.AdvanceTime(Planetarium.GetUniversalTime(),
                           Planetarium.InverseRotAngle);
     }
-    plotting_frame_selector_.Reset(plugin_);
+    plotting_frame_selector_.Initialize(plugin_);
     must_set_plotting_frame_ = true;
-    flight_planner_.Reset(plugin_);
+    flight_planner_.Initialize(plugin_);
   } catch (Exception e) {
     Log.Fatal("Exception while resetting plugin: " + e.ToString());
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -723,6 +723,8 @@ public partial class PrincipiaPluginAdapter
       main_window_rectangle_.InputLock(this);
 
       render_windows();
+    } else {
+      clear_locks();
     }
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -81,10 +81,6 @@ public partial class PrincipiaPluginAdapter
   private int чебышёв_plotting_method_ = 2;
   private const int чебышёв_plotting_methods_count = 3;
 
-  internal Controlled<ReferenceFrameSelector> plotting_frame_selector_;
-  private Controlled<FlightPlanner> flight_planner_;
-  private MapNodePool map_node_pool_;
-
   private bool selecting_active_vessel_target_ = false;
   private bool selecting_target_celestial_ = false;
 
@@ -233,6 +229,12 @@ public partial class PrincipiaPluginAdapter
   [KSPField(isPersistant = true)]
   private Dialog bad_installation_dialog_ = new Dialog();
 
+  // UI for the auxiliary windows.
+  internal Controlled<ReferenceFrameSelector> plotting_frame_selector_;
+  [KSPField(isPersistant = true)]
+  private FlightPlanner flight_planner_;
+  private MapNodePool map_node_pool_;
+
   public event Action render_windows;
 
   PrincipiaPluginAdapter() {
@@ -264,6 +266,7 @@ public partial class PrincipiaPluginAdapter
                 "; this build targets " + expected_version + ".");
     }
     map_node_pool_ = new MapNodePool();
+    flight_planner_ = new FlightPlanner(this);
   }
 
   ~PrincipiaPluginAdapter() {
@@ -654,7 +657,7 @@ public partial class PrincipiaPluginAdapter
                                      "Plotting frame"));
       previous_display_mode_ = null;
       must_set_plotting_frame_ = true;
-      flight_planner_.reset(new FlightPlanner(this, plugin_));
+      flight_planner_.Reset(plugin_);
 
       plugin_construction_ = DateTime.Now;
     } else {
@@ -2011,7 +2014,6 @@ public partial class PrincipiaPluginAdapter
     Interface.DeletePlugin(ref plugin_);
     plotting_frame_selector_.reset();
     previous_display_mode_ = null;
-    flight_planner_.reset();
     navball_changed_ = true;
   }
 
@@ -2085,7 +2087,7 @@ public partial class PrincipiaPluginAdapter
       }
       ReferenceFrameSelection();
       if (PluginRunning()) {
-        flight_planner_.get().RenderButton();
+        flight_planner_.RenderButton();
       }
       ToggleableSection(name   : "Prediction Settings",
                         show   : ref show_prediction_settings_,
@@ -2503,7 +2505,7 @@ public partial class PrincipiaPluginAdapter
                                    UpdateRenderingFrame,
                                    "Plotting frame"));
     must_set_plotting_frame_ = true;
-    flight_planner_.reset(new FlightPlanner(this, plugin_));
+    flight_planner_.Reset(plugin_);
   } catch (Exception e) {
     Log.Fatal("Exception while resetting plugin: " + e.ToString());
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -236,6 +236,7 @@ public partial class PrincipiaPluginAdapter
   private FlightPlanner flight_planner_;
   private MapNodePool map_node_pool_;
 
+  public event Action clear_locks;
   public event Action dispose_windows;
   public event Action render_windows;
 
@@ -1016,6 +1017,7 @@ public partial class PrincipiaPluginAdapter
           toolbar_button_);
     }
     Cleanup();
+    dispose_windows();
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.ObscenelyEarly,
                                     ObscenelyEarly);
     TimingManager.FixedUpdateRemove(TimingManager.TimingStage.Precalc,
@@ -2007,7 +2009,7 @@ public partial class PrincipiaPluginAdapter
     map_renderer_ = null;
     map_node_pool_.Clear();
     WindowUtilities.ClearLock(this);
-    dispose_windows();
+    clear_locks();
     Interface.DeletePlugin(ref plugin_);
     previous_display_mode_ = null;
     navball_changed_ = true;

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -32,19 +32,21 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
 
   public ReferenceFrameSelector(
       ISupervisor supervisor,
-      IntPtr plugin,
       Callback on_change,
       string name) : base(supervisor) {
-    plugin_ = plugin;
     on_change_ = on_change;
     name_ = name;
-    frame_type = FrameType.BODY_CENTRED_NON_ROTATING;
     expanded_ = new Dictionary<CelestialBody, bool>();
     foreach (CelestialBody celestial in FlightGlobals.Bodies) {
       if (!celestial.is_leaf() && !celestial.is_root()) {
         expanded_.Add(celestial, false);
       }
     }
+  }
+
+  public void Reset(IntPtr plugin) {
+    plugin_ = plugin;
+    frame_type = FrameType.BODY_CENTRED_NON_ROTATING;
     selected_celestial =
         FlightGlobals.currentMainBody ?? FlightGlobals.GetHomeBody();
     for (CelestialBody celestial = selected_celestial;
@@ -381,12 +383,12 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
     UnityEngine.GUI.skin.toggle.wordWrap = old_wrap;
   }
 
-  private Callback on_change_;
+  private readonly Callback on_change_;
+  private readonly string name_;
   // Not owned.
   private IntPtr plugin_;
   private bool show_selector_;
   private Dictionary<CelestialBody, bool> expanded_;
-  private readonly string name_;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -36,6 +36,12 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
       string name) : base(supervisor) {
     on_change_ = on_change;
     name_ = name;
+
+    // TODO(phl): Bogus initialization.  Find a way to get these data from the
+    // C++ side (we do for flight planning).
+    frame_type = FrameType.BODY_CENTRED_NON_ROTATING;
+    selected_celestial = FlightGlobals.GetHomeBody();
+
     expanded_ = new Dictionary<CelestialBody, bool>();
     foreach (CelestialBody celestial in FlightGlobals.Bodies) {
       if (!celestial.is_leaf() && !celestial.is_root()) {

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -140,28 +140,22 @@ internal abstract class BaseWindowRenderer : IConfigNode {
                            height : 0);
 }
 
-internal abstract class SupervisedWindowRenderer :
-    BaseWindowRenderer, IDisposable {
+internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   public interface ISupervisor {
+    event Action dispose_windows;
     event Action render_windows;
   }
 
   public SupervisedWindowRenderer(ISupervisor supervisor) : base() {
     supervisor_ = supervisor;
+    supervisor_.dispose_windows += DisposeWindow;
     supervisor_.render_windows += RenderWindow;
   }
 
-  ~SupervisedWindowRenderer() {
+  public void DisposeWindow() {
+    supervisor_.dispose_windows -= DisposeWindow;
     supervisor_.render_windows -= RenderWindow;
     ClearLock();
-  }
-
-  public void Dispose() {
-    if (supervisor_ != null) {
-      supervisor_.render_windows -= RenderWindow;
-    }
-    ClearLock();
-    GC.SuppressFinalize(this);
   }
 
   private ISupervisor supervisor_;

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -142,20 +142,24 @@ internal abstract class BaseWindowRenderer : IConfigNode {
 
 internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   public interface ISupervisor {
+    event Action clear_locks;
     event Action dispose_windows;
     event Action render_windows;
   }
 
   public SupervisedWindowRenderer(ISupervisor supervisor) : base() {
+      UnityEngine.Debug.LogError("A");
     supervisor_ = supervisor;
+    supervisor_.clear_locks += ClearLock;
     supervisor_.dispose_windows += DisposeWindow;
     supervisor_.render_windows += RenderWindow;
   }
 
   public void DisposeWindow() {
+      UnityEngine.Debug.LogError("R");
+    supervisor_.clear_locks -= ClearLock;
     supervisor_.dispose_windows -= DisposeWindow;
     supervisor_.render_windows -= RenderWindow;
-    ClearLock();
   }
 
   private ISupervisor supervisor_;

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -169,20 +169,5 @@ internal abstract class SupervisedWindowRenderer :
 
 internal abstract class UnsupervisedWindowRenderer : BaseWindowRenderer {}
 
-internal struct Controlled<T> where T : class, IDisposable {
-  public T get() {
-    return all_;
-  }
-
-  public void reset(T value = null) {
-    if (all_ != null) {
-      all_.Dispose();
-    }
-    all_ = value;
-  }
-
-  private T all_;
-}
-
 }  // namespace ksp_plugin_adapter
 }  // namespace principia

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -148,7 +148,6 @@ internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   }
 
   public SupervisedWindowRenderer(ISupervisor supervisor) : base() {
-      UnityEngine.Debug.LogError("A");
     supervisor_ = supervisor;
     supervisor_.clear_locks += ClearLock;
     supervisor_.dispose_windows += DisposeWindow;
@@ -156,7 +155,6 @@ internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   }
 
   public void DisposeWindow() {
-      UnityEngine.Debug.LogError("R");
     supervisor_.clear_locks -= ClearLock;
     supervisor_.dispose_windows -= DisposeWindow;
     supervisor_.render_windows -= RenderWindow;


### PR DESCRIPTION
* Windows are now constructed with just their supervisor and later initialized with the plugin.  This makes it possible to reuse the same window when the plugin gets recreated (e.g., reloaded from a save).
* Windows are no longer using the "disposable" pattern and are no longer wrapped in a `Controlled` object.  Instead, they use the `clear_locks` and `dispose_windows` events to release the locks and unregister themselves at the right place.
* A bug is fixed whereby locks were not cleared when the main window was hidden.
* A bit of code reordering to bring related things closer together.