### PR TITLE
Diurnal testing

### DIFF
--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -1310,7 +1310,7 @@ TEST_F(TrappistDynamicsTest, PlanetBPlanetDAlignment) {
 }
 #endif
 
-TEST_F(TrappistDynamicsTest, DISABLED_Optimization) {
+TEST_F(TrappistDynamicsTest, DISABLED_SECULAR_Optimization) {
   auto const gravity_model_message = ParseGravityModel(
       SOLUTION_DIR / "astronomy" / "trappist_gravity_model.proto.txt");
   auto const preoptimization_initial_state_message = ParseInitialState(

--- a/build_for_benchmarking.ps1
+++ b/build_for_benchmarking.ps1
@@ -2,11 +2,11 @@ $ErrorActionPreference = "Stop"
 
 $msbuild = &".\find_msbuild.ps1"
 
-&$msbuild                                        `
-    "/t:benchmarks;Scripts\benchmark_automation" `
-    /m                                           `
-    /property:Configuration=Release              `
-    /property:Platform=x64                       `
+&$msbuild                            `
+    "/t:Build"                       `
+    /m                               `
+    /property:Configuration=Release  `
+    /property:Platform=x64           `
     Principia.sln
 
 if (!$?) {

--- a/rebuild_release.ps1
+++ b/rebuild_release.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop"
 $msbuild = &".\find_msbuild.ps1"
 
 &$msbuild                            `
-    "/t:Build"                       `
+    "/t:Clean;Build"                 `
     /m                               `
     /property:Configuration=Release  `
     /property:Platform=x64           `


### PR DESCRIPTION
- Add support for filtering and running disabled tests in the parallel test runner;
- make the "build for benchmarking" script build the whole solution;
- mark the TRAPPIST-1 optimization secular, in the sense that it must not be run periodically.