### PR TITLE
Avoid a unbounded behavior introduced in #2279

### DIFF
--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -26,7 +26,7 @@ bool ForkableIterator<Tr4jectory, It3rator>::operator==(
   // this function returns false (which it does repeatedly in loops), it might
   // as well do so quickly.  There is a complication, however, because the two
   // iterators may not point to the same container, and we believe that
-  // comparing them would be unbounded behavior; hence the size comparison,
+  // comparing them would be undefined behaviour; hence the size comparison,
   // which ensures that the two iterators are in the same fork and therefore can
   // legitimately be compared.
   return ancestry_.size() == right.ancestry_.size() &&

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -24,14 +24,14 @@ bool ForkableIterator<Tr4jectory, It3rator>::operator==(
   DCHECK_EQ(trajectory(), right.trajectory());
   // The comparison of iterators is faster than the comparison of deques, so if
   // this function returns false (which it does repeatedly in loops), it might
-  // as well do so quickly.  However, we may end up comparing iterators from
-  // different containers, and in debug mode this is detected as a failure.
-  // Trust me, I know what I am doing.
-#if defined(_DEBUG)
-  return ancestry_ == right.ancestry_ && current_ == right.current_;
-#else
-  return current_ == right.current_ && ancestry_ == right.ancestry_;
-#endif
+  // as well do so quickly.  There is a complication, however, because the two
+  // iterators may not point to the same container, and we believe that
+  // comparing them would be unbounded behavior; hence the size comparison,
+  // which ensures that the two iterators are in the same fork and therefore can
+  // legitimately be compared.
+  return ancestry_.size() == right.ancestry_.size() &&
+         current_ == right.current_ &&
+         ancestry_ == right.ancestry_;
 }
 
 template<typename Tr4jectory, typename It3rator>


### PR DESCRIPTION
The performance gain wrt to the original implementation is reduced to 6-13%:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides         186739818 ns  185620573 ns        227
ApsidesBenchmark/ComputeApsides         186097324 ns  185070790 ns        227
ApsidesBenchmark/ComputeApsides         186573579 ns  185551850 ns        227
ApsidesBenchmark/ComputeApsides_mean    186470240 ns  185414404 ns          3
ApsidesBenchmark/ComputeApsides_median  186573579 ns  185551850 ns          3
ApsidesBenchmark/ComputeApsides_stddev     333480 ns     299556 ns          3
ApsidesBenchmark/ComputeNodes           102993301 ns  101456498 ns        419
ApsidesBenchmark/ComputeNodes           102936921 ns  101828815 ns        419
ApsidesBenchmark/ComputeNodes           102919142 ns  100935253 ns        419
ApsidesBenchmark/ComputeNodes_mean      102949788 ns  101406855 ns          3
ApsidesBenchmark/ComputeNodes_median    102936921 ns  101456498 ns          3
ApsidesBenchmark/ComputeNodes_stddev        38718 ns     448845 ns          3
```