### PR TITLE
 Some micro-optimizations of the trajectory iterators

### DIFF
--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -28,7 +28,7 @@ bool ForkableIterator<Tr4jectory, It3rator>::operator==(
   // different containers, and in debug mode this is detected as a failure.
   // Trust me, I know what I am doing.
 #if defined(_DEBUG)
-  return ancestry_ == right.ancestry_ && current_ == right.current_ ;
+  return ancestry_ == right.ancestry_ && current_ == right.current_;
 #else
   return current_ == right.current_ && ancestry_ == right.ancestry_;
 #endif

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -22,8 +22,9 @@ template<typename Tr4jectory, typename It3rator>
 bool ForkableIterator<Tr4jectory, It3rator>::operator==(
     It3rator const& right) const {
   DCHECK_EQ(trajectory(), right.trajectory());
-  // This comparison is optimized for the case where == returns false, which
-  // happens frequently in loops.
+  // The comparison of iterators is faster than the comparison of deques, so if
+  // this function returns false (which it does repeatedly in loops), it might
+  // as well do so quickly.
   return current_ == right.current_ && ancestry_ == right.ancestry_;
 }
 
@@ -111,7 +112,8 @@ void ForkableIterator<Tr4jectory, It3rator>::NormalizeIfEnd() {
 
 template<typename Tr4jectory, typename It3rator>
 void ForkableIterator<Tr4jectory, It3rator>::CheckNormalizedIfEnd() {
-  // Short-circuit when the trajectory is a root.
+  // Checking if the trajectory is a root is faster than obtaining the end of
+  // the front of the deque, so it should be done first.
   CHECK(ancestry_.size() == 1 ||
         current_ != ancestry_.front()->timeline_end());
 }

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -24,8 +24,14 @@ bool ForkableIterator<Tr4jectory, It3rator>::operator==(
   DCHECK_EQ(trajectory(), right.trajectory());
   // The comparison of iterators is faster than the comparison of deques, so if
   // this function returns false (which it does repeatedly in loops), it might
-  // as well do so quickly.
+  // as well do so quickly.  However, we may end up comparing iterators from
+  // different containers, and in debug mode this is detected as a failure.
+  // Trust me, I know what I am doing.
+#if defined(_DEBUG)
+  return ancestry_ == right.ancestry_ && current_ == right.current_ ;
+#else
   return current_ == right.current_ && ancestry_ == right.ancestry_;
+#endif
 }
 
 template<typename Tr4jectory, typename It3rator>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -22,7 +22,9 @@ template<typename Tr4jectory, typename It3rator>
 bool ForkableIterator<Tr4jectory, It3rator>::operator==(
     It3rator const& right) const {
   DCHECK_EQ(trajectory(), right.trajectory());
-  return ancestry_ == right.ancestry_ && current_ == right.current_;
+  // This comparison is optimized for the case where == returns false, which
+  // happens frequently in loops.
+  return current_ == right.current_ && ancestry_ == right.ancestry_;
 }
 
 template<typename Tr4jectory, typename It3rator>
@@ -109,8 +111,9 @@ void ForkableIterator<Tr4jectory, It3rator>::NormalizeIfEnd() {
 
 template<typename Tr4jectory, typename It3rator>
 void ForkableIterator<Tr4jectory, It3rator>::CheckNormalizedIfEnd() {
-  CHECK(current_ != ancestry_.front()->timeline_end() ||
-        ancestry_.size() == 1);
+  // Short-circuit when the trajectory is a root.
+  CHECK(ancestry_.size() == 1 ||
+        current_ != ancestry_.front()->timeline_end());
 }
 
 template<typename Tr4jectory, typename It3rator>


### PR DESCRIPTION
This speeds up the apsides/nodes computations by 8-16%, and will benefit all the code that iterates over discrete trajectories.  Contributes to solving #2261.

Before:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides         198228715 ns  197061641 ns        212
ApsidesBenchmark/ComputeApsides         198536061 ns  197944665 ns        212
ApsidesBenchmark/ComputeApsides         198661021 ns  197797494 ns        212
ApsidesBenchmark/ComputeApsides_mean    198475266 ns  197601267 ns          3
ApsidesBenchmark/ComputeApsides_median  198536061 ns  197797494 ns          3
ApsidesBenchmark/ComputeApsides_stddev     222473 ns     473088 ns          3
ApsidesBenchmark/ComputeNodes           116951906 ns  116201299 ns        361
ApsidesBenchmark/ComputeNodes           116936454 ns  116590221 ns        361
ApsidesBenchmark/ComputeNodes           117827473 ns  117324852 ns        361
ApsidesBenchmark/ComputeNodes_mean      117238611 ns  116705457 ns          3
ApsidesBenchmark/ComputeNodes_median    116951906 ns  116590221 ns          3
ApsidesBenchmark/ComputeNodes_stddev       510028 ns     570572 ns          3
```
After:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides         183527862 ns  182588997 ns        230
ApsidesBenchmark/ComputeApsides         182827937 ns  181096813 ns        230
ApsidesBenchmark/ComputeApsides         182881180 ns  182114211 ns        230
ApsidesBenchmark/ComputeApsides_mean    183078993 ns  181933340 ns          3
ApsidesBenchmark/ComputeApsides_median  182881180 ns  182114211 ns          3
ApsidesBenchmark/ComputeApsides_stddev     389642 ns     762357 ns          3
ApsidesBenchmark/ComputeNodes            98583813 ns   98130840 ns        427
ApsidesBenchmark/ComputeNodes            98651381 ns   97948169 ns        427
ApsidesBenchmark/ComputeNodes            98514366 ns   97984703 ns        427
ApsidesBenchmark/ComputeNodes_mean       98583186 ns   98021237 ns          3
ApsidesBenchmark/ComputeNodes_median     98583813 ns   97984703 ns          3
ApsidesBenchmark/ComputeNodes_stddev        68509 ns      96660 ns          3
```