### PR TITLE
A node has no name

### DIFF
--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -87,11 +87,9 @@ internal class MapNodePool {
         // Ensure that KSP thinks the type changed, and reattaches icon
         // labels next time around, otherwise we might end up with no labels.
         // Null nodes do not have a label, so inducing a type change through
-        // Null does not result in spurious labels.
-        if(properties_[nodes_[pool_index_]].visible == false) {
-          UnityEngine.Debug.LogError(
-              "NodeUpdate to type Null whereas visible is false.");
-        }
+        // Null does not result in spurious labels.  Note that the type is
+        // updated only if the node is visible.
+        properties_[nodes_[pool_index_]].visible = true;
         properties_[nodes_[pool_index_]].object_type =
             MapObject.ObjectType.Null;
         nodes_[pool_index_].NodeUpdate();

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -68,13 +68,13 @@ internal class MapNodePool {
       if (pool_index_ == nodes_.Count) {
         nodes_.Add(MakePoolNode());
       } else if (properties_[nodes_[pool_index_]].object_type != type ||
-                 properties_[nodes_[pool_index_]].source != source) {
+                 properties_[nodes_[pool_index_]].celestial != celestial) {
         // KSP attaches labels to its map nodes, but never detaches them.
         // If the node changes type, we end up with an arbitrary combination of
         // labels Ap, Pe, AN, DN.
-        // If the node changes source, the colour of the icon label is not
-        // updated to match the icon (making it unreadable in some cases).
-        // Recreating the node entirely takes a long time (approximately
+        // Similarly, if the node changes celestial, the colour of the icon
+        // label is not updated to match the icon (making it unreadable in some
+        // cases). Recreating the node entirely takes a long time (approximately
         // 𝑁 * 70 μs, where 𝑁 is the total number of map nodes in existence),
         // instead we manually get rid of the labels.
         foreach (var component in
@@ -88,6 +88,10 @@ internal class MapNodePool {
         // labels next time around, otherwise we might end up with no labels.
         // Null nodes do not have a label, so inducing a type change through
         // Null does not result in spurious labels.
+        if(properties_[nodes_[pool_index_]].visible == false) {
+          UnityEngine.Debug.LogError(
+              "NodeUpdate to type Null whereas visible is false.");
+        }
         properties_[nodes_[pool_index_]].object_type =
             MapObject.ObjectType.Null;
         nodes_[pool_index_].NodeUpdate();


### PR DESCRIPTION
Fix #2156; also fix an issue where nodes would have text written in the wrong colour; screenshot showcasing both (some `Ap` are written in blue, other markers have no text):
<img width="291" alt="2156 et al" src="https://user-images.githubusercontent.com/2284290/57570040-05efcd80-73fe-11e9-8dc7-278703de101e.png">
