### PR TITLE
No UnityEngine.Rect.zero in KSP 1.3.1

### DIFF
--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -147,7 +147,7 @@ internal abstract class BaseWindowRenderer : IConfigNode {
   private readonly String lock_name_;
   private bool must_centre_ = true;
   private bool show_ = false;
-  private UnityEngine.Rect rectangle_ = UnityEngine.Rect.zero;
+  private UnityEngine.Rect rectangle_;
 }
 
 internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {


### PR DESCRIPTION
Not that we needed it anyway; `Rect` is a `struct`.