### PR TITLE
A mechanism to override version checking

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -56,6 +56,8 @@ public partial class PrincipiaPluginAdapter
       "principia_gravity_model";
   private const string principia_numerics_blueprint_config_name_ =
       "principia_numerics_blueprint";
+  private const string principia_override_version_check_config_name_ =
+      "principia_override_version_check";
 
   private KSP.UI.Screens.ApplicationLauncherButton toolbar_button_;
   private bool hide_all_gui_ = false;
@@ -205,9 +207,15 @@ public partial class PrincipiaPluginAdapter
       string expected_version =
           "1.7.0, 1.6.1, 1.5.1, 1.4.5, 1.4.4, 1.4.3, 1.4.2, and 1.4.1";
 #endif
-      Log.Fatal("Unexpected KSP version " + Versioning.version_major + "." +
-                Versioning.version_minor + "." + Versioning.Revision +
-                "; this build targets " + expected_version + ".");
+      string message = $@"Unexpected KSP version {Versioning.version_major}.{
+          Versioning.version_minor}.{Versioning.Revision}; this build targets {
+          expected_version}.";
+      if (GameDatabase.Instance.GetAtMostOneNode(
+              principia_override_version_check_config_name_) == null) {
+        Log.Fatal(message);
+      } else {
+        Log.Error(message);
+      }
     }
     map_node_pool_ = new MapNodePool();
     flight_planner_ = new FlightPlanner(this);


### PR DESCRIPTION
##### Example
Without `principia_override_version_check {}`
```
Log file created at: 2019/06/29 12:54:22
Running on machine: BELLINI
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0629 12:54:22.463878 32608 interface.cpp:628] Initialized Google logging for Principia
I0629 12:54:22.464879 32608 interface.cpp:629] Principia version 2019060310-Fatou-27-g9c250e0d609be7ecdea3fd7de47088062ba20e13-dirty built on 2019-06-02T23:08:18Z by Microsoft Visual C++ version 192227724 for Windows x86-64
I0629 12:54:22.464879 32608 interface.cpp:642] Base address is 000007FEC49E0000
I0629 12:54:22.464879 32608 ksp_physics_lib.cpp:18] Principia KSP physics DLL version 2019060310-Fatou-27-g9c250e0d609be7ecdea3fd7de47088062ba20e13-dirty built on 2019-06-02T23:08:18Z by Microsoft Visual C++ version 192227724 for Windows x86-64
I0629 12:54:22.464879 32608 ksp_physics_lib.cpp:30] Base address is 000007FEC9F00000
    @   000007FEC4A66B84        principia__LogFatal [0x000007FEC4A66B83+227] (C:\Users\robin\Projects\Kerbal Space Program\Plugins\Principia\ksp_plugin\interface.cpp:848)
    @   000000001DB66A98        (No symbol) [0x000000001DB66A97]
F0629 12:54:22.466878 32608 ksp_plugin_adapter.cs:218] Unexpected KSP version 1.7.2; this build targets 1.7.0, 1.6.1, 1.5.1, 1.4.5, 1.4.4, 1.4.3, 1.4.2, and 1.4.1.
```
With `principia_override_version_check {}`
```
Log file created at: 2019/06/29 12:57:14
Running on machine: BELLINI
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0629 12:57:14.770107 28424 interface.cpp:628] Initialized Google logging for Principia
I0629 12:57:14.771107 28424 interface.cpp:629] Principia version 2019060310-Fatou-27-g9c250e0d609be7ecdea3fd7de47088062ba20e13-dirty built on 2019-06-02T23:08:18Z by Microsoft Visual C++ version 192227724 for Windows x86-64
I0629 12:57:14.771107 28424 interface.cpp:642] Base address is 000007FEC4CC0000
I0629 12:57:14.771107 28424 ksp_physics_lib.cpp:18] Principia KSP physics DLL version 2019060310-Fatou-27-g9c250e0d609be7ecdea3fd7de47088062ba20e13-dirty built on 2019-06-02T23:08:18Z by Microsoft Visual C++ version 192227724 for Windows x86-64
I0629 12:57:14.771107 28424 ksp_physics_lib.cpp:30] Base address is 000007FEC9F00000
E0629 12:57:14.773108 28424 ksp_plugin_adapter.cs:220] Unexpected KSP version 1.7.2; this build targets 1.7.0, 1.6.1, 1.5.1, 1.4.5, 1.4.4, 1.4.3, 1.4.2, and 1.4.1.
I0629 12:57:14.782109 28424 ksp_plugin_adapter.cs:505] principia.ksp_plugin_adapter.PrincipiaPluginAdapter.OnAwake()
W0629 12:57:14.855116 28424 ksp_plugin_adapter.cs:620] No principia state found, creating one
[...]
```