### PR TITLE
Properly deal with a changing time base in the burn editor

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -101,6 +101,7 @@ class FlightPlanner : SupervisedWindowRenderer {
             editor.Close();
           }
           burn_editors_ = null;
+          Shrink();
         }
         vessel_ = FlightGlobals.ActiveVessel;
       }


### PR DESCRIPTION
1. Nail the initial time and use the slider to (effectively) edit `initial_time_ - time_base`.
1. Shrink the flight plan when the number of manoeuvres changes.

Fix #2154.