### PR TITLE
Restructure the rendering of the flight plan

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -572,6 +572,7 @@ bool principia__HasVessel(Plugin* const plugin,
                           char const* const vessel_guid) {
   journal::Method<journal::HasVessel> m({plugin,  vessel_guid});
   CHECK_NOTNULL(plugin);
+  CHECK_NOTNULL(vessel_guid);
   return m.Return(plugin->HasVessel(vessel_guid));
 }
 

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -35,13 +35,11 @@ internal class DifferentialSlider {
   // Renders the |DifferentialSlider|.  Returns true if and only if |value|
   // changed.
   public bool Render(bool enabled) {
-      UnityEngine.Debug.LogError("HS0");
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
     bool value_changed = false;
 
     using (new UnityEngine.GUILayout.HorizontalScope()) {
-      UnityEngine.Debug.LogError("HS1");
       var style = new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label);
       if (text_colour_.HasValue) {
         style.normal.textColor = text_colour_.Value;
@@ -50,7 +48,6 @@ internal class DifferentialSlider {
                                   options    : UnityEngine.GUILayout.Width(75),
                                   style      : style);
 
-      UnityEngine.Debug.LogError("HS2");
       var old_alignment = UnityEngine.GUI.skin.label.alignment;
       UnityEngine.GUI.skin.label.alignment = UnityEngine.TextAnchor.UpperRight;
       UnityEngine.GUILayout.Label(
@@ -62,7 +59,6 @@ internal class DifferentialSlider {
           text       : unit_ ?? "",
           options    : UnityEngine.GUILayout.Width(unit_ == null ? 0 : 50));
 
-      UnityEngine.Debug.LogError("HS3");
       if (enabled) {
         if (!UnityEngine.Input.GetMouseButton(0)) {
           slider_position_ = 0;
@@ -75,13 +71,11 @@ internal class DifferentialSlider {
             rightValue : 1,
             options    : UnityEngine.GUILayout.ExpandWidth(true));
 
-      UnityEngine.Debug.LogError("HS4");
         if (UnityEngine.GUILayout.Button("0",
                                          UnityEngine.GUILayout.Width(20))) {
           value_changed = true;
           value = 0;
         }
-      UnityEngine.Debug.LogError("HS5");
         if (slider_position_ != 0.0) {
           value_changed = true;
           value += Math.Sign(slider_position_) *
@@ -94,7 +88,6 @@ internal class DifferentialSlider {
       } else {
         slider_position_ = 0;
       }
-      UnityEngine.Debug.LogError("HS6");
       last_time_ = System.DateTime.Now;
     }
 

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -44,9 +44,9 @@ internal class DifferentialSlider {
       if (text_colour_.HasValue) {
         style.normal.textColor = text_colour_.Value;
       }
-      UnityEngine.GUILayout.Label(text       : label_,
-                                  options    : UnityEngine.GUILayout.Width(75),
-                                  style      : style);
+      UnityEngine.GUILayout.Label(text    : label_,
+                                  options : UnityEngine.GUILayout.Width(75),
+                                  style   : style);
 
       var old_alignment = UnityEngine.GUI.skin.label.alignment;
       UnityEngine.GUI.skin.label.alignment = UnityEngine.TextAnchor.UpperRight;
@@ -56,8 +56,8 @@ internal class DifferentialSlider {
                         125 + (unit_ == null ? 50 : 0)));
       UnityEngine.GUI.skin.label.alignment = old_alignment;
       UnityEngine.GUILayout.Label(
-          text       : unit_ ?? "",
-          options    : UnityEngine.GUILayout.Width(unit_ == null ? 0 : 50));
+          text    : unit_ ?? "",
+          options : UnityEngine.GUILayout.Width(unit_ == null ? 0 : 50));
 
       if (enabled) {
         if (!UnityEngine.Input.GetMouseButton(0)) {

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -35,30 +35,34 @@ internal class DifferentialSlider {
   // Renders the |DifferentialSlider|.  Returns true if and only if |value|
   // changed.
   public bool Render(bool enabled) {
+      UnityEngine.Debug.LogError("HS0");
     var old_skin = UnityEngine.GUI.skin;
     UnityEngine.GUI.skin = null;
     bool value_changed = false;
 
     using (new UnityEngine.GUILayout.HorizontalScope()) {
+      UnityEngine.Debug.LogError("HS1");
       var style = new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label);
       if (text_colour_.HasValue) {
         style.normal.textColor = text_colour_.Value;
       }
-      UnityEngine.GUILayout.Label(
-          text       : label_,
-          options    : UnityEngine.GUILayout.Width(75),
-          style      : style);
+      UnityEngine.GUILayout.Label(text       : label_,
+                                  options    : UnityEngine.GUILayout.Width(75),
+                                  style      : style);
 
+      UnityEngine.Debug.LogError("HS2");
       var old_alignment = UnityEngine.GUI.skin.label.alignment;
       UnityEngine.GUI.skin.label.alignment = UnityEngine.TextAnchor.UpperRight;
       UnityEngine.GUILayout.Label(
           text    : format_(value),
-          options : UnityEngine.GUILayout.Width(125 + (unit_ == null ? 50 : 0)));
+          options : UnityEngine.GUILayout.Width(
+                        125 + (unit_ == null ? 50 : 0)));
       UnityEngine.GUI.skin.label.alignment = old_alignment;
       UnityEngine.GUILayout.Label(
           text       : unit_ ?? "",
           options    : UnityEngine.GUILayout.Width(unit_ == null ? 0 : 50));
 
+      UnityEngine.Debug.LogError("HS3");
       if (enabled) {
         if (!UnityEngine.Input.GetMouseButton(0)) {
           slider_position_ = 0;
@@ -71,11 +75,13 @@ internal class DifferentialSlider {
             rightValue : 1,
             options    : UnityEngine.GUILayout.ExpandWidth(true));
 
+      UnityEngine.Debug.LogError("HS4");
         if (UnityEngine.GUILayout.Button("0",
                                          UnityEngine.GUILayout.Width(20))) {
           value_changed = true;
           value = 0;
         }
+      UnityEngine.Debug.LogError("HS5");
         if (slider_position_ != 0.0) {
           value_changed = true;
           value += Math.Sign(slider_position_) *
@@ -88,6 +94,7 @@ internal class DifferentialSlider {
       } else {
         slider_position_ = 0;
       }
+      UnityEngine.Debug.LogError("HS6");
       last_time_ = System.DateTime.Now;
     }
 

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -49,13 +49,11 @@ class FlightPlanner : SupervisedWindowRenderer {
             !plugin_.FlightPlanExists(vessel_guid) ||
             plugin_.FlightPlanNumberOfManoeuvres(vessel_guid) !=
                 burn_editors_?.Count) {
-      UnityEngine.Debug.LogError("RS1");
           Reset();
         }
       }
 
       if (vessel_ != null) {
-                  UnityEngine.Debug.LogError("HV");
         string vessel_guid = vessel_.id.ToString();
         if (burn_editors_ == null) {
           if (plugin_.HasVessel(vessel_guid)) {
@@ -76,7 +74,6 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Last().Reset(
                     plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
               }
-      UnityEngine.Debug.LogError("Add "+plugin_.FlightPlanNumberOfManoeuvres(vessel_guid));
             } else {
               if (UnityEngine.GUILayout.Button("Create flight plan")) {
                 plugin_.FlightPlanCreate(vessel_guid,
@@ -85,24 +82,18 @@ class FlightPlanner : SupervisedWindowRenderer {
                 final_time_.value =
                     plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
                 Shrink();
-      UnityEngine.Debug.LogError("SH1");
               }
             }
           }
         } else {
-      UnityEngine.Debug.LogError("Render1");
           if (final_time_.Render(enabled : true)) {
-      UnityEngine.Debug.LogError("RenderFTB");
             plugin_.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                   final_time_.value);
             final_time_.value =
                 plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
-      UnityEngine.Debug.LogError("RenderFTE");
           }
-                    UnityEngine.Debug.LogError("RenderAFT");
           double actual_final_time =
               plugin_.FlightPlanGetActualFinalTime(vessel_guid);
-                    UnityEngine.Debug.LogError("RenderTFB");
 
           UnityEngine.GUILayout.TextField(
               (final_time_.value == actual_final_time)
@@ -111,16 +102,12 @@ class FlightPlanner : SupervisedWindowRenderer {
                         FormatPositiveTimeSpan(TimeSpan.FromSeconds(
                             actual_final_time -
                             plugin_.FlightPlanGetInitialTime(vessel_guid))));
-      UnityEngine.Debug.LogError("RenderTFE");
 
           FlightPlanAdaptiveStepParameters parameters =
               plugin_.FlightPlanGetAdaptiveStepParameters(vessel_guid);
 
-                    UnityEngine.Debug.LogError("RenderUsing");
           using (new UnityEngine.GUILayout.HorizontalScope()) {
-      UnityEngine.Debug.LogError("H");
             using (new UnityEngine.GUILayout.HorizontalScope()) {
-      UnityEngine.Debug.LogError("HH1");
               UnityEngine.GUILayout.Label("Max. steps per segment:",
                                           UnityEngine.GUILayout.Width(150));
               const int factor = 4;
@@ -142,7 +129,6 @@ class FlightPlanner : SupervisedWindowRenderer {
               }
             }
             using (new UnityEngine.GUILayout.HorizontalScope()) {
-      UnityEngine.Debug.LogError("HH2");
               UnityEngine.GUILayout.Label("Tolerance:",
                                           UnityEngine.GUILayout.Width(75));
               if (parameters.length_integration_tolerance <= 1e-6) {
@@ -168,7 +154,6 @@ class FlightPlanner : SupervisedWindowRenderer {
             }
           }
 
-      UnityEngine.Debug.LogError("Render2");
           double Δv = (from burn_editor in burn_editors_
                        select burn_editor.Δv()).Sum();
           UnityEngine.GUILayout.Label(
@@ -177,7 +162,6 @@ class FlightPlanner : SupervisedWindowRenderer {
           if (burn_editors_.Count == 0 && 
               UnityEngine.GUILayout.Button("Delete flight plan")) {
             plugin_.FlightPlanDelete(vessel_guid);
-      UnityEngine.Debug.LogError("RS2");
             Reset();
           } else {
             if (burn_editors_.Count > 0) {
@@ -187,7 +171,6 @@ class FlightPlanner : SupervisedWindowRenderer {
               UnityEngine.GUILayout.TextArea("Manœuvre #" + (i + 1) + ":");
               burn_editors_[i].Render(enabled : false);
             }
-      UnityEngine.Debug.LogError("Render "+burn_editors_.Count);
             if (burn_editors_.Count > 0) {
               BurnEditor last_burn = burn_editors_.Last();
               UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
@@ -205,7 +188,6 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Last().Close();
                 burn_editors_.RemoveAt(burn_editors_.Count - 1);
                 Shrink();
-      UnityEngine.Debug.LogError("SH2");
               }
             }
             if (UnityEngine.GUILayout.Button(
@@ -231,7 +213,6 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Add(editor);
               }
               Shrink();
-      UnityEngine.Debug.LogError("SH3");
             }
           }
         }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -111,7 +111,7 @@ class FlightPlanner : SupervisedWindowRenderer {
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      if (final_time_.Render(enabled: true)) {
+      if (final_time_.Render(enabled : true)) {
         plugin_.FlightPlanSetDesiredFinalTime(vessel_guid,
                                               final_time_.value);
         final_time_.value =

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -17,8 +17,8 @@ class FlightPlanner : SupervisedWindowRenderer {
     final_time_ = new DifferentialSlider(
                 label            : "Plan length",
                 unit             : null,
-                log10_lower_rate : Log10TimeLowerRate,
-                log10_upper_rate : Log10TimeUpperRate,
+                log10_lower_rate : log10_time_lower_rate,
+                log10_upper_rate : log10_time_upper_rate,
                 min_value        : 10,
                 max_value        : double.PositiveInfinity,
                 formatter        : value =>
@@ -180,7 +180,7 @@ class FlightPlanner : SupervisedWindowRenderer {
       }
 
       double Δv = (from burn_editor in burn_editors_
-                    select burn_editor.Δv()).Sum();
+                   select burn_editor.Δv()).Sum();
       UnityEngine.GUILayout.Label(
           "Total Δv : " + Δv.ToString("0.000") + " m/s");
 
@@ -200,12 +200,12 @@ class FlightPlanner : SupervisedWindowRenderer {
         if (burn_editors_.Count > 0) {
           BurnEditor last_burn = burn_editors_.Last();
           UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
-                                          (burn_editors_.Count) + ":");
+                                         (burn_editors_.Count) + ":");
           if (last_burn.Render(enabled: true)) {
             plugin_.FlightPlanReplaceLast(vessel_guid, last_burn.Burn());
             last_burn.Reset(
                 plugin_.FlightPlanGetManoeuvre(vessel_guid,
-                                                burn_editors_.Count - 1));
+                                               burn_editors_.Count - 1));
           }
           if (UnityEngine.GUILayout.Button(
                   "Delete last manœuvre",
@@ -232,7 +232,7 @@ class FlightPlanner : SupervisedWindowRenderer {
               new BurnEditor(adapter_, plugin_, vessel_, initial_time);
           Burn candidate_burn = editor.Burn();
           bool inserted = plugin_.FlightPlanAppend(vessel_guid,
-                                                    candidate_burn);
+                                                   candidate_burn);
           if (inserted) {
             editor.Reset(plugin_.FlightPlanGetManoeuvre(
                 vessel_guid, burn_editors_.Count));
@@ -366,8 +366,8 @@ class FlightPlanner : SupervisedWindowRenderer {
   private bool show_guidance_ = false;
   private ManeuverNode guidance_node_;
   
-  private const double Log10TimeLowerRate = 0.0;
-  private const double Log10TimeUpperRate = 7.0;
+  private const double log10_time_lower_rate = 0.0;
+  private const double log10_time_upper_rate = 7.0;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -40,7 +40,12 @@ class FlightPlanner : SupervisedWindowRenderer {
   protected override String Title { get; } = "Flight plan";
 
   protected override void RenderWindow(int window_id) {
-    using (new UnityEngine.GUILayout.VerticalScope()) {
+    // We must ensure that the GUI elements don't change between Layout and
+    // Repaint.  This means that any state change must occur before Layout or
+    // after Repaint.  This if statement implements the former.  It updates the
+    // vessel and the editors to reflect the current state of the plugin and
+    // then proceeds with the UI code.
+    if (UnityEngine.Event.current.type == UnityEngine.EventType.Layout) {
       {
         string vessel_guid = vessel_?.id.ToString();
         if (vessel_guid == null ||
@@ -49,176 +54,194 @@ class FlightPlanner : SupervisedWindowRenderer {
             !plugin_.FlightPlanExists(vessel_guid) ||
             plugin_.FlightPlanNumberOfManoeuvres(vessel_guid) !=
                 burn_editors_?.Count) {
-          Reset();
+          if (burn_editors_ != null) {
+            foreach (BurnEditor editor in burn_editors_) {
+              editor.Close();
+            }
+            burn_editors_ = null;
+          }
+          vessel_ = FlightGlobals.ActiveVessel;
         }
       }
 
-      if (vessel_ != null) {
-        string vessel_guid = vessel_.id.ToString();
-        if (burn_editors_ == null) {
-          if (plugin_.HasVessel(vessel_guid)) {
-            if (plugin_.FlightPlanExists(vessel_guid)) {
-              // TODO(phl): Evil change of state between the two calls to
-              // RenderPlanner.
-              burn_editors_ = new List<BurnEditor>();
-              for (int i = 0;
-                   i < plugin_.FlightPlanNumberOfManoeuvres(vessel_guid);
-                   ++i) {
-                // Dummy initial time, we call |Reset| immediately afterwards.
-                final_time_.value =
-                    plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
-                burn_editors_.Add(new BurnEditor(adapter_,
-                                                 plugin_,
-                                                 vessel_,
-                                                 initial_time : 0));
-                burn_editors_.Last().Reset(
-                    plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
-              }
-            } else {
-              if (UnityEngine.GUILayout.Button("Create flight plan")) {
-                plugin_.FlightPlanCreate(vessel_guid,
-                                         plugin_.CurrentTime() + 1000,
-                                         vessel_.GetTotalMass());
-                final_time_.value =
-                    plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
-                Shrink();
-              }
-            }
-          }
-        } else {
-          if (final_time_.Render(enabled : true)) {
-            plugin_.FlightPlanSetDesiredFinalTime(vessel_guid,
-                                                  final_time_.value);
+      if (burn_editors_ == null) {
+        string vessel_guid = vessel_?.id.ToString();
+        if (vessel_guid != null &&
+            plugin_.HasVessel(vessel_guid) &&
+            plugin_.FlightPlanExists(vessel_guid)) {
+          burn_editors_ = new List<BurnEditor>();
+          for (int i = 0;
+               i < plugin_.FlightPlanNumberOfManoeuvres(vessel_guid);
+               ++i) {
+            // Dummy initial time, we call |Reset| immediately afterwards.
             final_time_.value =
                 plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
-          }
-          double actual_final_time =
-              plugin_.FlightPlanGetActualFinalTime(vessel_guid);
-
-          UnityEngine.GUILayout.TextField(
-              (final_time_.value == actual_final_time)
-                  ? ""
-                  : "Timed out after " +
-                        FormatPositiveTimeSpan(TimeSpan.FromSeconds(
-                            actual_final_time -
-                            plugin_.FlightPlanGetInitialTime(vessel_guid))));
-
-          FlightPlanAdaptiveStepParameters parameters =
-              plugin_.FlightPlanGetAdaptiveStepParameters(vessel_guid);
-
-          using (new UnityEngine.GUILayout.HorizontalScope()) {
-            using (new UnityEngine.GUILayout.HorizontalScope()) {
-              UnityEngine.GUILayout.Label("Max. steps per segment:",
-                                          UnityEngine.GUILayout.Width(150));
-              const int factor = 4;
-              if (parameters.max_steps <= 100) {
-                UnityEngine.GUILayout.Button("min");
-              } else if (UnityEngine.GUILayout.Button("-")) {
-                parameters.max_steps /= factor;
-                plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
-                                                            parameters);
-              }
-              UnityEngine.GUILayout.TextArea(parameters.max_steps.ToString(),
-                                             UnityEngine.GUILayout.Width(75));
-              if (parameters.max_steps >= Int64.MaxValue / factor) {
-                UnityEngine.GUILayout.Button("max");
-              } else if (UnityEngine.GUILayout.Button("+")) {
-                parameters.max_steps *= factor;
-                plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
-                                                            parameters);
-              }
-            }
-            using (new UnityEngine.GUILayout.HorizontalScope()) {
-              UnityEngine.GUILayout.Label("Tolerance:",
-                                          UnityEngine.GUILayout.Width(75));
-              if (parameters.length_integration_tolerance <= 1e-6) {
-                UnityEngine.GUILayout.Button("min");
-              } else if (UnityEngine.GUILayout.Button("-")) {
-                parameters.length_integration_tolerance /= 2;
-                parameters.speed_integration_tolerance /= 2;
-                plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
-                                                            parameters);
-              }
-              UnityEngine.GUILayout.TextArea(
-                  parameters.length_integration_tolerance.ToString("0.0e0") +
-                      " m",
-                  UnityEngine.GUILayout.Width(75));
-              if (parameters.length_integration_tolerance >= 1e6) {
-                UnityEngine.GUILayout.Button("max");
-              } else if (UnityEngine.GUILayout.Button("+")) {
-                parameters.length_integration_tolerance *= 2;
-                parameters.speed_integration_tolerance *= 2;
-                plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
-                                                            parameters);
-              }
-            }
-          }
-
-          double Δv = (from burn_editor in burn_editors_
-                       select burn_editor.Δv()).Sum();
-          UnityEngine.GUILayout.Label(
-              "Total Δv : " + Δv.ToString("0.000") + " m/s");
-
-          if (burn_editors_.Count == 0 && 
-              UnityEngine.GUILayout.Button("Delete flight plan")) {
-            plugin_.FlightPlanDelete(vessel_guid);
-            Reset();
-          } else {
-            if (burn_editors_.Count > 0) {
-              RenderUpcomingEvents();
-            }
-            for (int i = 0; i < burn_editors_.Count - 1; ++i) {
-              UnityEngine.GUILayout.TextArea("Manœuvre #" + (i + 1) + ":");
-              burn_editors_[i].Render(enabled : false);
-            }
-            if (burn_editors_.Count > 0) {
-              BurnEditor last_burn = burn_editors_.Last();
-              UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
-                                             (burn_editors_.Count) + ":");
-              if (last_burn.Render(enabled : true)) {
-                plugin_.FlightPlanReplaceLast(vessel_guid, last_burn.Burn());
-                last_burn.Reset(
-                    plugin_.FlightPlanGetManoeuvre(vessel_guid,
-                                                   burn_editors_.Count - 1));
-              }
-              if (UnityEngine.GUILayout.Button(
-                      "Delete last manœuvre",
-                      UnityEngine.GUILayout.ExpandWidth(true))) {
-                plugin_.FlightPlanRemoveLast(vessel_guid);
-                burn_editors_.Last().Close();
-                burn_editors_.RemoveAt(burn_editors_.Count - 1);
-                Shrink();
-              }
-            }
-            if (UnityEngine.GUILayout.Button(
-                    "Add manœuvre",
-                    UnityEngine.GUILayout.ExpandWidth(true))) {
-              double initial_time;
-              if (burn_editors_.Count == 0) {
-                initial_time = plugin_.CurrentTime() + 60;
-              } else {
-                initial_time =
-                    plugin_.FlightPlanGetManoeuvre(
-                        vessel_guid,
-                        burn_editors_.Count - 1).final_time + 60;
-              }
-              var editor =
-                  new BurnEditor(adapter_, plugin_, vessel_, initial_time);
-              Burn candidate_burn = editor.Burn();
-              bool inserted = plugin_.FlightPlanAppend(vessel_guid,
-                                                       candidate_burn);
-              if (inserted) {
-                editor.Reset(plugin_.FlightPlanGetManoeuvre(
-                    vessel_guid, burn_editors_.Count));
-                burn_editors_.Add(editor);
-              }
-              Shrink();
-            }
+            burn_editors_.Add(new BurnEditor(adapter_,
+                                             plugin_,
+                                             vessel_,
+                                             initial_time : 0));
+            burn_editors_.Last().Reset(
+                plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
           }
         }
       }
     }
+
+    // The UI code proper, executed identically for Layout and Repaint.
+    {
+      string vessel_guid = vessel_?.id.ToString();
+      if (vessel_guid == null ||
+          !plugin_.HasVessel(vessel_guid)) {
+        return;
+      }
+
+      if (plugin_.FlightPlanExists(vessel_guid)) {
+        RenderFlightPlan(vessel_guid);
+      } else if (UnityEngine.GUILayout.Button("Create flight plan")) {
+        plugin_.FlightPlanCreate(vessel_guid,
+                                  plugin_.CurrentTime() + 1000,
+                                  vessel_.GetTotalMass());
+        final_time_.value =
+            plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
+        Shrink();
+      }
+    }
     UnityEngine.GUI.DragWindow();
+  }
+
+  private void RenderFlightPlan(string vessel_guid) {
+    using (new UnityEngine.GUILayout.VerticalScope()) {
+      if (final_time_.Render(enabled: true)) {
+        plugin_.FlightPlanSetDesiredFinalTime(vessel_guid,
+                                              final_time_.value);
+        final_time_.value =
+            plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
+      }
+      double actual_final_time =
+          plugin_.FlightPlanGetActualFinalTime(vessel_guid);
+
+      UnityEngine.GUILayout.TextField(
+          (final_time_.value == actual_final_time)
+              ? ""
+              : "Timed out after " +
+                    FormatPositiveTimeSpan(TimeSpan.FromSeconds(
+                        actual_final_time -
+                        plugin_.FlightPlanGetInitialTime(vessel_guid))));
+
+      FlightPlanAdaptiveStepParameters parameters =
+          plugin_.FlightPlanGetAdaptiveStepParameters(vessel_guid);
+
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        using (new UnityEngine.GUILayout.HorizontalScope()) {
+          UnityEngine.GUILayout.Label("Max. steps per segment:",
+                                      UnityEngine.GUILayout.Width(150));
+          const int factor = 4;
+          if (parameters.max_steps <= 100) {
+            UnityEngine.GUILayout.Button("min");
+          } else if (UnityEngine.GUILayout.Button("-")) {
+            parameters.max_steps /= factor;
+            plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
+                                                        parameters);
+          }
+          UnityEngine.GUILayout.TextArea(parameters.max_steps.ToString(),
+                                          UnityEngine.GUILayout.Width(75));
+          if (parameters.max_steps >= Int64.MaxValue / factor) {
+            UnityEngine.GUILayout.Button("max");
+          } else if (UnityEngine.GUILayout.Button("+")) {
+            parameters.max_steps *= factor;
+            plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
+                                                        parameters);
+          }
+        }
+        using (new UnityEngine.GUILayout.HorizontalScope()) {
+          UnityEngine.GUILayout.Label("Tolerance:",
+                                      UnityEngine.GUILayout.Width(75));
+          if (parameters.length_integration_tolerance <= 1e-6) {
+            UnityEngine.GUILayout.Button("min");
+          } else if (UnityEngine.GUILayout.Button("-")) {
+            parameters.length_integration_tolerance /= 2;
+            parameters.speed_integration_tolerance /= 2;
+            plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
+                                                        parameters);
+          }
+          UnityEngine.GUILayout.TextArea(
+              parameters.length_integration_tolerance.ToString("0.0e0") +
+                  " m",
+              UnityEngine.GUILayout.Width(75));
+          if (parameters.length_integration_tolerance >= 1e6) {
+            UnityEngine.GUILayout.Button("max");
+          } else if (UnityEngine.GUILayout.Button("+")) {
+            parameters.length_integration_tolerance *= 2;
+            parameters.speed_integration_tolerance *= 2;
+            plugin_.FlightPlanSetAdaptiveStepParameters(vessel_guid,
+                                                        parameters);
+          }
+        }
+      }
+
+      double Δv = (from burn_editor in burn_editors_
+                    select burn_editor.Δv()).Sum();
+      UnityEngine.GUILayout.Label(
+          "Total Δv : " + Δv.ToString("0.000") + " m/s");
+
+      if (burn_editors_.Count == 0 &&
+          UnityEngine.GUILayout.Button("Delete flight plan")) {
+        plugin_.FlightPlanDelete(vessel_guid);
+        Shrink();
+        // The state change will happen the next time we go through OnGUI.
+      } else {
+        if (burn_editors_.Count > 0) {
+          RenderUpcomingEvents();
+        }
+        for (int i = 0; i < burn_editors_.Count - 1; ++i) {
+          UnityEngine.GUILayout.TextArea("Manœuvre #" + (i + 1) + ":");
+          burn_editors_[i].Render(enabled: false);
+        }
+        if (burn_editors_.Count > 0) {
+          BurnEditor last_burn = burn_editors_.Last();
+          UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
+                                          (burn_editors_.Count) + ":");
+          if (last_burn.Render(enabled: true)) {
+            plugin_.FlightPlanReplaceLast(vessel_guid, last_burn.Burn());
+            last_burn.Reset(
+                plugin_.FlightPlanGetManoeuvre(vessel_guid,
+                                                burn_editors_.Count - 1));
+          }
+          if (UnityEngine.GUILayout.Button(
+                  "Delete last manœuvre",
+                  UnityEngine.GUILayout.ExpandWidth(true))) {
+            plugin_.FlightPlanRemoveLast(vessel_guid);
+            burn_editors_.Last().Close();
+            burn_editors_.RemoveAt(burn_editors_.Count - 1);
+            Shrink();
+          }
+        }
+        if (UnityEngine.GUILayout.Button(
+                "Add manœuvre",
+                UnityEngine.GUILayout.ExpandWidth(true))) {
+          double initial_time;
+          if (burn_editors_.Count == 0) {
+            initial_time = plugin_.CurrentTime() + 60;
+          } else {
+            initial_time =
+                plugin_.FlightPlanGetManoeuvre(
+                    vessel_guid,
+                    burn_editors_.Count - 1).final_time + 60;
+          }
+          var editor =
+              new BurnEditor(adapter_, plugin_, vessel_, initial_time);
+          Burn candidate_burn = editor.Burn();
+          bool inserted = plugin_.FlightPlanAppend(vessel_guid,
+                                                    candidate_burn);
+          if (inserted) {
+            editor.Reset(plugin_.FlightPlanGetManoeuvre(
+                vessel_guid, burn_editors_.Count));
+            burn_editors_.Add(editor);
+          }
+          Shrink();
+        }
+      }
+    }
   }
 
   private void RenderUpcomingEvents() {

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -49,11 +49,13 @@ class FlightPlanner : SupervisedWindowRenderer {
             !plugin_.FlightPlanExists(vessel_guid) ||
             plugin_.FlightPlanNumberOfManoeuvres(vessel_guid) !=
                 burn_editors_?.Count) {
+      UnityEngine.Debug.LogError("RS1");
           Reset();
         }
       }
 
       if (vessel_ != null) {
+                  UnityEngine.Debug.LogError("HV");
         string vessel_guid = vessel_.id.ToString();
         if (burn_editors_ == null) {
           if (plugin_.HasVessel(vessel_guid)) {
@@ -74,6 +76,7 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Last().Reset(
                     plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
               }
+      UnityEngine.Debug.LogError("Add "+plugin_.FlightPlanNumberOfManoeuvres(vessel_guid));
             } else {
               if (UnityEngine.GUILayout.Button("Create flight plan")) {
                 plugin_.FlightPlanCreate(vessel_guid,
@@ -82,18 +85,25 @@ class FlightPlanner : SupervisedWindowRenderer {
                 final_time_.value =
                     plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
                 Shrink();
+      UnityEngine.Debug.LogError("SH1");
               }
             }
           }
         } else {
-          if (final_time_.Render(enabled: true)) {
+      UnityEngine.Debug.LogError("Render1");
+          if (final_time_.Render(enabled : true)) {
+      UnityEngine.Debug.LogError("RenderFTB");
             plugin_.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                   final_time_.value);
             final_time_.value =
                 plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
+      UnityEngine.Debug.LogError("RenderFTE");
           }
+                    UnityEngine.Debug.LogError("RenderAFT");
           double actual_final_time =
               plugin_.FlightPlanGetActualFinalTime(vessel_guid);
+                    UnityEngine.Debug.LogError("RenderTFB");
+
           UnityEngine.GUILayout.TextField(
               (final_time_.value == actual_final_time)
                   ? ""
@@ -101,12 +111,16 @@ class FlightPlanner : SupervisedWindowRenderer {
                         FormatPositiveTimeSpan(TimeSpan.FromSeconds(
                             actual_final_time -
                             plugin_.FlightPlanGetInitialTime(vessel_guid))));
+      UnityEngine.Debug.LogError("RenderTFE");
 
           FlightPlanAdaptiveStepParameters parameters =
               plugin_.FlightPlanGetAdaptiveStepParameters(vessel_guid);
 
+                    UnityEngine.Debug.LogError("RenderUsing");
           using (new UnityEngine.GUILayout.HorizontalScope()) {
+      UnityEngine.Debug.LogError("H");
             using (new UnityEngine.GUILayout.HorizontalScope()) {
+      UnityEngine.Debug.LogError("HH1");
               UnityEngine.GUILayout.Label("Max. steps per segment:",
                                           UnityEngine.GUILayout.Width(150));
               const int factor = 4;
@@ -128,6 +142,7 @@ class FlightPlanner : SupervisedWindowRenderer {
               }
             }
             using (new UnityEngine.GUILayout.HorizontalScope()) {
+      UnityEngine.Debug.LogError("HH2");
               UnityEngine.GUILayout.Label("Tolerance:",
                                           UnityEngine.GUILayout.Width(75));
               if (parameters.length_integration_tolerance <= 1e-6) {
@@ -153,6 +168,7 @@ class FlightPlanner : SupervisedWindowRenderer {
             }
           }
 
+      UnityEngine.Debug.LogError("Render2");
           double Δv = (from burn_editor in burn_editors_
                        select burn_editor.Δv()).Sum();
           UnityEngine.GUILayout.Label(
@@ -161,6 +177,7 @@ class FlightPlanner : SupervisedWindowRenderer {
           if (burn_editors_.Count == 0 && 
               UnityEngine.GUILayout.Button("Delete flight plan")) {
             plugin_.FlightPlanDelete(vessel_guid);
+      UnityEngine.Debug.LogError("RS2");
             Reset();
           } else {
             if (burn_editors_.Count > 0) {
@@ -170,6 +187,7 @@ class FlightPlanner : SupervisedWindowRenderer {
               UnityEngine.GUILayout.TextArea("Manœuvre #" + (i + 1) + ":");
               burn_editors_[i].Render(enabled : false);
             }
+      UnityEngine.Debug.LogError("Render "+burn_editors_.Count);
             if (burn_editors_.Count > 0) {
               BurnEditor last_burn = burn_editors_.Last();
               UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
@@ -187,6 +205,7 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Last().Close();
                 burn_editors_.RemoveAt(burn_editors_.Count - 1);
                 Shrink();
+      UnityEngine.Debug.LogError("SH2");
               }
             }
             if (UnityEngine.GUILayout.Button(
@@ -212,6 +231,7 @@ class FlightPlanner : SupervisedWindowRenderer {
                 burn_editors_.Add(editor);
               }
               Shrink();
+      UnityEngine.Debug.LogError("SH3");
             }
           }
         }


### PR DESCRIPTION
This ensures that we don't change state between Layout and Repaint, and it eliminates a funky null pointer exception when first creating a flight plan.