### PR TITLE
Remove NOLINT(build/namespaces)

### DIFF
--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -88,7 +88,7 @@ using ::testing::AllOf;
 using ::testing::Gt;
 using ::testing::Lt;
 
-using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+using namespace std::chrono_literals;
 
 namespace astronomy {
 

--- a/base/bundle_test.cpp
+++ b/base/bundle_test.cpp
@@ -12,7 +12,7 @@ namespace principia {
 
 using ::testing::Eq;
 
-using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+using namespace std::chrono_literals;
 
 namespace base {
 

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -714,7 +714,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
   // Polling for the integration to happen.
   do {
     plugin.UpdatePrediction(vessel_guid);
-    using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+    using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
   } while (plugin.GetVessel(vessel_guid)->prediction().Size() != 15);
 

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -272,7 +272,7 @@ TEST_F(VesselTest, Prediction) {
   // Polling for the integration to happen.
   do {
     vessel_.RefreshPrediction(astronomy::J2000 + 1 * Second);
-    using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+    using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
   } while (vessel_.prediction().last().time() == astronomy::J2000);
 
@@ -342,7 +342,7 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
   // Polling for the integration to happen.
   do {
     vessel_.RefreshPrediction();
-    using namespace std::chrono_literals;  // NOLINT(build/namespaces)
+    using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
   } while (vessel_.prediction().Size() != 3);
 


### PR DESCRIPTION
The lint check has been disabled, fixing #2093; remove the `NOLINT`s.