### PR TITLE
Properly detect changes to the navigation frame

### DIFF
--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -88,7 +88,7 @@ TEST_F(PlayerTest, DISABLED_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(C:\Program Files\Kerbal Space Program\1.6.1\glog\Principia\JOURNAL.20190425-223810)";  // NOLINT
+      R"(C:\Program Files\Kerbal Space Program\1.6.1\glog\Principia\JOURNAL.20190511-140327)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play()) {

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -51,7 +51,6 @@ class BurnEditor : ScalingRenderer {
                                     adapter_,
                                     ReferenceFrameChanged,
                                     "Manœuvring frame");
-    UnityEngine.Debug.LogError("BurnEditor");
     reference_frame_selector_.SetFrameParameters(
         adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();
@@ -112,22 +111,16 @@ class BurnEditor : ScalingRenderer {
         changed = true;
         is_inertially_fixed_ = !is_inertially_fixed_;
       }
-      UnityEngine.Debug.Log("T "+changed);
       changed |= Δv_tangent_.Render(enabled);
-      UnityEngine.Debug.Log("N "+changed);
       changed |= Δv_normal_.Render(enabled);
-      UnityEngine.Debug.Log("B "+changed);
       changed |= Δv_binormal_.Render(enabled);
-      UnityEngine.Debug.Log("D "+changed);
       changed |= previous_coast_duration_.Render(enabled);
       UnityEngine.GUILayout.Label(
           index_ == 0 ? "Time base: start of flight plan"
                       : $"Time base: end of manœuvre #{index_}",
           style : new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
               alignment = UnityEngine.TextAnchor.UpperLeft});
-      UnityEngine.Debug.Log("R "+changed);
       changed |= changed_reference_frame_;
-      UnityEngine.Debug.Log("E "+changed);
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label(
             "Manœuvre Δv : " + Δv().ToString("0.000") + " m/s",
@@ -155,7 +148,6 @@ class BurnEditor : ScalingRenderer {
     Δv_binormal_.value = burn.delta_v.z;
     previous_coast_duration_.value =
         burn.initial_time - time_base;
-    UnityEngine.Debug.LogError("Reset");
     reference_frame_selector_.SetFrameParameters(burn.frame);
     is_inertially_fixed_ = burn.is_inertially_fixed;
     duration_ = manoeuvre.duration;

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -51,6 +51,7 @@ class BurnEditor : ScalingRenderer {
                                     adapter_,
                                     ReferenceFrameChanged,
                                     "Manœuvring frame");
+    UnityEngine.Debug.LogError("BurnEditor");
     reference_frame_selector_.SetFrameParameters(
         adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();
@@ -111,16 +112,22 @@ class BurnEditor : ScalingRenderer {
         changed = true;
         is_inertially_fixed_ = !is_inertially_fixed_;
       }
+      UnityEngine.Debug.Log("T "+changed);
       changed |= Δv_tangent_.Render(enabled);
+      UnityEngine.Debug.Log("N "+changed);
       changed |= Δv_normal_.Render(enabled);
+      UnityEngine.Debug.Log("B "+changed);
       changed |= Δv_binormal_.Render(enabled);
+      UnityEngine.Debug.Log("D "+changed);
       changed |= previous_coast_duration_.Render(enabled);
       UnityEngine.GUILayout.Label(
           index_ == 0 ? "Time base: start of flight plan"
                       : $"Time base: end of manœuvre #{index_}",
           style : new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
               alignment = UnityEngine.TextAnchor.UpperLeft});
+      UnityEngine.Debug.Log("R "+changed);
       changed |= changed_reference_frame_;
+      UnityEngine.Debug.Log("E "+changed);
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label(
             "Manœuvre Δv : " + Δv().ToString("0.000") + " m/s",
@@ -148,6 +155,7 @@ class BurnEditor : ScalingRenderer {
     Δv_binormal_.value = burn.delta_v.z;
     previous_coast_duration_.value =
         burn.initial_time - time_base;
+    UnityEngine.Debug.LogError("Reset");
     reference_frame_selector_.SetFrameParameters(burn.frame);
     is_inertially_fixed_ = burn.is_inertially_fixed;
     duration_ = manoeuvre.duration;

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -275,25 +275,9 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
     }
   }
 
-  public FrameType frame_type {
-    get => frame_type_;
-    private set {
-      if (frame_type_ != value) {
-        frame_changed_ = true;
-      }
-      frame_type_ = value;
-    }
-  }
-
-  public CelestialBody selected_celestial {
-    get => selected_celestial_;
-    private set {
-      if (selected_celestial_ != value) {
-        frame_changed_ = true;
-      }
-      selected_celestial_ = value;
-    }
-  }
+  public FrameType frame_type { get; private set; }
+  public CelestialBody selected_celestial { get; private set; }
+  public Vessel target_override { get; set; }
 
   protected override String Title {
     get {
@@ -389,24 +373,21 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
     }
   }
 
+  // Runs an action that may change the frame and run on_change_ if there
+  // actually was a change.
   private void EffectChange(Action action) {
-    frame_changed_ = false;
+    var old_frame_type = frame_type;
+    var old_selected_celestial = selected_celestial;
     action();
-    if (frame_changed_) {
+    if (frame_type != old_frame_type ||
+        selected_celestial != old_selected_celestial) {
       on_change_(FrameParameters());
-      frame_changed_ = false;
     }
   }
-
-  public Vessel target_override { get; set; }
 
   private readonly Callback on_change_;
   private readonly string name_;
   private Dictionary<CelestialBody, bool> expanded_;
-
-  private bool frame_changed_ = false;
-  private FrameType frame_type_;
-  private CelestialBody selected_celestial_;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -63,7 +63,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
         }
       }
     });
-    UnityEngine.Debug.LogError("UMB");
   }
 
   public void SetFrameParameters(NavigationFrameParameters parameters) {
@@ -82,7 +81,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
           break;
       }
     });
-    UnityEngine.Debug.LogError("SFP");
   }
 
   // Sets the |frame_type| to |type| unless this would be invalid for the
@@ -98,7 +96,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
         frame_type = type;
       }
     });
-    UnityEngine.Debug.LogError("SFT");
   }
 
   // Sets the |frame_type| to |BODY_SURFACE| and sets |selected_celestial| to
@@ -108,7 +105,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
       frame_type = FrameType.BODY_SURFACE;
       selected_celestial = celestial;
     });
-    UnityEngine.Debug.LogError("STSFO");
   }
 
   public static String Name(FrameType type,
@@ -346,7 +342,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
             frame_type = FrameType.BODY_CENTRED_NON_ROTATING;
           }
         });
-    UnityEngine.Debug.LogError("RS");
       }
     }
     if (celestial.is_root() || (!celestial.is_leaf() && expanded_[celestial])) {
@@ -369,7 +364,6 @@ class ReferenceFrameSelector : SupervisedWindowRenderer {
       EffectChange(() => {
         frame_type = value;
       });
-      UnityEngine.Debug.LogError("TS");
     }
   }
 


### PR DESCRIPTION
We had a curious game of ping-pong: Frame 1, the burn editor notices that the reference frame has recently changed, so it returns that information to the flight plan; the flight plan reloads all the data from the C++ side, including the reference frame.  Frame 2, the burn editor notices that the reference frame has recently changed, etc.

The fix is to change the burn editor so that it only reports a change if the frame loaded from C++ is actually different from the one it was using.

Fix #2157.