### PR TITLE
Refer manœuvre times to a time base, not to the current time

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -117,7 +117,7 @@ class BurnEditor : ScalingRenderer {
       UnityEngine.GUILayout.Label(
           index_ == 0 ? "Time base: start of flight plan"
                       : $"Time base: end of manœuvre #{index_}",
-          style: new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
+          style : new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
               alignment = UnityEngine.TextAnchor.UpperLeft});
       changed |= changed_reference_frame_;
       using (new UnityEngine.GUILayout.HorizontalScope()) {

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -10,10 +10,13 @@ class BurnEditor : ScalingRenderer {
   public BurnEditor(PrincipiaPluginAdapter adapter,
                     IntPtr plugin,
                     Vessel vessel,
-                    double initial_time) {
+                    double initial_time,
+                    int index,
+                    BurnEditor previous_burn) {
     adapter_ = adapter;
     plugin_ = plugin;
     vessel_ = vessel;
+    index_ = index;
     Δv_tangent_ =
         new DifferentialSlider(label            : "Δv tangent",
                                unit             : "m / s",
@@ -41,9 +44,11 @@ class BurnEditor : ScalingRenderer {
                 min_value        : 0,
                 max_value        : double.PositiveInfinity,
                 formatter        : value =>
-                    FlightPlanner.FormatTimeSpan(
+                    FlightPlanner.FormatPositiveTimeSpan(
                         TimeSpan.FromSeconds(
-                            Planetarium.GetUniversalTime() - value)));
+                            value - (previous_burn?.final_time ??
+                                     plugin_.FlightPlanGetInitialTime(
+                                         vessel_.id.ToString())))));
     initial_time_.value = initial_time;
     reference_frame_selector_ = new ReferenceFrameSelector(
                                     adapter_,
@@ -109,6 +114,11 @@ class BurnEditor : ScalingRenderer {
       changed |= Δv_normal_.Render(enabled);
       changed |= Δv_binormal_.Render(enabled);
       changed |= initial_time_.Render(enabled);
+      UnityEngine.GUILayout.Label(
+          index_ == 0 ? "Time base: start of flight plan"
+                      : $"Time base: end of manœuvre #{index_}",
+          style: new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
+              alignment = UnityEngine.TextAnchor.UpperLeft});
       changed |= changed_reference_frame_;
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label(
@@ -245,6 +255,8 @@ class BurnEditor : ScalingRenderer {
     specific_impulse_in_seconds_g0_ = range;
   }
 
+  private double final_time => initial_time_.value + duration_;
+
   private bool is_inertially_fixed_;
   private DifferentialSlider Δv_tangent_;
   private DifferentialSlider Δv_normal_;
@@ -266,6 +278,7 @@ class BurnEditor : ScalingRenderer {
   // Not owned.
   private readonly IntPtr plugin_;
   private readonly Vessel vessel_;
+  private readonly int index_;
   private readonly PrincipiaPluginAdapter adapter_;
 
   private bool changed_reference_frame_ = false;

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -108,9 +108,9 @@ class FlightPlanner : SupervisedWindowRenderer {
               new BurnEditor(adapter_,
                              plugin_,
                              vessel_,
-                             initial_time: 0,
-                             index: burn_editors_.Count,
-                             previous_burn: burn_editors_.LastOrDefault()));
+                             initial_time  : 0,
+                             index         : burn_editors_.Count,
+                             previous_burn : burn_editors_.LastOrDefault()));
           burn_editors_.Last().Reset(
               plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
         }
@@ -203,13 +203,13 @@ class FlightPlanner : SupervisedWindowRenderer {
         }
         for (int i = 0; i < burn_editors_.Count - 1; ++i) {
           UnityEngine.GUILayout.TextArea("Manœuvre #" + (i + 1) + ":");
-          burn_editors_[i].Render(enabled: false);
+          burn_editors_[i].Render(enabled : false);
         }
         if (burn_editors_.Count > 0) {
           BurnEditor last_burn = burn_editors_.Last();
           UnityEngine.GUILayout.TextArea("Editing manœuvre #" +
                                          (burn_editors_.Count) + ":");
-          if (last_burn.Render(enabled: true)) {
+          if (last_burn.Render(enabled : true)) {
             plugin_.FlightPlanReplaceLast(vessel_guid, last_burn.Burn());
             last_burn.Reset(
                 plugin_.FlightPlanGetManoeuvre(vessel_guid,
@@ -241,8 +241,8 @@ class FlightPlanner : SupervisedWindowRenderer {
                              plugin_,
                              vessel_,
                              initial_time,
-                             index: burn_editors_.Count,
-                             previous_burn: burn_editors_.LastOrDefault());
+                             index         : burn_editors_.Count,
+                             previous_burn : burn_editors_.LastOrDefault());
           Burn candidate_burn = editor.Burn();
           bool inserted = plugin_.FlightPlanAppend(vessel_guid,
                                                    candidate_burn);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -104,10 +104,13 @@ class FlightPlanner : SupervisedWindowRenderer {
           // Dummy initial time, we call |Reset| immediately afterwards.
           final_time_.value =
               plugin_.FlightPlanGetDesiredFinalTime(vessel_guid);
-          burn_editors_.Add(new BurnEditor(adapter_,
-                                           plugin_,
-                                           vessel_,
-                                           initial_time: 0));
+          burn_editors_.Add(
+              new BurnEditor(adapter_,
+                             plugin_,
+                             vessel_,
+                             initial_time: 0,
+                             index: burn_editors_.Count,
+                             previous_burn: burn_editors_.LastOrDefault()));
           burn_editors_.Last().Reset(
               plugin_.FlightPlanGetManoeuvre(vessel_guid, i));
         }
@@ -234,7 +237,12 @@ class FlightPlanner : SupervisedWindowRenderer {
                     burn_editors_.Count - 1).final_time + 60;
           }
           var editor =
-              new BurnEditor(adapter_, plugin_, vessel_, initial_time);
+              new BurnEditor(adapter_,
+                             plugin_,
+                             vessel_,
+                             initial_time,
+                             index: burn_editors_.Count,
+                             previous_burn: burn_editors_.LastOrDefault());
           Burn candidate_burn = editor.Burn();
           bool inserted = plugin_.FlightPlanAppend(vessel_guid,
                                                    candidate_burn);


### PR DESCRIPTION
See the discussion in #2121: for far future manœuvres separated by a short time interval, this avoids the awkwardness of having two nearly equal long countdowns; further, since the displayed value becomes stable, this paves the way for editing it.

Note that a countdown is still shown for the first upcoming manœuvre.