### PR TITLE
Make sure that the FlightPlan operations return an error for an anomalous flight plan

### DIFF
--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -399,7 +399,10 @@ Status FlightPlan::ComputeSegments(
     std::vector<NavigationManœuvre>::iterator const begin,
     std::vector<NavigationManœuvre>::iterator const end) {
   CHECK(!segments_.empty());
-  Status overall_status;
+  if (anomalous_segments_ == 0) {
+    anomalous_status_ = Status::OK;
+  }
+  Status overall_status = anomalous_status_;
   for (auto it = begin; it != end; ++it) {
     auto& manœuvre = *it;
     auto& coast = segments_.back();
@@ -410,6 +413,7 @@ Status FlightPlan::ComputeSegments(
       if (!status.ok()) {
         overall_status.Update(status);
         anomalous_segments_ = 1;
+        anomalous_status_ = status;
       }
     }
 
@@ -421,6 +425,7 @@ Status FlightPlan::ComputeSegments(
       if (!status.ok()) {
         overall_status.Update(status);
         anomalous_segments_ = 1;
+        anomalous_status_ = status;
       }
     }
 
@@ -431,6 +436,7 @@ Status FlightPlan::ComputeSegments(
     if (!status.ok()) {
       overall_status.Update(status);
       anomalous_segments_ = 1;
+      anomalous_status_ = status;
     }
   }
   return overall_status;

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -207,6 +207,9 @@ class FlightPlan {
   // either end prematurely or follow an anomalous trajectory; in the latter
   // case they are empty.
   int anomalous_segments_ = 0;
+  // The status of the first anomalous segment.  Set and used exclusively by
+  // |ComputeSegments|.
+  Status anomalous_status_;
 
   std::vector<NavigationManœuvre> manœuvres_;
   not_null<Ephemeris<Barycentric>*> ephemeris_;

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -230,6 +230,20 @@ TEST_F(FlightPlanTest, Singular) {
                           /*Δv=*/1 * Metre / Second)),
       StatusIs(integrators::termination_condition::VanishingStepSize));
   EXPECT_EQ(1, flight_plan_->number_of_anomalous_manœuvres());
+
+  // Add another manœuvre and check the status.
+  EXPECT_THAT(
+      flight_plan_->Append(
+          MakeTangentBurn(/*thrust=*/1 * Newton,
+                          /*specific_impulse=*/1 * Newton * Second / Kilogram,
+                          /*initial_time=*/singularity + 10 * Second,
+                          /*Δv=*/1 * Metre / Second)),
+      StatusIs(integrators::termination_condition::VanishingStepSize));
+  EXPECT_EQ(2, flight_plan_->number_of_anomalous_manœuvres());
+
+  // Check that RemoveLast returns the proper statuses.
+  EXPECT_THAT(flight_plan_->RemoveLast(),
+              StatusIs(integrators::termination_condition::VanishingStepSize));
   flight_plan_->RemoveLast();
 
   // The singularity occurs during the burn: we're boosting towards the


### PR DESCRIPTION
Shows up on (at least) `Append` and `RemoveLast` when there is a preceding anomalous segment.