### PR TITLE
Use constexpr std::array aggregates instead of std::initializer_list

### DIFF
--- a/integrators/cohen_hubbard_oesterwinter_body.hpp
+++ b/integrators/cohen_hubbard_oesterwinter_body.hpp
@@ -8,198 +8,198 @@ namespace integrators {
 
 template<>
 inline CohenHubbardOesterwinter<1> const& CohenHubbardOesterwinterOrder<1>() {
-  static CohenHubbardOesterwinter<1> const cohen_hubbard_oesterwinter{{1.0},
-                                                                      2.0};
+  static constexpr CohenHubbardOesterwinter<1> cohen_hubbard_oesterwinter{
+      {{1.0}}, 2.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<2> const& CohenHubbardOesterwinterOrder<2>() {
-  static CohenHubbardOesterwinter<2> const cohen_hubbard_oesterwinter{
-      {2.0, 1.0}, 6.0};
+  static constexpr CohenHubbardOesterwinter<2> cohen_hubbard_oesterwinter{
+      {{2.0, 1.0}}, 6.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<3> const& CohenHubbardOesterwinterOrder<3>() {
-  static CohenHubbardOesterwinter<3> const cohen_hubbard_oesterwinter{
-      {7.0, 6.0, -1.0}, 24.0};
+  static constexpr CohenHubbardOesterwinter<3> cohen_hubbard_oesterwinter{
+      {{7.0, 6.0, -1.0}}, 24.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<4> const& CohenHubbardOesterwinterOrder<4>() {
-  static CohenHubbardOesterwinter<4> const cohen_hubbard_oesterwinter{
-      {97.0, 114.0, -39.0, 8.0}, 360.0};
+  static constexpr CohenHubbardOesterwinter<4> cohen_hubbard_oesterwinter{
+      {{97.0, 114.0, -39.0, 8.0}}, 360.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<5> const& CohenHubbardOesterwinterOrder<5>() {
-  static CohenHubbardOesterwinter<5> const cohen_hubbard_oesterwinter{
-      {367.0, 540.0, -282.0, 116.0, -21.0}, 1440.0};
+  static constexpr CohenHubbardOesterwinter<5> cohen_hubbard_oesterwinter{
+      {{367.0, 540.0, -282.0, 116.0, -21.0}}, 1440.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<6> const& CohenHubbardOesterwinterOrder<6>() {
-  static CohenHubbardOesterwinter<6> const cohen_hubbard_oesterwinter{
-      {2462.0, 4315.0, -3044.0, 1882.0, -682.0, 107.0}, 10080.0};
+  static constexpr CohenHubbardOesterwinter<6> cohen_hubbard_oesterwinter{
+      {{2462.0, 4315.0, -3044.0, 1882.0, -682.0, 107.0}}, 10080.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<7> const& CohenHubbardOesterwinterOrder<7>() {
-  static CohenHubbardOesterwinter<7> const cohen_hubbard_oesterwinter{
-      {28549.0, 57750.0, -51453.0, 42484.0, -23109.0, 7254.0, -995.0},
+  static constexpr CohenHubbardOesterwinter<7> cohen_hubbard_oesterwinter{
+      {{28549.0, 57750.0, -51453.0, 42484.0, -23109.0, 7254.0, -995.0}},
       120960.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<8> const& CohenHubbardOesterwinterOrder<8>() {
-  static CohenHubbardOesterwinter<8> const cohen_hubbard_oesterwinter{
-      {416173.0,
-       950684.0,
-       -1025097.0,
-       1059430.0,
-       -768805.0,
-       362112.0,
-       -99359.0,
-       12062.0},
+  static constexpr CohenHubbardOesterwinter<8> cohen_hubbard_oesterwinter{
+      {{416173.0,
+        950684.0,
+        -1025097.0,
+        1059430.0,
+        -768805.0,
+        362112.0,
+        -99359.0,
+        12062.0}},
       1814400.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<9> const& CohenHubbardOesterwinterOrder<9>() {
-  static CohenHubbardOesterwinter<9> const cohen_hubbard_oesterwinter{
-      {1624505.0,
-       4124232.0,
-       -5225624.0,
-       6488192.0,
-       -5888310.0,
-       3698920.0,
-       -1522672.0,
-       369744.0,
-       -40187.0},
+  static constexpr CohenHubbardOesterwinter<9> cohen_hubbard_oesterwinter{
+      {{1624505.0,
+        4124232.0,
+        -5225624.0,
+        6488192.0,
+        -5888310.0,
+        3698920.0,
+        -1522672.0,
+        369744.0,
+        -40187.0}},
       7257600.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<10> const& CohenHubbardOesterwinterOrder<10>() {
-  static CohenHubbardOesterwinter<10> const cohen_hubbard_oesterwinter{
-      {52478684.0,
-       146269485.0,
-       -213124908.0,
-       309028740.0,
-       -336691836.0,
-       264441966.0,
-       -145166580.0,
-       52880868.0,
-       -11496000.0,
-       1129981.0},
+  static constexpr CohenHubbardOesterwinter<10> cohen_hubbard_oesterwinter{
+      {{52478684.0,
+        146269485.0,
+        -213124908.0,
+        309028740.0,
+        -336691836.0,
+        264441966.0,
+        -145166580.0,
+        52880868.0,
+        -11496000.0,
+        1129981.0}},
       239500800.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<11> const& CohenHubbardOesterwinterOrder<11>() {
-  static CohenHubbardOesterwinter<11> const cohen_hubbard_oesterwinter{
-      {205994615.0,
-       624279150.0,
-       -1028905077.0,
-       1706529480.0,
-       -2169992754.0,
-       2045638356.0,
-       -1403891730.0,
-       681937992.0,
-       -222389445.0,
-       43721134.0,
-       -3920121.0},
+  static constexpr CohenHubbardOesterwinter<11> cohen_hubbard_oesterwinter{
+      {{205994615.0,
+        624279150.0,
+        -1028905077.0,
+        1706529480.0,
+        -2169992754.0,
+        2045638356.0,
+        -1403891730.0,
+        681937992.0,
+        -222389445.0,
+        43721134.0,
+        -3920121.0}},
       958003200.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<12> const& CohenHubbardOesterwinterOrder<12>() {
-  static CohenHubbardOesterwinter<12> const cohen_hubbard_oesterwinter{
-      {92158447389.0,
-       301307140046.0,
-       -554452444015.0,
-       1035372815340.0,
-       -1505150506950.0,
-       1655690777412.0,
-       -1363696062582.0,
-       828085590240.0,
-       -360089099415.0,
-       106193749950.0,
-       -19043781851.0,
-       1569102436.0},
+  static constexpr CohenHubbardOesterwinter<12> cohen_hubbard_oesterwinter{
+      {{92158447389.0,
+        301307140046.0,
+        -554452444015.0,
+        1035372815340.0,
+        -1505150506950.0,
+        1655690777412.0,
+        -1363696062582.0,
+        828085590240.0,
+        -360089099415.0,
+        106193749950.0,
+        -19043781851.0,
+        1569102436.0}},
       435891456000.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<13> const& CohenHubbardOesterwinterOrder<13>() {
-  static CohenHubbardOesterwinter<13> const cohen_hubbard_oesterwinter{
-      {1089142980505.0,
-       3816786338508.0,
-       -7759482946938.0,
-       16111319179940.0,
-       -26357208224085.0,
-       33140932754040.0,
-       -31849103413596.0,
-       23209670507976.0,
-       -12616471333665.0,
-       4961170395260.0,
-       -1334579000970.0,
-       219929887188.0,
-       -16758388163.0},
+  static constexpr CohenHubbardOesterwinter<13> cohen_hubbard_oesterwinter{
+      {{1089142980505.0,
+        3816786338508.0,
+        -7759482946938.0,
+        16111319179940.0,
+        -26357208224085.0,
+        33140932754040.0,
+        -31849103413596.0,
+        23209670507976.0,
+        -12616471333665.0,
+        4961170395260.0,
+        -1334579000970.0,
+        219929887188.0,
+        -16758388163.0}},
       5230697472000.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<14> const& CohenHubbardOesterwinterOrder<14>() {
-  static CohenHubbardOesterwinter<14> const cohen_hubbard_oesterwinter{
-      {3222245907974.0,
-       12037738451557.0,
-       -26802725457012.0,
-       61256305132546.0,
-       -111377493654070.0,
-       157573362429387.0,
-       -173081395797144.0,
-       147163097080284.0,
-       -95999978168262.0,
-       47189380167595.0,
-       -16926084595636.0,
-       4184066277762.0,
-       -637654600522.0,
-       45183033541.0},
+  static constexpr CohenHubbardOesterwinter<14> cohen_hubbard_oesterwinter{
+      {{3222245907974.0,
+        12037738451557.0,
+        -26802725457012.0,
+        61256305132546.0,
+        -111377493654070.0,
+        157573362429387.0,
+        -173081395797144.0,
+        147163097080284.0,
+        -95999978168262.0,
+        47189380167595.0,
+        -16926084595636.0,
+        4184066277762.0,
+        -637654600522.0,
+        45183033541.0}},
       15692092416000.0};
   return cohen_hubbard_oesterwinter;
 }
 
 template<>
 inline CohenHubbardOesterwinter<15> const& CohenHubbardOesterwinterOrder<15>() {
-  static CohenHubbardOesterwinter<15> const cohen_hubbard_oesterwinter{
-      {12725213787853.0,
-       50443731622830.0,
-       -122113957635961.0,
-       304637443761836.0,
-       -609443588503323.0,
-       958160677491634.0,
-       -1184126424849705.0,
-       1150710493076712.0,
-       -875800754334177.0,
-       516624748444466.0,
-       -231637952269587.0,
-       76348488342700.0,
-       -17453674210001.0,
-       2473509950766.0,
-       -163769844043.0},
+  static constexpr CohenHubbardOesterwinter<15> cohen_hubbard_oesterwinter{
+      {{12725213787853.0,
+        50443731622830.0,
+        -122113957635961.0,
+        304637443761836.0,
+        -609443588503323.0,
+        958160677491634.0,
+        -1184126424849705.0,
+        1150710493076712.0,
+        -875800754334177.0,
+        516624748444466.0,
+        -231637952269587.0,
+        76348488342700.0,
+        -17453674210001.0,
+        2473509950766.0,
+        -163769844043.0}},
       62768369664000.0};
   return cohen_hubbard_oesterwinter;
 }

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <array>
-#include <initializer_list>
 #include <vector>
 
 #include "quantities/named_quantities.hpp"
@@ -26,13 +25,12 @@ class FixedVector final {
   constexpr FixedVector();
   explicit FixedVector(uninitialized_t);
 
-  constexpr explicit FixedVector(std::array<Scalar, size_> const& data);
-  constexpr explicit FixedVector(std::array<Scalar, size_>&& data);
-  FixedVector(
-      std::initializer_list<Scalar> const& data);  // NOLINT(runtime/explicit)
+  // TODO(egg): Figure out why we have a move-conversion for |FixedVector| but
+  // not the matrices.
+  constexpr FixedVector(std::array<Scalar, size_> const& data);
+  constexpr FixedVector(std::array<Scalar, size_>&& data);
 
   bool operator==(FixedVector const& right) const;
-  FixedVector& operator=(std::initializer_list<Scalar> const& right);
 
   constexpr Scalar& operator[](int index);
   constexpr Scalar const& operator[](int index) const;
@@ -57,13 +55,9 @@ class FixedMatrix final {
   explicit FixedMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
-  constexpr explicit FixedMatrix(
-      std::array<Scalar, rows * columns> const& data);
-  FixedMatrix(
-      std::initializer_list<Scalar> const& data);  // NOLINT(runtime/explicit)
+  constexpr FixedMatrix(std::array<Scalar, rows * columns> const& data);
 
   bool operator==(FixedMatrix const& right) const;
-  FixedMatrix& operator=(std::initializer_list<Scalar> const& right);
 
   template<int r>
   class Row {
@@ -118,14 +112,10 @@ class FixedStrictlyLowerTriangularMatrix final {
   explicit FixedStrictlyLowerTriangularMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
-  constexpr explicit FixedStrictlyLowerTriangularMatrix(
+  constexpr FixedStrictlyLowerTriangularMatrix(
       std::array<Scalar, dimension> const& data);
-  FixedStrictlyLowerTriangularMatrix(
-      std::initializer_list<Scalar> const& data);  // NOLINT(runtime/explicit)
 
   bool operator==(FixedStrictlyLowerTriangularMatrix const& right) const;
-  FixedStrictlyLowerTriangularMatrix& operator=(
-      std::initializer_list<Scalar> const& right);
 
   // For  0 < j < i < rows, the entry a_ij is accessed as |a[i][j]|.
   // if i and j do not satisfy these conditions, the expression |a[i][j]| is
@@ -147,14 +137,10 @@ class FixedLowerTriangularMatrix final {
   explicit FixedLowerTriangularMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
-  constexpr explicit FixedLowerTriangularMatrix(
+  constexpr FixedLowerTriangularMatrix(
       std::array<Scalar, dimension> const& data);
-  FixedLowerTriangularMatrix(
-      std::initializer_list<Scalar> const& data);  // NOLINT(runtime/explicit)
 
   bool operator==(FixedLowerTriangularMatrix const& right) const;
-  FixedLowerTriangularMatrix& operator=(
-      std::initializer_list<Scalar> const& right);
 
   // For  0 < j <= i < rows, the entry a_ij is accessed as |a[i][j]|.
   // if i and j do not satisfy these conditions, the expression |a[i][j]| is

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -68,23 +68,8 @@ constexpr FixedVector<Scalar, size_>::FixedVector(
     : data_(std::move(data)) {}
 
 template<typename Scalar, int size_>
-FixedVector<Scalar, size_>::FixedVector(
-    std::initializer_list<Scalar> const& data) {
-  CHECK_EQ(size, data.size());
-  std::copy(data.begin(), data.end(), data_.begin());
-}
-
-template<typename Scalar, int size_>
 bool FixedVector<Scalar, size_>::operator==(FixedVector const& right) const {
   return data_ == right.data_;
-}
-
-template<typename Scalar, int size_>
-FixedVector<Scalar, size_>& FixedVector<Scalar, size_>::operator=(
-    std::initializer_list<Scalar> const& right) {
-  CHECK_EQ(size, right.size());
-  std::copy(right.begin(), right.end(), data_.begin());
-  return *this;
 }
 
 template<typename Scalar, int size_>
@@ -118,25 +103,9 @@ constexpr FixedMatrix<Scalar, rows, columns>::FixedMatrix(
     : data_(data) {}
 
 template<typename Scalar, int rows, int columns>
-FixedMatrix<Scalar, rows, columns>::FixedMatrix(
-    std::initializer_list<Scalar> const& data) {
-  CHECK_EQ(rows * columns, data.size());
-  std::copy(data.begin(), data.end(), data_.begin());
-}
-
-template<typename Scalar, int rows, int columns>
 bool FixedMatrix<Scalar, rows, columns>::operator==(
     FixedMatrix const& right) const {
   return data_ == right.data_;
-}
-
-template<typename Scalar, int rows, int columns>
-FixedMatrix<Scalar, rows, columns>&
-FixedMatrix<Scalar, rows, columns>::operator=(
-    std::initializer_list<Scalar> const& right) {
-  CHECK_EQ(rows * columns, right.size());
-  std::copy(right.begin(), right.end(), data_.begin());
-  return *this;
 }
 
 template<typename Scalar, int rows, int columns>
@@ -220,26 +189,9 @@ constexpr FixedStrictlyLowerTriangularMatrix<Scalar, rows>::
     : data_(data) {}
 
 template<typename Scalar, int rows>
-FixedStrictlyLowerTriangularMatrix<Scalar, rows>::
-    FixedStrictlyLowerTriangularMatrix(
-        std::initializer_list<Scalar> const& data) {
-  CHECK_EQ(dimension, data.size());
-  std::copy(data.begin(), data.end(), data_.begin());
-}
-
-template<typename Scalar, int rows>
 bool FixedStrictlyLowerTriangularMatrix<Scalar, rows>::operator==(
     FixedStrictlyLowerTriangularMatrix const& right) const {
   return data_ == right.data_;
-}
-
-template<typename Scalar, int rows>
-FixedStrictlyLowerTriangularMatrix<Scalar, rows>&
-FixedStrictlyLowerTriangularMatrix<Scalar, rows>::operator=(
-    std::initializer_list<Scalar> const& right) {
-  CHECK_EQ(dimension, right.size());
-  std::copy(right.begin(), right.end(), data_.begin());
-  return *this;
 }
 
 template<typename Scalar, int rows>
@@ -272,25 +224,9 @@ constexpr FixedLowerTriangularMatrix<Scalar, rows>::
     : data_(data) {}
 
 template<typename Scalar, int rows>
-FixedLowerTriangularMatrix<Scalar, rows>::
-    FixedLowerTriangularMatrix(std::initializer_list<Scalar> const& data) {
-  CHECK_EQ(dimension, data.size());
-  std::copy(data.begin(), data.end(), data_.begin());
-}
-
-template<typename Scalar, int rows>
 bool FixedLowerTriangularMatrix<Scalar, rows>::operator==(
     FixedLowerTriangularMatrix const& right) const {
   return data_ == right.data_;
-}
-
-template<typename Scalar, int rows>
-FixedLowerTriangularMatrix<Scalar, rows>&
-FixedLowerTriangularMatrix<Scalar, rows>::operator=(
-    std::initializer_list<Scalar> const& right) {
-  CHECK_EQ(dimension, right.size());
-  std::copy(right.begin(), right.end(), data_.begin());
-  return *this;
 }
 
 template<typename Scalar, int rows>

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -32,37 +32,37 @@ class FixedArraysTest : public ::testing::Test {
 
 TEST_F(FixedArraysTest, Assignment) {
   FixedVector<double, 2> u2({1, 2});
-  FixedVector<double, 2> v2 = {1, 2};
+  FixedVector<double, 2> v2 = {{1, 2}};
   FixedVector<double, 2> w2;
-  w2 = {1, 2};
+  w2 = {{1, 2}};
   EXPECT_EQ(u2, v2);
   EXPECT_EQ(u2, w2);
 
   FixedMatrix<double, 2, 3> l23({1, 2, 3,
                                  4, 5, 6});
-  FixedMatrix<double, 2, 3> m23 = {1, 2, 3,
-                                   4, 5, 6};
-  FixedMatrix<double, 2, 3> n23 = {0, 0, 0,
-                                   0, 0, 0};
-  n23 = {1, 2, 3,
-         4, 5, 6};
+  FixedMatrix<double, 2, 3> m23 = {{1, 2, 3,
+                                    4, 5, 6}};
+  FixedMatrix<double, 2, 3> n23 = {{0, 0, 0,
+                                    0, 0, 0}};
+  n23 = {{1, 2, 3,
+          4, 5, 6}};
   EXPECT_EQ(l23, m23);
   EXPECT_EQ(l23, n23);
 
   FixedStrictlyLowerTriangularMatrix<double, 3> l3({
                                                     1,
                                                     2, 3});
-  FixedStrictlyLowerTriangularMatrix<double, 3> m3 = {
-                                                      1,
-                                                      2, 3};
-  FixedStrictlyLowerTriangularMatrix<double, 3> n3 = {
-                                                      0,
-                                                      0, 0};
+  FixedStrictlyLowerTriangularMatrix<double, 3> m3 = {{
+                                                       1,
+                                                       2, 3}};
+  FixedStrictlyLowerTriangularMatrix<double, 3> n3 = {{
+                                                       0,
+                                                       0, 0}};
   FixedStrictlyLowerTriangularMatrix<double, 3> o3;
   EXPECT_EQ(o3, n3);
-  n3 = {
-        1,
-        2, 3};
+  n3 = {{
+         1,
+         2, 3}};
   EXPECT_EQ(l3, m3);
   EXPECT_EQ(l3, n3);
 }
@@ -110,7 +110,7 @@ TEST_F(FixedArraysTest, Row) {
                                4, -5, 6});
   FixedMatrix<double, 2, 3>::Row<0> r0 = m.row<0>();
   FixedMatrix<double, 2, 3>::Row<1> r1 = m.row<1>();
-  FixedVector<double, 3> v = {1, 2, -3};
+  FixedVector<double, 3> v = {{1, 2, -3}};
 
   EXPECT_EQ(-4, r0 * v);
   EXPECT_EQ(-24, r1 * v);


### PR DESCRIPTION
The overload meant
```C++
FixedMatrix<double, 1, 1>{{{0}}}
```
was not a constant expression, whereas
```C++
FixedMatrix<double, 2, 2>{{{1, 0
                            0, 1}}}
```
was.

With the overload gone, these are both constexpr, and can even be rewritten with fewer brackets as
```C++
FixedMatrix<double, 1, 1>{{0}}
FixedMatrix<double, 2, 2>{{1, 0
                           0, 1}}
```