### PR TITLE
A benchmark for ComputeApsides and ComputeNodes

### DIFF
--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -1,14 +1,18 @@
 ﻿
+// .\Release\x64\benchmarks.exe --benchmark_repetitions=3 --benchmark_filter=Apsides --benchmark_min_time=30  // NOLINT(whitespace/line_length)
+
 #include "astronomy/epoch.hpp"
 #include "astronomy/frames.hpp"
 #include "astronomy/standard_product_3.hpp"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
+#include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/methods.hpp"
 #include "integrators/symmetric_linear_multistep_integrator.hpp"
 #include "physics/apsides.hpp"
+#include "physics/body_centred_non_rotating_dynamic_frame.hpp"
 #include "physics/body_surface_dynamic_frame.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/solar_system.hpp"
@@ -17,6 +21,7 @@
 
 namespace principia {
 
+using astronomy::GCRS;
 using astronomy::ICRS;
 using astronomy::InfiniteFuture;
 using astronomy::ITRS;
@@ -24,6 +29,7 @@ using astronomy::StandardProduct3;
 using base::dynamic_cast_not_null;
 using base::not_null;
 using geometry::Position;
+using geometry::Vector;
 using integrators::EmbeddedExplicitRungeKuttaNyströmIntegrator;
 using integrators::methods::DormandالمكاوىPrince1986RKN434FM;
 using integrators::methods::QuinlanTremaine1990Order12;
@@ -54,7 +60,6 @@ class ApsidesBenchmark : public benchmark::Fixture {
       earth_ = dynamic_cast_not_null<OblateBody<ICRS> const*>(
           solar_system_2010_->massive_body(*ephemeris_, "Earth"));
       earth_trajectory_ = ephemeris_->trajectory(earth_);
-      BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_.get(), earth_);
 
       StandardProduct3 const ilrsa_lageos2_sp3(
           SOLUTION_DIR / "astronomy" / "standard_product_3" /
@@ -67,11 +72,13 @@ class ApsidesBenchmark : public benchmark::Fixture {
           ilrsa_lageos2_sp3.orbit(lageos2_id).front();
       auto const begin = ilrsa_lageos2_trajectory_itrs->Begin();
       ephemeris_->Prolong(begin.time());
-      ilrsa_lageos2_trajectory_.Append(
+
+      BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_.get(), earth_);
+      ilrsa_lageos2_trajectory_icrs_.Append(
           begin.time(),
           itrs.FromThisFrameAtTime(begin.time())(begin.degrees_of_freedom()));
       ephemeris_->FlowWithAdaptiveStep(
-          &ilrsa_lageos2_trajectory_,
+          &ilrsa_lageos2_trajectory_icrs_,
           Ephemeris<ICRS>::NoIntrinsicAcceleration,
           begin.time() + 1 * JulianYear,
           Ephemeris<ICRS>::AdaptiveStepParameters(
@@ -84,6 +91,16 @@ class ApsidesBenchmark : public benchmark::Fixture {
           /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max(),
           /*last_point_only=*/false);
 
+      BodyCentredNonRotatingDynamicFrame<ICRS, GCRS> const gcrs(
+          ephemeris_.get(), earth_);
+      for (auto it = ilrsa_lageos2_trajectory_icrs_.Begin();
+           it != ilrsa_lageos2_trajectory_icrs_.End();
+           ++it) {
+        ilrsa_lageos2_trajectory_gcrs_.Append(
+            it.time(),
+            gcrs.ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+      }
+
       setup_done_ = true;
     }
   }
@@ -93,7 +110,8 @@ class ApsidesBenchmark : public benchmark::Fixture {
   std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
   OblateBody<ICRS> const* earth_;
   ContinuousTrajectory<ICRS> const* earth_trajectory_;
-  DiscreteTrajectory<ICRS> ilrsa_lageos2_trajectory_;
+  DiscreteTrajectory<ICRS> ilrsa_lageos2_trajectory_icrs_;
+  DiscreteTrajectory<GCRS> ilrsa_lageos2_trajectory_gcrs_;
 };
 
 BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
@@ -101,22 +119,26 @@ BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
     DiscreteTrajectory<ICRS> apoapsides;
     DiscreteTrajectory<ICRS> periapsides;
     ComputeApsides(*earth_trajectory_,
-                   ilrsa_lageos2_trajectory_.Begin(),
-                   ilrsa_lageos2_trajectory_.End(),
+                   ilrsa_lageos2_trajectory_icrs_.Begin(),
+                   ilrsa_lageos2_trajectory_icrs_.End(),
                    apoapsides,
                    periapsides);
+    CHECK_EQ(2364, apoapsides.Size());
+    CHECK_EQ(2365, periapsides.Size());
   }
 }
 
 BENCHMARK_F(ApsidesBenchmark, ComputeNodes)(benchmark::State& state) {
   for (auto _ : state) {
-    DiscreteTrajectory<ICRS> ascending;
-    DiscreteTrajectory<ICRS> descending;
-    ComputeNodes(ilrsa_lageos2_trajectory_.Begin(),
-                 ilrsa_lageos2_trajectory_.End(),
-                 earth_->polar_axis(),
+    DiscreteTrajectory<GCRS> ascending;
+    DiscreteTrajectory<GCRS> descending;
+    ComputeNodes(ilrsa_lageos2_trajectory_gcrs_.Begin(),
+                 ilrsa_lageos2_trajectory_gcrs_.End(),
+                 Vector<double, GCRS>({0, 0, 1}),
                  ascending,
                  descending);
+    CHECK_EQ(2365, ascending.Size());
+    CHECK_EQ(2365, descending.Size());
   }
 }
 

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -1,6 +1,8 @@
 ﻿
 // .\Release\x64\benchmarks.exe --benchmark_repetitions=3 --benchmark_filter=Apsides --benchmark_min_time=30  // NOLINT(whitespace/line_length)
 
+#include <limits>
+
 #include "astronomy/epoch.hpp"
 #include "astronomy/frames.hpp"
 #include "astronomy/standard_product_3.hpp"
@@ -107,7 +109,10 @@ class ApsidesBenchmark : public benchmark::Fixture {
   }
 
   void SetUp(benchmark::State&) override {
-    static int const set_up_fixture = [](){ SetUpFixture(); return 0; }();
+    static int const set_up_fixture = []() {
+      SetUpFixture();
+      return 0;
+    }();
   }
 
   static SolarSystem<ICRS>* solar_system_2010_;

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -108,5 +108,17 @@ BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
   }
 }
 
+BENCHMARK_F(ApsidesBenchmark, ComputeNodes)(benchmark::State& state) {
+  for (auto _ : state) {
+    DiscreteTrajectory<ICRS> ascending;
+    DiscreteTrajectory<ICRS> descending;
+    ComputeNodes(ilrsa_lageos2_trajectory_.Begin(),
+                 ilrsa_lageos2_trajectory_.End(),
+                 earth_->polar_axis(),
+                 ascending,
+                 descending);
+  }
+}
+
 }  // namespace physics
 }  // namespace principia

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -1,0 +1,89 @@
+
+#include "astronomy/frames.hpp"
+#include "astronomy/standard_product_3.hpp"
+#include "base/not_null.hpp"
+#include "benchmark/benchmark.h"
+#include "geometry/named_quantities.hpp"
+#include "integrators/methods.hpp"
+#include "integrators/symmetric_linear_multistep_integrator.hpp"
+#include "physics/apsides.hpp"
+#include "physics/body_surface_dynamic_frame.hpp"
+#include "physics/ephemeris.hpp"
+#include "physics/solar_system.hpp"
+#include "quantities/si.hpp"
+
+namespace principia {
+
+using astronomy::ICRS;
+using astronomy::ITRS;
+using astronomy::StandardProduct3;
+using base::dynamic_cast_not_null;
+using base::not_null;
+using geometry::Position;
+using integrators::methods::QuinlanTremaine1990Order12;
+using integrators::SymmetricLinearMultistepIntegrator;
+using quantities::si::Metre;
+using quantities::si::Milli;
+using quantities::si::Minute;
+
+namespace physics {
+
+class ApsidesBenchmark : public benchmark::Fixture {
+ protected:
+  void SetUp(const benchmark::State&) override {
+    solar_system_2010_ = std::make_unique<SolarSystem<ICRS>>(
+        SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+        SOLUTION_DIR / "astronomy" /
+            "sol_initial_state_jd_2455200_500000000.proto.txt");
+    ephemeris_ = solar_system_2010_->MakeEphemeris(
+        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                 /*geopotential_tolerance=*/0x1p-24},
+        Ephemeris<ICRS>::FixedStepParameters(
+            SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
+                                               Position<ICRS>>(),
+            /*step=*/10 * Minute));
+    earth_ = dynamic_cast_not_null<OblateBody<ICRS> const*>(
+        solar_system_2010_->massive_body(*ephemeris_, "Earth"));
+    earth_trajectory_ = ephemeris_->trajectory(earth_);
+
+    StandardProduct3 const ilrsa_lageos2_sp3(
+        SOLUTION_DIR / "astronomy" / "standard_product_3" /
+            "ilrsa.orb.lageos2.160319.v35.sp3",
+        StandardProduct3::Dialect::ILRSA);
+    StandardProduct3::SatelliteIdentifier const lageos2_id{
+        StandardProduct3::SatelliteGroup::General, 52};
+
+    BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_.get(), earth_);
+    auto const ilrsa_lageos2_trajectory_itrs =
+        ilrsa_lageos2_sp3.orbit(lageos2_id).front();
+    ephemeris_->Prolong(ilrsa_lageos2_trajectory_itrs->last().time());
+    for (auto it = ilrsa_lageos2_trajectory_itrs->Begin();
+         it != ilrsa_lageos2_trajectory_itrs->End();
+         ++it) {
+      ilrsa_lageos2_trajectory_.Append(
+          it.time(),
+          itrs.FromThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+    }
+  }
+
+  std::unique_ptr<SolarSystem<ICRS>> solar_system_2010_;
+  std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
+  OblateBody<ICRS> const* earth_;
+  ContinuousTrajectory<ICRS> const* earth_trajectory_;
+  DiscreteTrajectory<ICRS> ilrsa_lageos2_trajectory_;
+};
+
+BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
+  for (auto _ : state) {
+    DiscreteTrajectory<ICRS> apoapsides;
+    DiscreteTrajectory<ICRS> periapsides;
+    ComputeApsides(*earth_trajectory_,
+                   ilrsa_lageos2_trajectory_.Begin(),
+                   ilrsa_lageos2_trajectory_.End(),
+                   apoapsides,
+                   periapsides);
+  }
+}
+
+}  // namespace physics
+}  // namespace principia

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -1,71 +1,94 @@
-
+﻿
+#include "astronomy/epoch.hpp"
 #include "astronomy/frames.hpp"
 #include "astronomy/standard_product_3.hpp"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
 #include "geometry/named_quantities.hpp"
+#include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/methods.hpp"
 #include "integrators/symmetric_linear_multistep_integrator.hpp"
 #include "physics/apsides.hpp"
 #include "physics/body_surface_dynamic_frame.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/solar_system.hpp"
+#include "quantities/astronomy.hpp"
 #include "quantities/si.hpp"
 
 namespace principia {
 
 using astronomy::ICRS;
+using astronomy::InfiniteFuture;
 using astronomy::ITRS;
 using astronomy::StandardProduct3;
 using base::dynamic_cast_not_null;
 using base::not_null;
 using geometry::Position;
+using integrators::EmbeddedExplicitRungeKuttaNyströmIntegrator;
+using integrators::methods::DormandالمكاوىPrince1986RKN434FM;
 using integrators::methods::QuinlanTremaine1990Order12;
 using integrators::SymmetricLinearMultistepIntegrator;
+using quantities::astronomy::JulianYear;
 using quantities::si::Metre;
 using quantities::si::Milli;
 using quantities::si::Minute;
+using quantities::si::Second;
 
 namespace physics {
 
 class ApsidesBenchmark : public benchmark::Fixture {
  protected:
-  void SetUp(const benchmark::State&) override {
-    solar_system_2010_ = std::make_unique<SolarSystem<ICRS>>(
-        SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
-        SOLUTION_DIR / "astronomy" /
-            "sol_initial_state_jd_2455200_500000000.proto.txt");
-    ephemeris_ = solar_system_2010_->MakeEphemeris(
-        /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
-                                 /*geopotential_tolerance=*/0x1p-24},
-        Ephemeris<ICRS>::FixedStepParameters(
-            SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
-                                               Position<ICRS>>(),
-            /*step=*/10 * Minute));
-    earth_ = dynamic_cast_not_null<OblateBody<ICRS> const*>(
-        solar_system_2010_->massive_body(*ephemeris_, "Earth"));
-    earth_trajectory_ = ephemeris_->trajectory(earth_);
+  void SetUp(benchmark::State&) override {
+    if (!setup_done_) {
+      solar_system_2010_ = std::make_unique<SolarSystem<ICRS>>(
+          SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+          SOLUTION_DIR / "astronomy" /
+              "sol_initial_state_jd_2455200_500000000.proto.txt");
+      ephemeris_ = solar_system_2010_->MakeEphemeris(
+          /*accuracy_parameters=*/{/*fitting_tolerance=*/5 * Milli(Metre),
+                                   /*geopotential_tolerance=*/0x1p-24},
+          Ephemeris<ICRS>::FixedStepParameters(
+              SymmetricLinearMultistepIntegrator<QuinlanTremaine1990Order12,
+                                                 Position<ICRS>>(),
+              /*step=*/10 * Minute));
+      earth_ = dynamic_cast_not_null<OblateBody<ICRS> const*>(
+          solar_system_2010_->massive_body(*ephemeris_, "Earth"));
+      earth_trajectory_ = ephemeris_->trajectory(earth_);
+      BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_.get(), earth_);
 
-    StandardProduct3 const ilrsa_lageos2_sp3(
-        SOLUTION_DIR / "astronomy" / "standard_product_3" /
-            "ilrsa.orb.lageos2.160319.v35.sp3",
-        StandardProduct3::Dialect::ILRSA);
-    StandardProduct3::SatelliteIdentifier const lageos2_id{
-        StandardProduct3::SatelliteGroup::General, 52};
+      StandardProduct3 const ilrsa_lageos2_sp3(
+          SOLUTION_DIR / "astronomy" / "standard_product_3" /
+              "ilrsa.orb.lageos2.160319.v35.sp3",
+          StandardProduct3::Dialect::ILRSA);
+      StandardProduct3::SatelliteIdentifier const lageos2_id{
+          StandardProduct3::SatelliteGroup::General, 52};
 
-    BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_.get(), earth_);
-    auto const ilrsa_lageos2_trajectory_itrs =
-        ilrsa_lageos2_sp3.orbit(lageos2_id).front();
-    ephemeris_->Prolong(ilrsa_lageos2_trajectory_itrs->last().time());
-    for (auto it = ilrsa_lageos2_trajectory_itrs->Begin();
-         it != ilrsa_lageos2_trajectory_itrs->End();
-         ++it) {
+      auto const ilrsa_lageos2_trajectory_itrs =
+          ilrsa_lageos2_sp3.orbit(lageos2_id).front();
+      auto const begin = ilrsa_lageos2_trajectory_itrs->Begin();
+      ephemeris_->Prolong(begin.time());
       ilrsa_lageos2_trajectory_.Append(
-          it.time(),
-          itrs.FromThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+          begin.time(),
+          itrs.FromThisFrameAtTime(begin.time())(begin.degrees_of_freedom()));
+      ephemeris_->FlowWithAdaptiveStep(
+          &ilrsa_lageos2_trajectory_,
+          Ephemeris<ICRS>::NoIntrinsicAcceleration,
+          begin.time() + 1 * JulianYear,
+          Ephemeris<ICRS>::AdaptiveStepParameters(
+              EmbeddedExplicitRungeKuttaNyströmIntegrator<
+                  DormandالمكاوىPrince1986RKN434FM,
+                  Position<ICRS>>(),
+              std::numeric_limits<std::int64_t>::max(),
+              /*length_integration_tolerance=*/1 * Milli(Metre),
+              /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
+          /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max(),
+          /*last_point_only=*/false);
+
+      setup_done_ = true;
     }
   }
 
+  bool setup_done_ = false;
   std::unique_ptr<SolarSystem<ICRS>> solar_system_2010_;
   std::unique_ptr<Ephemeris<ICRS>> ephemeris_;
   OblateBody<ICRS> const* earth_;

--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -6,12 +6,14 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)principia.props" />
   <ItemGroup>
+    <ClCompile Include="..\astronomy\standard_product_3.cpp" />
     <ClCompile Include="..\base\status.cpp" />
     <ClCompile Include="..\ksp_plugin\planetarium.cpp" />
     <ClCompile Include="..\numerics\cbrt.cpp" />
     <ClCompile Include="..\numerics\elliptic_integrals.cpp" />
     <ClCompile Include="..\numerics\elliptic_functions.cpp" />
     <ClCompile Include="..\numerics\fast_sin_cos_2π.cpp" />
+    <ClCompile Include="apsides.cpp" />
     <ClCompile Include="dynamic_frame.cpp" />
     <ClCompile Include="elliptic_integrals_benchmark.cpp" />
     <ClCompile Include="elliptic_functions_benchmark.cpp" />

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -80,6 +80,12 @@
     <ClCompile Include="..\numerics\elliptic_functions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="apsides.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\astronomy\standard_product_3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp">

--- a/ksp_physics/ksp_physics_lib.hpp
+++ b/ksp_physics/ksp_physics_lib.hpp
@@ -36,6 +36,10 @@ PHYSICS_DLL_TEMPLATE_CLASS
 // For the plugin tests.
 // TODO(egg): ifdef this out for the actual plugin.
 PHYSICS_DLL_TEMPLATE_CLASS
+    internal_ephemeris::Ephemeris<astronomy::ICRS>;
+PHYSICS_DLL_TEMPLATE_CLASS
+    internal_ephemeris::Ephemeris<astronomy::ICRS>::AdaptiveStepParameters;
+PHYSICS_DLL_TEMPLATE_CLASS
     internal_rotating_body::RotatingBody<astronomy::ICRS>;
 PHYSICS_DLL_TEMPLATE_CLASS internal_oblate_body::OblateBody<astronomy::ICRS>;
 #endif  // OS_WIN


### PR DESCRIPTION
The first step in addressing #2261.
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides         198228715 ns  197061641 ns        212
ApsidesBenchmark/ComputeApsides         198536061 ns  197944665 ns        212
ApsidesBenchmark/ComputeApsides         198661021 ns  197797494 ns        212
ApsidesBenchmark/ComputeApsides_mean    198475266 ns  197601267 ns          3
ApsidesBenchmark/ComputeApsides_median  198536061 ns  197797494 ns          3
ApsidesBenchmark/ComputeApsides_stddev     222473 ns     473088 ns          3
ApsidesBenchmark/ComputeNodes           116951906 ns  116201299 ns        361
ApsidesBenchmark/ComputeNodes           116936454 ns  116590221 ns        361
ApsidesBenchmark/ComputeNodes           117827473 ns  117324852 ns        361
ApsidesBenchmark/ComputeNodes_mean      117238611 ns  116705457 ns          3
ApsidesBenchmark/ComputeNodes_median    116951906 ns  116590221 ns          3
ApsidesBenchmark/ComputeNodes_stddev       510028 ns     570572 ns          3
```