### PR TITLE
Support edition of all manœuvres in a flight plan

### DIFF
--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -200,10 +200,6 @@ Status FlightPlan::Replace(NavigationManœuvre::Burn const& burn,
   return ComputeSegments(manœuvres_.begin() + index, manœuvres_.end());
 }
 
-Status FlightPlan::ReplaceLast(NavigationManœuvre::Burn const& burn) {
-  return Replace(burn, manœuvres_.size() - 1);
-}
-
 Status FlightPlan::SetDesiredFinalTime(Instant const& desired_final_time) {
   if (desired_final_time < start_of_last_coast()) {
     return BadDesiredFinalTime();

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -97,10 +97,6 @@ class FlightPlan {
   // Otherwise, updates the flight plan and returns the integration status.
   virtual Status Replace(NavigationManœuvre::Burn const& burn, int index);
 
-  // Same as above, but for the last manœuvre.  |number_of_manœuvres()| must be
-  // at least one..
-  virtual Status ReplaceLast(NavigationManœuvre::Burn const& burn);
-
   // Updates the desired final time of the flight plan.  Returns an error and
   // has no effect |desired_final_time| is before the beginning of the last
   // coast.

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -469,18 +469,6 @@ Status principia__FlightPlanReplace(Plugin const* const plugin,
                                        index)));
 }
 
-Status principia__FlightPlanReplaceLast(Plugin const* const plugin,
-                                        char const* const vessel_guid,
-                                        Burn const burn) {
-  journal::Method<journal::FlightPlanReplaceLast> m({plugin,
-                                                     vessel_guid,
-                                                     burn});
-  CHECK_NOTNULL(plugin);
-  auto& flight_plan = GetFlightPlan(*plugin, vessel_guid);
-  return m.Return(ToStatus(GetFlightPlan(*plugin, vessel_guid).
-                               ReplaceLast(FromInterfaceBurn(*plugin, burn))));
-}
-
 Status principia__FlightPlanSetAdaptiveStepParameters(
     Plugin const* const plugin,
     char const* const vessel_guid,

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -59,11 +59,10 @@ class BurnEditor : ScalingRenderer {
 
   // Renders the |BurnEditor|.  Returns true if and only if the settings were
   // changed.
-  public bool Render(string header,
-                     double? actual_final_time = null) {
+  public bool Render(string header, double actual_final_time) {
     bool changed = false;
-    previous_coast_duration_.max_value =
-        (actual_final_time ?? double.PositiveInfinity) - time_base;
+    //TODO(phl):Is this right?
+    previous_coast_duration_.max_value = actual_final_time - time_base;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(header);
       string frame_info = "";

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -60,7 +60,6 @@ class BurnEditor : ScalingRenderer {
   // Renders the |BurnEditor|.  Returns true if and only if the settings were
   // changed.
   public bool Render(string header,
-                     bool enabled,
                      double? actual_final_time = null) {
     bool changed = false;
     previous_coast_duration_.max_value =
@@ -86,26 +85,22 @@ class BurnEditor : ScalingRenderer {
         engine_warning_ = "";
         ComputeEngineCharacteristics();
       }
-      if (enabled) {
-        using (new UnityEngine.GUILayout.HorizontalScope()) {
-          if (UnityEngine.GUILayout.Button("Active Engines")) {
-            engine_warning_ = "";
-            ComputeEngineCharacteristics();
-            changed = true;
-          } else if (UnityEngine.GUILayout.Button("Active RCS")) {
-            engine_warning_ = "";
-            ComputeRCSCharacteristics();
-            changed = true;
-          } else if (UnityEngine.GUILayout.Button("Instant Impulse")) {
-            engine_warning_ = "";
-            UseTheForceLuke();
-            changed = true;
-          }
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        if (UnityEngine.GUILayout.Button("Active Engines")) {
+          engine_warning_ = "";
+          ComputeEngineCharacteristics();
+          changed = true;
+        } else if (UnityEngine.GUILayout.Button("Active RCS")) {
+          engine_warning_ = "";
+          ComputeRCSCharacteristics();
+          changed = true;
+        } else if (UnityEngine.GUILayout.Button("Instant Impulse")) {
+          engine_warning_ = "";
+          UseTheForceLuke();
+          changed = true;
         }
-        reference_frame_selector_.RenderButton();
-      } else {
-        reference_frame_selector_.Hide();
       }
+      reference_frame_selector_.RenderButton();
       if (is_inertially_fixed_ !=
           UnityEngine.GUILayout.Toggle(is_inertially_fixed_,
                                        "Inertially fixed")) {
@@ -113,13 +108,13 @@ class BurnEditor : ScalingRenderer {
         is_inertially_fixed_ = !is_inertially_fixed_;
       }
       changed |= changed_reference_frame_;
-      changed |= Δv_tangent_.Render(enabled);
-      changed |= Δv_normal_.Render(enabled);
-      changed |= Δv_binormal_.Render(enabled);
+      changed |= Δv_tangent_.Render();
+      changed |= Δv_normal_.Render();
+      changed |= Δv_binormal_.Render();
       {
         var render_time_base = time_base;
         previous_coast_duration_.value = initial_time_ - render_time_base;
-        if (previous_coast_duration_.Render(enabled)) {
+        if (previous_coast_duration_.Render()) {
           changed = true;
           initial_time_ = previous_coast_duration_.value + render_time_base;
         }
@@ -140,7 +135,7 @@ class BurnEditor : ScalingRenderer {
                                   Style.Warning(UnityEngine.GUI.skin.label));
       changed_reference_frame_ = false;
     }
-    return changed && enabled;
+    return changed;
   }
 
   public double Δv() {

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -59,10 +59,10 @@ class BurnEditor : ScalingRenderer {
 
   // Renders the |BurnEditor|.  Returns true if and only if the settings were
   // changed.
-  public bool Render(string header, double actual_final_time) {
+  public bool Render(string header, double final_time) {
     bool changed = false;
     //TODO(phl):Is this right?
-    previous_coast_duration_.max_value = actual_final_time - time_base;
+    previous_coast_duration_.max_value = final_time - time_base;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(header);
       string frame_info = "";

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -61,7 +61,6 @@ class BurnEditor : ScalingRenderer {
   // changed.
   public bool Render(string header, double final_time) {
     bool changed = false;
-    //TODO(phl):Is this right?
     previous_coast_duration_.max_value = final_time - time_base;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(header);

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -59,7 +59,9 @@ class BurnEditor : ScalingRenderer {
 
   // Renders the |BurnEditor|.  Returns true if and only if the settings were
   // changed.
-  public bool Render(string header, double final_time) {
+  public bool Render(string header, 
+                     bool anomalous,
+                     double final_time) {
     bool changed = false;
     previous_coast_duration_.max_value = final_time - time_base;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -83,22 +85,29 @@ class BurnEditor : ScalingRenderer {
         engine_warning_ = "";
         ComputeEngineCharacteristics();
       }
-      using (new UnityEngine.GUILayout.HorizontalScope()) {
-        if (UnityEngine.GUILayout.Button("Active Engines")) {
-          engine_warning_ = "";
-          ComputeEngineCharacteristics();
-          changed = true;
-        } else if (UnityEngine.GUILayout.Button("Active RCS")) {
-          engine_warning_ = "";
-          ComputeRCSCharacteristics();
-          changed = true;
-        } else if (UnityEngine.GUILayout.Button("Instant Impulse")) {
-          engine_warning_ = "";
-          UseTheForceLuke();
-          changed = true;
+
+      // The frame selector is disabled for an anomalous manœuvre as is has no
+      // effect.
+      if (anomalous) {
+         reference_frame_selector_.Hide();
+      } else {
+        using (new UnityEngine.GUILayout.HorizontalScope()) {
+          if (UnityEngine.GUILayout.Button("Active Engines")) {
+            engine_warning_ = "";
+            ComputeEngineCharacteristics();
+            changed = true;
+          } else if (UnityEngine.GUILayout.Button("Active RCS")) {
+            engine_warning_ = "";
+            ComputeRCSCharacteristics();
+            changed = true;
+          } else if (UnityEngine.GUILayout.Button("Instant Impulse")) {
+            engine_warning_ = "";
+            UseTheForceLuke();
+            changed = true;
+          }
         }
+        reference_frame_selector_.RenderButton();
       }
-      reference_frame_selector_.RenderButton();
       if (is_inertially_fixed_ !=
           UnityEngine.GUILayout.Toggle(is_inertially_fixed_,
                                        "Inertially fixed")) {
@@ -106,13 +115,19 @@ class BurnEditor : ScalingRenderer {
         is_inertially_fixed_ = !is_inertially_fixed_;
       }
       changed |= changed_reference_frame_;
-      changed |= Δv_tangent_.Render();
-      changed |= Δv_normal_.Render();
-      changed |= Δv_binormal_.Render();
+
+      // The Δv controls are disabled for an anomalous manœuvre as they have no
+      // effect.
+      changed |= Δv_tangent_.Render(enabled : !anomalous);
+      changed |= Δv_normal_.Render(enabled : !anomalous);
+      changed |= Δv_binormal_.Render(enabled : !anomalous);
       {
         var render_time_base = time_base;
         previous_coast_duration_.value = initial_time_ - render_time_base;
-        if (previous_coast_duration_.Render()) {
+
+        // The duration of the previous coast is always enabled as it can make
+        // a manœuvre non-anomalous.
+        if (previous_coast_duration_.Render(enabled : true)) {
           changed = true;
           initial_time_ = previous_coast_duration_.value + render_time_base;
         }

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -68,7 +68,7 @@ internal class DifferentialSlider : ScalingRenderer {
 
   // Renders the |DifferentialSlider|.  Returns true if and only if |value|
   // changed.
-  public bool Render() {
+  public bool Render(bool enabled) {
     bool value_changed = false;
 
     using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -82,10 +82,7 @@ internal class DifferentialSlider : ScalingRenderer {
                                     style   : style);
       }
 
-      // Draw the text field and give it a name to be able to detect if it has
-      // focus.
-      String text_field_name = GetHashCode() + ":text_field";
-      {
+      if (enabled) {
         // If the text is not syntactically correct, or it exceeds the upper
         // bound, inform the user by drawing it in the warning style.  Note the
         // fudge factor to account for uncertainty in text/double conversions.
@@ -95,73 +92,85 @@ internal class DifferentialSlider : ScalingRenderer {
           style = Style.Warning(style);
         }
 
+        // Draw the text field and give it a name to be able to detect if it has
+        // focus.
+        String text_field_name = GetHashCode() + ":text_field";
         UnityEngine.GUI.SetNextControlName(text_field_name);
         formatted_value_ = UnityEngine.GUILayout.TextField(
             text    : formatted_value_,
             style   : style,
             options : GUILayoutWidth(5 + (unit_ == null ? 2 : 0)));
-      }
 
-      // See if the user typed 'Return' in the field, or moved focus
-      // elsewhere, in which case we terminate text entry.
-      bool terminate_text_entry = false;
-      var current_event = UnityEngine.Event.current;
-      if (UnityEngine.Event.current.isKey &&
-          UnityEngine.Event.current.keyCode == UnityEngine.KeyCode.Return &&
-          UnityEngine.GUI.GetNameOfFocusedControl() == text_field_name) {
-        terminate_text_entry = true;
-      } else if (UnityEngine.GUI.GetNameOfFocusedControl() !=
-                      text_field_name &&
-                  formatted_value_ != formatter_(value_.Value)) {
-        terminate_text_entry = true;
-      }
-      if (terminate_text_entry) {
-        // Try to parse the input.  If that fails, go back to the previous
-        // legal value.
-        if (parser_(formatted_value_, out double v2)) {
-          value_changed = true;
-          value = v2;
-          slider_position_ = 0;
-          // TODO(phl): If the value computed here is rejected by the C++, we
-          // revert to the previous value just as if there was a parsing error
-          // and this is not nice.
-        } else {
-          // Go back to the previous legal value.
-          formatted_value_ = formatter_(value_.Value);
+        // See if the user typed 'Return' in the field, or moved focus
+        // elsewhere, in which case we terminate text entry.
+        bool terminate_text_entry = false;
+        var current_event = UnityEngine.Event.current;
+        if (UnityEngine.Event.current.isKey &&
+            UnityEngine.Event.current.keyCode == UnityEngine.KeyCode.Return &&
+            UnityEngine.GUI.GetNameOfFocusedControl() == text_field_name) {
+          terminate_text_entry = true;
+        } else if (UnityEngine.GUI.GetNameOfFocusedControl() !=
+                       text_field_name &&
+                   formatted_value_ != formatter_(value_.Value)) {
+          terminate_text_entry = true;
         }
+        if (terminate_text_entry) {
+          // Try to parse the input.  If that fails, go back to the previous
+          // legal value.
+          if (parser_(formatted_value_, out double v2)) {
+            value_changed = true;
+            value = v2;
+            slider_position_ = 0;
+            // TODO(phl): If the value computed here is rejected by the C++, we
+            // revert to the previous value just as if there was a parsing error
+            // and this is not nice.
+          } else {
+            // Go back to the previous legal value.
+            formatted_value_ = formatter_(value_.Value);
+          }
+        }
+      } else {
+        UnityEngine.GUILayout.Label(
+            text    : formatted_value_,
+            style   : Style.RightAligned(UnityEngine.GUI.skin.label),
+            options : GUILayoutWidth(5 + (unit_ == null ? 2 : 0)));
       }
       UnityEngine.GUILayout.Label(
           text    : unit_ ?? "",
           options : GUILayoutWidth(unit_ == null ? 0 : 2));
 
-      if (!UnityEngine.Input.GetMouseButton(0)) {
-        slider_position_ = 0;
-      }
-      slider_position_ = UnityEngine.GUILayout.HorizontalSlider(
-          value      : slider_position_,
-          leftValue  : -1,
-          rightValue : 1,
-          options    : UnityEngine.GUILayout.ExpandWidth(true));
-
-      if (UnityEngine.GUILayout.Button("0", GUILayoutWidth(1))) {
-        value_changed = true;
-        // Force a change of value so that any input is discarded.
-        value_ = null;
-        value = zero_value_;
-      }
-      if (slider_position_ != 0.0) {
-        value_changed = true;
-        // Moving the slider doesn't always cause a loss of focus so we
-        // terminate input if necessary.
-        if (parser_(formatted_value_, out double v)) {
-          value = v;
+      if (enabled) {
+        if (!UnityEngine.Input.GetMouseButton(0)) {
+          slider_position_ = 0;
         }
-        value += Math.Sign(slider_position_) *
-              Math.Pow(10, log10_lower_rate_ +
-                              (log10_upper_rate_ - log10_lower_rate_) *
-                                  Math.Abs(slider_position_)) *
-              (DateTime.Now - last_time_).TotalSeconds;
-        value = Math.Min(Math.Max(min_value_, value), max_value_);
+        slider_position_ = UnityEngine.GUILayout.HorizontalSlider(
+            value      : slider_position_,
+            leftValue  : -1,
+            rightValue : 1,
+            options    : UnityEngine.GUILayout.ExpandWidth(true));
+
+        if (UnityEngine.GUILayout.Button("0", GUILayoutWidth(1))) {
+          value_changed = true;
+          // Force a change of value so that any input is discarded.
+          value_ = null;
+          value = zero_value_;
+        }
+        if (slider_position_ != 0.0) {
+          value_changed = true;
+          // Moving the slider doesn't always cause a loss of focus so we
+          // terminate input if necessary.
+          if (parser_(formatted_value_, out double v)) {
+            value = v;
+          }
+          value += Math.Sign(slider_position_) *
+                Math.Pow(10, log10_lower_rate_ +
+                                (log10_upper_rate_ - log10_lower_rate_) *
+                                    Math.Abs(slider_position_)) *
+                (DateTime.Now - last_time_).TotalSeconds;
+          value = Math.Min(Math.Max(min_value_, value), max_value_);
+        }
+      } else {
+        slider_position_ = 0;
       }
       last_time_ = DateTime.Now;
     }

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -68,7 +68,7 @@ internal class DifferentialSlider : ScalingRenderer {
 
   // Renders the |DifferentialSlider|.  Returns true if and only if |value|
   // changed.
-  public bool Render(bool enabled) {
+  public bool Render() {
     bool value_changed = false;
 
     using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -82,7 +82,10 @@ internal class DifferentialSlider : ScalingRenderer {
                                     style   : style);
       }
 
-      if (enabled) {
+      // Draw the text field and give it a name to be able to detect if it has
+      // focus.
+      String text_field_name = GetHashCode() + ":text_field";
+      {
         // If the text is not syntactically correct, or it exceeds the upper
         // bound, inform the user by drawing it in the warning style.  Note the
         // fudge factor to account for uncertainty in text/double conversions.
@@ -92,85 +95,73 @@ internal class DifferentialSlider : ScalingRenderer {
           style = Style.Warning(style);
         }
 
-        // Draw the text field and give it a name to be able to detect if it has
-        // focus.
-        String text_field_name = GetHashCode() + ":text_field";
         UnityEngine.GUI.SetNextControlName(text_field_name);
         formatted_value_ = UnityEngine.GUILayout.TextField(
             text    : formatted_value_,
             style   : style,
             options : GUILayoutWidth(5 + (unit_ == null ? 2 : 0)));
+      }
 
-        // See if the user typed 'Return' in the field, or moved focus
-        // elsewhere, in which case we terminate text entry.
-        bool terminate_text_entry = false;
-        var current_event = UnityEngine.Event.current;
-        if (UnityEngine.Event.current.isKey &&
-            UnityEngine.Event.current.keyCode == UnityEngine.KeyCode.Return &&
-            UnityEngine.GUI.GetNameOfFocusedControl() == text_field_name) {
-          terminate_text_entry = true;
-        } else if (UnityEngine.GUI.GetNameOfFocusedControl() !=
-                       text_field_name &&
-                   formatted_value_ != formatter_(value_.Value)) {
-          terminate_text_entry = true;
+      // See if the user typed 'Return' in the field, or moved focus
+      // elsewhere, in which case we terminate text entry.
+      bool terminate_text_entry = false;
+      var current_event = UnityEngine.Event.current;
+      if (UnityEngine.Event.current.isKey &&
+          UnityEngine.Event.current.keyCode == UnityEngine.KeyCode.Return &&
+          UnityEngine.GUI.GetNameOfFocusedControl() == text_field_name) {
+        terminate_text_entry = true;
+      } else if (UnityEngine.GUI.GetNameOfFocusedControl() !=
+                      text_field_name &&
+                  formatted_value_ != formatter_(value_.Value)) {
+        terminate_text_entry = true;
+      }
+      if (terminate_text_entry) {
+        // Try to parse the input.  If that fails, go back to the previous
+        // legal value.
+        if (parser_(formatted_value_, out double v2)) {
+          value_changed = true;
+          value = v2;
+          slider_position_ = 0;
+          // TODO(phl): If the value computed here is rejected by the C++, we
+          // revert to the previous value just as if there was a parsing error
+          // and this is not nice.
+        } else {
+          // Go back to the previous legal value.
+          formatted_value_ = formatter_(value_.Value);
         }
-        if (terminate_text_entry) {
-          // Try to parse the input.  If that fails, go back to the previous
-          // legal value.
-          if (parser_(formatted_value_, out double v2)) {
-            value_changed = true;
-            value = v2;
-            slider_position_ = 0;
-            // TODO(phl): If the value computed here is rejected by the C++, we
-            // revert to the previous value just as if there was a parsing error
-            // and this is not nice.
-          } else {
-            // Go back to the previous legal value.
-            formatted_value_ = formatter_(value_.Value);
-          }
-        }
-      } else {
-        UnityEngine.GUILayout.Label(
-            text    : formatted_value_,
-            style   : Style.RightAligned(UnityEngine.GUI.skin.label),
-            options : GUILayoutWidth(5 + (unit_ == null ? 2 : 0)));
       }
       UnityEngine.GUILayout.Label(
           text    : unit_ ?? "",
           options : GUILayoutWidth(unit_ == null ? 0 : 2));
 
-      if (enabled) {
-        if (!UnityEngine.Input.GetMouseButton(0)) {
-          slider_position_ = 0;
-        }
-        slider_position_ = UnityEngine.GUILayout.HorizontalSlider(
-            value      : slider_position_,
-            leftValue  : -1,
-            rightValue : 1,
-            options    : UnityEngine.GUILayout.ExpandWidth(true));
-
-        if (UnityEngine.GUILayout.Button("0", GUILayoutWidth(1))) {
-          value_changed = true;
-          // Force a change of value so that any input is discarded.
-          value_ = null;
-          value = zero_value_;
-        }
-        if (slider_position_ != 0.0) {
-          value_changed = true;
-          // Moving the slider doesn't always cause a loss of focus so we
-          // terminate input if necessary.
-          if (parser_(formatted_value_, out double v)) {
-            value = v;
-          }
-          value += Math.Sign(slider_position_) *
-                Math.Pow(10, log10_lower_rate_ +
-                                (log10_upper_rate_ - log10_lower_rate_) *
-                                    Math.Abs(slider_position_)) *
-                (DateTime.Now - last_time_).TotalSeconds;
-          value = Math.Min(Math.Max(min_value_, value), max_value_);
-        }
-      } else {
+      if (!UnityEngine.Input.GetMouseButton(0)) {
         slider_position_ = 0;
+      }
+      slider_position_ = UnityEngine.GUILayout.HorizontalSlider(
+          value      : slider_position_,
+          leftValue  : -1,
+          rightValue : 1,
+          options    : UnityEngine.GUILayout.ExpandWidth(true));
+
+      if (UnityEngine.GUILayout.Button("0", GUILayoutWidth(1))) {
+        value_changed = true;
+        // Force a change of value so that any input is discarded.
+        value_ = null;
+        value = zero_value_;
+      }
+      if (slider_position_ != 0.0) {
+        value_changed = true;
+        // Moving the slider doesn't always cause a loss of focus so we
+        // terminate input if necessary.
+        if (parser_(formatted_value_, out double v)) {
+          value = v;
+        }
+        value += Math.Sign(slider_position_) *
+              Math.Pow(10, log10_lower_rate_ +
+                              (log10_upper_rate_ - log10_lower_rate_) *
+                                  Math.Abs(slider_position_)) *
+              (DateTime.Now - last_time_).TotalSeconds;
+        value = Math.Min(Math.Max(min_value_, value), max_value_);
       }
       last_time_ = DateTime.Now;
     }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -239,13 +239,20 @@ class FlightPlanner : SupervisedWindowRenderer {
           RenderUpcomingEvents();
         }
 
+        // Compute the final times for each manœuvre before displaying them.
+        var final_times = new List<double>();
+        for (int i = 0; i < burn_editors_.Count - 1; ++i) {
+          final_times.Add(
+              plugin.FlightPlanGetManoeuvre(vessel_guid, i + 1).
+                  burn.initial_time);
+        }
+        final_times.Add(plugin.FlightPlanGetActualFinalTime(vessel_guid));
+
         for (int i = 0; i < burn_editors_.Count; ++i) {
           Style.HorizontalLine();
           BurnEditor burn = burn_editors_[i];
-          if (burn.Render(header            : "Manœuvre #" + (i + 1),
-                          actual_final_time :
-                              plugin.FlightPlanGetManoeuvre(
-                                  vessel_guid, i).final_time)) {
+          if (burn.Render(header     : "Manœuvre #" + (i + 1),
+                          final_time : final_times[i])) {
             var status = plugin.FlightPlanReplace(vessel_guid, burn.Burn(), i);
             UpdateStatus(status, i);
             burn.Reset(plugin.FlightPlanGetManoeuvre(vessel_guid, i));

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -238,23 +238,21 @@ class FlightPlanner : SupervisedWindowRenderer {
         if (burn_editors_.Count > 0) {
           RenderUpcomingEvents();
         }
-        for (int i = 0; i < burn_editors_.Count - 1; ++i) {
+
+        for (int i = 0; i < burn_editors_.Count; ++i) {
           Style.HorizontalLine();
-          burn_editors_[i].Render(header: "Manœuvre #" + (i + 1));
-        }
-        if (burn_editors_.Count > 0) {
-          Style.HorizontalLine();
-          BurnEditor last_burn = burn_editors_.Last();
-          if (last_burn.Render(header            : "Editing manœuvre #" +
-                                                   (burn_editors_.Count),
-                               actual_final_time : actual_final_time)) {
-            var status = plugin.FlightPlanReplaceLast(vessel_guid,
-                                                      last_burn.Burn());
-            UpdateStatus(status, burn_editors_.Count - 1);
-            last_burn.Reset(
-                plugin.FlightPlanGetManoeuvre(vessel_guid,
-                                              burn_editors_.Count - 1));
+          BurnEditor burn = burn_editors_[i];
+          if (burn.Render(header            : "Manœuvre #" + (i + 1),
+                          actual_final_time :
+                              plugin.FlightPlanGetManoeuvre(
+                                  vessel_guid, i).final_time)) {
+            var status = plugin.FlightPlanReplace(vessel_guid, burn.Burn(), i);
+            UpdateStatus(status, i);
+            burn.Reset(plugin.FlightPlanGetManoeuvre(vessel_guid, i));
           }
+        }
+
+        if (burn_editors_.Count > 0) {
           if (UnityEngine.GUILayout.Button(
                   "Delete last manœuvre",
                   UnityEngine.GUILayout.ExpandWidth(true))) {

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -132,12 +132,12 @@ class FlightPlanner : SupervisedWindowRenderer {
     if (burn_editors_ != null) {
       string vessel_guid = vessel_?.id.ToString();
       double current_time = plugin.CurrentTime();
-      first_future_manoeuvre_ = null;
+      first_future_manœuvre_ = null;
       for (int i = 0; i < burn_editors_.Count; ++i) {
-        NavigationManoeuvre manoeuvre =
+        NavigationManoeuvre manœuvre =
             plugin.FlightPlanGetManoeuvre(vessel_guid, i);
-        if (current_time < manoeuvre.final_time) {
-          first_future_manoeuvre_ = i;
+        if (current_time < manœuvre.final_time) {
+          first_future_manœuvre_ = i;
           break;
         }
       }
@@ -297,26 +297,26 @@ class FlightPlanner : SupervisedWindowRenderer {
     double current_time = plugin.CurrentTime();
 
     Style.HorizontalLine();
-    if (first_future_manoeuvre_.HasValue) {
-      int first_future_manoeuvre = first_future_manoeuvre_.Value;
-      NavigationManoeuvre manoeuvre =
-          plugin.FlightPlanGetManoeuvre(vessel_guid, first_future_manoeuvre);
-      if (manoeuvre.burn.initial_time > current_time) {
+    if (first_future_manœuvre_.HasValue) {
+      int first_future_manœuvre = first_future_manœuvre_.Value;
+      NavigationManoeuvre manœuvre =
+          plugin.FlightPlanGetManoeuvre(vessel_guid, first_future_manœuvre);
+      if (manœuvre.burn.initial_time > current_time) {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label("Upcoming manœuvre #" +
-                                      (first_future_manoeuvre + 1) + ":");
+                                      (first_future_manœuvre + 1) + ":");
           UnityEngine.GUILayout.Label(
               "Ignition " + FormatTimeSpan(TimeSpan.FromSeconds(
-                                current_time - manoeuvre.burn.initial_time)),
+                                current_time - manœuvre.burn.initial_time)),
               style : Style.RightAligned(UnityEngine.GUI.skin.label));
         }
       } else {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label("Ongoing manœuvre #" +
-                                      (first_future_manoeuvre + 1) + ":");
+                                      (first_future_manœuvre + 1) + ":");
           UnityEngine.GUILayout.Label(
               "Cutoff " + FormatTimeSpan(TimeSpan.FromSeconds(
-                              current_time - manoeuvre.final_time)),
+                              current_time - manœuvre.final_time)),
               style : Style.RightAligned(UnityEngine.GUI.skin.label));
         }
       }
@@ -330,7 +330,7 @@ class FlightPlanner : SupervisedWindowRenderer {
           show_guidance_ =
               UnityEngine.GUILayout.Toggle(show_guidance_, "Show on navball");
           if (UnityEngine.GUILayout.Button("Warp to manœuvre")) {
-            TimeWarp.fetch.WarpTo(manoeuvre.burn.initial_time - 60);
+            TimeWarp.fetch.WarpTo(manœuvre.burn.initial_time - 60);
           }
         }
       }
@@ -407,15 +407,15 @@ class FlightPlanner : SupervisedWindowRenderer {
     return true;
   }
 
-  private void UpdateStatus(Status status, int? error_manoeuvre) {
+  private void UpdateStatus(Status status, int? error_manœuvre) {
     if (message_was_displayed_) {
       status_ = Status.OK;
-      first_error_manoeuvre_ = null;
+      first_error_manœuvre_ = null;
       message_was_displayed_ = false;
     }
     if (status_.ok() && !status.ok()) {
       status_ = status;
-      first_error_manoeuvre_ = error_manoeuvre;
+      first_error_manœuvre_ = error_manœuvre;
     }
   }
 
@@ -423,9 +423,9 @@ class FlightPlanner : SupervisedWindowRenderer {
     string vessel_guid = vessel_?.id.ToString();
     string message = "";
     if (vessel_guid != null && !status_.ok()) {
-      int anomalous_manoeuvres =
+      int anomalous_manœuvres =
           plugin.FlightPlanNumberOfAnomalousManoeuvres(vessel_guid);
-      int manoeuvres = plugin.FlightPlanNumberOfManoeuvres(vessel_guid);
+      int manœuvres = plugin.FlightPlanNumberOfManoeuvres(vessel_guid);
       double actual_final_time =
           plugin.FlightPlanGetActualFinalTime(vessel_guid);
       bool timed_out = actual_final_time < final_time_.value;
@@ -448,41 +448,41 @@ class FlightPlanner : SupervisedWindowRenderer {
                          "centre of a celestial)" + time_out_message;
         remedy_message = "avoiding collisions with a celestial";
       } else if (status_.is_invalid_argument()) {
-        status_message = "manoeuvre #" + (first_error_manoeuvre_.Value + 1) +
+        status_message = "manœuvre #" + (first_error_manœuvre_.Value + 1) +
                          " would result in an infinite or indeterminate " +
                          "velocity";
-        remedy_message = "adjusting the duration of manoeuvre #" +
-                         (first_error_manoeuvre_.Value + 1);
+        remedy_message = "adjusting the duration of manœuvre #" +
+                         (first_error_manœuvre_.Value + 1);
       } else if (status_.is_out_of_range()) {
-        if (first_error_manoeuvre_.HasValue) {
-          status_message = "manoeuvre #" + (first_error_manoeuvre_.Value + 1) +
+        if (first_error_manœuvre_.HasValue) {
+          status_message = "manœuvre #" + (first_error_manœuvre_.Value + 1) +
                            " overlaps with " + 
-                           ((first_error_manoeuvre_.Value == 0)
+                           ((first_error_manœuvre_.Value == 0)
                                 ? "the start of the flight plan"
-                                : "manoeuvre #" +
-                                  first_error_manoeuvre_.Value) + " or " +
-                           ((first_error_manoeuvre_.Value == manoeuvres - 1)
+                                : "manœuvre #" +
+                                  first_error_manœuvre_.Value) + " or " +
+                           ((first_error_manœuvre_.Value == manœuvres - 1)
                                 ? "the end of the flight plan"
-                                : "manoeuvre #" +
-                                  (first_error_manoeuvre_.Value + 2));
-          remedy_message = ((first_error_manoeuvre_.Value == manoeuvres - 1)
+                                : "manœuvre #" +
+                                  (first_error_manœuvre_.Value + 2));
+          remedy_message = ((first_error_manœuvre_.Value == manœuvres - 1)
                                ? "extending the flight plan or "
                                : "") +
                            "increasing the initial time or reducing the " +
-                           "duration of manoeuvre #" +
-                           (first_error_manoeuvre_.Value + 1);
+                           "duration of manœuvre #" +
+                           (first_error_manœuvre_.Value + 1);
         } else {
           status_message = "flight plan final time overlaps the last " +
-                           "manoeuvre";
+                           "manœuvre";
           remedy_message = "increasing the flight plan duration";
         }
       }
 
-      if (anomalous_manoeuvres > 0) {
-        message = "The last " + anomalous_manoeuvres + " manoeuvres could " +
+      if (anomalous_manœuvres > 0) {
+        message = "The last " + anomalous_manœuvres + " manœuvres could " +
                   "not be drawn because the " + status_message + "; try " +
-                  remedy_message + " or adjusting manoeuvre " +
-                  (manoeuvres - anomalous_manoeuvres - 1) + ".";
+                  remedy_message + " or adjusting manœuvre " +
+                  (manœuvres - anomalous_manœuvres - 1) + ".";
       } else {
         message = "The " + status_message + "; try " + remedy_message + ".";
       }
@@ -497,13 +497,13 @@ class FlightPlanner : SupervisedWindowRenderer {
   private Vessel vessel_;
   private List<BurnEditor> burn_editors_;
   private DifferentialSlider final_time_;
-  private int? first_future_manoeuvre_;
+  private int? first_future_manœuvre_;
 
   private bool show_guidance_ = false;
   private float warning_height_ = 1;
 
   private Status status_ = Status.OK;
-  private int? first_error_manoeuvre_;
+  private int? first_error_manœuvre_;
   private bool message_was_displayed_ = false;
   
   private const double log10_time_lower_rate = 0.0;

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -475,7 +475,7 @@ class FlightPlanner : SupervisedWindowRenderer {
           remedy_message = ((first_error_manœuvre_.Value == manœuvres - 1)
                                ? "extending the flight plan or "
                                : "") +
-                           "increasing the initial time or reducing the " +
+                           "adjusting the initial time or reducing the " +
                            "duration of manœuvre #" +
                            (first_error_manœuvre_.Value + 1);
         } else {

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -146,7 +146,7 @@ class FlightPlanner : SupervisedWindowRenderer {
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      if (final_time_.Render()) {
+      if (final_time_.Render(enabled : true)) {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                           final_time_.value);
         UpdateStatus(status, null);
@@ -247,11 +247,15 @@ class FlightPlanner : SupervisedWindowRenderer {
                   burn.initial_time);
         }
         final_times.Add(plugin.FlightPlanGetActualFinalTime(vessel_guid));
+        int number_of_anomalous_manœuvres =
+            plugin.FlightPlanNumberOfAnomalousManoeuvres(vessel_guid);
 
         for (int i = 0; i < burn_editors_.Count; ++i) {
           Style.HorizontalLine();
           BurnEditor burn = burn_editors_[i];
           if (burn.Render(header     : "Manœuvre #" + (i + 1),
+                          anomalous  : i >= (burn_editors_.Count -
+                                             number_of_anomalous_manœuvres),
                           final_time : final_times[i])) {
             var status = plugin.FlightPlanReplace(vessel_guid, burn.Burn(), i);
             UpdateStatus(status, i);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -146,7 +146,7 @@ class FlightPlanner : SupervisedWindowRenderer {
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      if (final_time_.Render(enabled : true)) {
+      if (final_time_.Render()) {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                           final_time_.value);
         UpdateStatus(status, null);
@@ -240,15 +240,13 @@ class FlightPlanner : SupervisedWindowRenderer {
         }
         for (int i = 0; i < burn_editors_.Count - 1; ++i) {
           Style.HorizontalLine();
-          burn_editors_[i].Render(header: "Manœuvre #" + (i + 1),
-                                  enabled : false);
+          burn_editors_[i].Render(header: "Manœuvre #" + (i + 1));
         }
         if (burn_editors_.Count > 0) {
           Style.HorizontalLine();
           BurnEditor last_burn = burn_editors_.Last();
           if (last_burn.Render(header            : "Editing manœuvre #" +
                                                    (burn_editors_.Count),
-                               enabled           : true,
                                actual_final_time : actual_final_time)) {
             var status = plugin.FlightPlanReplaceLast(vessel_guid,
                                                       last_burn.Burn());

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -277,11 +277,12 @@ TEST_F(FlightPlanTest, Singular) {
   // analytic expression for the time at which we reach the singularity, are
   // left as an exercise to the reader.
   EXPECT_THAT(
-      flight_plan_->ReplaceLast(
+      flight_plan_->Replace(
           MakeTangentBurn(/*thrust=*/10 * Newton,
                           /*specific_impulse=*/1 * Newton * Second / Kilogram,
                           /*initial_time=*/t0_ + 0.5 * Second,
-                          /*Δv=*/-1 * Metre / Second)),
+                          /*Δv=*/-1 * Metre / Second),
+          /*index=*/0),
       StatusIs(integrators::termination_condition::VanishingStepSize));
   EXPECT_EQ(0, flight_plan_->number_of_anomalous_manœuvres());
 
@@ -397,21 +398,21 @@ TEST_F(FlightPlanTest, RemoveLast) {
   EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
 }
 
-TEST_F(FlightPlanTest, ReplaceLast) {
+TEST_F(FlightPlanTest, Replace) {
   flight_plan_->SetDesiredFinalTime(t0_ + 1.7 * Second);
   EXPECT_OK(flight_plan_->Append(MakeFirstBurn()));
   Mass const old_final_mass =
       flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
           final_mass();
   EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
-  EXPECT_THAT(flight_plan_->ReplaceLast(MakeThirdBurn()),
+  EXPECT_THAT(flight_plan_->Replace(MakeThirdBurn(), /*index=*/0),
               StatusIs(FlightPlan::does_not_fit));
   EXPECT_EQ(old_final_mass,
             flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
                 final_mass());
   EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
   flight_plan_->SetDesiredFinalTime(t0_ + 42 * Second);
-  EXPECT_OK(flight_plan_->ReplaceLast(MakeThirdBurn()));
+  EXPECT_OK(flight_plan_->Replace(MakeThirdBurn(), /*index=*/0));
   EXPECT_GT(old_final_mass,
             flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
                 final_mass());
@@ -527,7 +528,7 @@ TEST_F(FlightPlanTest, GuidedBurn) {
   auto guided_burn = MakeFirstBurn();
   guided_burn.thrust /= 10;
   guided_burn.is_inertially_fixed = false;
-  EXPECT_OK(flight_plan_->ReplaceLast(std::move(guided_burn)));
+  EXPECT_OK(flight_plan_->Replace(std::move(guided_burn), /*index=*/0));
   flight_plan_->GetAllSegments(begin, end);
   last = --end;
   Speed const guided_final_speed = last.degrees_of_freedom().velocity().Norm();

--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -386,19 +386,22 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
                     new StrictMock<MockDynamicFrame<Barycentric, Navigation>>));
   auto const manœuvre = NavigationManœuvre(/*initial_mass=*/1 * Kilogram, burn);
   EXPECT_CALL(flight_plan,
-              ReplaceLast(
+              Replace(
                   AllOf(HasThrust(10 * Kilo(Newton)),
                         HasSpecificImpulse(2 * Second * StandardGravity),
                         HasInitialTime(Instant() + 3 * Second),
                         HasΔv(Velocity<Frenet<Navigation>>(
                                   {4 * (Metre / Second),
                                    5 * (Metre / Second),
-                                   6 * (Metre / Second)})))))
+                                   6 * (Metre / Second)}))),
+                  flight_plan.number_of_manœuvres() - 1))
       .WillOnce(Return(base::Status::OK));
   EXPECT_EQ(0,
-            principia__FlightPlanReplaceLast(plugin_.get(),
-                                             vessel_guid,
-                                             interface_burn).error);
+            principia__FlightPlanReplace(plugin_.get(),
+                                         vessel_guid,
+                                         interface_burn,
+                                         flight_plan.number_of_manœuvres() - 1)
+                .error);
 
   EXPECT_CALL(flight_plan, RemoveLast());
   principia__FlightPlanRemoveLast(plugin_.get(), vessel_guid);

--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -385,23 +385,19 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
       .WillOnce(FillUniquePtr<1>(
                     new StrictMock<MockDynamicFrame<Barycentric, Navigation>>));
   auto const manœuvre = NavigationManœuvre(/*initial_mass=*/1 * Kilogram, burn);
-  EXPECT_CALL(flight_plan,
-              Replace(
-                  AllOf(HasThrust(10 * Kilo(Newton)),
-                        HasSpecificImpulse(2 * Second * StandardGravity),
-                        HasInitialTime(Instant() + 3 * Second),
-                        HasΔv(Velocity<Frenet<Navigation>>(
-                                  {4 * (Metre / Second),
-                                   5 * (Metre / Second),
-                                   6 * (Metre / Second)}))),
-                  flight_plan.number_of_manœuvres() - 1))
+  EXPECT_CALL(
+      flight_plan,
+      Replace(
+          AllOf(HasThrust(10 * Kilo(Newton)),
+                HasSpecificImpulse(2 * Second * StandardGravity),
+                HasInitialTime(Instant() + 3 * Second),
+                HasΔv(Velocity<Frenet<Navigation>>({4 * (Metre / Second),
+                                                    5 * (Metre / Second),
+                                                    6 * (Metre / Second)}))),
+          42))
       .WillOnce(Return(base::Status::OK));
-  EXPECT_EQ(0,
-            principia__FlightPlanReplace(plugin_.get(),
-                                         vessel_guid,
-                                         interface_burn,
-                                         flight_plan.number_of_manœuvres() - 1)
-                .error);
+  EXPECT_EQ(0, principia__FlightPlanReplace(
+                   plugin_.get(), vessel_guid, interface_burn, 42).error);
 
   EXPECT_CALL(flight_plan, RemoveLast());
   principia__FlightPlanRemoveLast(plugin_.get(), vessel_guid);

--- a/ksp_plugin_test/mock_flight_plan.hpp
+++ b/ksp_plugin_test/mock_flight_plan.hpp
@@ -18,7 +18,8 @@ class MockFlightPlan : public FlightPlan {
 
   MOCK_METHOD1(Append, Status(NavigationManœuvre::Burn const& burn));
   MOCK_METHOD0(RemoveLast, Status());
-  MOCK_METHOD1(ReplaceLast, Status(NavigationManœuvre::Burn const& burn));
+  MOCK_METHOD2(Replace,
+               Status(NavigationManœuvre::Burn const& burn, int index));
 
   MOCK_METHOD1(SetDesiredFinalTime, Status(Instant const& final_time));
 

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -843,23 +843,6 @@ message FlightPlanReplace {
   optional Return return = 3;
 }
 
-message FlightPlanReplaceLast{
-  extend Method {
-    optional FlightPlanReplaceLast extension = 5066;
-  }
-  message In {
-    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
-                                 (is_subject) = true];
-    required string vessel_guid = 2;
-    required Burn burn = 3;
-  }
-  message Return {
-    required Status result = 1;
-  }
-  optional In in = 1;
-  optional Return return = 3;
-}
-
 message FlightPlanSetAdaptiveStepParameters {
   extend Method {
     optional FlightPlanSetAdaptiveStepParameters extension = 5080;


### PR DESCRIPTION
* Remove `ReplaceLast` everywhere and use `Replace` instead.
* Remove the `enabled` boolean from the UI: all burn editors are always enabled.
* Change the flight planner to handle all burn editors identically.

Fix #1936.