### PR TITLE
A better reference plane for the the ECI etc. frames.

### DIFF
--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -219,20 +219,20 @@ TEST_F(GeodesyTest, LAGEOS2) {
                             primary_actual_final_dof.position()),
               AnyOf(IsNear(237 * Metre),    // Linux.
                     IsNear(28 * Metre),     // No FMA.
-                    IsNear(8.0 * Metre)));  // FMA.
+                    IsNear(98 * Metre)));   // FMA.
   // Angular error at the geocentre.
   EXPECT_THAT(AngleBetween(secondary_actual_final_dof.position() - ITRS::origin,
                            primary_actual_final_dof.position() - ITRS::origin),
               AnyOf(IsNear(4.0 * ArcSecond),     // Linux.
                     IsNear(0.47 * ArcSecond),    // No FMA.
-                    IsNear(0.13 * ArcSecond)));  // FMA.
+                    IsNear(1.6 * ArcSecond)));   // FMA.
   // Radial error at the geocentre.
   EXPECT_THAT(AbsoluteError(
                   (secondary_actual_final_dof.position() - ITRS::origin).Norm(),
                   (primary_actual_final_dof.position() - ITRS::origin).Norm()),
               AnyOf(IsNear(99 * Centi(Metre)),     // Linux.
                     IsNear(11 * Centi(Metre)),     // No FMA.
-                    IsNear(1.2 * Centi(Metre))));  // FMA.
+                    IsNear(43 * Centi(Metre))));   // FMA.
 }
 
 #endif

--- a/ksp_plugin_test/manœuvre_test.cpp
+++ b/ksp_plugin_test/manœuvre_test.cpp
@@ -35,7 +35,9 @@ using physics::DiscreteTrajectory;
 using physics::MassiveBody;
 using physics::MockDynamicFrame;
 using physics::MockEphemeris;
+using quantities::GravitationalParameter;
 using quantities::Pow;
+using quantities::SIUnit;
 using quantities::si::Kilo;
 using quantities::si::Kilogram;
 using quantities::si::Metre;
@@ -366,8 +368,9 @@ TEST_F(ManœuvreTest, Serialization) {
   EXPECT_TRUE(message.has_frame());
 
   MockEphemeris<World> ephemeris;
+  MassiveBody const body(SIUnit<GravitationalParameter>());
   EXPECT_CALL(ephemeris, body_for_serialization_index(666))
-      .WillOnce(Return(make_not_null<MassiveBody const*>()));
+      .WillOnce(Return(&body));
   EXPECT_CALL(ephemeris, trajectory(_))
       .WillOnce(Return(make_not_null<ContinuousTrajectory<World> const*>()));
   Manœuvre<World, Rendering> const manœuvre_read =

--- a/physics/body_centred_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centred_non_rotating_dynamic_frame.hpp
@@ -44,7 +44,7 @@ using quantities::Acceleration;
 // - the Z axis is the pole Z from the figure.
 // Note that, when |InertialFrame| is the ICRS, these axes make |ThisFrame| the
 // usual celestial reference frame (the GCRS) if |centre| is the Earth, as the X
-// axis will point towards ♈; however, if |centre| is another planet,
+// axis will point towards ♈︎; however, if |centre| is another planet,
 // |ThisFrame| will not have the axes of its natural celestial reference frame,
 // as the X axis will not point towards its equinox.
 // REMOVE BEFORE FLIGHT: Do we really want that? This seems like a very

--- a/physics/body_centred_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centred_non_rotating_dynamic_frame.hpp
@@ -47,10 +47,6 @@ using quantities::Acceleration;
 // axis will point towards ♈︎; however, if |centre| is another planet,
 // |ThisFrame| will not have the axes of its natural celestial reference frame,
 // as the X axis will not point towards its equinox.
-// REMOVE BEFORE FLIGHT: Do we really want that? This seems like a very
-// contrived way get something that only makes sense for the Earth with respect
-// to the ICRS; in particular, if the XY plane of |InertialFrame| is the
-// invariable plane, Q should naturally be the X axis, not the Y axis.
 template<typename InertialFrame, typename ThisFrame>
 class BodyCentredNonRotatingDynamicFrame
     : public DynamicFrame<InertialFrame, ThisFrame> {

--- a/physics/body_centred_non_rotating_dynamic_frame.hpp
+++ b/physics/body_centred_non_rotating_dynamic_frame.hpp
@@ -26,12 +26,31 @@ namespace internal_body_centred_non_rotating_dynamic_frame {
 
 using base::not_null;
 using geometry::Instant;
+using geometry::OrthogonalMap;
 using geometry::Position;
 using geometry::Vector;
 using quantities::Acceleration;
 
-// The origin of the frame is the centre of mass of the body.  The axes are
-// those of |InertialFrame|.
+// The origin of the frame is the centre of mass of the body.  The Y axis is at
+// the intersection of the equator and the XY plane of |InertialFrame|, in the
+// direction 90° + α from the X axis of |InertialFrame|, where α is the right
+// ascension of the |polar_axis|.  The Z axis is the |polar_axis|.  The X axis
+// in on the equator so that the frame has the same orientation as
+// |InertialFrame|.
+// For a non-rotating body, the axes are the same as those of |InertialFrame|.
+// With respect to figure 1 of the 2015 report of the IAU WGCCRE if |polar_axis|
+// is the north pole, or figure 2 if |polar_axis| is the positive pole,
+// - the Y axis is the node Q from the figure;
+// - the Z axis is the pole Z from the figure.
+// Note that, when |InertialFrame| is the ICRS, these axes make |ThisFrame| the
+// usual celestial reference frame (the GCRS) if |centre| is the Earth, as the X
+// axis will point towards ♈; however, if |centre| is another planet,
+// |ThisFrame| will not have the axes of its natural celestial reference frame,
+// as the X axis will not point towards its equinox.
+// REMOVE BEFORE FLIGHT: Do we really want that? This seems like a very
+// contrived way get something that only makes sense for the Earth with respect
+// to the ICRS; in particular, if the XY plane of |InertialFrame| is the
+// invariable plane, Q should naturally be the X axis, not the Y axis.
 template<typename InertialFrame, typename ThisFrame>
 class BodyCentredNonRotatingDynamicFrame
     : public DynamicFrame<InertialFrame, ThisFrame> {
@@ -66,6 +85,7 @@ class BodyCentredNonRotatingDynamicFrame
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;
   not_null<MassiveBody const*> const centre_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const centre_trajectory_;
+  OrthogonalMap<InertialFrame, ThisFrame> const orthogonal_map_;
 };
 
 

--- a/physics/body_centred_non_rotating_dynamic_frame_body.hpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_body.hpp
@@ -4,6 +4,7 @@
 #include "physics/body_centred_non_rotating_dynamic_frame.hpp"
 
 #include "geometry/identity.hpp"
+#include "geometry/rotation.hpp"
 
 namespace principia {
 namespace physics {
@@ -11,15 +12,37 @@ namespace internal_body_centred_non_rotating_dynamic_frame {
 
 using geometry::AngularVelocity;
 using geometry::Identity;
+using geometry::OrthogonalMap;
+using geometry::Rotation;
 
 template<typename InertialFrame, typename ThisFrame>
 BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
-BodyCentredNonRotatingDynamicFrame(
-    not_null<Ephemeris<InertialFrame> const*> const ephemeris,
-    not_null<MassiveBody const*> const centre)
+    BodyCentredNonRotatingDynamicFrame(
+        not_null<Ephemeris<InertialFrame> const*> const ephemeris,
+        not_null<MassiveBody const*> const centre)
     : ephemeris_(ephemeris),
       centre_(centre),
-      centre_trajectory_(ephemeris_->trajectory(centre_)) {}
+      centre_trajectory_(ephemeris_->trajectory(centre_)),
+      orthogonal_map_(
+          [this]() {
+            // Note that we cannot do this by making |equatorial| and
+            // |biequatorial| virtual members of |MassiveBody|, because that
+            // class is not templatized on |InertialFrame|.
+            auto const rotating_body =
+                dynamic_cast<RotatingBody<InertialFrame> const*>(&*centre_);
+            if (rotating_body == nullptr) {
+              return Identity<InertialFrame, ThisFrame>().Forget();
+            }
+            // In coordinates, the third parameter is |polar_axis|, but we seem
+            // to be a bit confused as to which of these things should be
+            // vectors or bivectors here.
+            // TODO(egg): Figure that out.
+            return Rotation<InertialFrame, ThisFrame>(
+                rotating_body->equatorial(),
+                rotating_body->biequatorial(),
+                Wedge(rotating_body->equatorial(),
+                      rotating_body->biequatorial())).Forget();
+          }()) {}
 
 template<typename InertialFrame, typename ThisFrame>
 not_null<MassiveBody const*>
@@ -45,10 +68,9 @@ BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
     Instant const& t) const {
   DegreesOfFreedom<InertialFrame> const centre_degrees_of_freedom =
       centre_trajectory_->EvaluateDegreesOfFreedom(t);
-  RigidTransformation<InertialFrame, ThisFrame> const
-      rigid_transformation(centre_degrees_of_freedom.position(),
-                           ThisFrame::origin,
-                           Identity<InertialFrame, ThisFrame>().Forget());
+
+  RigidTransformation<InertialFrame, ThisFrame> const rigid_transformation(
+      centre_degrees_of_freedom.position(), ThisFrame::origin, orthogonal_map_);
   return RigidMotion<InertialFrame, ThisFrame>(
              rigid_transformation,
              AngularVelocity<InertialFrame>(),

--- a/physics/body_centred_non_rotating_dynamic_frame_body.hpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_body.hpp
@@ -17,9 +17,9 @@ using geometry::Rotation;
 
 template<typename InertialFrame, typename ThisFrame>
 BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::
-    BodyCentredNonRotatingDynamicFrame(
-        not_null<Ephemeris<InertialFrame> const*> const ephemeris,
-        not_null<MassiveBody const*> const centre)
+BodyCentredNonRotatingDynamicFrame(
+    not_null<Ephemeris<InertialFrame> const*> const ephemeris,
+    not_null<MassiveBody const*> const centre)
     : ephemeris_(ephemeris),
       centre_(centre),
       centre_trajectory_(ephemeris_->trajectory(centre_)),
@@ -69,8 +69,10 @@ BodyCentredNonRotatingDynamicFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
   DegreesOfFreedom<InertialFrame> const centre_degrees_of_freedom =
       centre_trajectory_->EvaluateDegreesOfFreedom(t);
 
-  RigidTransformation<InertialFrame, ThisFrame> const rigid_transformation(
-      centre_degrees_of_freedom.position(), ThisFrame::origin, orthogonal_map_);
+  RigidTransformation<InertialFrame, ThisFrame> const
+      rigid_transformation(centre_degrees_of_freedom.position(),
+                           ThisFrame::origin,
+                           orthogonal_map_);
   return RigidMotion<InertialFrame, ThisFrame>(
              rigid_transformation,
              AngularVelocity<InertialFrame>(),

--- a/physics/body_centred_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_test.cpp
@@ -155,14 +155,19 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, Inverse) {
     auto const to_big_frame_at_t = big_frame_->ToThisFrameAtTime(t);
     auto const small_initial_state_transformed_and_back =
         from_big_frame_at_t(to_big_frame_at_t(small_initial_state_));
-    EXPECT_THAT(small_initial_state_transformed_and_back.position(),
-                AlmostEquals(small_initial_state_.position(), 0));
+    auto const position_coordinates =
+        (small_initial_state_.position() - ICRS::origin).coordinates();
+    auto const velocity_coordinates =
+        small_initial_state_.velocity().coordinates();
     EXPECT_THAT(
-        small_initial_state_transformed_and_back.velocity(),
-        Componentwise(
-            AlmostEquals(small_initial_state_.velocity().coordinates().x, 0, 1),
-            VanishesBefore(small_initial_state_.velocity().coordinates().x, 0),
-            AlmostEquals(small_initial_state_.velocity().coordinates().z, 0)));
+        small_initial_state_transformed_and_back.position() - ICRS::origin,
+        Componentwise(AlmostEquals(position_coordinates.x, 0),
+                      AlmostEquals(position_coordinates.y, 0),
+                      VanishesBefore(position_coordinates.y, 0)));
+    EXPECT_THAT(small_initial_state_transformed_and_back.velocity(),
+                Componentwise(AlmostEquals(velocity_coordinates.x, 0, 1),
+                              VanishesBefore(velocity_coordinates.x, 0),
+                              VanishesBefore(velocity_coordinates.x, 0)));
   }
 }
 

--- a/physics/body_centred_non_rotating_dynamic_frame_test.cpp
+++ b/physics/body_centred_non_rotating_dynamic_frame_test.cpp
@@ -20,7 +20,9 @@
 #include "quantities/si.hpp"
 #include "serialization/geometry.pb.h"
 #include "testing_utilities/almost_equals.hpp"
+#include "testing_utilities/componentwise.hpp"
 #include "testing_utilities/numerics.hpp"
+#include "testing_utilities/vanishes_before.hpp"
 
 namespace principia {
 namespace physics {
@@ -50,6 +52,8 @@ using quantities::si::Radian;
 using quantities::si::Second;
 using testing_utilities::AbsoluteError;
 using testing_utilities::AlmostEquals;
+using testing_utilities::Componentwise;
+using testing_utilities::VanishesBefore;
 using ::testing::IsNull;
 using ::testing::Lt;
 using ::testing::Not;
@@ -152,9 +156,13 @@ TEST_F(BodyCentredNonRotatingDynamicFrameTest, Inverse) {
     auto const small_initial_state_transformed_and_back =
         from_big_frame_at_t(to_big_frame_at_t(small_initial_state_));
     EXPECT_THAT(small_initial_state_transformed_and_back.position(),
-                AlmostEquals(small_initial_state_.position(), 0, 1));
-    EXPECT_THAT(small_initial_state_transformed_and_back.velocity(),
-                AlmostEquals(small_initial_state_.velocity(), 0, 1));
+                AlmostEquals(small_initial_state_.position(), 0));
+    EXPECT_THAT(
+        small_initial_state_transformed_and_back.velocity(),
+        Componentwise(
+            AlmostEquals(small_initial_state_.velocity().coordinates().x, 0, 1),
+            VanishesBefore(small_initial_state_.velocity().coordinates().x, 0),
+            AlmostEquals(small_initial_state_.velocity().coordinates().z, 0)));
   }
 }
 

--- a/physics/body_surface_dynamic_frame.hpp
+++ b/physics/body_surface_dynamic_frame.hpp
@@ -34,6 +34,9 @@ using quantities::Acceleration;
 // the intersection of the equator and the prime meridian.  The Z axis is the
 // |polar_axis|.  The Y axis in on the equator so that the frame has the same
 // orientation as |InertialFrame|.
+// The X, Y, Z axes are the same as those shown on figure 1 of the 2015 report
+// of the IAU WGCCRE if |polar_axis| is the north pole, or figure 2 if
+// |polar_axis| is the positive pole.
 template<typename InertialFrame, typename ThisFrame>
 class BodySurfaceDynamicFrame
     : public DynamicFrame<InertialFrame, ThisFrame> {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -771,13 +771,10 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
             &trajectory, it.time()));
   }
 
-  // The small residual in x comes from the fact that the cosine of the
-  // declination (90 degrees) is not exactly zero, so the axis of our Earth is
-  // slightly tilted.  Also, the geopotential is not rotationally symmetrical,
-  // so there is a tiny residual in y too.  This greatly annoys the elephant.
+  // Tthe geopotential is not rotationally symmetrical, so there is a tiny
+  // residual in y.  This greatly annoys the elephant.
   EXPECT_THAT(elephant_positions.size(), Eq(5));
-  EXPECT_THAT(elephant_positions.back().coordinates().x,
-              IsNear(-9.8e-19 * Metre));
+  EXPECT_THAT(elephant_positions.back().coordinates().x, Eq(0 * Metre));
   EXPECT_THAT(elephant_positions.back().coordinates().y,
               AnyOf(IsNear(-2.3e-31 * Metre), Eq(0 * Metre)));
   EXPECT_LT(RelativeError(elephant_positions.back().coordinates().z,
@@ -785,7 +782,7 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
 
   EXPECT_THAT(elephant_accelerations.size(), Eq(5));
   EXPECT_THAT(elephant_accelerations.back().coordinates().x,
-              IsNear(-2.0e-18 * Metre / Second / Second));
+              Eq(0 * Metre / Second / Second));
   EXPECT_THAT(elephant_accelerations.back().coordinates().y,
               AnyOf(IsNear(-2.7e-30 * Metre / Second / Second),
                     Eq(0 * Metre / Second / Second)));

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -13,8 +13,8 @@
 #include "geometry/frame.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
+#include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/methods.hpp"
 #include "integrators/symmetric_linear_multistep_integrator.hpp"
 #include "integrators/symplectic_runge_kutta_nyström_integrator.hpp"
@@ -30,10 +30,12 @@
 #include "serialization/geometry.pb.h"
 #include "serialization/physics.pb.h"
 #include "testing_utilities/almost_equals.hpp"
+#include "testing_utilities/componentwise.hpp"
 #include "testing_utilities/is_near.hpp"
 #include "testing_utilities/matchers.hpp"
 #include "testing_utilities/numerics.hpp"
 #include "testing_utilities/solar_system_factory.hpp"
+#include "testing_utilities/vanishes_before.hpp"
 
 namespace principia {
 namespace physics {
@@ -76,13 +78,15 @@ using quantities::si::Milli;
 using quantities::si::Minute;
 using quantities::si::Radian;
 using quantities::si::Second;
-using testing_utilities::AlmostEquals;
 using testing_utilities::AbsoluteError;
+using testing_utilities::AlmostEquals;
+using testing_utilities::Componentwise;
 using testing_utilities::EqualsProto;
 using testing_utilities::IsNear;
 using testing_utilities::RelativeError;
 using testing_utilities::SolarSystemFactory;
 using testing_utilities::StatusIs;
+using testing_utilities::VanishesBefore;
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::Gt;
@@ -822,7 +826,7 @@ TEST_P(EphemerisTest, CollisionDetection) {
                                /*geopotential_tolerance=*/0x1p-24},
       Ephemeris<ICRS>::FixedStepParameters(integrator(), short_duration / 100));
 
-  // The apple's initial position and velocity
+  // The apple's initial position and velocity.
   DiscreteTrajectory<ICRS> trajectory;
   trajectory.Append(
       t0_,
@@ -876,24 +880,24 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
   bodies.emplace_back(std::unique_ptr<MassiveBody const>(b3));
 
   Velocity<ICRS> const v({0 * SIUnit<Speed>(),
-                                      0 * SIUnit<Speed>(),
-                                      0 * SIUnit<Speed>()});
+                          0 * SIUnit<Speed>(),
+                          0 * SIUnit<Speed>()});
   Position<ICRS> const q0 = ICRS::origin +
       Vector<Length, ICRS>({0 * AstronomicalUnit,
-                                        0 * AstronomicalUnit,
-                                        0 * AstronomicalUnit});
+                            0 * AstronomicalUnit,
+                            0 * AstronomicalUnit});
   Position<ICRS> const q1 = ICRS::origin +
       Vector<Length, ICRS>({1 * AstronomicalUnit,
-                                        0 * AstronomicalUnit,
-                                        0 * AstronomicalUnit});
+                            0 * AstronomicalUnit,
+                            0 * AstronomicalUnit});
   Position<ICRS> const q2 = ICRS::origin +
       Vector<Length, ICRS>({1 * AstronomicalUnit,
-                                        0 * AstronomicalUnit,
-                                        1 * AstronomicalUnit});
+                            0 * AstronomicalUnit,
+                            1 * AstronomicalUnit});
   Position<ICRS> const q3 = ICRS::origin +
       Vector<Length, ICRS>({0 * AstronomicalUnit,
-                                        0 * AstronomicalUnit,
-                                        1 * AstronomicalUnit});
+                            0 * AstronomicalUnit,
+                            1 * AstronomicalUnit});
   initial_state.emplace_back(q0, v);
   initial_state.emplace_back(q1, v);
   initial_state.emplace_back(q2, v);
@@ -920,8 +924,11 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
            0 * SIUnit<Acceleration>(),
            (-3 * μ3 + (3 / Sqrt(512)) * μ2) * Pow<2>(radius) * j2 /
                Pow<4>((q0 - q1).Norm())});
-  EXPECT_THAT(actual_acceleration0,
-              AlmostEquals(expected_acceleration0, 0, 6));
+  EXPECT_THAT(
+      actual_acceleration0,
+      Componentwise(AlmostEquals(expected_acceleration0.coordinates().x, 1),
+                    VanishesBefore(expected_acceleration0.coordinates().x, 0),
+                    AlmostEquals(expected_acceleration0.coordinates().z, 2)));
 
   Vector<Acceleration, ICRS> actual_acceleration1 =
       ephemeris.ComputeGravitationalAccelerationOnMassiveBody(b1, t0_);
@@ -933,8 +940,11 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
           {-1.5 * μ0 * Pow<2>(radius) * j2 / Pow<4>((q0 - q1).Norm()),
            0 * SIUnit<Acceleration>(),
            0 * SIUnit<Acceleration>()});
-  EXPECT_THAT(actual_acceleration1,
-              AlmostEquals(expected_acceleration1, 0, 4));
+  EXPECT_THAT(
+      actual_acceleration1,
+      Componentwise(AlmostEquals(expected_acceleration1.coordinates().x, 2),
+                    VanishesBefore(expected_acceleration1.coordinates().x, 0),
+                    AlmostEquals(expected_acceleration1.coordinates().z, 0)));
 
   Vector<Acceleration, ICRS> actual_acceleration2 =
       ephemeris.ComputeGravitationalAccelerationOnMassiveBody(b2, t0_);
@@ -947,8 +957,11 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
                                   0 * SIUnit<Acceleration>(),
                                   (-3 / Sqrt(512)) * μ0 * Pow<2>(radius) * j2 /
                                       Pow<4>((q0 - q1).Norm())});
-  EXPECT_THAT(actual_acceleration2,
-              AlmostEquals(expected_acceleration2, 0, 6));
+  EXPECT_THAT(
+      actual_acceleration2,
+      Componentwise(AlmostEquals(expected_acceleration2.coordinates().x, 4),
+                    VanishesBefore(expected_acceleration2.coordinates().x, 0),
+                    AlmostEquals(expected_acceleration2.coordinates().z, 1)));
 
   Vector<Acceleration, ICRS> actual_acceleration3 =
       ephemeris.ComputeGravitationalAccelerationOnMassiveBody(b3, t0_);
@@ -960,8 +973,11 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
           {0 * SIUnit<Acceleration>(),
            0 * SIUnit<Acceleration>(),
            3 * μ0 * Pow<2>(radius) * j2 / Pow<4>((q0 - q1).Norm())});
-  EXPECT_THAT(actual_acceleration3,
-              AlmostEquals(expected_acceleration3, 0, 4));
+  EXPECT_THAT(
+      actual_acceleration3,
+      Componentwise(AlmostEquals(expected_acceleration3.coordinates().x, 3),
+                    VanishesBefore(expected_acceleration3.coordinates().x, 0),
+                    AlmostEquals(expected_acceleration3.coordinates().z, 0)));
 }
 
 TEST_P(EphemerisTest, ComputeApsidesContinuousTrajectory) {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -771,20 +771,23 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
             &trajectory, it.time()));
   }
 
-  // Tthe geopotential is not rotationally symmetrical, so there is a tiny
-  // residual in y.  This greatly annoys the elephant.
+  // The small residual in x comes from the fact that the cosine of the
+  // declination (90 degrees) is not exactly zero, so the axis of our Earth is
+  // slightly tilted.  Also, the geopotential is not rotationally symmetrical,
+  // so there is a tiny residual in y too.  This greatly annoys the elephant.
   EXPECT_THAT(elephant_positions.size(), Eq(5));
-  EXPECT_THAT(elephant_positions.back().coordinates().x, Eq(0 * Metre));
+  EXPECT_THAT(elephant_positions.back().coordinates().x,
+              IsNear(-9.8e-19 * Metre));
   EXPECT_THAT(elephant_positions.back().coordinates().y,
-              AnyOf(IsNear(-2.3e-31 * Metre), Eq(0 * Metre)));
+              AnyOf(IsNear(6.0e-35 * Metre), Eq(0 * Metre)));
   EXPECT_LT(RelativeError(elephant_positions.back().coordinates().z,
                           TerrestrialPolarRadius), 8e-7);
 
   EXPECT_THAT(elephant_accelerations.size(), Eq(5));
   EXPECT_THAT(elephant_accelerations.back().coordinates().x,
-              Eq(0 * Metre / Second / Second));
+              IsNear(-2.0e-18 * Metre / Second / Second));
   EXPECT_THAT(elephant_accelerations.back().coordinates().y,
-              AnyOf(IsNear(-2.7e-30 * Metre / Second / Second),
+              AnyOf(IsNear(1.2e-34 * Metre / Second / Second),
                     Eq(0 * Metre / Second / Second)));
   EXPECT_LT(RelativeError(elephant_accelerations.back().coordinates().z,
                           -9.832 * SIUnit<Acceleration>()), 6.7e-6);

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -434,8 +434,8 @@ Acceleration(Geopotential<Frame> const& geopotential,
   UnitVector ŷ;
   UnitVector const ẑ = body.polar_axis();
   if (is_zonal) {
-    x̂ = body.biequatorial();
-    ŷ = body.equatorial();
+    x̂ = body.equatorial();
+    ŷ = body.biequatorial();
   } else {
     auto const from_surface_frame =
       body.template FromSurfaceFrame<SurfaceFrame>(t);

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -192,7 +192,7 @@ TEST_F(GeopotentialTest, J2) {
         geopotential,
         Instant(),
         Displacement<World>({6 * Metre, -4 * Metre, 5 * Metre}));
-    EXPECT_THAT(acceleration1, AlmostEquals(acceleration2, 4));
+    EXPECT_THAT(acceleration1, AlmostEquals(acceleration2, 3));
   }
 }
 

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -192,7 +192,7 @@ TEST_F(GeopotentialTest, J2) {
         geopotential,
         Instant(),
         Displacement<World>({6 * Metre, -4 * Metre, 5 * Metre}));
-    EXPECT_THAT(acceleration1, AlmostEquals(acceleration2, 3));
+    EXPECT_THAT(acceleration1, AlmostEquals(acceleration2, 4));
   }
 }
 

--- a/physics/rotating_body.hpp
+++ b/physics/rotating_body.hpp
@@ -72,8 +72,10 @@ class RotatingBody : public MassiveBody {
   Vector<double, Frame> const& polar_axis() const;
 
   // Two unit vectors in the equatorial plane of the body.  |biequatorial| is
-  // also in the equatorial plane of Frame.  The basis |biequatorial|,
-  // |equatorial|, |polar_axis| is direct.
+  // also in the equatorial plane of Frame.  The basis |equatorial|,
+  // |biequatorial|, |polar_axis| has the same orientation as that of |Frame|.
+  // In the figures of the 2015 IAU WGCCRE report (figure 1 or 2 depending on
+  // the convention used for |polar_axis|), |biequatorial| is the node Q.
   Vector<double, Frame> const& biequatorial() const;
   Vector<double, Frame> const& equatorial() const;
 
@@ -134,8 +136,8 @@ class RotatingBody : public MassiveBody {
  private:
   Parameters const parameters_;
   Vector<double, Frame> const polar_axis_;
-  Vector<double, Frame> biequatorial_;
-  Vector<double, Frame> equatorial_;
+  Vector<double, Frame> const biequatorial_;
+  Vector<double, Frame> const equatorial_;
   AngularVelocity<Frame> const angular_velocity_;
 };
 

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -55,23 +55,17 @@ RotatingBody<Frame>::RotatingBody(
                       1.0,
                       parameters.declination_of_pole_,
                       parameters.right_ascension_of_pole_).ToCartesian()),
+      biequatorial_(RadiusLatitudeLongitude(
+                        1.0,
+                        0 * Radian,
+                        π / 2 * Radian +
+                            parameters.right_ascension_of_pole_).ToCartesian()),
+      equatorial_(RadiusLatitudeLongitude(
+                      1.0,
+                      0 * Radian,
+                      parameters.right_ascension_of_pole_).ToCartesian()),
       angular_velocity_(polar_axis_.coordinates() *
-                        parameters.angular_frequency_) {
-  biequatorial_ = NormalizeOrZero(Vector<double, Frame>(
-      {-polar_axis_.coordinates().y,
-       polar_axis_.coordinates().x,
-       0}));
-  if (biequatorial_ == Vector<double, Frame>{}) {
-    biequatorial_ = Vector<double, Frame>({1, 0, 0});
-    equatorial_ = Vector<double, Frame>({0, 1, 0});
-  } else {
-    // TODO(phl): It is somewhat unpleasant that we have to make this a vector
-    // when it would want to be a bivector.  The inner products in Geopotential
-    // would then yield trivectors and we are not sure what that means.
-    equatorial_ = Vector<double, Frame>(Cross(polar_axis_.coordinates(),
-                                              biequatorial_.coordinates()));
-  }
-}
+                        parameters.angular_frequency_) {}
 
 template<typename Frame>
 Length RotatingBody<Frame>::mean_radius() const {

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -60,10 +60,7 @@ RotatingBody<Frame>::RotatingBody(
                         0 * Radian,
                         π / 2 * Radian +
                             parameters.right_ascension_of_pole_).ToCartesian()),
-      equatorial_(RadiusLatitudeLongitude(
-                      1.0,
-                      0 * Radian,
-                      parameters.right_ascension_of_pole_).ToCartesian()),
+      equatorial_(Wedge(biequatorial_, polar_axis_).coordinates()),
       angular_velocity_(polar_axis_.coordinates() *
                         parameters.angular_frequency_) {}
 


### PR DESCRIPTION
This will make it possible to address #1841; additional logic would be needed for to properly address the irrelevance of the solar equator, other than that this is a simple matter of changing the following condition in the adapter.
https://github.com/mockingbirdnest/Principia/blob/80be4b3fdf0c0fe0b6f9e038815171ffc1ba82f7/ksp_plugin_adapter/ksp_plugin_adapter.cs#L1922-L1925

Note: this breaks tests (some values that were very small have become 0 because of the changes in (bi)equatorial), and it probably needs some new tests to check the orientation.