### PR TITLE
Elements

### DIFF
--- a/astronomy/astronomy.vcxproj
+++ b/astronomy/astronomy.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="ksp_system_test.cpp" />
     <ClCompile Include="geodesy_test.cpp" />
     <ClCompile Include="lunar_orbit_test.cpp" />
+    <ClCompile Include="orbital_elements_test.cpp" />
     <ClCompile Include="orbit_recurrence_test.cpp" />
     <ClCompile Include="solar_system_dynamics_test.cpp" />
     <ClCompile Include="standard_product_3.cpp" />

--- a/astronomy/astronomy.vcxproj
+++ b/astronomy/astronomy.vcxproj
@@ -62,6 +62,8 @@
     <ClInclude Include="date_time.hpp" />
     <ClInclude Include="date_time_body.hpp" />
     <ClInclude Include="fortran_astrodynamics_toolkit.hpp" />
+    <ClInclude Include="orbital_elements.hpp" />
+    <ClInclude Include="orbital_elements_body.hpp" />
     <ClInclude Include="orbit_recurrence.hpp" />
     <ClInclude Include="orbit_recurrence_body.hpp" />
     <ClInclude Include="solar_system_fingerprints.hpp" />

--- a/astronomy/astronomy.vcxproj.filters
+++ b/astronomy/astronomy.vcxproj.filters
@@ -284,5 +284,8 @@
     <ClCompile Include="orbit_recurrence_test.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="orbital_elements_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/astronomy/astronomy.vcxproj.filters
+++ b/astronomy/astronomy.vcxproj.filters
@@ -219,6 +219,12 @@
     <ClInclude Include="orbit_recurrence_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="orbital_elements_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="orbital_elements.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="lunar_eclipse_test.cpp">

--- a/astronomy/frames.hpp
+++ b/astronomy/frames.hpp
@@ -60,7 +60,7 @@ using ICRS = Frame<serialization::Frame::SolarSystemTag,
 //   the BCRS; in particular, the equations of motion in the GCRS include de
 //   Sitter and Lense–Thirring precession.
 // - The time coordinate of the BCRS is TCB, and the time coordinate of the GCRS
-//   is TCG; TT is a linear scaling of TCG, and TDB is a linear scaling of TDB;
+//   is TCG; TT is a linear scaling of TCG, and TDB is a linear scaling of TCB;
 //   for practical purposes TT and TDB are within 2 ms of each other;
 //   Principia's |Instant| is TT.
 using GCRS = Frame<serialization::Frame::SolarSystemTag,

--- a/astronomy/orbit_recurrence.hpp
+++ b/astronomy/orbit_recurrence.hpp
@@ -32,7 +32,7 @@ using quantities::Time;
 // definitions of the day:
 // — for a sun-synchronous orbit (see sections 7.5.4, 7.5.5), this day is the
 //   mean solar day;
-// — for an orbit with no nodal precession (, i.e., a strictly polar orbit, see
+// — for an orbit with no nodal precession (i.e., a strictly polar orbit, see
 //   section 7.1.3), this day is the stellar day.
 // These days are counted negatively for a body with retrograde rotation.
 class OrbitRecurrence final {

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -64,10 +64,11 @@ class OrbitalElements {
   // NOTE(egg): The argument of periapsis ω typically precesses as well.
   // However, long-period variations tend to be comparatively large, so that a
   // precession rate computed over a few orbits would be highly inaccurate.
-  // Further, whereas the actual value of Ω′ is relevant to, e.g., orbit
-  // recurrence computation or sun-synchronicity, one typically cares about ω′
-  // only when requiring that ω′ be 0 (in a frozen orbit), in which case the
-  // more relevant requirement is that ω stays close to some reference value.
+  // More importantly, whereas the actual value of Ω′ is relevant to, e.g.,
+  // orbit recurrence computation or sun-synchronicity, one typically cares
+  // about ω′ only when requiring that ω′ be 0 (in a frozen orbit), in which
+  // case the more relevant requirement is that ω stays close to some reference
+  // value.
 
   // Of the mean classical elements (a, e, i, Ω, ω, M), under the influence of
   // gravitational forces,

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -19,6 +19,7 @@ using physics::DiscreteTrajectory;
 using physics::MassiveBody;
 using quantities::Angle;
 using quantities::AngularFrequency;
+using quantities::Difference;
 using quantities::Infinity;
 using quantities::Length;
 using quantities::Time;
@@ -96,6 +97,9 @@ class OrbitalElements {
   struct Interval {
     T min = +Infinity<T>();
     T max = -Infinity<T>();
+
+    Difference<T> measure() const;
+    T midpoint() const;
 
     // Extends this interval so that it contains x.
     void Include(T const& x);

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -107,11 +107,11 @@ class OrbitalElements {
   };
 
   // REMOVE BEFORE FLIGHT: rename these to mean_meow_range.
-  Interval<Length> mean_semimajor_axis() const;
-  Interval<double> mean_eccentricity() const;
-  Interval<Angle> mean_inclination() const;
-  Interval<Angle> mean_longitude_of_ascending_node() const;
-  Interval<Angle> mean_argument_of_periapsis() const;
+  Interval<Length> mean_semimajor_axis_range() const;
+  Interval<double> mean_eccentricity_range() const;
+  Interval<Angle> mean_inclination_range() const;
+  Interval<Angle> mean_longitude_of_ascending_node_range() const;
+  Interval<Angle> mean_argument_of_periapsis_range() const;
 
   // The equinoctial elements, and in particular the osculating equinoctial
   // elements, are not directly interesting; anything that could be derived from
@@ -179,11 +179,11 @@ class OrbitalElements {
   Time nodal_period_;
   AngularFrequency nodal_precession_;
 
-  Interval<Length> mean_semimajor_axis_;
-  Interval<double> mean_eccentricity_;
-  Interval<Angle> mean_inclination_;
-  Interval<Angle> mean_longitude_of_ascending_node_;
-  Interval<Angle> mean_argument_of_periapsis_;
+  Interval<Length> mean_semimajor_axis_range_;
+  Interval<double> mean_eccentricity_range_;
+  Interval<Angle> mean_inclination_range_;
+  Interval<Angle> mean_longitude_of_ascending_node_range_;
+  Interval<Angle> mean_argument_of_periapsis_range_;
 };
 
 }  // namespace internal_orbital_elements

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include <vector>
+
 #include "base/status_or.hpp"
 #include "geometry/named_quantities.hpp"
 #include "physics/body.hpp"

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -81,16 +81,16 @@ class OrbitalElements {
   //   that case, the frozen value may occasionally be relevant: for CoRoT, it
   //   determines the region of the sky that may be observed.
   // — ω exhibits a secular variation, except for frozen orbits or orbits at the
-  // critical inclination; For frozen
-  //   orbits (type II frozen orbits in the terminology of Ulrich Walter), its
-  //   constant value must be eithre 90° or 270°; for orbits at the critical
-  //   inclination (type I frozen orbits), ω is arbitrary; in highly eccentric
-  //   cases, it is often chosen to be 270° so that the apogee is at high
-  //   latitudes (Молния, みちびき, etc.).
+  //   critical inclination; For frozen orbits (type II frozen orbits in the
+  //   terminology of Ulrich Walter (2018), Astronautics: The Physics of Space
+  //   Flight), its constant value must be either 90° or 270°; for orbits at the
+  //   critical inclination (type I frozen orbits), ω is arbitrary; in highly
+  //   eccentric cases, it is often chosen to be 270° so that the apogee is at
+  //   high latitudes (Молния, みちびき, etc.).
   // — a, e, i exhibit no secular variation.
   // However, the elements that exhibit no secular variation still have
   // long-period variations; instead of trying to characterize these complex
-  // effects, we provide the range of values taken by these elements over the
+  // effects, we provide the interval of values taken by these elements over the
   // trajectory being analysed.
 
   // Represents the interval [min, max].
@@ -101,18 +101,20 @@ class OrbitalElements {
     T min = +Infinity<T>();
     T max = -Infinity<T>();
 
+    // The Lebesgue measure of this interval.
     Difference<T> measure() const;
+    // The midpoint of this interval; NaN if the interval is empty (min > max).
     T midpoint() const;
 
     // Extends this interval so that it contains x.
     void Include(T const& x);
   };
 
-  Interval<Length> mean_semimajor_axis_range() const;
-  Interval<double> mean_eccentricity_range() const;
-  Interval<Angle> mean_inclination_range() const;
-  Interval<Angle> mean_longitude_of_ascending_node_range() const;
-  Interval<Angle> mean_argument_of_periapsis_range() const;
+  Interval<Length> mean_semimajor_axis_interval() const;
+  Interval<double> mean_eccentricity_interval() const;
+  Interval<Angle> mean_inclination_interval() const;
+  Interval<Angle> mean_longitude_of_ascending_node_interval() const;
+  Interval<Angle> mean_argument_of_periapsis_interval() const;
 
   // The equinoctial elements, and in particular the osculating equinoctial
   // elements, are not directly interesting; anything that could be derived from
@@ -125,16 +127,27 @@ class OrbitalElements {
   // The equinoctial elements, together with an epoch.
   // See Broucke and Cefola (1972), On the equinoctial orbit elements.
   struct EquinoctialElements {
+    // The epoch of the elements.
     Instant t;
+    // The semimajor axis.
     Length a;
+    // e sin ϖ, where e is the eccentricity and ϖ = Ω + ω is the longitude of
+    // the periapsis.
     double h;
+    // e cos ϖ.
     double k;
+    // The mean longitude ϖ + M = Ω + ω + M.
     Angle λ;
+    // tg i/2 sin Ω, where i is the inclination and Ω the longitude of the
+    // ascending node.
     double p;
+    // tg i/2 cos Ω.
     double q;
     // pʹ and qʹ use the cotangent of the half-inclination instead of its
     // tangent; they are better suited to retrograde orbits.
+    // cotg i/2 sin Ω.
     double pʹ;
+    // cotg i/2 cos Ω.
     double qʹ;
   };
 
@@ -156,7 +169,8 @@ class OrbitalElements {
       std::vector<EquinoctialElements> const& equinoctial_elements);
 
   // |osculating| must contain at least 2 elements.
-  // The resulting elements are averaged over one period, centred on t.
+  // The resulting elements are averaged over one period, centred on
+  // their |EquinoctialElements::t|.
   static std::vector<EquinoctialElements> MeanEquinoctialElements(
       std::vector<EquinoctialElements> const& osculating,
       Time const& period);
@@ -170,7 +184,9 @@ class OrbitalElements {
   // element computation is based on it, so it gets computed earlier).
   void ComputePeriodsAndPrecession();
 
-  void ComputeMeanElementRanges();
+  // |mean_classical_elements_| must have been computed; sets
+  // |mean_*_interval_| accordingly.
+  void ComputeMeanElementIntervals();
 
   std::vector<EquinoctialElements> osculating_equinoctial_elements_;
   Time sidereal_period_;
@@ -180,11 +196,11 @@ class OrbitalElements {
   Time nodal_period_;
   AngularFrequency nodal_precession_;
 
-  Interval<Length> mean_semimajor_axis_range_;
-  Interval<double> mean_eccentricity_range_;
-  Interval<Angle> mean_inclination_range_;
-  Interval<Angle> mean_longitude_of_ascending_node_range_;
-  Interval<Angle> mean_argument_of_periapsis_range_;
+  Interval<Length> mean_semimajor_axis_interval_;
+  Interval<double> mean_eccentricity_interval_;
+  Interval<Angle> mean_inclination_interval_;
+  Interval<Angle> mean_longitude_of_ascending_node_interval_;
+  Interval<Angle> mean_argument_of_periapsis_interval_;
 };
 
 }  // namespace internal_orbital_elements

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -25,6 +25,12 @@ using quantities::Time;
 
 class OrbitalElements {
  public:
+  template<typename PrimaryCentred>
+  static StatusOr<OrbitalElements> ForTrajectory(
+      DiscreteTrajectory<PrimaryCentred> const& trajectory,
+      MassiveBody const& primary,
+      Body const& secondary);
+
   // The classical Keplerian elements (a, e, i, Ω, ω, M),
   // together with an epoch.
   struct ClassicalElements {
@@ -37,11 +43,9 @@ class OrbitalElements {
     Angle mean_anomaly;
   };
 
-  template<typename PrimaryCentred>
-  static StatusOr<OrbitalElements> ForTrajectory(
-      DiscreteTrajectory<PrimaryCentred> const& trajectory,
-      MassiveBody const& primary,
-      Body const& secondary);
+  // Mean element time series.  These elements are free of short-period
+  // variations, i.e., variations whose period is the orbital period.
+  std::vector<ClassicalElements> const& mean_elements() const;
 
   // The period of the (osculating) mean longitude λ = Ω + ω + M.
   // Note that since our mean elements are filtered by integration over this
@@ -63,10 +67,6 @@ class OrbitalElements {
   // recurrence computation or sun-synchronicity, one typically cares about ω′
   // only when requiring that ω′ be 0 (in a frozen orbit), in which case the
   // more relevant requirement is that ω stays close to some reference value.
-
-  // Mean element time series.  These elements are free of short-period
-  // variations, i.e., variations whose period is the orbital period.
-  std::vector<ClassicalElements> const& mean_elements() const;
 
   // Of the mean classical elements (a, e, i, Ω, ω, M), under the influence of
   // gravitational forces,

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -106,7 +106,6 @@ class OrbitalElements {
     void Include(T const& x);
   };
 
-  // REMOVE BEFORE FLIGHT: rename these to mean_meow_range.
   Interval<Length> mean_semimajor_axis_range() const;
   Interval<double> mean_eccentricity_range() const;
   Interval<Angle> mean_inclination_range() const;

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -1,0 +1,190 @@
+﻿#pragma once
+
+#include "base/status_or.hpp"
+#include "geometry/named_quantities.hpp"
+#include "physics/body.hpp"
+#include "physics/discrete_trajectory.hpp"
+#include "physics/massive_body.hpp"
+#include "quantities/named_quantities.hpp"
+#include "quantities/quantities.hpp"
+
+namespace principia {
+namespace astronomy {
+namespace internal_orbital_elements {
+
+using base::StatusOr;
+using geometry::Instant;
+using physics::Body;
+using physics::DiscreteTrajectory;
+using physics::MassiveBody;
+using quantities::Angle;
+using quantities::AngularFrequency;
+using quantities::Infinity;
+using quantities::Length;
+using quantities::Time;
+
+class OrbitalElements {
+ public:
+  // The classical Keplerian elements (a, e, i, Ω, ω, M),
+  // together with an epoch.
+  struct ClassicalElements {
+    Instant time;
+    Length semimajor_axis;
+    double eccentricity;
+    Angle inclination;
+    Angle longitude_of_ascending_node;
+    Angle argument_of_periapsis;
+    Angle mean_anomaly;
+  };
+
+  template<typename PrimaryCentred>
+  static StatusOr<OrbitalElements> ForTrajectory(
+      DiscreteTrajectory<PrimaryCentred> const& trajectory,
+      MassiveBody const& primary,
+      Body const& secondary);
+
+  // The period of the (osculating) mean longitude λ = Ω + ω + M.
+  // Note that since our mean elements are filtered by integration over this
+  // period, it does not make much sense to recompute it based on our mean
+  // elements.
+  Time sidereal_period() const;
+  // The period of the (mean) mean argument of latitude u = ω + M.
+  Time nodal_period() const;
+  // The period of the (mean) mean anomaly M.
+  Time anomalistic_period() const;
+
+  // The rate of precession of Ω.
+  AngularFrequency nodal_precession() const;
+
+  // NOTE(egg): The argument of periapsis ω typically precesses as well.
+  // However, long-period variations tend to be comparatively large, so that a
+  // precession rate computed over a few orbits would be highly inaccurate.
+  // Further, whereas the actual value of Ω′ is relevant to, e.g., orbit
+  // recurrence computation or sun-synchronicity, one typically cares about ω′
+  // only when requiring that ω′ be 0 (in a frozen orbit), in which case the
+  // more relevant requirement is that ω stays close to some reference value.
+
+  // Mean element time series.  These elements are free of short-period
+  // variations, i.e., variations whose period is the orbital period.
+  std::vector<ClassicalElements> const& mean_elements() const;
+
+  // Of the mean classical elements (a, e, i, Ω, ω, M), under the influence of
+  // gravitational forces,
+  // — M always exhibits a fast secular variation (anomalistic mean motion);
+  // — Ω often exhibits a secular variation (nodal precession); there are
+  //   however rare cases where it is kept constant (so-called inertial orbits
+  //   that achieve Ω′ = 0 by being polar, e.g., CoRoT or Gravity Probe B); in
+  //   that case, the frozen value may occasionally be relevant: for CoRoT, it
+  //   determines the region of the sky that may be observed.
+  // — ω exhibits a secular variation, except for frozen orbits or orbits at the
+  // critical inclination; For frozen
+  //   orbits (type II frozen orbits in the terminology of Ulrich Walter), its
+  //   constant value must be eithre 90° or 270°; for orbits at the critical
+  //   inclination (type I frozen orbits), ω is arbitrary; in highly eccentric
+  //   cases, it is often chosen to be 270° so that the apogee is at high
+  //   latitudes (Молния, みちびき, etc.).
+  // — a, e, i exhibit no secular variation.
+  // However, the elements that exhibit no secular variation still have
+  // long-period variations; instead of trying to characterize these complex
+  // effects, we provide the range of values taken by these elements over the
+  // trajectory being analysed.
+
+  // Represents the interval [min, max].
+  // TODO(egg): This makes sense for T = instant, but InfinitePast and
+  // InfiniteFuture work differently from Infinity.
+  template<typename T>
+  struct Interval {
+    T min = +Infinity<T>();
+    T max = -Infinity<T>();
+
+    // Extends this interval so that it contains x.
+    void Include(T const& x);
+  };
+
+  Interval<Length> mean_semimajor_axis() const;
+  Interval<double> mean_eccentricity() const;
+  Interval<Angle> mean_inclination() const;
+  Interval<Angle> mean_longitude_of_ascending_node() const;
+  Interval<Angle> mean_argument_of_periapsis() const;
+
+  // The equinoctial elements, and in particular the osculating equinoctial
+  // elements, are not directly interesting; anything that could be derived from
+  // them should be directly computed by this class instead.  They are however
+  // useful for experimentation in Mathematica, to see whether the
+  // transformation from osculating to mean elements is well-behaved, whether
+  // the mean elements are stable, and what useful quantities can be derived
+  // from the mean elements.
+
+  // The equinoctial elements, together with an epoch.
+  // See Broucke and Cefola (1972), On the equinoctial orbit elements.
+  struct EquinoctialElements {
+    Instant t;
+    Length a;
+    double h;
+    double k;
+    Angle λ;
+    double p;
+    double q;
+    // pʹ and qʹ use the cotangent of the half-inclination instead of its
+    // tangent; they are better suited to retrograde orbits.
+    double pʹ;
+    double qʹ;
+  };
+
+  std::vector<EquinoctialElements> const& osculating_equinoctial_elements()
+      const;
+  std::vector<EquinoctialElements> const& mean_equinoctial_elements() const;
+
+ private:
+  OrbitalElements() = default;
+
+  template<typename PrimaryCentred>
+  static std::vector<EquinoctialElements> OsculatingEquinoctialElements(
+      DiscreteTrajectory<PrimaryCentred> const& trajectory,
+      MassiveBody const& primary,
+      Body const& secondary);
+
+  // |equinoctial_elements| must contain at least 2 elements.
+  static Time SiderealPeriod(
+      std::vector<EquinoctialElements> const& equinoctial_elements);
+
+  // |osculating| must contain at least 2 elements.
+  // The resulting elements are averaged over one period, centred on t.
+  static std::vector<EquinoctialElements> MeanEquinoctialElements(
+      std::vector<EquinoctialElements> const& osculating,
+      Time const& period);
+
+  static std::vector<ClassicalElements> ToClassicalElements(
+      std::vector<EquinoctialElements> const& equinoctial_elements);
+
+  // |mean_classical_elements_| must have been computed; sets
+  // |anomalistic_period_|, |nodal_period_|, and |nodal_precession_|
+  // accordingly. Note that this does not compute |sidereal_period_| (our mean
+  // element computation is based on it, so it gets computed earlier).
+  void ComputePeriodsAndPrecession();
+
+  void ComputeMeanElementRanges();
+
+  std::vector<EquinoctialElements> osculating_equinoctial_elements_;
+  Time sidereal_period_;
+  std::vector<EquinoctialElements> mean_equinoctial_elements_;
+  std::vector<ClassicalElements> mean_classical_elements_;
+  Time anomalistic_period_;
+  Time nodal_period_;
+  AngularFrequency nodal_precession_;
+
+  Interval<Length> mean_semimajor_axis_;
+  Interval<double> mean_eccentricity_;
+  Interval<Angle> mean_inclination_;
+  Interval<Angle> mean_longitude_of_ascending_node_;
+  Interval<Angle> mean_argument_of_periapsis_;
+};
+
+}  // namespace internal_orbital_elements
+
+using internal_orbital_elements::OrbitalElements;
+
+}  // namespace astronomy
+}  // namespace principia
+
+#include "astronomy/orbital_elements_body.hpp"

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -106,6 +106,7 @@ class OrbitalElements {
     void Include(T const& x);
   };
 
+  // REMOVE BEFORE FLIGHT: rename these to mean_meow_range.
   Interval<Length> mean_semimajor_axis() const;
   Interval<double> mean_eccentricity() const;
   Interval<Angle> mean_inclination() const;

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -127,28 +127,17 @@ class OrbitalElements {
   // The equinoctial elements, together with an epoch.
   // See Broucke and Cefola (1972), On the equinoctial orbit elements.
   struct EquinoctialElements {
-    // The epoch of the elements.
-    Instant t;
-    // The semimajor axis.
-    Length a;
-    // e sin ϖ, where e is the eccentricity and ϖ = Ω + ω is the longitude of
-    // the periapsis.
-    double h;
-    // e cos ϖ.
-    double k;
-    // The mean longitude ϖ + M = Ω + ω + M.
-    Angle λ;
-    // tg i/2 sin Ω, where i is the inclination and Ω the longitude of the
-    // ascending node.
-    double p;
-    // tg i/2 cos Ω.
-    double q;
+    Instant t;  // The epoch of the elements.
+    Length a;   // The semimajor axis.
+    double h;   // e sin ϖ = e sin (Ω + ω).
+    double k;   // e cos ϖ = e cos (Ω + ω).
+    Angle λ;    // The mean longitude ϖ + M = Ω + ω + M.
+    double p;   // tg i/2 sin Ω.
+    double q;   // tg i/2 cos Ω.
     // pʹ and qʹ use the cotangent of the half-inclination instead of its
     // tangent; they are better suited to retrograde orbits.
-    // cotg i/2 sin Ω.
-    double pʹ;
-    // cotg i/2 cos Ω.
-    double qʹ;
+    double pʹ;  // cotg i/2 sin Ω.
+    double qʹ;  // cotg i/2 cos Ω.
   };
 
   std::vector<EquinoctialElements> const& osculating_equinoctial_elements()

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -342,20 +342,22 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
   auto const Δt³ = Pow<3>(Δt);
   // We compute the mean rate (slope) of the mean anomaly M(t), the mean
   // argument of latitude u(t), and the longitude of the ascending node Ω(t).
-  // On an interval [-Δt/2, Δt/2], the slope of э is computed as
-  //   ∫ э(t) t dt / ∫ t² dt;
+  // On an interval [t̄ - Δt/2, t̄ + Δt/2], the slope of э is computed as
+  //   ∫ (э(t) - э̄) (t - t̄) dt / ∫ (t - t̄)² dt;
   // this is the continuous analogue of a simple linear regression.
-  // With ∫ t² dt = Δt³ / 12, this simplifies to
-  //   12 ∫ э(t) t dt / Δt³.
-  // We first compute ∫ э(t) t dt for the three elements of interest.
+  // With ∫ (t - t̄)² dt = Δt³ / 12, and
+  //   ∫ э̄ (t - t̄) = э̄ ∫ (t - t̄) dt = 0,
+  // this simplifies to
+  //   12 ∫ э(t) (t - t̄) dt / Δt³.
+  // We first compute ∫ э(t) (t - t̄) dt for the three elements of interest.
 
   Product<Angle, Square<Time>> ſ_Mt_dt;
   Product<Angle, Square<Time>> ſ_ut_dt;
   Product<Angle, Square<Time>> ſ_Ωt_dt;
 
-  Instant const t0 = mean_classical_elements_.front().time + Δt / 2;
+  Instant const t̄ = mean_classical_elements_.front().time + Δt / 2;
   auto const first = mean_classical_elements_.begin();
-  Time first_t = first->time - t0;
+  Time first_t = first->time - t̄;
   Product<Angle, Time> previous_Mt = first->mean_anomaly * first_t;
   Product<Angle, Time> previous_ut =
       (first->argument_of_periapsis + first->mean_anomaly) * first_t;
@@ -367,7 +369,7 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
     Angle const u = it->argument_of_periapsis + it->mean_anomaly;
     Angle const& M = it->mean_anomaly;
     Angle const& Ω = it->longitude_of_ascending_node;
-    Time const t = it->time - t0;
+    Time const t = it->time - t̄;
     auto const Mt = M * t;
     auto const ut = u * t;
     auto const Ωt = Ω * t;

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -80,6 +80,11 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
   return result;
 }
 
+inline std::vector<OrbitalElements::ClassicalElements> const&
+OrbitalElements::mean_elements() const {
+  return mean_classical_elements_;
+}
+
 inline Time OrbitalElements::sidereal_period() const {
   return sidereal_period_;
 }
@@ -94,11 +99,6 @@ inline Time OrbitalElements::anomalistic_period() const {
 
 inline AngularFrequency OrbitalElements::nodal_precession() const {
   return nodal_precession_;
-}
-
-inline std::vector<OrbitalElements::ClassicalElements> const&
-OrbitalElements::mean_elements() const {
-  return mean_classical_elements_;
 }
 
 inline OrbitalElements::Interval<Length>

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -12,6 +12,7 @@ using base::Error;
 using base::Status;
 using quantities::ArcTan;
 using quantities::Cos;
+using quantities::NaN;
 using quantities::Pow;
 using quantities::Product;
 using quantities::Sin;
@@ -41,6 +42,16 @@ inline std::vector<Angle> Unwind(std::vector<Angle> const& angles) {
     unwound_angles.push_back(UnwindFrom(unwound_angles.back(), angles[i]));
   }
   return unwound_angles;
+}
+
+template<typename T>
+Difference<T> OrbitalElements::Interval<T>::measure() const {
+  return max >= min ? max - min : Difference<T>{};
+}
+
+template<typename T>
+T OrbitalElements::Interval<T>::midpoint() const {
+  return max >= min ? min + measure() / 2 : NaN<T>();
 }
 
 template<typename T>
@@ -158,7 +169,6 @@ OrbitalElements::OsculatingEquinoctialElements(
          /*.pʹ = */ cotg_½i * Sin(Ω),
          /*.qʹ = */ cotg_½i * Cos(Ω)});
   }
-  LOG(ERROR) << result.size();
   return result;
 }
 

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -24,7 +24,8 @@ using quantities::Square;
 using quantities::Tan;
 using quantities::si::Radian;
 
-// Returns the element of {α + 2nπ | n ∈ ℤ} which is closest to |previous_angle|.
+// Returns the element of {α + 2nπ | n ∈ ℤ} which is closest to
+// |previous_angle|.
 inline Angle UnwindFrom(Angle const& previous_angle, Angle const& α) {
   return α + std::nearbyint((previous_angle - α) / (2 * π * Radian)) * 2 * π *
                  Radian;
@@ -60,13 +61,15 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
       OsculatingEquinoctialElements(trajectory, primary, secondary);
   orbital_elements.sidereal_period_ =
       SiderealPeriod(orbital_elements.osculating_equinoctial_elements_);
-  orbital_elements.mean_equinoctial_elements_ = MeanEquinoctialElements(
-      orbital_elements.osculating_equinoctial_elements_, orbital_elements.sidereal_period_);
+  orbital_elements.mean_equinoctial_elements_ =
+      MeanEquinoctialElements(orbital_elements.osculating_equinoctial_elements_,
+                              orbital_elements.sidereal_period_);
   if (orbital_elements.mean_equinoctial_elements_.size() < 2) {
     return Status(
         Error::OUT_OF_RANGE,
         "trajectory does not span one sidereal period: sidereal period is " +
-            DebugString(orbital_elements.sidereal_period_) + ", trajectory spans " +
+            DebugString(orbital_elements.sidereal_period_) +
+            ", trajectory spans " +
             DebugString(trajectory.last().time() - trajectory.Begin().time()));
   }
   orbital_elements.mean_classical_elements_ =

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -113,26 +113,26 @@ inline AngularFrequency OrbitalElements::nodal_precession() const {
 }
 
 inline OrbitalElements::Interval<Length>
-OrbitalElements::mean_semimajor_axis() const {
-  return mean_semimajor_axis_;
+OrbitalElements::mean_semimajor_axis_range() const {
+  return mean_semimajor_axis_range_;
 }
 
-inline OrbitalElements::Interval<double> OrbitalElements::mean_eccentricity() const {
-  return mean_eccentricity_;
+inline OrbitalElements::Interval<double> OrbitalElements::mean_eccentricity_range() const {
+  return mean_eccentricity_range_;
 }
 
-inline OrbitalElements::Interval<Angle> OrbitalElements::mean_inclination() const {
-  return mean_inclination_;
-}
-
-inline OrbitalElements::Interval<Angle>
-OrbitalElements::mean_longitude_of_ascending_node() const {
-  return mean_longitude_of_ascending_node_;
+inline OrbitalElements::Interval<Angle> OrbitalElements::mean_inclination_range() const {
+  return mean_inclination_range_;
 }
 
 inline OrbitalElements::Interval<Angle>
-OrbitalElements::mean_argument_of_periapsis() const {
-  return mean_argument_of_periapsis_;
+OrbitalElements::mean_longitude_of_ascending_node_range() const {
+  return mean_longitude_of_ascending_node_range_;
+}
+
+inline OrbitalElements::Interval<Angle>
+OrbitalElements::mean_argument_of_periapsis_range() const {
+  return mean_argument_of_periapsis_range_;
 }
 
 template<typename PrimaryCentred>
@@ -352,12 +352,12 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
 
 inline void OrbitalElements::ComputeMeanElementRanges() {
   for (auto const& elements : mean_classical_elements_) {
-    mean_semimajor_axis_.Include(elements.semimajor_axis);
-    mean_eccentricity_.Include(elements.eccentricity);
-    mean_inclination_.Include(elements.inclination);
-    mean_longitude_of_ascending_node_.Include(
+    mean_semimajor_axis_range_.Include(elements.semimajor_axis);
+    mean_eccentricity_range_.Include(elements.eccentricity);
+    mean_inclination_range_.Include(elements.inclination);
+    mean_longitude_of_ascending_node_range_.Include(
         elements.longitude_of_ascending_node);
-    mean_argument_of_periapsis_.Include(elements.argument_of_periapsis);
+    mean_argument_of_periapsis_range_.Include(elements.argument_of_periapsis);
   }
 }
 

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -172,6 +172,16 @@ OrbitalElements::OsculatingEquinoctialElements(
   return result;
 }
 
+inline std::vector<OrbitalElements::EquinoctialElements> const&
+OrbitalElements::osculating_equinoctial_elements() const {
+  return osculating_equinoctial_elements_;
+}
+
+inline std::vector<OrbitalElements::EquinoctialElements> const&
+OrbitalElements::mean_equinoctial_elements() const {
+  return mean_equinoctial_elements_;
+}
+
 inline Time OrbitalElements::SiderealPeriod(
     std::vector<EquinoctialElements> const& equinoctial_elements) {
   Time const Δt =

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -27,23 +27,6 @@ inline Angle UnwindFrom(Angle const& previous_angle, Angle const& α) {
                  Radian;
 }
 
-// |angles| should be sampled from a slowly-varying continuous function
-// f: ℝ →  𝑆¹ = ℝ / 2π ℝ (specifically, consecutive angles should  differ by
-// less than π).  Returns the corresponding sampling of the continuous g: ℝ → ℝ
-// such that f = g mod 2π and f(0) = g(0).
-inline std::vector<Angle> Unwind(std::vector<Angle> const& angles) {
-  if (angles.empty()) {
-    return angles;
-  }
-  std::vector<Angle> unwound_angles;
-  unwound_angles.reserve(angles.size());
-  unwound_angles.push_back(angles.front());
-  for (int i = 1; i < angles.size(); ++i) {
-    unwound_angles.push_back(UnwindFrom(unwound_angles.back(), angles[i]));
-  }
-  return unwound_angles;
-}
-
 template<typename T>
 Difference<T> OrbitalElements::Interval<T>::measure() const {
   return max >= min ? max - min : Difference<T>{};
@@ -117,11 +100,13 @@ OrbitalElements::mean_semimajor_axis_range() const {
   return mean_semimajor_axis_range_;
 }
 
-inline OrbitalElements::Interval<double> OrbitalElements::mean_eccentricity_range() const {
+inline OrbitalElements::Interval<double>
+OrbitalElements::mean_eccentricity_range() const {
   return mean_eccentricity_range_;
 }
 
-inline OrbitalElements::Interval<Angle> OrbitalElements::mean_inclination_range() const {
+inline OrbitalElements::Interval<Angle>
+OrbitalElements::mean_inclination_range() const {
   return mean_inclination_range_;
 }
 

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -345,8 +345,7 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
   // On an interval [t̄ - Δt/2, t̄ + Δt/2], the slope of э is computed as
   //   ∫ (э(t) - э̄) (t - t̄) dt / ∫ (t - t̄)² dt;
   // this is the continuous analogue of a simple linear regression.
-  // With ∫ (t - t̄)² dt = Δt³ / 12, and
-  //   ∫ э̄ (t - t̄) = э̄ ∫ (t - t̄) dt = 0,
+  // With ∫ (t - t̄)² dt = Δt³ / 12 and ∫ э̄ (t - t̄) = э̄ ∫ (t - t̄) dt = 0,
   // this simplifies to
   //   12 ∫ э(t) (t - t̄) dt / Δt³.
   // We first compute ∫ э(t) (t - t̄) dt for the three elements of interest.

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -2,6 +2,9 @@
 
 #include "astronomy/orbital_elements.hpp"
 
+#include <algorithm>
+#include <vector>
+
 #include "quantities/elementary_functions.hpp"
 
 namespace principia {

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -177,7 +177,7 @@ inline Time OrbitalElements::SiderealPeriod(
   Time const Δt =
       equinoctial_elements.back().t - equinoctial_elements.front().t;
   Instant const t0 = equinoctial_elements.front().t + Δt / 2;
-  Product<Angle, Square<Time>> ſ_λt_dt;
+  Product<Angle, Square<Time>> ʃ_λt_dt;
 
   auto const first = equinoctial_elements.begin();
   Time const first_t = first->t - t0;
@@ -188,10 +188,10 @@ inline Time OrbitalElements::SiderealPeriod(
     Time const t = it->t - t0;
     auto const λt = it->λ * t;
     Time const dt = it->t - previous->t;
-    ſ_λt_dt += (λt + previous_λt) / 2 * dt;
+    ʃ_λt_dt += (λt + previous_λt) / 2 * dt;
     previous_λt = λt;
   }
-  return 2 * π * Radian * Pow<3>(Δt) / (12 * ſ_λt_dt);
+  return 2 * π * Radian * Pow<3>(Δt) / (12 * ʃ_λt_dt);
 }
 
 inline std::vector<OrbitalElements::EquinoctialElements>
@@ -220,14 +220,14 @@ OrbitalElements::MeanEquinoctialElements(
   struct IntegratedEquinoctialElements {
     Instant t_max;
     // The integrals are from t_min to t_max.
-    Product<Length, Time> ſ_a_dt;
-    Time ſ_h_dt;
-    Time ſ_k_dt;
-    Product<Angle, Time> ſ_λ_dt;
-    Time ſ_p_dt;
-    Time ſ_q_dt;
-    Time ſ_pʹ_dt;
-    Time ſ_qʹ_dt;
+    Product<Length, Time> ʃ_a_dt;
+    Time ʃ_h_dt;
+    Time ʃ_k_dt;
+    Product<Angle, Time> ʃ_λ_dt;
+    Time ʃ_p_dt;
+    Time ʃ_q_dt;
+    Time ʃ_pʹ_dt;
+    Time ʃ_qʹ_dt;
   };
   std::vector<IntegratedEquinoctialElements> integrals;
   integrals.push_back({t_min});
@@ -237,14 +237,14 @@ OrbitalElements::MeanEquinoctialElements(
     integrals.push_back(integrals.back());
     integrals.back().t_max = it->t;
     Time const dt = it->t - previous->t;
-    integrals.back().ſ_a_dt += (it->a + previous->a) / 2 * dt;
-    integrals.back().ſ_h_dt += (it->h + previous->h) / 2 * dt;
-    integrals.back().ſ_k_dt += (it->k + previous->k) / 2 * dt;
-    integrals.back().ſ_λ_dt += (it->λ + previous->λ) / 2 * dt;
-    integrals.back().ſ_p_dt += (it->p + previous->p) / 2 * dt;
-    integrals.back().ſ_q_dt += (it->q + previous->q) / 2 * dt;
-    integrals.back().ſ_pʹ_dt += (it->pʹ + previous->pʹ) / 2 * dt;
-    integrals.back().ſ_qʹ_dt += (it->qʹ + previous->qʹ) / 2 * dt;
+    integrals.back().ʃ_a_dt += (it->a + previous->a) / 2 * dt;
+    integrals.back().ʃ_h_dt += (it->h + previous->h) / 2 * dt;
+    integrals.back().ʃ_k_dt += (it->k + previous->k) / 2 * dt;
+    integrals.back().ʃ_λ_dt += (it->λ + previous->λ) / 2 * dt;
+    integrals.back().ʃ_p_dt += (it->p + previous->p) / 2 * dt;
+    integrals.back().ʃ_q_dt += (it->q + previous->q) / 2 * dt;
+    integrals.back().ʃ_pʹ_dt += (it->pʹ + previous->pʹ) / 2 * dt;
+    integrals.back().ʃ_qʹ_dt += (it->qʹ + previous->qʹ) / 2 * dt;
   }
 
   // Now compute the averages.
@@ -265,7 +265,7 @@ OrbitalElements::MeanEquinoctialElements(
     auto const& up_to_tⱼ₋₁ = integrals[j - 1];
     // |element| should be a pointer to a member of |EquinoctialElements|;
     // Integrates that element on [tⱼ₋₁, tᵢ + period].
-    auto ſ = [j, &period, &tᵢ, &tⱼ, &tⱼ₋₁, &osculating](auto element) {
+    auto ʃ = [j, &period, &tᵢ, &tⱼ, &tⱼ₋₁, &osculating](auto element) {
       auto const& next_osculating = osculating[j];
       Time const Δt = tⱼ - tⱼ₋₁;
       Time const dt = tᵢ + period - tⱼ₋₁;
@@ -277,28 +277,28 @@ OrbitalElements::MeanEquinoctialElements(
     mean_elements.emplace_back();
     mean_elements.back().t = tᵢ + period / 2;
     mean_elements.back().a =
-        (up_to_tⱼ₋₁.ſ_a_dt - up_to_tᵢ.ſ_a_dt + ſ(&EquinoctialElements::a)) /
+        (up_to_tⱼ₋₁.ʃ_a_dt - up_to_tᵢ.ʃ_a_dt + ʃ(&EquinoctialElements::a)) /
         period;
     mean_elements.back().h =
-        (up_to_tⱼ₋₁.ſ_h_dt - up_to_tᵢ.ſ_h_dt + ſ(&EquinoctialElements::h)) /
+        (up_to_tⱼ₋₁.ʃ_h_dt - up_to_tᵢ.ʃ_h_dt + ʃ(&EquinoctialElements::h)) /
         period;
     mean_elements.back().k =
-        (up_to_tⱼ₋₁.ſ_k_dt - up_to_tᵢ.ſ_k_dt + ſ(&EquinoctialElements::k)) /
+        (up_to_tⱼ₋₁.ʃ_k_dt - up_to_tᵢ.ʃ_k_dt + ʃ(&EquinoctialElements::k)) /
         period;
     mean_elements.back().λ =
-        (up_to_tⱼ₋₁.ſ_λ_dt - up_to_tᵢ.ſ_λ_dt + ſ(&EquinoctialElements::λ)) /
+        (up_to_tⱼ₋₁.ʃ_λ_dt - up_to_tᵢ.ʃ_λ_dt + ʃ(&EquinoctialElements::λ)) /
         period;
     mean_elements.back().p =
-        (up_to_tⱼ₋₁.ſ_p_dt - up_to_tᵢ.ſ_p_dt + ſ(&EquinoctialElements::p)) /
+        (up_to_tⱼ₋₁.ʃ_p_dt - up_to_tᵢ.ʃ_p_dt + ʃ(&EquinoctialElements::p)) /
         period;
     mean_elements.back().q =
-        (up_to_tⱼ₋₁.ſ_q_dt - up_to_tᵢ.ſ_q_dt + ſ(&EquinoctialElements::q)) /
+        (up_to_tⱼ₋₁.ʃ_q_dt - up_to_tᵢ.ʃ_q_dt + ʃ(&EquinoctialElements::q)) /
         period;
     mean_elements.back().pʹ =
-        (up_to_tⱼ₋₁.ſ_pʹ_dt - up_to_tᵢ.ſ_pʹ_dt + ſ(&EquinoctialElements::pʹ)) /
+        (up_to_tⱼ₋₁.ʃ_pʹ_dt - up_to_tᵢ.ʃ_pʹ_dt + ʃ(&EquinoctialElements::pʹ)) /
         period;
     mean_elements.back().qʹ =
-        (up_to_tⱼ₋₁.ſ_qʹ_dt - up_to_tᵢ.ſ_qʹ_dt + ſ(&EquinoctialElements::qʹ)) /
+        (up_to_tⱼ₋₁.ʃ_qʹ_dt - up_to_tᵢ.ʃ_qʹ_dt + ʃ(&EquinoctialElements::qʹ)) /
         period;
   }
   return mean_elements;
@@ -353,9 +353,9 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
   //   12 ∫ э(t) (t - t̄) dt / Δt³.
   // We first compute ∫ э(t) (t - t̄) dt for the three elements of interest.
 
-  Product<Angle, Square<Time>> ſ_Mt_dt;
-  Product<Angle, Square<Time>> ſ_ut_dt;
-  Product<Angle, Square<Time>> ſ_Ωt_dt;
+  Product<Angle, Square<Time>> ʃ_Mt_dt;
+  Product<Angle, Square<Time>> ʃ_ut_dt;
+  Product<Angle, Square<Time>> ʃ_Ωt_dt;
 
   Instant const t̄ = mean_classical_elements_.front().time + Δt / 2;
   auto const first = mean_classical_elements_.begin();
@@ -376,9 +376,9 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
     auto const ut = u * t;
     auto const Ωt = Ω * t;
     Time const dt = it->time - previous->time;
-    ſ_Mt_dt += (Mt + previous_Mt) / 2 * dt;
-    ſ_ut_dt += (ut + previous_ut) / 2 * dt;
-    ſ_Ωt_dt += (Ωt + previous_Ωt) / 2 * dt;
+    ʃ_Mt_dt += (Mt + previous_Mt) / 2 * dt;
+    ʃ_ut_dt += (ut + previous_ut) / 2 * dt;
+    ʃ_Ωt_dt += (Ωt + previous_Ωt) / 2 * dt;
     previous_Mt = Mt;
     previous_ut = ut;
     previous_Ωt = Ωt;
@@ -387,9 +387,9 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
   // The periods are 2π over the mean rate of the relevant element; the nodal
   // precession is the mean rate of Ω.
 
-  anomalistic_period_ = 2 * π * Radian * Δt³ / (12 * ſ_Mt_dt);
-  nodal_period_ = 2 * π * Radian * Δt³ / (12 * ſ_ut_dt);
-  nodal_precession_ = 12 * ſ_Ωt_dt / Δt³;
+  anomalistic_period_ = 2 * π * Radian * Δt³ / (12 * ʃ_Mt_dt);
+  nodal_period_ = 2 * π * Radian * Δt³ / (12 * ʃ_ut_dt);
+  nodal_precession_ = 12 * ʃ_Ωt_dt / Δt³;
 }
 
 inline void OrbitalElements::ComputeMeanElementIntervals() {

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -387,11 +387,11 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
   // the tesseral terms of the geopotential) as the very low inclination means
   // that these elements are singular.
   // The other elements are stable.
-  // A closer analysis would show that the longitude of periapsis exhibits a
-  // precession that is largely free of oscillations, and that, if its
-  // oscillations are filtered, the argument of periapsis precesses as expected;
-  // the longitude of the ascending node exhibits no obvious precession even if
-  // its daily oscillation is filtered out.
+  // A closer analysis would show that the longitude of periapsis ϖ = Ω + ω
+  // exhibits a precession that is largely free of oscillations, and that, if
+  // its oscillations are filtered, the argument of periapsis ω precesses as
+  // expected; the longitude of the ascending node Ω exhibits no obvious
+  // precession even if its daily oscillation is filtered out.
   EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
               IsNear(20 * Metre));
   EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(9.2e-5));

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -1,5 +1,9 @@
 ﻿#include "orbital_elements.hpp"
 
+#include <limits>
+#include <string>
+#include <vector>
+
 #include "astronomy/frames.hpp"
 #include "base/file.hpp"
 #include "base/not_null.hpp"

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -136,7 +136,8 @@ class OrbitalElementsTest : public ::testing::Test {
 
   // Completes |initial_osculating_elements| and returns a GCRS trajectory
   // obtained by flowing the corresponding initial conditions in |ephemeris|.
-  static not_null<std::unique_ptr<DiscreteTrajectory<GCRS>>> EarthCentredTrajectory(
+  static not_null<std::unique_ptr<DiscreteTrajectory<GCRS>>>
+  EarthCentredTrajectory(
       KeplerianElements<GCRS>& initial_osculating_elements,
       Instant const& initial_time,
       Instant const& final_time,
@@ -240,13 +241,14 @@ TEST_F(OrbitalElementsTest, KeplerOrbit) {
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
                             elements.mean_inclination_range().midpoint()),
               IsNear(0.56 * Micro(ArcSecond)));
+  EXPECT_THAT(AbsoluteError(
+                  initial_osculating.longitude_of_ascending_node,
+                  elements.mean_longitude_of_ascending_node_range().midpoint()),
+              IsNear(54 * ArcSecond));
   EXPECT_THAT(
-      AbsoluteError(initial_osculating.longitude_of_ascending_node,
-                    elements.mean_longitude_of_ascending_node_range().midpoint()),
-      IsNear(54 * ArcSecond));
-  EXPECT_THAT(AbsoluteError(*initial_osculating.argument_of_periapsis,
-                            elements.mean_argument_of_periapsis_range().midpoint()),
-              IsNear(61 * ArcSecond));
+      AbsoluteError(*initial_osculating.argument_of_periapsis,
+                    elements.mean_argument_of_periapsis_range().midpoint()),
+      IsNear(61 * ArcSecond));
 
   // Mean element stability.
   EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
@@ -390,9 +392,11 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
   // oscillations are filtered, the argument of periapsis precesses as expected;
   // the longitude of the ascending node exhibits no obvious precession even if
   // its daily oscillation is filtered out.
-  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(), IsNear(20 * Metre));
+  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
+              IsNear(20 * Metre));
   EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(9.2e-5));
-  EXPECT_THAT(elements.mean_inclination_range().measure(), IsNear(11 * ArcSecond));
+  EXPECT_THAT(elements.mean_inclination_range().measure(),
+              IsNear(11 * ArcSecond));
   EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
               IsNear(140 * Degree));
   EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -1,0 +1,206 @@
+﻿#include "orbital_elements.hpp"
+
+#include "astronomy/frames.hpp"
+#include "base/not_null.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "physics/body_centred_non_rotating_dynamic_frame.hpp"
+#include "physics/ephemeris.hpp"
+#include "physics/kepler_orbit.hpp"
+#include "physics/solar_system.hpp"
+#include "testing_utilities/matchers.hpp"
+#include "testing_utilities/numerics.hpp"
+#include "testing_utilities/almost_equals.hpp"
+#include "testing_utilities/is_near.hpp"
+
+namespace principia {
+namespace astronomy {
+
+using base::make_not_null_unique;
+using base::not_null;
+using geometry::Instant;
+using geometry::Position;
+using geometry::Velocity;
+using integrators::EmbeddedExplicitRungeKuttaNyströmIntegrator;
+using integrators::SymmetricLinearMultistepIntegrator;
+using integrators::methods::DormandالمكاوىPrince1986RKN434FM;
+using integrators::methods::QuinlanTremaine1990Order12;
+using physics::BodyCentredNonRotatingDynamicFrame;
+using physics::DegreesOfFreedom;
+using physics::DiscreteTrajectory;
+using physics::Ephemeris;
+using physics::KeplerianElements;
+using physics::KeplerOrbit;
+using physics::MassiveBody;
+using physics::MasslessBody;
+using physics::RotatingBody;
+using physics::SolarSystem;
+using quantities::astronomy::JulianYear;
+using quantities::si::Day;
+using quantities::si::Degree;
+using quantities::si::Kilo;
+using quantities::si::Metre;
+using quantities::si::Milli;
+using quantities::si::Minute;
+using quantities::si::Second;
+using testing_utilities::AlmostEquals;
+using testing_utilities::IsNear;
+using testing_utilities::IsOk;
+
+class OrbitalElementsTest : public ::testing::Test {
+ protected:
+  OrbitalElementsTest()
+      : solar_system_(
+            SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+            SOLUTION_DIR / "astronomy" /
+                "sol_initial_state_jd_2451545_000000000.proto.txt"),
+        real_ephemeris_(solar_system_.MakeEphemeris(
+            /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                     /*geopotential_tolerance=*/0x1p-24},
+            Ephemeris<ICRS>::FixedStepParameters(
+                SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
+                                                   Position<ICRS>>(),
+                /*step=*/10 * Minute))),
+        real_earth_(*solar_system_.massive_body(*real_ephemeris_, "Earth")),
+        oblate_earth_ephemeris_([this] {
+          std::vector<std::string> const names = solar_system_.names();
+          for (auto const& name : names) {
+            if (name != "Earth") {
+              solar_system_.RemoveMassiveBody(name);
+            }
+          }
+          solar_system_.LimitOblatenessToDegree("Earth", 2);
+          solar_system_.LimitOblatenessToZonal("Earth");
+          return solar_system_.MakeEphemeris(
+              /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                       /*geopotential_tolerance=*/0x1p-24},
+              Ephemeris<ICRS>::FixedStepParameters(
+                  SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
+                                                     Position<ICRS>>(),
+                  /*step=*/1 * JulianYear));
+        }()),
+        oblate_earth_(
+            *solar_system_.massive_body(*oblate_earth_ephemeris_, "Earth")),
+        spherical_earth_ephemeris_([this] {
+          solar_system_.LimitOblatenessToDegree("Earth", 0);
+          return solar_system_.MakeEphemeris(
+              /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                                       /*geopotential_tolerance=*/0x1p-24},
+              Ephemeris<ICRS>::FixedStepParameters(
+                  SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
+                                                     Position<ICRS>>(),
+                  /*step=*/1 * JulianYear));
+        }()),
+        spherical_earth_(
+            *solar_system_.massive_body(*spherical_earth_ephemeris_, "Earth")) {
+  }
+
+  // Completes |initial_osculating_elements| and returns a GCRS trajectory
+  // obtained by flowing the corresponding initial conditions in |ephemeris|.
+  static not_null<std::unique_ptr<DiscreteTrajectory<GCRS>>> EarthCentredTrajectory(
+      KeplerianElements<GCRS>& initial_osculating_elements,
+      Instant const& initial_time,
+      Instant const& final_time,
+      Ephemeris<ICRS>& ephemeris) {
+    MassiveBody const& earth = [&ephemeris]() -> MassiveBody const& {
+      for (not_null<MassiveBody const*> const body : ephemeris.bodies()) {
+        if (body->name() == "Earth") {
+          return *body;
+        }
+      }
+      LOG(FATAL) << "Ephemeris has no Earth";
+    }();
+    ephemeris.Prolong(final_time);
+    BodyCentredNonRotatingDynamicFrame<ICRS, GCRS> gcrs{&ephemeris, &earth};
+    DiscreteTrajectory<ICRS> icrs_trajectory;
+    KeplerOrbit<GCRS> initial_osculating_orbit{earth,
+                                               MasslessBody{},
+                                               initial_osculating_elements,
+                                               initial_time};
+    initial_osculating_elements = initial_osculating_orbit.elements_at_epoch();
+    icrs_trajectory.Append(
+        initial_time,
+        gcrs.FromThisFrameAtTime(initial_time)(
+            DegreesOfFreedom<GCRS>{GCRS::origin, Velocity<GCRS>{}} +
+            initial_osculating_orbit.StateVectors(initial_time)));
+    ephemeris.FlowWithAdaptiveStep(
+        &icrs_trajectory,
+        Ephemeris<ICRS>::NoIntrinsicAcceleration,
+        final_time,
+        Ephemeris<ICRS>::AdaptiveStepParameters{
+            EmbeddedExplicitRungeKuttaNyströmIntegrator<
+                DormandالمكاوىPrince1986RKN434FM,
+                Position<ICRS>>(),
+            /*max_steps=*/std::numeric_limits<std::int16_t>::max(),
+            /*length_integration_tolerance=*/1 * Milli(Metre),
+            /*speed_integration_tolerance=*/1 * Milli(Metre) / Second
+        },
+        /*max_ephemeris_steps=*/std::numeric_limits<std::int16_t>::max(),
+        /*last_point_only=*/false);
+    auto result = make_not_null_unique<DiscreteTrajectory<GCRS>>();
+    for (auto it = icrs_trajectory.Begin(); it != icrs_trajectory.End(); ++it) {
+      result->Append(
+          it.time(),
+          gcrs.ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+    }
+    return result;
+  }
+
+  SolarSystem<ICRS> solar_system_;
+
+  // The solar system.
+  not_null<std::unique_ptr<Ephemeris<ICRS>>> real_ephemeris_;
+  MassiveBody const& real_earth_;
+
+  // An oblate Earth with no other bodies.
+  not_null<std::unique_ptr<Ephemeris<ICRS>>> oblate_earth_ephemeris_;
+  MassiveBody const& oblate_earth_;
+
+  // A spherical Earth with no other bodies.
+  not_null<std::unique_ptr<Ephemeris<ICRS>>> spherical_earth_ephemeris_;
+  MassiveBody const& spherical_earth_;
+};
+
+
+TEST_F(OrbitalElementsTest, CircularEquatorialKeplerOrbit) {
+  KeplerianElements<GCRS> initial_osculating;
+  initial_osculating.semimajor_axis = 7000 * Kilo(Metre);
+  initial_osculating.eccentricity = 1e-9;
+  initial_osculating.inclination = 1.0 / (60 * 60) * Degree;
+  initial_osculating.longitude_of_ascending_node = 10 * Degree;
+  initial_osculating.argument_of_periapsis = 20 * Degree;
+  initial_osculating.mean_anomaly = 30 * Degree;
+  auto const status_or_elements = OrbitalElements::ForTrajectory(
+      *EarthCentredTrajectory(initial_osculating,
+                              J2000,
+                              J2000 + 10 * Day,
+                              *spherical_earth_ephemeris_),
+      spherical_earth_,
+      MasslessBody{});
+  ASSERT_THAT(status_or_elements, IsOk());
+  OrbitalElements const& elements = status_or_elements.ValueOrDie();
+  EXPECT_THAT(elements.anomalistic_period(),
+              AlmostEquals(*initial_osculating.period, 0));
+  EXPECT_THAT(elements.nodal_period(),
+              AlmostEquals(*initial_osculating.period, 0));
+  EXPECT_THAT(elements.sidereal_period(),
+              AlmostEquals(*initial_osculating.period, 0));
+
+  EXPECT_THAT(elements.nodal_precession(),
+              AlmostEquals(0 * Degree / Second, 0));
+
+  EXPECT_THAT(elements.mean_semimajor_axis().min,
+              AlmostEquals(*initial_osculating.semimajor_axis, 0));
+  EXPECT_THAT(elements.mean_eccentricity().min,
+              AlmostEquals(*initial_osculating.eccentricity, 0));
+  EXPECT_THAT(elements.mean_inclination().min,
+              AlmostEquals(initial_osculating.inclination, 0));
+
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node().min,
+              AlmostEquals(initial_osculating.longitude_of_ascending_node, 0));
+  EXPECT_THAT(elements.mean_argument_of_periapsis().min,
+              AlmostEquals(initial_osculating.longitude_of_ascending_node, 0));
+}
+
+}  // namespace astronomy
+}  // namespace principia

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -232,31 +232,31 @@ TEST_F(OrbitalElementsTest, KeplerOrbit) {
 
   // Mean element values.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis().midpoint()),
+                            elements.mean_semimajor_axis_range().midpoint()),
               IsNear(100 * Micro(Metre)));
   EXPECT_THAT(AbsoluteError(*initial_osculating.eccentricity,
-                            elements.mean_eccentricity().midpoint()),
+                            elements.mean_eccentricity_range().midpoint()),
               IsNear(1.5e-11));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination().midpoint()),
+                            elements.mean_inclination_range().midpoint()),
               IsNear(0.56 * Micro(ArcSecond)));
   EXPECT_THAT(
       AbsoluteError(initial_osculating.longitude_of_ascending_node,
-                    elements.mean_longitude_of_ascending_node().midpoint()),
+                    elements.mean_longitude_of_ascending_node_range().midpoint()),
       IsNear(54 * ArcSecond));
   EXPECT_THAT(AbsoluteError(*initial_osculating.argument_of_periapsis,
-                            elements.mean_argument_of_periapsis().midpoint()),
+                            elements.mean_argument_of_periapsis_range().midpoint()),
               IsNear(61 * ArcSecond));
 
   // Mean element stability.
-  EXPECT_THAT(elements.mean_semimajor_axis().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
               IsNear(1.0 * Milli(Metre)));
-  EXPECT_THAT(elements.mean_eccentricity().measure(), IsNear(1.0e-10));
-  EXPECT_THAT(elements.mean_inclination().measure(),
+  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(1.0e-10));
+  EXPECT_THAT(elements.mean_inclination_range().measure(),
               IsNear(0.61 * Micro(ArcSecond)));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node().measure(),
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
               IsNear(1.9 * ArcMinute));
-  EXPECT_THAT(elements.mean_argument_of_periapsis().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
               IsNear(2.2 * ArcMinute));
 
   OFStream f(SOLUTION_DIR / "mathematica" /
@@ -295,9 +295,9 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
 
   // The notation for the computation of the theoretical precessions follows
   // Capderou (2012), Satellites : de Kepler au GPS, section 7.1.1.
-  double const η = elements.mean_semimajor_axis().midpoint() /
+  double const η = elements.mean_semimajor_axis_range().midpoint() /
                    oblate_earth_.reference_radius();
-  Angle const i = elements.mean_inclination().midpoint();
+  Angle const i = elements.mean_inclination_range().midpoint();
   AngularFrequency const K0 = 3.0 / 2.0 * oblate_earth_.j2() *
                               Sqrt(oblate_earth_.gravitational_parameter() /
                                    Pow<3>(oblate_earth_.reference_radius())) *
@@ -316,23 +316,23 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
   // Mean element values.  Since Ω and ω precess rapidly, the midpoint of the
   // range of values is of no interest.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis().midpoint()),
+                            elements.mean_semimajor_axis_range().midpoint()),
               IsNear(25 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity().midpoint(), IsNear(0.0013));
+  EXPECT_THAT(elements.mean_eccentricity_range().midpoint(), IsNear(0.0013));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination().midpoint()),
+                            elements.mean_inclination_range().midpoint()),
               IsNear(1.9 * Micro(ArcSecond)));
 
   // Mean element stability: Ω and ω precess as expected, the other elements are
   // stable.
-  EXPECT_THAT(elements.mean_semimajor_axis().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
               IsNear(70 * Milli(Metre)));
-  EXPECT_THAT(elements.mean_eccentricity().measure(), IsNear(3.7e-9));
-  EXPECT_THAT(elements.mean_inclination().measure(),
+  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(3.7e-9));
+  EXPECT_THAT(elements.mean_inclination_range().measure(),
               IsNear(1.1 * Micro(ArcSecond)));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node().measure(),
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
               IsNear(-theoretical_Ωʹ * mission_duration));
-  EXPECT_THAT(elements.mean_argument_of_periapsis().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
               IsNear(theoretical_ωʹ * mission_duration));
 
   OFStream f(SOLUTION_DIR / "mathematica" /
@@ -374,11 +374,11 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
 
   // Mean element values.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis().midpoint()),
+                            elements.mean_semimajor_axis_range().midpoint()),
               IsNear(100 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity().midpoint(), IsNear(0.0014));
+  EXPECT_THAT(elements.mean_eccentricity_range().midpoint(), IsNear(0.0014));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination().midpoint()),
+                            elements.mean_inclination_range().midpoint()),
               IsNear(6.0 * ArcSecond));
 
   // Mean element stability: Ω and ω exhibit a daily oscillation (likely due to
@@ -390,12 +390,12 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
   // oscillations are filtered, the argument of periapsis precesses as expected;
   // the longitude of the ascending node exhibits no obvious precession even if
   // its daily oscillation is filtered out.
-  EXPECT_THAT(elements.mean_semimajor_axis().measure(), IsNear(20 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity().measure(), IsNear(9.2e-5));
-  EXPECT_THAT(elements.mean_inclination().measure(), IsNear(11 * ArcSecond));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(), IsNear(20 * Metre));
+  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(9.2e-5));
+  EXPECT_THAT(elements.mean_inclination_range().measure(), IsNear(11 * ArcSecond));
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
               IsNear(140 * Degree));
-  EXPECT_THAT(elements.mean_argument_of_periapsis().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
               IsNear(150 * Degree));
 
   OFStream f(SOLUTION_DIR / "mathematica" /

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -349,6 +349,8 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
                            elements.mean_equinoctial_elements());
 }
 
+#if NDEBUG
+
 TEST_F(OrbitalElementsTest, RealPerturbation) {
   Time const mission_duration = 10 * Day;
 
@@ -413,6 +415,8 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
   f << mathematica::Assign("fullyPerturbedMean",
                            elements.mean_equinoctial_elements());
 }
+
+#endif
 
 }  // namespace astronomy
 }  // namespace principia

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -237,32 +237,33 @@ TEST_F(OrbitalElementsTest, KeplerOrbit) {
 
   // Mean element values.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis_range().midpoint()),
+                            elements.mean_semimajor_axis_interval().midpoint()),
               IsNear(100 * Micro(Metre)));
   EXPECT_THAT(AbsoluteError(*initial_osculating.eccentricity,
-                            elements.mean_eccentricity_range().midpoint()),
+                            elements.mean_eccentricity_interval().midpoint()),
               IsNear(1.5e-11));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination_range().midpoint()),
+                            elements.mean_inclination_interval().midpoint()),
               IsNear(0.56 * Micro(ArcSecond)));
-  EXPECT_THAT(AbsoluteError(
-                  initial_osculating.longitude_of_ascending_node,
-                  elements.mean_longitude_of_ascending_node_range().midpoint()),
-              IsNear(54 * ArcSecond));
+  EXPECT_THAT(
+      AbsoluteError(
+          initial_osculating.longitude_of_ascending_node,
+          elements.mean_longitude_of_ascending_node_interval().midpoint()),
+      IsNear(54 * ArcSecond));
   EXPECT_THAT(
       AbsoluteError(*initial_osculating.argument_of_periapsis,
-                    elements.mean_argument_of_periapsis_range().midpoint()),
+                    elements.mean_argument_of_periapsis_interval().midpoint()),
       IsNear(61 * ArcSecond));
 
   // Mean element stability.
-  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               IsNear(1.0 * Milli(Metre)));
-  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(1.0e-10));
-  EXPECT_THAT(elements.mean_inclination_range().measure(),
+  EXPECT_THAT(elements.mean_eccentricity_interval().measure(), IsNear(1.0e-10));
+  EXPECT_THAT(elements.mean_inclination_interval().measure(),
               IsNear(0.61 * Micro(ArcSecond)));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_interval().measure(),
               IsNear(1.9 * ArcMinute));
-  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
               IsNear(2.2 * ArcMinute));
 
   OFStream f(SOLUTION_DIR / "mathematica" /
@@ -301,9 +302,9 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
 
   // The notation for the computation of the theoretical precessions follows
   // Capderou (2012), Satellites : de Kepler au GPS, section 7.1.1.
-  double const η = elements.mean_semimajor_axis_range().midpoint() /
+  double const η = elements.mean_semimajor_axis_interval().midpoint() /
                    oblate_earth_.reference_radius();
-  Angle const i = elements.mean_inclination_range().midpoint();
+  Angle const i = elements.mean_inclination_interval().midpoint();
   AngularFrequency const K0 = 3.0 / 2.0 * oblate_earth_.j2() *
                               Sqrt(oblate_earth_.gravitational_parameter() /
                                    Pow<3>(oblate_earth_.reference_radius())) *
@@ -322,23 +323,23 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
   // Mean element values.  Since Ω and ω precess rapidly, the midpoint of the
   // range of values is of no interest.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis_range().midpoint()),
+                            elements.mean_semimajor_axis_interval().midpoint()),
               IsNear(25 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity_range().midpoint(), IsNear(0.0013));
+  EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(), IsNear(0.0013));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination_range().midpoint()),
+                            elements.mean_inclination_interval().midpoint()),
               IsNear(1.9 * Micro(ArcSecond)));
 
   // Mean element stability: Ω and ω precess as expected, the other elements are
   // stable.
-  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               IsNear(70 * Milli(Metre)));
-  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(3.7e-9));
-  EXPECT_THAT(elements.mean_inclination_range().measure(),
+  EXPECT_THAT(elements.mean_eccentricity_interval().measure(), IsNear(3.7e-9));
+  EXPECT_THAT(elements.mean_inclination_interval().measure(),
               IsNear(1.1 * Micro(ArcSecond)));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_interval().measure(),
               IsNear(-theoretical_Ωʹ * mission_duration));
-  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
               IsNear(theoretical_ωʹ * mission_duration));
 
   OFStream f(SOLUTION_DIR / "mathematica" /
@@ -382,11 +383,11 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
 
   // Mean element values.
   EXPECT_THAT(AbsoluteError(*initial_osculating.semimajor_axis,
-                            elements.mean_semimajor_axis_range().midpoint()),
+                            elements.mean_semimajor_axis_interval().midpoint()),
               IsNear(100 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity_range().midpoint(), IsNear(0.0014));
+  EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(), IsNear(0.0014));
   EXPECT_THAT(AbsoluteError(initial_osculating.inclination,
-                            elements.mean_inclination_range().midpoint()),
+                            elements.mean_inclination_interval().midpoint()),
               IsNear(6.0 * ArcSecond));
 
   // Mean element stability: Ω and ω exhibit a daily oscillation (likely due to
@@ -398,14 +399,14 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
   // its oscillations are filtered, the argument of periapsis ω precesses as
   // expected; the longitude of the ascending node Ω exhibits no obvious
   // precession even if its daily oscillation is filtered out.
-  EXPECT_THAT(elements.mean_semimajor_axis_range().measure(),
+  EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               IsNear(20 * Metre));
-  EXPECT_THAT(elements.mean_eccentricity_range().measure(), IsNear(9.2e-5));
-  EXPECT_THAT(elements.mean_inclination_range().measure(),
+  EXPECT_THAT(elements.mean_eccentricity_interval().measure(), IsNear(9.2e-5));
+  EXPECT_THAT(elements.mean_inclination_interval().measure(),
               IsNear(11 * ArcSecond));
-  EXPECT_THAT(elements.mean_longitude_of_ascending_node_range().measure(),
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_interval().measure(),
               IsNear(140 * Degree));
-  EXPECT_THAT(elements.mean_argument_of_periapsis_range().measure(),
+  EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
               IsNear(150 * Degree));
 
   OFStream f(SOLUTION_DIR / "mathematica" /

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -169,11 +169,11 @@ class OrbitalElementsTest : public ::testing::Test {
             EmbeddedExplicitRungeKuttaNyströmIntegrator<
                 DormandالمكاوىPrince1986RKN434FM,
                 Position<ICRS>>(),
-            /*max_steps=*/std::numeric_limits<std::int16_t>::max(),
+            /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
             /*length_integration_tolerance=*/1 * Milli(Metre),
             /*speed_integration_tolerance=*/1 * Milli(Metre) / Second
         },
-        /*max_ephemeris_steps=*/std::numeric_limits<std::int16_t>::max(),
+        /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max(),
         /*last_point_only=*/false);
     auto result = make_not_null_unique<DiscreteTrajectory<GCRS>>();
     for (auto it = icrs_trajectory.Begin(); it != icrs_trajectory.End(); ++it) {

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -19,13 +19,19 @@ namespace principia {
 
 namespace mathematica {
 namespace internal_mathematica {
+
+using astronomy::J2000;
+using quantities::si::Metre;
+using quantities::si::Radian;
+using quantities::si::Second;
+
 std::string ToMathematica(
     astronomy::OrbitalElements::EquinoctialElements const& elements) {
-  return ToMathematica(std::make_tuple(elements.t,
-                                       elements.a,
+  return ToMathematica(std::make_tuple((elements.t - J2000) / Second,
+                                       elements.a / Metre,
                                        elements.h,
                                        elements.k,
-                                       elements.λ,
+                                       elements.λ / Radian,
                                        elements.p,
                                        elements.q,
                                        elements.pʹ,
@@ -175,6 +181,7 @@ class OrbitalElementsTest : public ::testing::Test {
           it.time(),
           gcrs.ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
     }
+    LOG(ERROR) << (result->last().time() - result->Begin().time()) / Day;
     return result;
   }
 
@@ -320,7 +327,7 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
   EXPECT_THAT(elements.mean_argument_of_periapsis().measure(),
               IsNear(theoretical_ωʹ * mission_duration));
 
-  OFStream f(SOLUTION_DIR / "mathematica" / "j2_perturbed_elements");
+  OFStream f(SOLUTION_DIR / "mathematica" / "j2_perturbed_elements.generated.wl");
   f << mathematica::Assign("j2PerturbedOsculating",
                            elements.osculating_equinoctial_elements());
   f << mathematica::Assign("j2PerturbedMean",

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -149,7 +149,6 @@ class OrbitalElementsTest : public ::testing::Test {
   }
 };
 
-
 TEST_F(OrbitalElementsTest, KeplerOrbit) {
   // The satellite is under the influence of an isotropic Earth and no third
   // bodies.
@@ -357,7 +356,6 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
                                              Position<ICRS>>(),
           /*step=*/10 * Minute));
   MassiveBody const& earth = *solar_system.massive_body(*ephemeris, "Earth");
-
 
   Time const mission_duration = 10 * Day;
 

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -350,7 +350,7 @@ TEST_F(OrbitalElementsTest, J2Perturbation) {
                            elements.mean_equinoctial_elements());
 }
 
-#if NDEBUG
+#if !defined(_DEBUG)
 
 TEST_F(OrbitalElementsTest, RealPerturbation) {
   Time const mission_duration = 10 * Day;

--- a/physics/kepler_orbit.hpp
+++ b/physics/kepler_orbit.hpp
@@ -89,7 +89,11 @@ std::ostream& operator<<(std::ostream& out,
 
 template<typename Frame>
 class KeplerOrbit final {
-  static_assert(Frame::is_inertial, "Frame must be inertial");
+  // TODO(egg): This class used to require:
+  //   static_assert(Frame::is_inertial, "Frame must be inertial");
+  // However, it only requires a non-rotating frame; for instance, it is often
+  // used with a body-centred non-rotating frame.  Perhaps we should have a
+  // concept of non-rotating frame.
 
  public:
   // Exactly one of the |optional|s must be filled in the given


### PR DESCRIPTION
Mean element computation.

Tests covering more diverse orbits—including, notably, retrograde orbits, which go through a different code path, computing the mean inclination from the average of (cotg i/2 cos Ω, cotg i/2 sin Ω) instead of (tg i/2 cos Ω, tg i/2 sin Ω)—will come in a subsequent pull request; these will be based on SP3 files, and their addition would make this one unwieldy.