### PR TITLE
Make the hide/show status of windows persistent

### DIFF
--- a/ksp_plugin_adapter/dialog.cs
+++ b/ksp_plugin_adapter/dialog.cs
@@ -14,21 +14,14 @@ internal class Dialog : UnsupervisedWindowRenderer, IConfigNode {
     }
   }
 
-  public void Show() {
-    RenderWindow();
-  }
+  protected override String Title { get; } = "Principia";
 
-  protected override void RenderWindow() {
-    UnityEngine.GUI.skin = null;
-    Window(func : (int id) => {
-             using (new UnityEngine.GUILayout.VerticalScope())
-             {
-               UnityEngine.GUILayout.TextArea(
-                   message_ ?? "SHOW WITHOUT MESSAGE");
-             }
-             UnityEngine.GUI.DragWindow();
-           },
-           text : "Principia");
+  protected override void RenderWindow(int window_id) {
+    using (new UnityEngine.GUILayout.VerticalScope())
+    {
+      UnityEngine.GUILayout.TextArea(message_ ?? "SHOW WITHOUT MESSAGE");
+    }
+    UnityEngine.GUI.DragWindow();
   }
 
   public new void Load(ConfigNode node) {

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -28,28 +28,18 @@ class FlightPlanner : SupervisedWindowRenderer {
                                         vessel_.id.ToString()))));
   }
 
-  protected override void RenderWindow() {
-    var old_skin = UnityEngine.GUI.skin;
-    UnityEngine.GUI.skin = null;
-    if (show_planner_) {
-      Window(func : RenderPlanner,
-             text : "Flight plan");
-    } else {
-      ClearLock();
-    }
-    UnityEngine.GUI.skin = old_skin;
-  }
-
   public void RenderButton() {
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
     if (UnityEngine.GUILayout.Button("Flight plan...")) {
-      show_planner_ = !show_planner_;
+      Toggle();
     }
     UnityEngine.GUI.skin = old_skin;
   }
 
-  private void RenderPlanner(int window_id) {
+  protected override String Title { get; } = "Flight plan";
+
+  protected override void RenderWindow(int window_id) {
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
 
@@ -360,7 +350,6 @@ class FlightPlanner : SupervisedWindowRenderer {
 
   private DifferentialSlider final_time_;
 
-  private bool show_planner_ = false;
   private bool show_guidance_ = false;
   private ManeuverNode guidance_node_;
   

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -222,12 +222,7 @@ class FlightPlanner : SupervisedWindowRenderer {
       }
     }
 
-    UnityEngine.GUI.DragWindow(
-        position : new UnityEngine.Rect(x      : 0f,
-                                        y      : 0f,
-                                        width  : 10000f,
-                                        height : 10000f));
-
+    UnityEngine.GUI.DragWindow();
     UnityEngine.GUI.skin = old_skin;
   }
 

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -40,11 +40,7 @@ class FlightPlanner : SupervisedWindowRenderer {
   protected override String Title { get; } = "Flight plan";
 
   protected override void RenderWindow(int window_id) {
-    var old_skin = UnityEngine.GUI.skin;
-    UnityEngine.GUI.skin = null;
-
     using (new UnityEngine.GUILayout.VerticalScope()) {
-
       {
         string vessel_guid = vessel_?.id.ToString();
         if (vessel_guid == null ||
@@ -221,9 +217,7 @@ class FlightPlanner : SupervisedWindowRenderer {
         }
       }
     }
-
     UnityEngine.GUI.DragWindow();
-    UnityEngine.GUI.skin = old_skin;
   }
 
   private void RenderUpcomingEvents() {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -218,9 +218,6 @@ public partial class PrincipiaPluginAdapter
       new Dictionary<uint, QP>();
 
   // UI for the apocalypse notification.
-  // Whether we have encountered an apocalypse already.
-  [KSPField(isPersistant = true)]
-  private bool is_post_apocalyptic_ = false;
   [KSPField(isPersistant = true)]
   private Dialog apocalypse_dialog_ = new Dialog();
 
@@ -679,12 +676,11 @@ public partial class PrincipiaPluginAdapter
   private void OnGUI() {
     if (is_bad_installation_) {
       bad_installation_dialog_.Show();
+      bad_installation_dialog_.RenderWindow();
       return;
     }
 
-    if (is_post_apocalyptic_) {
-      apocalypse_dialog_.Show();
-    }
+    apocalypse_dialog_.RenderWindow();
 
     if (KSP.UI.Screens.ApplicationLauncher.Ready && toolbar_button_ == null) {
       UnityEngine.Texture toolbar_button_texture;
@@ -1376,11 +1372,11 @@ public partial class PrincipiaPluginAdapter
       time_is_advancing_ = time_is_advancing(universal_time);
       if (time_is_advancing_) {
         plugin_.AdvanceTime(universal_time, Planetarium.InverseRotAngle);
-        if (!is_post_apocalyptic_) {
+        if (!apocalypse_dialog_.Shown()) {
           String revelation = "";
           if (plugin_.HasEncounteredApocalypse(out revelation)) {
-            is_post_apocalyptic_ = true;
             apocalypse_dialog_.Message = revelation;
+            apocalypse_dialog_.Show();
           }
         }
         foreach (var vessel in FlightGlobals.Vessels) {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2105,11 +2105,7 @@ public partial class PrincipiaPluginAdapter
                         render : CrashOptions);
 #endif
     }
-    UnityEngine.GUI.DragWindow(
-        position : new UnityEngine.Rect(x      : 0f,
-                                        y      : 0f,
-                                        width  : 10000f,
-                                        height : 10000f));
+    UnityEngine.GUI.DragWindow();
   }
 
   delegate void GUIRenderer();

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -267,10 +267,9 @@ public partial class PrincipiaPluginAdapter
     }
     map_node_pool_ = new MapNodePool();
     flight_planner_ = new FlightPlanner(this);
-    plotting_frame_selector_ =
-        new ReferenceFrameSelector(this,
-                                   UpdateRenderingFrame,
-                                   "Plotting frame");
+    plotting_frame_selector_ = new ReferenceFrameSelector(this,
+                                                          UpdateRenderingFrame,
+                                                          "Plotting frame");
   }
 
   ~PrincipiaPluginAdapter() {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -242,10 +242,14 @@ public partial class PrincipiaPluginAdapter
     // platform problems in C++.
     System.IO.Directory.CreateDirectory("glog/Principia");
     string load_error = Loader.LoadPrincipiaDllAndInitGoogleLogging();
-    if (load_error != null) {
+    if (load_error == null) {
+      is_bad_installation_ = false;
+      bad_installation_dialog_.Hide();
+    } else {
       is_bad_installation_ = true;
       bad_installation_dialog_.Message =
           "The Principia DLL failed to load.\n" + load_error;
+      bad_installation_dialog_.Show();
     }
 #if KSP_VERSION_1_3_1
     if (Versioning.version_major != 1 ||
@@ -674,7 +678,6 @@ public partial class PrincipiaPluginAdapter
 
   private void OnGUI() {
     if (is_bad_installation_) {
-      bad_installation_dialog_.Show();
       bad_installation_dialog_.RenderWindow();
       return;
     }

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -281,9 +281,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
   }
 
   protected override void RenderWindow(int window_id) {
-    var old_skin = UnityEngine.GUI.skin;
-    UnityEngine.GUI.skin = null;
-
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       // Left-hand side: tree view for celestial selection.
       using (new UnityEngine.GUILayout.VerticalScope(
@@ -311,9 +308,7 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
         }
       }
     }
-
     UnityEngine.GUI.DragWindow();
-    UnityEngine.GUI.skin = old_skin;
   }
 
   private void RenderSubtree(CelestialBody celestial, int depth) {

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -312,12 +312,7 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
       }
     }
 
-    UnityEngine.GUI.DragWindow(
-        position : new UnityEngine.Rect(x      : 0f,
-                                        y      : 0f,
-                                        width  : 10000f,
-                                        height : 10000f));
-
+    UnityEngine.GUI.DragWindow();
     UnityEngine.GUI.skin = old_skin;
   }
 

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -33,7 +33,7 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
   public ReferenceFrameSelector(
       ISupervisor supervisor,
       Callback on_change,
-      string name) : base(supervisor) {
+      string name) : base(supervisor, UnityEngine.GUILayout.MinWidth(0)) {
     on_change_ = on_change;
     name_ = name;
 

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -264,33 +264,23 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
     }
   }
 
-  public void Hide() {
-    show_selector_ = false;
-  }
-
   public void RenderButton() {
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
     if (UnityEngine.GUILayout.Button(name_ + " selection (" + Name() +
                                      ")...")) {
-      show_selector_ = !show_selector_;
+      Toggle();
     }
     UnityEngine.GUI.skin = old_skin;
   }
 
-  protected override void RenderWindow() {
-    var old_skin = UnityEngine.GUI.skin;
-    UnityEngine.GUI.skin = null;
-    if (show_selector_) {
-      Window(func : RenderSelector,
-             text : name_ + " selection (" + Name() + ")");
-    } else {
-      ClearLock();
+  protected override String Title {
+    get {
+      return name_ + " selection (" + Name() + ")";
     }
-    UnityEngine.GUI.skin = old_skin;
   }
 
-  private void RenderSelector(int window_id) {
+  protected override void RenderWindow(int window_id) {
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
 
@@ -397,7 +387,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
   private readonly string name_;
   // Not owned.
   private IntPtr plugin_;
-  private bool show_selector_;
   private Dictionary<CelestialBody, bool> expanded_;
 }
 


### PR DESCRIPTION
* Move the hide/show bit to `WindowRenderer` and save/load it.
* Add `Hide`, `Show`, `Shown` and `Toggle` to manage that bit.
* Make `RenderWindow` nonabstract to factor out logic that's common to all the windows (e.g., clearing the lock when hiding).
* Subclasses are now expected to override `Title` and a new `RenderWindow(int)` method.
* Pass GUI options at construction if needed with a reasonable default.
* Drudgery to centre a window the first time it is shown.