### PR TITLE
Speed up debug tests

### DIFF
--- a/base/bundle_test.cpp
+++ b/base/bundle_test.cpp
@@ -43,7 +43,11 @@ TEST_F(BundleDeathTest, AddAfterJoin) {
 }
 
 TEST_F(BundleTest, MatrixVectorProduct) {
+#if defined(_DEBUG)
+  constexpr std::int64_t short_dimension = 100;
+#else
   constexpr std::int64_t short_dimension = 1000;
+#endif
   constexpr std::int64_t long_dimension = 100000;
   std::vector<std::int64_t> matrix(short_dimension * long_dimension, 1);
   std::vector<std::int64_t> vector(long_dimension);

--- a/base/push_deserializer_test.cpp
+++ b/base/push_deserializer_test.cpp
@@ -36,7 +36,11 @@ using ::testing::ElementsAreArray;
 
 namespace {
 int const deserializer_chunk_size = 99;
-int const runs_per_test = 1000;
+#if defined(_DEBUG)
+constexpr int runs_per_test = 100;
+#else
+constexpr int runs_per_test = 1000;
+#endif
 int const serializer_chunk_size = 99;
 int const number_of_chunks = 3;
 const char start[] = "START";

--- a/base/thread_pool_test.cpp
+++ b/base/thread_pool_test.cpp
@@ -22,7 +22,11 @@ class ThreadPoolTest : public ::testing::Test {
 // Check that execution occurs in parallel.  If things were sequential, the
 // integers in |numbers| would be monotonically increasing.
 TEST_F(ThreadPoolTest, ParallelExecution) {
-  static constexpr int number_of_calls = 1'000'000;
+#if defined(_DEBUG)
+  constexpr int number_of_calls = 100'000;
+#else
+  constexpr int number_of_calls = 1'000'000;
+#endif
 
   absl::Mutex lock;
   std::vector<std::int64_t> numbers;

--- a/numerics/fast_sin_cos_2π_test.cpp
+++ b/numerics/fast_sin_cos_2π_test.cpp
@@ -22,7 +22,7 @@ namespace numerics {
 class FastSinCos2πTest : public ::testing::Test {
  protected:
 #if defined(_DEBUG)
-  static constexpr int iterations_ = 1e7;
+  static constexpr int iterations_ = 1e6;
 #else
   static constexpr int iterations_ = 1e8;
 #endif


### PR DESCRIPTION
I noticed that some of the *debug* tests had become quite slow.  There is really no reason for `base` to be more costly than the selenopotential.  I am fixing the glitch.