### PR TITLE
I didn’t shoot the text caption

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1934,13 +1934,13 @@ public partial class PrincipiaPluginAdapter
         map_node_pool_.RenderMarkers(
             ascending_nodes_iterator,
             MapObject.ObjectType.AscendingNode,
-            MapNodePool.NodeSource.PREDICTION,
+            MapNodePool.NodeSource.FLIGHT_PLAN,
             vessel    : null,
             celestial : primary);
         map_node_pool_.RenderMarkers(
             descending_nodes_iterator,
             MapObject.ObjectType.DescendingNode,
-            MapNodePool.NodeSource.PREDICTION,
+            MapNodePool.NodeSource.FLIGHT_PLAN,
             vessel    : null,
             celestial : primary);
       }

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -67,10 +67,13 @@ internal class MapNodePool {
 
       if (pool_index_ == nodes_.Count) {
         nodes_.Add(MakePoolNode());
-      } else if (properties_[nodes_[pool_index_]].object_type != type) {
+      } else if (properties_[nodes_[pool_index_]].object_type != type ||
+                 properties_[nodes_[pool_index_]].source != source) {
         // KSP attaches labels to its map nodes, but never detaches them.
         // If the node changes type, we end up with an arbitrary combination of
         // labels Ap, Pe, AN, DN.
+        // If the node changes source, the colour of the icon label is not
+        // updated to match the icon (making it unreadable in some cases).
         // Recreating the node entirely takes a long time (approximately
         // 𝑁 * 70 μs, where 𝑁 is the total number of map nodes in existence),
         // instead we manually get rid of the labels.
@@ -81,7 +84,7 @@ internal class MapNodePool {
             UnityEngine.Object.Destroy(component.gameObject);
           }
         }
-        // Ensure that KSP knows that the type changed, and reattaches icon
+        // Ensure that KSP thinks the type changed, and reattaches icon
         // labels next time around, otherwise we might end up with no labels.
         // Null nodes do not have a label, so inducing a type change through
         // Null does not result in spurious labels.

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -81,6 +81,13 @@ internal class MapNodePool {
             UnityEngine.Object.Destroy(component.gameObject);
           }
         }
+        // Ensure that KSP knows that the type changed, and reattaches icon
+        // labels next time around, otherwise we might end up with no labels.
+        // Null nodes do not have a label, so inducing a type change through
+        // Null does not result in spurious labels.
+        properties_[nodes_[pool_index_]].object_type =
+            MapObject.ObjectType.Null;
+        nodes_[pool_index_].NodeUpdate();
       }
       properties_[nodes_[pool_index_++]] = node_properties;
     }

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -77,7 +77,7 @@ internal class MapNodePool {
         foreach (var component in
                  nodes_[pool_index_].transform.GetComponentsInChildren<
                      TMPro.TextMeshProUGUI>()) {
-          if (component.name == "iconLabel") {
+          if (component.name == "iconLabel(Clone)") {
             UnityEngine.Object.Destroy(component.gameObject);
           }
         }

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -71,9 +71,9 @@ internal class MapNodePool {
         // KSP attaches labels to its map nodes, but never detaches them.
         // If the node changes type, we end up with an arbitrary combination of
         // labels Ap, Pe, AN, DN.
-        // Recreating the node entirely takes a long time (approximately 50 ns *
-        // 𝑁, where 𝑁 is the total number of map nodes in existence), instead
-        // we manually get rid of the labels.
+        // Recreating the node entirely takes a long time (approximately
+        // 𝑁 * 70 μs, where 𝑁 is the total number of map nodes in existence),
+        // instead we manually get rid of the labels.
         foreach (var component in
                  nodes_[pool_index_].transform.GetComponentsInChildren<
                      TMPro.TextMeshProUGUI>()) {

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -77,7 +77,9 @@ internal class MapNodePool {
         foreach (var component in
                  nodes_[pool_index_].transform.GetComponentsInChildren<
                      TMPro.TextMeshProUGUI>()) {
-          UnityEngine.Object.Destroy(component.gameObject);
+          if (component.name == "iconLabel") {
+            UnityEngine.Object.Destroy(component.gameObject);
+          }
         }
       }
       properties_[nodes_[pool_index_++]] = node_properties;


### PR DESCRIPTION
Without the check for `component.name`, we end up destroying the `textCaption` member of the `MapNode` (the hovertext), which is not what we want, and causes a `MapView` callback to systematically throw, preventing all nodes from ever being updated again.