### PR TITLE
Add support for Disco Dingo and Clang 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ LIBS          := $(DEP_DIR)protobuf/src/.libs/libprotobuf.a \
 	$(DEP_DIR)abseil-cpp/absl/debugging/libabsl_*.a \
 	$(DEP_DIR)abseil-cpp/absl/numeric/libabsl_*.a \
 	$(DEP_DIR)abseil-cpp/absl/base/libabsl_*.a \
-	$(DEP_DIR)glog/.libs/libglog.a -lpthread -lc++ -lc++abi
+	$(DEP_DIR)glog/.libs/libglog.a -lpthread -lc++ -lc++abi -lc++fs
 TEST_INCLUDES := \
 	-I$(DEP_DIR)googletest/googlemock/include -I$(DEP_DIR)googletest/googletest/include \
 	-I$(DEP_DIR)googletest/googlemock/ -I$(DEP_DIR)googletest/googletest/ -I$(DEP_DIR)benchmark/include
-INCLUDES      := -I. -I$(DEP_DIR)glog/src -I$(DEP_DIR)protobuf/src -I$(DEP_DIR)compatibility/filesystem \
+INCLUDES      := -I. -I$(DEP_DIR)glog/src -I$(DEP_DIR)protobuf/src \
 	-I$(DEP_DIR)gipfeli/include -I$(DEP_DIR)abseil-cpp
 SHARED_ARGS   := \
 	-std=c++1z -stdlib=libc++ -O3 -g                           \
@@ -96,7 +96,7 @@ ifeq ($(UNAME_S),Linux)
     SHAREDFLAG := -shared
 endif
 ifeq ($(UNAME_S),Darwin)
-    INCLUDES += -I$(DEP_DIR)compatibility/optional -I$(DEP_DIR)Optional
+    INCLUDES += -I$(DEP_DIR)compatibility/filesystem -I$(DEP_DIR)compatibility/optional -I$(DEP_DIR)Optional
     SHARED_ARGS += -mmacosx-version-min=10.12 -arch x86_64
     MDTOOL ?= "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool"
     SHAREDFLAG := -dynamiclib
@@ -282,7 +282,12 @@ $(ADAPTER): $(GENERATED_PROFILES)
 
 ######### Distribution
 
-release: $(ADAPTER) $(KSP_PLUGIN)
+# Something got broken in Disco where building the adapter is no longer possible
+# because /usr/lib/mono/msbuild/15.0/bin/System.Reflection.Metadata.dll points
+# to a missing Roslyn directory.  We don't care, we don't use the adapter built
+# on Linux
+# release: $(ADAPTER) $(KSP_PLUGIN)
+release: $(KSP_PLUGIN)
 	cd $(FINAL_PRODUCTS_DIR); tar -c -z -f - GameData/ > principia_$(UNAME_S)-$(shell git describe --tags --always --dirty --abbrev=40 --long).tar.gz
 ########## Cleaning
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,10 @@
 # Note: Use 'sudo su' in the ubuntu machine before make'ing.
 Vagrant.configure("2") do |config|
 
-  config.vm.define "ubuntu" do |ubuntu|
-    ubuntu.vm.box = "ubuntu/bionic64"
-    ubuntu.vm.box_url = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180315.0.0/providers/virtualbox.box"
-    ubuntu.vm.synced_folder "../KSP Assemblies", "/home/vagrant/KSP Assemblies", id: "Assemblies"
+  config.vm.define "bionic" do |bionic|
+    bionic.vm.box = "ubuntu/bionic64"
+    bionic.vm.box_url = "https://app.vagrantup.com/ubuntu/boxes/bionic64/versions/20180315.0.0/providers/virtualbox.box"
+    bionic.vm.synced_folder "../KSP Assemblies", "/home/vagrant/KSP Assemblies", id: "Assemblies"
 
     script = <<SCRIPT
 echo Provisioning Principia
@@ -33,9 +33,46 @@ cd principia
 if [ -d deps ]; then echo "Dependencies already installed, remove deps/ to reinstall."; else ./install_deps.sh; fi
 SCRIPT
 
-    ubuntu.vm.provision "shell", inline: script
+    bionic.vm.provision "shell", inline: script
 
-    ubuntu.vm.provider "virtualbox" do |v|
+    bionic.vm.provider "virtualbox" do |v|
+      v.memory = 8192
+      v.cpus = 4
+    end
+  end
+
+  config.vm.define "disco" do |disco|
+    disco.vm.box = "ubuntu/disco64"
+    disco.vm.box_url = "https://app.vagrantup.com/ubuntu/boxes/disco64/versions/20190828.0.0/providers/virtualbox.box"
+    disco.vm.synced_folder "../KSP Assemblies", "/home/vagrant/KSP Assemblies", id: "Assemblies"
+
+    script = <<SCRIPT
+echo Provisioning Principia
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list
+wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+add-apt-repository 'deb http://apt.llvm.org/disco/ llvm-toolchain-disco-8 main'
+apt-get update
+apt-get install -y clang-8 clang-tools-8 clang-format-8 clang-tidy-8 git unzip wget libc++-dev libc++abi-dev binutils make automake libtool curl cmake monodevelop
+ln -s /usr/bin/clang-8 /usr/bin/clang
+clang --version
+ln -s /usr/bin/clang++-8 /usr/bin/clang++
+clang++ --version
+ln -s /usr/bin/clang-format-8 /usr/bin/clang-format
+clang-format --version
+ln -s /usr/bin/clang-format-diff-8 /usr/bin/clang-format-diff
+clang-format-diff --help
+ln -s /usr/bin/clang-tidy-8 /usr/bin/clang-tidy
+clang-tidy --version
+git clone https://github.com/mockingbirdnest/Principia.git principia
+chown -R vagrant:vagrant principia KSP
+cd principia
+if [ -d deps ]; then echo "Dependencies already installed, remove deps/ to reinstall."; else ./install_deps.sh; fi
+SCRIPT
+
+    disco.vm.provision "shell", inline: script
+
+    disco.vm.provider "virtualbox" do |v|
       v.memory = 8192
       v.cpus = 4
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,9 @@
 # vi: set ft=ruby :
 
 # Note: Use 'sudo su' in the ubuntu machine before make'ing.
+# To mount:
+# mkdir "/home/vagrant/KSP Assemblies"
+# mount -t vboxsf Assemblies "/home/vagrant/KSP Assemblies"
 Vagrant.configure("2") do |config|
 
   config.vm.define "bionic" do |bionic|


### PR DESCRIPTION
Some tolerances have changed but they are not fixed in this PR:
```
[ RUN      ] ApsidesTest.ComputeApsidesDiscreteTrajectory
physics/apsides_test.cpp:122: Failure
Value of: time - *previous_time
Expected: is within 118 to 2792 ULPs of +1.05340260072161824e+08 s
  Actual: +1.05340260072119743e+08 s, the numbers are separated by 2824 ULPs
physics/apsides_test.cpp:146: Failure
Value of: time - *previous_time
Expected: is within 103 to 4936 ULPs of +5.26701300360809118e+07 s
  Actual: +5.26701300360429287e+07 s, the numbers are separated by 5098 ULPs
[  FAILED  ] ApsidesTest.ComputeApsidesDiscreteTrajectory (263 ms)
[ RUN      ] OrbitalElementsTest.KeplerOrbit
astronomy/orbital_elements_test.cpp:181: Failure
Value of: elements.nodal_period()
Expected: has an absolute error from +5.82851668421396244e+03 s that is < +3.79999999999999999e-03 s
  Actual: +5.82852057386323213e+03 s, whose absolute error from the expected value is +3.88964926969492808e-03 s
astronomy/orbital_elements_test.cpp:186: Failure
Value of: elements.nodal_precession()
Expected: is < +7.18979905820667107e-10 s^-1 rad
  Actual: +7.19721456808449299e-10 s^-1 rad
astronomy/orbital_elements_test.cpp:197: Failure
Value of: elements.mean_inclination_interval().midpoint()
Expected: has an absolute error from +4.84813681109536008e-08 rad that is < +2.76343798232435498e-12 rad
  Actual: +4.84844493480715204e-08 rad, whose absolute error from the expected value is +3.08123711791962462e-12 rad
astronomy/orbital_elements_test.cpp:200: Failure
Value of: elements.mean_longitude_of_ascending_node_interval().midpoint()
Expected: has an absolute error from +1.74532925199432948e-01 rad that is < +2.81191935043530856e-04 rad
  Actual: +1.74832976875673701e-01 rad, whose absolute error from the expected value is +3.00051676240753462e-04 rad
astronomy/orbital_elements_test.cpp:211: Failure
Value of: elements.mean_inclination_interval().measure()
Expected: is < +3.78154671265438096e-12 rad
  Actual: +6.52748221127703369e-12 rad
astronomy/orbital_elements_test.cpp:213: Failure
Value of: elements.mean_longitude_of_ascending_node_interval().measure()
Expected: is < +6.10865238198015389e-04 rad
  Actual: +6.32260521729044456e-04 rad
[  FAILED  ] OrbitalElementsTest.KeplerOrbit (2997 ms)
[ RUN      ] OrbitalElementsTest.J2Perturbation
astronomy/orbital_elements_test.cpp:323: Failure
Value of: RelativeError( -theoretical_Ωʹ * mission_duration, elements.mean_longitude_of_ascending_node_interval().measure())
Expected: is near 0.0039(1)
  Actual: 0.00379925 (of type double), which is not near 0.0039(1) (being 1.00747 ulps away)
[  FAILED  ] OrbitalElementsTest.J2Perturbation (2988 ms)
```
Contributes to #2307.