### PR TITLE
Move-only is better than incorrectly-copied

### DIFF
--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -1334,7 +1334,7 @@ TEST_F(TrappistDynamicsTest, DISABLED_Optimization) {
                           &gravity_model_message,
                           &preoptimization_initial_state_message](
                              genetics::Genome const& genome,
-                               std::string& info) {
+                             std::string& info) {
     SolarSystem<Sky> modified_system(gravity_model_message,
                                      preoptimization_initial_state_message);
     auto const& elements = genome.elements();

--- a/physics/solar_system.hpp
+++ b/physics/solar_system.hpp
@@ -42,8 +42,11 @@ class SolarSystem final {
               serialization::InitialState const& initial_state,
               bool ignore_frame = false);
 
-  SolarSystem(SolarSystem const& other);
-  SolarSystem& operator=(const SolarSystem& other);
+  SolarSystem(SolarSystem const& other) = delete;
+  SolarSystem& operator=(const SolarSystem& other) = delete;
+
+  SolarSystem(SolarSystem&& other) = default;
+  SolarSystem& operator=(SolarSystem&& other) = default;
 
   // Constructs an ephemeris for this object using the specified parameters.
   // The bodies and initial state are constructed from the data passed to

--- a/physics/solar_system.hpp
+++ b/physics/solar_system.hpp
@@ -28,6 +28,11 @@ using geometry::Instant;
 using quantities::GravitationalParameter;
 using quantities::Length;
 
+serialization::GravityModel ParseGravityModel(
+    std::filesystem::path const& gravity_model_filename);
+serialization::InitialState ParseInitialState(
+    std::filesystem::path const& initial_state_filename);
+
 template<typename Frame>
 class SolarSystem final {
  public:
@@ -168,6 +173,8 @@ class SolarSystem final {
 
 }  // namespace internal_solar_system
 
+using internal_solar_system::ParseGravityModel;
+using internal_solar_system::ParseInitialState;
 using internal_solar_system::SolarSystem;
 
 }  // namespace physics

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -169,27 +169,6 @@ SolarSystem<Frame>::SolarSystem(
 }
 
 template<typename Frame>
-SolarSystem<Frame>::SolarSystem(SolarSystem const& other)
-    : SolarSystem(other.gravity_model_,
-                  other.initial_state_,
-                  /*ignore_frame=*/true) {}
-
-template<typename Frame>
-SolarSystem<Frame>& SolarSystem<Frame>::operator=(const SolarSystem& other) {
-  if (&other == this) {
-    return *this;
-  }
-  SolarSystem copy(other);  // NOLINT(build/include_what_you_use)
-  gravity_model_.Swap(copy.gravity_model_);
-  initial_state_.Swap(copy.initial_state_);
-  epoch_ = copy.epoch_;
-  names_.swap(copy.names_);
-  gravity_model_map_.swap(copy.gravity_model_map_);
-  cartesian_initial_state_map_.swap(copy.cartesian_initial_state_map_);
-  keplerian_initial_state_map_.swap(copy.keplerian_initial_state_map_);
-}
-
-template<typename Frame>
 not_null<std::unique_ptr<Ephemeris<Frame>>> SolarSystem<Frame>::MakeEphemeris(
     typename Ephemeris<Frame>::AccuracyParameters const& accuracy_parameters,
     typename Ephemeris<Frame>::FixedStepParameters const& fixed_step_parameters)


### PR DESCRIPTION
Copying a `SolarSystem` would discard the effect of `RemoveMassiveBody` and the like.