### PR TITLE
Map node pool improvements

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1489,8 +1489,7 @@ public partial class PrincipiaPluginAdapter
     // otherwise, the map nodes will lag behind when the camera is moved.
     // The only timing that satisfies these constraints is BetterLateThanNever
     // in LateUpdate.
-    string main_vessel_guid = (FlightGlobals.ActiveVessel ??
-                               space_tracking?.SelectedVessel)?.id.ToString();
+    string main_vessel_guid = PredictedVessel()?.id.ToString();
     if (MapView.MapIsEnabled && main_vessel_guid != null &&
         PluginRunning() && plugin_.HasVessel(main_vessel_guid)) {
       XYZ sun_world_position = (XYZ)Planetarium.fetch.Sun.position;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1555,6 +1555,13 @@ public partial class PrincipiaPluginAdapter
   }
 
   private void BetterLateThanNeverLateUpdate() {
+    // While we draw the trajectories directly (and thus do so after everything
+    // else has been rendered), we rely on the game to render its map nodes.
+    // Since the screen position is determined in |MapNode.NodeUpdate|, it must
+    // be called before rendering occurs, but after the cameras have moved;
+    // otherwise, the map nodes will lag behind when the camera is moved.
+    // The only timing that satisfies these constraints is BetterLateThanNever
+    // in LateUpdate.
     string main_vessel_guid = (FlightGlobals.ActiveVessel ??
                                space_tracking?.SelectedVessel)?.id.ToString();
     if (MapView.MapIsEnabled && main_vessel_guid != null &&

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -47,7 +47,7 @@ internal class MapNodePool {
                             NodeSource source,
                             Vessel vessel,
                             CelestialBody celestial) {
-    // We render at least 64 markers of one type and one provenance (e.g., at
+    // We render at most 64 markers of one type and one provenance (e.g., at
     // most 64 perilunes for the prediction of the active vessel).  This is
     // more than is readable, and keeps the size of the map node pool under
     // control.
@@ -71,8 +71,9 @@ internal class MapNodePool {
         // KSP attaches labels to its map nodes, but never detaches them.
         // If the node changes type, we end up with an arbitrary combination of
         // labels Ap, Pe, AN, DN.
-        // Recreating the node entirely takes a long time, instead we manually
-        // get rid of the labels.
+        // Recreating the node entirely takes a long time (approximately 50 ns *
+        // 𝑁, where 𝑁 is the total number of map nodes in existence), instead
+        // we manually get rid of the labels.
         foreach (var component in
                  nodes_[pool_index_].transform.GetComponentsInChildren<
                      TMPro.TextMeshProUGUI>()) {

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -47,8 +47,12 @@ internal class MapNodePool {
                             NodeSource source,
                             Vessel vessel,
                             CelestialBody celestial) {
-    for (; !apsis_iterator.IteratorAtEnd();
-         apsis_iterator.IteratorIncrement()) {
+    // We render at least 64 markers of one type and one provenance (e.g., at
+    // most 64 perilunes for the prediction of the active vessel).  This is
+    // more than is readable, and keeps the size of the map node pool under
+    // control.
+    for (int i = 0; i < 64 && !apsis_iterator.IteratorAtEnd();
+         ++i, apsis_iterator.IteratorIncrement()) {
       QP apsis = apsis_iterator.IteratorGetDiscreteTrajectoryQP();
       MapNodeProperties node_properties = new MapNodeProperties {
         visible = true,


### PR DESCRIPTION
Since `MapNode`s are costly to `Create` (proportionally to the number of existing `MapNode`s),
- reuse `MapNode`s as much as possible:
  - make unused nodes invisible instead of terminating them,
  - do not clear the `MapNodePool` when there is no trajectory to render;
- limit the number of map nodes of one kind to 64.

Further, fix the execution order issue that caused the nodes to lag behind the trajectories when moving the camera.