### PR TITLE
Improve error reporting for bad installations

### DIFF
--- a/documentation/Setup.md
+++ b/documentation/Setup.md
@@ -12,7 +12,7 @@ tool for our own use, so if you use a different edition, just do
 and test the mod.
 
 These instructions use the git Powershell provided by [GitHub for Windows](https://windows.github.com/).
-We assume a working installation of Kerbal Space Program version 1.7.0 is found in `<KSP directory>`.
+We assume a working installation of Kerbal Space Program version 1.7.2 is found in `<KSP directory>`.
 
 The repository is found at https://github.com/mockingbirdnest/Principia.git.
 Pick a directory `<root>` in which you will install Principia and its
@@ -50,7 +50,7 @@ In `<root>`, run `git clone https://github.com/mockingbirdnest/Principia.git`.
 
 ### KSP and Unity assemblies
 
-In order to build for KSP 1.3.1, copy the corresponding KSP 1.3.1 assemblies to `<root>\KSP Assemblies\1.3.1`.  For KSP 1.7.0 copy the corresponding KSP 1.7.0 assemblies to `<root>\KSP Assemblies\1.7.0`
+In order to build for KSP 1.7.2, copy the corresponding KSP 1.7.2 assemblies to `<root>\KSP Assemblies\1.7.2`
 
 ### Downloading the Google libraries
 

--- a/ksp_plugin_adapter/dialog.cs
+++ b/ksp_plugin_adapter/dialog.cs
@@ -26,7 +26,7 @@ internal class Dialog : UnsupervisedWindowRenderer, IConfigNode {
     UnityEngine.GUI.DragWindow();
   }
 
-  public new void Load(ConfigNode node) {
+  public override void Load(ConfigNode node) {
     if (persist_state_) {
       base.Load(node);
       message_ = node.GetAtMostOneValue("message");
@@ -42,7 +42,7 @@ internal class Dialog : UnsupervisedWindowRenderer, IConfigNode {
     }
   }
 
-  public new void Save(ConfigNode node) {
+  public override void Save(ConfigNode node) {
     base.Save(node);
     if (persist_state_ && message_ != null) {
       node.SetValue("message", message_, createIfNotFound: true);

--- a/ksp_plugin_adapter/dialog.cs
+++ b/ksp_plugin_adapter/dialog.cs
@@ -12,22 +12,23 @@ internal class Dialog : UnsupervisedWindowRenderer, IConfigNode {
   protected override string Title => "Principia";
 
   protected override void RenderWindow(int window_id) {
-    using (new UnityEngine.GUILayout.VerticalScope())
-    {
-      UnityEngine.GUILayout.TextArea(message_ ?? "SHOW WITHOUT MESSAGE");
+    using (new UnityEngine.GUILayout.VerticalScope()) {
+      UnityEngine.GUILayout.TextArea(message_ ?? "SHOW WITHOUT MESSAGE",
+                                     style: Style.Multiline(
+                                         UnityEngine.GUI.skin.textArea));
     }
     UnityEngine.GUI.DragWindow();
   }
 
   public new void Load(ConfigNode node) {
+    // Whether a dialog is shown or not should not be a persisted property.
+    // It's convenient to save and restore show_ in the base class, but we
+    // override this behaviour here.  For the same reason, we don't persist the
+    // message.
+    bool saved_shown = Shown();
     base.Load(node);
-    message_ = node.GetAtMostOneValue("message");
-  }
-
-  public new void Save(ConfigNode node) {
-    base.Save(node);
-    if (message_ != null) {
-      node.SetValue("message", message_, createIfNotFound : true);
+    if (saved_shown != Shown()) {
+      Toggle();
     }
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -162,12 +162,13 @@ public partial class PrincipiaPluginAdapter
 
   // UI for the apocalypse notification.
   [KSPField(isPersistant = true)]
-  private readonly Dialog apocalypse_dialog_ = new Dialog();
+  private readonly Dialog apocalypse_dialog_ = new Dialog(persist_state: true);
 
   // UI for the bad installation notification.
   private readonly bool is_bad_installation_ = false;  // Don't persist.
   [KSPField(isPersistant = true)]
-  private readonly Dialog bad_installation_dialog_ = new Dialog();
+  private readonly Dialog bad_installation_dialog_ =
+      new Dialog(persist_state: false);
 
   // The game windows.
   [KSPField(isPersistant = true)]

--- a/ksp_plugin_adapter/loader.cs
+++ b/ksp_plugin_adapter/loader.cs
@@ -17,7 +17,7 @@ internal static class Loader {
       return "32-bit platforms are no longer supported; " +
              "use the 64-bit KSP executable.";
     }
-    string[] possible_dll_paths = null;
+    string[] possible_dll_paths;
     bool? is_cxx_installed;
     string required_cxx_packages;
     switch (Environment.OSVersion.Platform) {
@@ -26,14 +26,13 @@ internal static class Loader {
         required_cxx_packages =
             "the Microsoft Visual C++ 2015-2019 Redistributable (x86) - " +
             "14.22.27821";
-        possible_dll_paths =
-            new string[] {@"GameData\Principia\x64\principia.dll"};
+        possible_dll_paths = new [] {@"GameData\Principia\x64\principia.dll"};
         break;
       // Both Mac and Linux report |PlatformID.Unix|, so we treat them together
       // (we probably don't actually encounter |PlatformID.MacOSX|).
       case PlatformID.Unix:
       case PlatformID.MacOSX:
-        possible_dll_paths = new string[] {
+        possible_dll_paths = new [] {
             @"GameData/Principia/Linux64/principia.so",
             @"GameData/Principia/MacOS64/principia.so"};
         is_cxx_installed = null;

--- a/ksp_plugin_adapter/loader.cs
+++ b/ksp_plugin_adapter/loader.cs
@@ -24,8 +24,8 @@ internal static class Loader {
       case PlatformID.Win32NT:
         is_cxx_installed = IsVCRedistInstalled();
         required_cxx_packages =
-            "the Visual C++ Redistributable Packages for Visual Studio " +
-            "2017 on x64";
+            "the Microsoft Visual C++ 2015-2019 Redistributable (x86) - " +
+            "14.22.27821";
         possible_dll_paths =
             new string[] {@"GameData\Principia\x64\principia.dll"};
         break;
@@ -46,7 +46,7 @@ internal static class Loader {
     }
     if (!possible_dll_paths.Any(File.Exists)) {
       return "The principia DLL was not found at '" +
-             string.Join("', '", possible_dll_paths) + "' in directory '" + 
+             string.Join("', '", possible_dll_paths) + "' in directory '" +
              Directory.GetCurrentDirectory() + "'.";
     }
     try {
@@ -54,9 +54,9 @@ internal static class Loader {
       // No kernel32 on *nix, so we throw an exception and immediately resume
       // after the try block.
       try {
-        // We dynamically link glog, protobuf, the serialization DLL, and an
-        // optimized subset of the physics library on Windows, so we need that
-        // to be in the DLL search path for the main DLL to load.
+        // We dynamically link glog, protobuf, and the serialization DLL on
+        // Windows, so we need that to be in the DLL search path for the main
+        // DLL to load.
         if (!SetDllDirectory(@"GameData\Principia\x64")) {
           return "Failed to set DLL directory (error code " +
                  Marshal.GetLastWin32Error() + ").";
@@ -80,20 +80,20 @@ internal static class Loader {
 
   private static bool IsVCRedistInstalled() {
     // NOTE(phl): This GUID is specific to:
-    //   Microsoft Visual C++ 2017 Redistributable (x64) - 14.16.27012
+    //   Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.22.27821
     // It will need to be updated when new versions of Visual C++
     // Redistributable are released by Microsoft.
     RegistryKey key = Registry.LocalMachine.OpenSubKey(
-         @"Software\Classes\Installer\Dependencies\" +
-         @"VC,redist.x64,amd64,14.16,bundle",
-         writable : false);
+        @"Software\Classes\Installer\Dependencies\" +
+        @"VC,redist.x64,amd64,14.22,bundle",
+        writable : false);
     if (key == null) {
       return false;
     } else {
       string version = (string)key.GetValue("Version");
       // NOTE(phl): This string needs to be updated when new versions of Visual
       // C++ Redistributable are released by Microsoft.
-      return version != null && version == "14.16.27012.6";
+      return version != null && version == "14.22.27821.0";
     }
   }
 


### PR DESCRIPTION
* We lost the "bad installation" dialog because its state was incorrectly restored from the save.
* The VC++ redistributable version should mention the unified 2015-2019 runtime.

This was prompted by #2297.