### PR TITLE
Use structured bindings

### DIFF
--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -433,9 +433,7 @@ TEST_P(KSPSystemConvergenceTest, DISABLED_Convergence) {
 
   std::map<std::string, std::vector<RelativeDegreesOfFreedom<KSP>>>
       name_to_errors;
-  for (auto const& pair : name_to_degrees_of_freedom) {
-    auto const& name = pair.first;
-    auto const& degrees_of_freedom = pair.second;
+  for (auto const& [name, degrees_of_freedom] : name_to_degrees_of_freedom) {
     CHECK_EQ(degrees_of_freedom.size(), iterations());
     for (int i = 1; i < iterations(); ++i) {
       name_to_errors[name].emplace_back(degrees_of_freedom[i] -
@@ -450,9 +448,7 @@ TEST_P(KSPSystemConvergenceTest, DISABLED_Convergence) {
   std::vector<std::string> worst_body(iterations() - 1);
   MathematicaEntries mathematica_entries;
   for (int i = 0; i < iterations() - 1; ++i) {
-    for (auto const& pair : name_to_errors) {
-      auto const& name = pair.first;
-      auto const& errors = pair.second;
+    for (auto const& [name, errors] : name_to_errors) {
       if (position_errors[i] < errors[i].displacement().Norm()) {
         worst_body[i] = name;
       }

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -669,9 +669,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
 
   std::map<std::string, std::vector<RelativeDegreesOfFreedom<ICRS>>>
       name_to_errors;
-  for (auto const& pair : name_to_degrees_of_freedom) {
-    auto const& name = pair.first;
-    auto const& degrees_of_freedom = pair.second;
+  for (auto const& [name, degrees_of_freedom] : name_to_degrees_of_freedom) {
     CHECK_EQ(degrees_of_freedom.size(), iterations());
     for (int i = 1; i < iterations(); ++i) {
       name_to_errors[name].emplace_back(degrees_of_freedom[i] -
@@ -686,9 +684,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
   std::vector<std::string> worst_body(iterations() - 1);
   MathematicaEntries mathematica_entries;
   for (int i = 0; i < iterations() - 1; ++i) {
-    for (auto const& pair : name_to_errors) {
-      auto const& name = pair.first;
-      auto const& errors = pair.second;
+    for (auto const& [name, errors] : name_to_errors) {
       if (position_errors[i] < errors[i].displacement().Norm()) {
         worst_body[i] = name;
       }

--- a/astronomy/trappist_dynamics_test.cpp
+++ b/astronomy/trappist_dynamics_test.cpp
@@ -1048,9 +1048,7 @@ class TrappistDynamicsTest : public ::testing::Test {
     Time total_Δt;
     std::string transit_with_max_Δt;
     int number_of_observations = 0;
-    for (auto const& pair : observations) {
-      auto const& name = pair.first;
-      auto const& observed_transits = pair.second;
+    for (auto const& [name, observed_transits] : observations) {
       auto const& computed_transits = computations.at(name);
       if (computed_transits.empty()) {
         return std::numeric_limits<double>::infinity();

--- a/base/disjoint_sets.hpp
+++ b/base/disjoint_sets.hpp
@@ -30,7 +30,8 @@ class Subset final {
   };
 
   // The |SubsetPropertiesArgs| are forwarded to the constructor of
-  // |Properties|.
+  // |Properties|; the constructed |Properties| are owned by
+  // |*Node::Get(element)|, and thus by element.
   template<typename... SubsetPropertiesArgs>
   static Subset MakeSingleton(
       T& element,

--- a/journal/profiles.cpp
+++ b/journal/profiles.cpp
@@ -23,7 +23,7 @@ void Insert(Player::PointerMap& pointer_map,
             T* const pointer) {
   void* const inserted_pointer = static_cast<void*>(
       const_cast<typename std::remove_cv<T>::type*>(pointer));
-  auto [it, inserted] = pointer_map.emplace(address, inserted_pointer);
+  auto const [it, inserted] = pointer_map.emplace(address, inserted_pointer);
   if (!inserted) {
     CHECK_EQ(it->second, inserted_pointer);
   }

--- a/journal/profiles.cpp
+++ b/journal/profiles.cpp
@@ -23,9 +23,9 @@ void Insert(Player::PointerMap& pointer_map,
             T* const pointer) {
   void* const inserted_pointer = static_cast<void*>(
       const_cast<typename std::remove_cv<T>::type*>(pointer));
-  auto inserted = pointer_map.emplace(address, inserted_pointer);
-  if (!inserted.second) {
-    CHECK_EQ(inserted.first->second, inserted_pointer);
+  auto [it, inserted] = pointer_map.emplace(address, inserted_pointer);
+  if (!inserted) {
+    CHECK_EQ(it->second, inserted_pointer);
   }
 }
 

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -180,7 +180,7 @@ serialization::OblateBody::Geopotential MakeGeopotential(
   }
 
   serialization::OblateBody::Geopotential result;
-  for (auto const& [degree, row] : rows) {
+  for (auto const& [_, row] : rows) {
     *result.add_row() = row;
   }
   return result;

--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -180,8 +180,8 @@ serialization::OblateBody::Geopotential MakeGeopotential(
   }
 
   serialization::OblateBody::Geopotential result;
-  for (auto const& pair : rows) {
-    *result.add_row() = pair.second;
+  for (auto const& [degree, row] : rows) {
+    *result.add_row() = row;
   }
   return result;
 }

--- a/ksp_plugin/part_subsets.hpp
+++ b/ksp_plugin/part_subsets.hpp
@@ -35,6 +35,7 @@ class Subset<ksp_plugin::Part>::Properties final {
   using PileUps = std::list<ksp_plugin::PileUp*>;
 
  public:
+  // |*part| must outlive the constructed object.
   explicit Properties(not_null<ksp_plugin::Part*> part);
 
   // If |*this| and |other| are subsets of different |PileUp|s, or one is a

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -142,15 +142,13 @@ void PileUp::WriteToMessage(not_null<serialization::PileUp*> message) const {
   intrinsic_force_.WriteToMessage(message->mutable_intrinsic_force());
   history_->WriteToMessage(message->mutable_history(),
                            /*forks=*/{psychohistory_});
-  for (auto const& pair : actual_part_degrees_of_freedom_) {
-    auto const part = pair.first;
-    auto const& degrees_of_freedom = pair.second;
+  for (auto const& [part, degrees_of_freedom] :
+       actual_part_degrees_of_freedom_) {
     degrees_of_freedom.WriteToMessage(&(
         (*message->mutable_actual_part_degrees_of_freedom())[part->part_id()]));
   }
-  for (auto const& pair : apparent_part_degrees_of_freedom_) {
-    auto const part = pair.first;
-    auto const& degrees_of_freedom = pair.second;
+  for (auto const& [part, degrees_of_freedom] :
+       apparent_part_degrees_of_freedom_) {
     degrees_of_freedom.WriteToMessage(&(
         (*message
               ->mutable_apparent_part_degrees_of_freedom())[part->part_id()]));
@@ -234,16 +232,14 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
   pile_up->mass_ = Mass::ReadFromMessage(message.mass());
   pile_up->intrinsic_force_ =
       Vector<Force, Barycentric>::ReadFromMessage(message.intrinsic_force());
-  for (auto const& pair : message.actual_part_degrees_of_freedom()) {
-    std::uint32_t const part_id = pair.first;
-    serialization::Pair const& degrees_of_freedom = pair.second;
+  for (auto const& [part_id, degrees_of_freedom] :
+       message.actual_part_degrees_of_freedom()) {
     pile_up->actual_part_degrees_of_freedom_.emplace(
         part_id_to_part(part_id),
         DegreesOfFreedom<RigidPileUp>::ReadFromMessage(degrees_of_freedom));
   }
-  for (auto const& pair : message.apparent_part_degrees_of_freedom()) {
-    std::uint32_t const part_id = pair.first;
-    serialization::Pair const& degrees_of_freedom = pair.second;
+  for (auto const& [part_id, degrees_of_freedom] :
+       message.apparent_part_degrees_of_freedom()) {
     pile_up->apparent_part_degrees_of_freedom_.emplace(
         part_id_to_part(part_id),
         DegreesOfFreedom<ApparentBubble>::ReadFromMessage(degrees_of_freedom));
@@ -285,9 +281,8 @@ void PileUp::DeformPileUpIfNeeded() {
 
   // Compute the apparent centre of mass of the parts.
   BarycentreCalculator<DegreesOfFreedom<ApparentBubble>, Mass> calculator;
-  for (auto const& pair : apparent_part_degrees_of_freedom_) {
-    auto const part = pair.first;
-    auto const& apparent_part_degrees_of_freedom = pair.second;
+  for (auto const& [part, apparent_part_degrees_of_freedom] :
+       apparent_part_degrees_of_freedom_) {
     calculator.Add(apparent_part_degrees_of_freedom, part->mass());
   }
   auto const apparent_centre_of_mass = calculator.Get();
@@ -307,9 +302,8 @@ void PileUp::DeformPileUpIfNeeded() {
 
   // Now update the positions of the parts in the pile-up frame.
   actual_part_degrees_of_freedom_.clear();
-  for (auto const& pair : apparent_part_degrees_of_freedom_) {
-    auto const part = pair.first;
-    auto const& apparent_part_degrees_of_freedom = pair.second;
+  for (auto const& [part, apparent_part_degrees_of_freedom] :
+       apparent_part_degrees_of_freedom_) {
     actual_part_degrees_of_freedom_.emplace(
         part,
         apparent_bubble_to_pile_up_motion(apparent_part_degrees_of_freedom));

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -97,9 +97,7 @@ std::list<not_null<Part*>> const& PileUp::parts() const {
 void PileUp::SetPartApparentDegreesOfFreedom(
     not_null<Part*> const part,
     DegreesOfFreedom<ApparentBubble> const& degrees_of_freedom) {
-  PartTo<DegreesOfFreedom<ApparentBubble>>::iterator it;
-  bool inserted;
-  std::tie(it, inserted) =
+  bool const inserted =
       apparent_part_degrees_of_freedom_.emplace(part, degrees_of_freedom);
   CHECK(inserted) << "Duplicate part " << part->ShortDebugString() << " at "
                   << degrees_of_freedom;

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -97,8 +97,8 @@ std::list<not_null<Part*>> const& PileUp::parts() const {
 void PileUp::SetPartApparentDegreesOfFreedom(
     not_null<Part*> const part,
     DegreesOfFreedom<ApparentBubble> const& degrees_of_freedom) {
-  bool const inserted =
-      apparent_part_degrees_of_freedom_.emplace(part, degrees_of_freedom);
+  bool const inserted = apparent_part_degrees_of_freedom_.emplace(
+      part, degrees_of_freedom).second;
   CHECK(inserted) << "Duplicate part " << part->ShortDebugString() << " at "
                   << degrees_of_freedom;
 }

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1323,9 +1323,9 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
     if (vessel_message.kept()) {
       plugin->kept_vessels_.insert(vessel.get());
     }
-    auto const inserted =
+    auto const [it, inserted] =
         plugin->vessels_.emplace(vessel_message.guid(), std::move(vessel));
-    CHECK(inserted.second);
+    CHECK(inserted);
   }
 
   for (auto const& [part_id, guid] : message.part_id_to_vessel()) {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -477,7 +477,7 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
 }
 
 void Plugin::PrepareToReportCollisions() {
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     // NOTE(egg): The lifetime requirement on the second argument of
     // |MakeSingleton| (which forwards to the argument of the constructor of
     // |Subset<Part>::Properties|) is that |part| outlives the constructed
@@ -542,7 +542,7 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
 
   // Bind the vessels.  This guarantees that all part subsets are disjoint
   // unions of vessels.
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     vessel->ForSomePart([&vessel](Part& first_part) {
       vessel->ForAllParts([&first_part](Part& part) {
         Subset<Part>::Unite(Subset<Part>::Find(first_part),
@@ -559,7 +559,7 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
     // vessel destroys its parts, which invalidates the intrusive |Subset| data
     // structure.
     VesselSet grounded_vessels;
-    for (auto const& [guid, vessel] : vessels_) {
+    for (auto const& [_, vessel] : vessels_) {
       vessel->ForSomePart([&vessel, &grounded_vessels](Part& part) {
         if (Subset<Part>::Find(part).properties().grounded()) {
           grounded_vessels.insert(vessel.get());
@@ -576,7 +576,7 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
 
   // We only need to collect one part per vessel, since the other parts are in
   // the same subset.
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     Instant const vessel_time =
         is_loaded(vessel.get()) ? current_time_ - Δt : current_time_;
     vessel->ForSomePart([&vessel_time, this](Part& first_part) {
@@ -719,7 +719,7 @@ void Plugin::CatchUpLaggingVessels(VesselSet& collided_vessels) {
   }
 
   // Update the vessels.
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     if (vessel->psychohistory().last().time() < current_time_) {
       if (Contains(collided_vessels, vessel.get())) {
         vessel->DisableDownsampling();
@@ -778,7 +778,7 @@ void Plugin::ForgetAllHistoriesBefore(Instant const& t) const {
   CHECK(!initializing_);
   CHECK_LT(t, current_time_);
   ephemeris_->EventuallyForgetBefore(t);
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     vessel->ForgetBefore(t);
   }
 }

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -239,9 +239,7 @@ void Plugin::EndInitialization() {
   }
 
   // Establish the parent relationships between the celestials.
-  for (auto const& pair : celestials_) {
-    Index const celestial_index = pair.first;
-    auto const& celestial = pair.second;
+  for (auto const& [celestial_index, celestial] : celestials_) {
     auto const& parent_index = FindOrDie(parents_, celestial_index);
     if (parent_index) {
       not_null<Celestial const*> parent =
@@ -1225,14 +1223,10 @@ void Plugin::WriteToMessage(
   CHECK(!initializing_);
   ephemeris_->Prolong(current_time_);
   std::map<not_null<Celestial const*>, Index const> celestial_to_index;
-  for (auto const& pair : celestials_) {
-    Index const index = pair.first;
-    auto const& owned_celestial = pair.second;
+  for (auto const& [index, owned_celestial] : celestials_) {
     celestial_to_index.emplace(owned_celestial.get(), index);
   }
-  for (auto const& pair : celestials_) {
-    Index const index = pair.first;
-    auto const& owned_celestial = pair.second.get();
+  for (auto const& [index, owned_celestial] : celestials_) {
     auto* const celestial_message = message->add_celestial();
     celestial_message->set_index(index);
     if (owned_celestial->has_parent()) {
@@ -1269,9 +1263,7 @@ void Plugin::WriteToMessage(
     vessel_message->set_loaded(Contains(loaded_vessels_, vessel));
     vessel_message->set_kept(Contains(kept_vessels_, vessel));
   }
-  for (auto const& pair : part_id_to_vessel_) {
-    PartId const part_id = pair.first;
-    not_null<Vessel*> const vessel = pair.second;
+  for (auto const& [part_id, vessel] : part_id_to_vessel_) {
     (*message->mutable_part_id_to_vessel())[part_id] = vessel_to_guid[vessel];
   }
 
@@ -1347,9 +1339,7 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
     CHECK(inserted.second);
   }
 
-  for (auto const& pair : message.part_id_to_vessel()) {
-    PartId const part_id = pair.first;
-    GUID const guid = pair.second;
+  for (auto const& [part_id, guid] : message.part_id_to_vessel()) {
     auto const& vessel = FindOrDie(plugin->vessels_, guid);
     plugin->part_id_to_vessel_.emplace(part_id, vessel.get());
   }

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -478,6 +478,10 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
 
 void Plugin::PrepareToReportCollisions() {
   for (auto const& [guid, vessel] : vessels_) {
+    // NOTE(egg): The lifetime requirement on the second argument of
+    // |MakeSingleton| (which forwards to the argument of the constructor of
+    // |Subset<Part>::Properties|) is that |part| outlives the constructed
+    // |Properties|; since these are owned by |part|, this is true.
     vessel->ForAllParts(
         [](Part& part) { Subset<Part>::MakeSingleton(part, &part); });
   }

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1325,8 +1325,8 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
     if (vessel_message.kept()) {
       plugin->kept_vessels_.insert(vessel.get());
     }
-    auto const [it, inserted] =
-        plugin->vessels_.emplace(vessel_message.guid(), std::move(vessel));
+    bool const inserted = plugin->vessels_.emplace(
+        vessel_message.guid(), std::move(vessel)).second;
     CHECK(inserted);
   }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -155,7 +155,7 @@ void Vessel::FreeParts() {
 }
 
 void Vessel::ClearAllIntrinsicForces() {
-  for (auto const& [part_id, part] : parts_) {
+  for (auto const& [_, part] : parts_) {
     part->clear_intrinsic_force();
   }
 }
@@ -191,7 +191,7 @@ void Vessel::ForSomePart(std::function<void(Part&)> action) const {
 }
 
 void Vessel::ForAllParts(std::function<void(Part&)> action) const {
-  for (auto const& [part_id, part] : parts_) {
+  for (auto const& [_, part] : parts_) {
     action(*part);
   }
 }
@@ -251,7 +251,7 @@ void Vessel::AdvanceTime() {
     }
   }
 
-  for (auto const& [part_id, part] : parts_) {
+  for (auto const& [_, part] : parts_) {
     part->ClearHistory();
   }
 }
@@ -340,7 +340,7 @@ void Vessel::WriteToMessage(not_null<serialization::Vessel*> const message,
   body_.WriteToMessage(message->mutable_body());
   prediction_adaptive_step_parameters_.WriteToMessage(
       message->mutable_prediction_adaptive_step_parameters());
-  for (auto const& [part_id, part] : parts_) {
+  for (auto const& [_, part] : parts_) {
     part->WriteToMessage(message->add_parts(), serialization_index_for_pile_up);
   }
   for (auto const& part_id : kept_parts_) {
@@ -550,7 +550,7 @@ void Vessel::AppendToVesselTrajectory(
   std::vector<DiscreteTrajectory<Barycentric>::Iterator> ends;
   its.reserve(parts_.size());
   ends.reserve(parts_.size());
-  for (auto const& [part_id, part] : parts_) {
+  for (auto const& [_, part] : parts_) {
     its.push_back((*part.*part_trajectory_begin)());
     ends.push_back((*part.*part_trajectory_end)());
   }
@@ -565,7 +565,7 @@ void Vessel::AppendToVesselTrajectory(
     // Loop over the parts at a given time.
     BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass> calculator;
     int i = 0;
-    for (auto const& [part_id, part] : parts_) {
+    for (auto const& [_, part] : parts_) {
       auto& it = its[i];
       CHECK_EQ(at_end_of_part_trajectory, it == ends[i]);
       if (!at_end_of_part_trajectory) {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -550,10 +550,9 @@ void Vessel::AppendToVesselTrajectory(
   std::vector<DiscreteTrajectory<Barycentric>::Iterator> ends;
   its.reserve(parts_.size());
   ends.reserve(parts_.size());
-  for (auto const& pair : parts_) {
-    Part& part = *pair.second;
-    its.push_back((part.*part_trajectory_begin)());
-    ends.push_back((part.*part_trajectory_end)());
+  for (auto const& [part_id, part] : parts_) {
+    its.push_back((*part.*part_trajectory_begin)());
+    ends.push_back((*part.*part_trajectory_end)());
   }
 
   // Loop over the times of the trajectory.

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -155,8 +155,7 @@ void Vessel::FreeParts() {
 }
 
 void Vessel::ClearAllIntrinsicForces() {
-  for (auto const& pair : parts_) {
-    auto const& part = pair.second;
+  for (auto const& [part_id, part] : parts_) {
     part->clear_intrinsic_force();
   }
 }
@@ -192,8 +191,8 @@ void Vessel::ForSomePart(std::function<void(Part&)> action) const {
 }
 
 void Vessel::ForAllParts(std::function<void(Part&)> action) const {
-  for (auto const& pair : parts_) {
-    action(*pair.second);
+  for (auto const& [part_id, part] : parts_) {
+    action(*part);
   }
 }
 
@@ -252,9 +251,8 @@ void Vessel::AdvanceTime() {
     }
   }
 
-  for (auto const& pair : parts_) {
-    Part& part = *pair.second;
-    part.ClearHistory();
+  for (auto const& [part_id, part] : parts_) {
+    part->ClearHistory();
   }
 }
 
@@ -342,8 +340,7 @@ void Vessel::WriteToMessage(not_null<serialization::Vessel*> const message,
   body_.WriteToMessage(message->mutable_body());
   prediction_adaptive_step_parameters_.WriteToMessage(
       message->mutable_prediction_adaptive_step_parameters());
-  for (auto const& pair : parts_) {
-    auto const& part = pair.second;
+  for (auto const& [part_id, part] : parts_) {
     part->WriteToMessage(message->add_parts(), serialization_index_for_pile_up);
   }
   for (auto const& part_id : kept_parts_) {
@@ -569,12 +566,11 @@ void Vessel::AppendToVesselTrajectory(
     // Loop over the parts at a given time.
     BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass> calculator;
     int i = 0;
-    for (auto const& pair : parts_) {
-      Part& part = *pair.second;
+    for (auto const& [part_id, part] : parts_) {
       auto& it = its[i];
       CHECK_EQ(at_end_of_part_trajectory, it == ends[i]);
       if (!at_end_of_part_trajectory) {
-        calculator.Add(it.degrees_of_freedom(), part.mass());
+        calculator.Add(it.degrees_of_freedom(), part->mass());
         CHECK_EQ(first_time, it.time());
         ++it;
       }

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -49,18 +49,15 @@ class TestablePlugin : public Plugin {
 };
 
 void TestablePlugin::KeepAllVessels() {
-  for (auto const& pair : vessels_) {
-    auto const& vessel = pair.second;
+  for (auto const& [guid, vessel] : vessels_) {
     kept_vessels_.insert(vessel.get());
   }
 }
 
 std::map<GUID, not_null<Vessel const*>> TestablePlugin::vessels() const {
   std::map<GUID, not_null<Vessel const*>> result;
-  for (auto const& pair : vessels_) {
-    auto const& guid = pair.first;
-    Vessel const* const vessel = pair.second.get();
-    result.insert(std::make_pair(guid, vessel));
+  for (auto const& [guid, vessel] : vessels_) {
+    result.insert(std::make_pair(guid, vessel.get()));
   }
   return result;
 }

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -49,7 +49,7 @@ class TestablePlugin : public Plugin {
 };
 
 void TestablePlugin::KeepAllVessels() {
-  for (auto const& [guid, vessel] : vessels_) {
+  for (auto const& [_, vessel] : vessels_) {
     kept_vessels_.insert(vessel.get());
   }
 }

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -726,7 +726,7 @@ TEST_F(PluginDeathTest, InsertUnloadedPartError) {
         guid,
         RelativeDegreesOfFreedom<AliceSun>(satellite_initial_displacement_,
                                            satellite_initial_velocity_));
-  }, "emplaced");
+  }, "inserted");
 }
 
 TEST_F(PluginDeathTest, AdvanceTimeError) {

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -138,9 +138,8 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
 
   previous_time = std::nullopt;
   std::optional<Position<World>> previous_position;
-  for (auto const& pair : all_apsides) {
-    Instant const time = pair.first;
-    Position<World> const position = pair.second.position();
+  for (auto const& [time, degrees_of_freedom] : all_apsides) {
+    Position<World> const position = degrees_of_freedom.position();
     if (previous_time) {
       EXPECT_THAT(time - *previous_time,
                   AlmostEquals(0.5 * T, 103, 5098));

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -108,7 +108,7 @@ Status ContinuousTrajectory<Frame>::Append(
     q.clear();
     v.clear();
 
-    for (auto const& [time, degrees_of_freedom] : last_points_) {
+    for (auto const& [_, degrees_of_freedom] : last_points_) {
       q.push_back(degrees_of_freedom.position() - Frame::origin);
       v.push_back(degrees_of_freedom.velocity());
     }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -108,7 +108,7 @@ Status ContinuousTrajectory<Frame>::Append(
     q.clear();
     v.clear();
 
-    for (auto const& pair : last_points_) {
+    for (auto const& [time, degrees_of_freedom] : last_points_) {
       DegreesOfFreedom<Frame> const& degrees_of_freedom = pair.second;
       q.push_back(degrees_of_freedom.position() - Frame::origin);
       v.push_back(degrees_of_freedom.velocity());
@@ -300,9 +300,7 @@ void ContinuousTrajectory<Frame>::WriteToCheckpoint(
   message->set_is_unstable(is_unstable_);
   message->set_degree(degree_);
   message->set_degree_age(degree_age_);
-  for (auto const& pair : last_points_) {
-    Instant const& instant = pair.first;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = pair.second;
+  for (auto const& [instant, degrees_of_freedom] : last_points_) {
     not_null<serialization::ContinuousTrajectory::
                  InstantaneousDegreesOfFreedom*> const
         instantaneous_degrees_of_freedom = message->add_last_point();

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -109,7 +109,6 @@ Status ContinuousTrajectory<Frame>::Append(
     v.clear();
 
     for (auto const& [time, degrees_of_freedom] : last_points_) {
-      DegreesOfFreedom<Frame> const& degrees_of_freedom = pair.second;
       q.push_back(degrees_of_freedom.position() - Frame::origin);
       v.push_back(degrees_of_freedom.velocity());
     }

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -496,9 +496,7 @@ void DiscreteTrajectory<Frame>::WriteSubTreeToMessage(
     not_null<serialization::DiscreteTrajectory*> const message,
     std::vector<DiscreteTrajectory<Frame>*>& forks) const {
   Forkable<DiscreteTrajectory, Iterator>::WriteSubTreeToMessage(message, forks);
-  for (auto const& pair : timeline_) {
-    Instant const& instant = pair.first;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = pair.second;
+  for (auto const& [instant, degrees_of_freedom] : timeline_) {
     auto const instantaneous_degrees_of_freedom = message->add_timeline();
     instant.WriteToMessage(instantaneous_degrees_of_freedom->mutable_instant());
     degrees_of_freedom.WriteToMessage(

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -267,14 +267,13 @@ Ephemeris<Frame>::Ephemeris(
     unowned_bodies_.emplace_back(body.get());
     unowned_bodies_indices_.emplace(body.get(), i);
 
-    auto const inserted = bodies_to_trajectories_.emplace(
-                              body.get(),
-                              std::make_unique<ContinuousTrajectory<Frame>>(
-                                  fixed_step_parameters_.step_,
-                                  accuracy_parameters_.fitting_tolerance_));
-    CHECK(inserted.second);
-    ContinuousTrajectory<Frame>* const trajectory =
-        inserted.first->second.get();
+    auto const [it, inserted] = bodies_to_trajectories_.emplace(
+        body.get(),
+        std::make_unique<ContinuousTrajectory<Frame>>(
+            fixed_step_parameters_.step_,
+            accuracy_parameters_.fitting_tolerance_));
+    CHECK(inserted);
+    ContinuousTrajectory<Frame>* const trajectory = it->second.get();
     CHECK_OK(trajectory->Append(initial_time, degrees_of_freedom));
 
     if (body->is_oblate()) {

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -321,7 +321,7 @@ not_null<ContinuousTrajectory<Frame> const*> Ephemeris<Frame>::trajectory(
 
 template<typename Frame>
 bool Ephemeris<Frame>::empty() const {
-  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
+  for (auto const& [_, trajectory] : bodies_to_trajectories_) {
     if (trajectory->empty()) {
       return true;
     }
@@ -338,7 +338,7 @@ Instant Ephemeris<Frame>::t_min() const {
 template<typename Frame>
 Instant Ephemeris<Frame>::t_max() const {
   Instant t_max = bodies_to_trajectories_.begin()->second->t_max();
-  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
+  for (auto const& [_, trajectory] : bodies_to_trajectories_) {
     t_max = std::min(t_max, trajectory->t_max());
   }
   return t_max;
@@ -361,7 +361,7 @@ template<typename Frame>
 bool Ephemeris<Frame>::EventuallyForgetBefore(Instant const& t) {
   auto forget_before_t = [this, t]() {
     absl::MutexLock l(&lock_);
-    for (auto& [body, trajectory] : bodies_to_trajectories_) {
+    for (auto& [_, trajectory] : bodies_to_trajectories_) {
       trajectory->ForgetBefore(t);
     }
     checkpointer_->ForgetBefore(t);
@@ -939,7 +939,7 @@ template<typename Frame>
 Instant Ephemeris<Frame>::t_min_locked() const {
   lock_.AssertReaderHeld();
   Instant t_min = bodies_to_trajectories_.begin()->second->t_min();
-  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
+  for (auto const& [_, trajectory] : bodies_to_trajectories_) {
     t_min = std::max(t_min, trajectory->t_min());
   }
   return t_min;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -322,8 +322,7 @@ not_null<ContinuousTrajectory<Frame> const*> Ephemeris<Frame>::trajectory(
 
 template<typename Frame>
 bool Ephemeris<Frame>::empty() const {
-  for (auto const& pair : bodies_to_trajectories_) {
-    auto const& trajectory = pair.second;
+  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
     if (trajectory->empty()) {
       return true;
     }
@@ -340,8 +339,7 @@ Instant Ephemeris<Frame>::t_min() const {
 template<typename Frame>
 Instant Ephemeris<Frame>::t_max() const {
   Instant t_max = bodies_to_trajectories_.begin()->second->t_max();
-  for (auto const& pair : bodies_to_trajectories_) {
-    auto const& trajectory = pair.second;
+  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
     t_max = std::min(t_max, trajectory->t_max());
   }
   return t_max;
@@ -364,9 +362,8 @@ template<typename Frame>
 bool Ephemeris<Frame>::EventuallyForgetBefore(Instant const& t) {
   auto forget_before_t = [this, t]() {
     absl::MutexLock l(&lock_);
-    for (auto& pair : bodies_to_trajectories_) {
-      ContinuousTrajectory<Frame>& trajectory = *pair.second;
-      trajectory.ForgetBefore(t);
+    for (auto& [body, trajectory] : bodies_to_trajectories_) {
+      trajectory->ForgetBefore(t);
     }
     checkpointer_->ForgetBefore(t);
   };
@@ -943,8 +940,7 @@ template<typename Frame>
 Instant Ephemeris<Frame>::t_min_locked() const {
   lock_.AssertReaderHeld();
   Instant t_min = bodies_to_trajectories_.begin()->second->t_min();
-  for (auto const& pair : bodies_to_trajectories_) {
-    auto const& trajectory = pair.second;
+  for (auto const& [body, trajectory] : bodies_to_trajectories_) {
     t_min = std::max(t_min, trajectory->t_min());
   }
   return t_min;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -360,8 +360,7 @@ void Forkable<Tr4jectory, It3rator>::AttachForkToCopiedBegin(
   // |begin()| are referencing a point that will soon be removed from the
   // timeline.  They must now point at |end()| to indicate that their fork time
   // is not in |fork|'s timeline.
-  for (auto const& pair : fork->children_) {
-    std::unique_ptr<Tr4jectory> const& child = pair.second;
+  for (auto const& [fork_time, child] : fork->children_) {
     if (child->position_in_parent_timeline_ == fork_timeline_begin) {
       child->position_in_parent_timeline_ = fork_timeline_end;
     }
@@ -390,8 +389,7 @@ Forkable<Tr4jectory, It3rator>::DetachForkWithCopiedBegin() {
   // The children whose |position_in_parent_timeline_| was at |end()| are those
   // whose fork time was not in this object's timeline.  The caller must have
   // ensured that now it is, so point them to the beginning of this timeline.
-  for (auto const& pair : children_) {
-    std::unique_ptr<Tr4jectory> const& child = pair.second;
+  for (auto const& [fork_time, child] : children_) {
     if (child->position_in_parent_timeline_ == timeline_end()) {
       child->position_in_parent_timeline_ = timeline_begin();
     }
@@ -438,10 +436,7 @@ void Forkable<Tr4jectory, It3rator>::WriteSubTreeToMessage(
     std::vector<Tr4jectory*>& forks) const {
   std::optional<Instant> last_instant;
   serialization::DiscreteTrajectory::Litter* litter = nullptr;
-  for (auto const& pair : children_) {
-    Instant const& fork_time = pair.first;
-    std::unique_ptr<Tr4jectory> const& child = pair.second;
-
+  for (auto const& [fork_time, child] : children_) {
     // Determine if this |child| needs to be serialized.  If so, record its
     // position in |fork_positions| and null out its pointer in |forks|.
     // Apologies for the O(N) search.

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -360,7 +360,7 @@ void Forkable<Tr4jectory, It3rator>::AttachForkToCopiedBegin(
   // |begin()| are referencing a point that will soon be removed from the
   // timeline.  They must now point at |end()| to indicate that their fork time
   // is not in |fork|'s timeline.
-  for (auto const& [fork_time, child] : fork->children_) {
+  for (auto const& [_, child] : fork->children_) {
     if (child->position_in_parent_timeline_ == fork_timeline_begin) {
       child->position_in_parent_timeline_ = fork_timeline_end;
     }
@@ -389,7 +389,7 @@ Forkable<Tr4jectory, It3rator>::DetachForkWithCopiedBegin() {
   // The children whose |position_in_parent_timeline_| was at |end()| are those
   // whose fork time was not in this object's timeline.  The caller must have
   // ensured that now it is, so point them to the beginning of this timeline.
-  for (auto const& [fork_time, child] : children_) {
+  for (auto const& [_, child] : children_) {
     if (child->position_in_parent_timeline_ == timeline_end()) {
       child->position_in_parent_timeline_ = timeline_begin();
     }

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -58,16 +58,17 @@ OblateBody<Frame>::Parameters::ReadFromMessage(
   for (auto const& row : message.row()) {
     const int n = row.degree();
     CHECK_LE(n, OblateBody<Frame>::max_geopotential_degree);
-    CHECK(degrees_seen.insert(n).second)
-        << "Degree " << n << " specified multiple times";
+    bool const inserted = degrees_seen.insert(n).second;
+    CHECK(inserted) << "Degree " << n << " specified multiple times";
     CHECK_LE(row.column_size(), n + 1)
         << "Degree " << n << " has " << row.column_size() << " coefficients";
     std::set<int> orders_seen;
     for (auto const& column : row.column()) {
       const int m = column.order();
       CHECK_LE(m, n);
-      CHECK(orders_seen.insert(m).second)
-          << "Degree " << n << " order " << m << " specified multiple times";
+      bool const inserted = orders_seen.insert(m).second;
+      CHECK(inserted) << "Degree " << n << " order " << m
+                      << " specified multiple times";
 
       // If j was specified, check that it is legit and compute cos.
       double cos = column.cos();

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -181,7 +181,7 @@ template<typename Frame>
 std::vector<not_null<std::unique_ptr<MassiveBody const>>>
 SolarSystem<Frame>::MakeAllMassiveBodies() const {
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
-  for (auto const& [name, body] : gravity_model_map_) {
+  for (auto const& [_, body] : gravity_model_map_) {
     bodies.emplace_back(MakeMassiveBody(*body));
   }
   return bodies;
@@ -604,7 +604,7 @@ std::vector<DegreesOfFreedom<Frame>>
 SolarSystem<Frame>::MakeAllDegreesOfFreedom() const {
   std::vector<DegreesOfFreedom<Frame>> degrees_of_freedom;
   if (!cartesian_initial_state_map_.empty()) {
-    for (auto const& [name, body] : cartesian_initial_state_map_) {
+    for (auto const& [_, body] : cartesian_initial_state_map_) {
       degrees_of_freedom.push_back(MakeDegreesOfFreedom(*body));
     }
   }

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -109,16 +109,14 @@ SolarSystem<Frame>::SolarSystem(
 
   // Store the data in maps keyed by body name.
   for (auto& body : *gravity_model_.mutable_body()) {
-    bool inserted;
-    std::tie(std::ignore, inserted) =
-        gravity_model_map_.insert(std::make_pair(body.name(), &body));
+    bool const inserted =
+        gravity_model_map_.insert(std::make_pair(body.name(), &body)).second;
     CHECK(inserted) << body.name();
   }
   if (initial_state_.has_cartesian()) {
     for (auto const& body : initial_state_.cartesian().body()) {
-      bool inserted;
-      std::tie(std::ignore, inserted) =
-          cartesian_initial_state_map_.emplace(body.name(), &body);
+      bool const inserted =
+          cartesian_initial_state_map_.emplace(body.name(), &body).second;
       CHECK(inserted) << body.name();
     }
 
@@ -135,9 +133,8 @@ SolarSystem<Frame>::SolarSystem(
     CHECK(it2 == cartesian_initial_state_map_.end()) << it2->first;
   } else {
     for (auto& body : *initial_state_.mutable_keplerian()->mutable_body()) {
-      bool inserted;
-      std::tie(std::ignore, inserted) =
-          keplerian_initial_state_map_.emplace(body.name(), &body);
+      bool const inserted =
+          keplerian_initial_state_map_.emplace(body.name(), &body).second;
       CHECK(inserted) << body.name();
     }
 

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -184,8 +184,7 @@ template<typename Frame>
 std::vector<not_null<std::unique_ptr<MassiveBody const>>>
 SolarSystem<Frame>::MakeAllMassiveBodies() const {
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
-  for (auto const& pair : gravity_model_map_) {
-    serialization::GravityModel::Body const* const body = pair.second;
+  for (auto const& [name, body] : gravity_model_map_) {
     bodies.emplace_back(MakeMassiveBody(*body));
   }
   return bodies;
@@ -395,9 +394,7 @@ SolarSystem<Frame>::MakeHierarchicalSystem() const {
   std::map<std::string,
             not_null<std::unique_ptr<MassiveBody const>>> owned_bodies;
   std::map<std::string, not_null<MassiveBody const*>> unowned_bodies;
-  for (auto const& pair : keplerian_initial_state_map_) {
-    const auto& name = pair.first;
-    serialization::InitialState::Keplerian::Body* const body = pair.second;
+  for (auto const& [name, body] : keplerian_initial_state_map_) {
     CHECK_EQ(body->has_parent(), body->has_elements()) << name;
     if (!body->has_parent()) {
       CHECK(primary.empty()) << name;
@@ -415,9 +412,7 @@ SolarSystem<Frame>::MakeHierarchicalSystem() const {
   std::set<std::string> previous_layer = {primary};
   std::set<std::string> current_layer;
   do {
-    for (auto const& pair : keplerian_initial_state_map_) {
-      const auto& name = pair.first;
-      serialization::InitialState::Keplerian::Body* const body = pair.second;
+    for (auto const& [name, body] : keplerian_initial_state_map_) {
       if (Contains(previous_layer, body->parent())) {
         current_layer.insert(name);
         KeplerianElements<Frame> const elements =
@@ -612,9 +607,7 @@ std::vector<DegreesOfFreedom<Frame>>
 SolarSystem<Frame>::MakeAllDegreesOfFreedom() const {
   std::vector<DegreesOfFreedom<Frame>> degrees_of_freedom;
   if (!cartesian_initial_state_map_.empty()) {
-    for (auto const& pair : cartesian_initial_state_map_) {
-      serialization::InitialState::Cartesian::Body const* const body =
-          pair.second;
+    for (auto const& [name, body] : cartesian_initial_state_map_) {
       degrees_of_freedom.push_back(MakeDegreesOfFreedom(*body));
     }
   }


### PR DESCRIPTION
### Iteration on maps
This changes most instances of
```C++
for (auto const& pair : ⟨map⟩)
```
to
```C++
for (auto const& [key, value] : ⟨map⟩)
```
The exceptions are
https://github.com/mockingbirdnest/Principia/blob/a8cfa72ed7356caee03945da2f68e9c253bcefa2/physics/solar_system_body.hpp#L636-L638
where the name `degrees_of_freedom` is taken,
and the public functions of the journal proto processor:
https://github.com/mockingbirdnest/Principia/blob/a8cfa72ed7356caee03945da2f68e9c253bcefa2/tools/journal_proto_processor.cpp#L112-L188
In both cases, switching to structured bindings felt clumsier than the existing code. It is noteworthy that both are examples of the same pattern, turning the values of a map into a vector; perhaps we could write an utility function for that.

#### `_` for unused keys

Where the key is unused, this pull request uses
```C++
for (auto const& [_, value] : ⟨map⟩)
```
In the future, we will probably want to introduce an iterator adapter `ValuesIn` and change these usages to
```C++
for (auto const& value : ValuesIn(⟨map⟩))
```
Iterator adapters would also make it possible to turn usages of `Vessel::ForAllParts` into actual loops.

### `insert` and `emplace`

use `bool const inserted = ⟨container⟩.insert(...).second` if only the boolean is used, reusing an existing `bool inserted` if there are scoping issues; use structured bindings if both are used (where previously either `std::tie` or references into the pair would be used).

One usage of `std::tie` remains, which is a proper tie of pre-existing variables:
https://github.com/mockingbirdnest/Principia/blob/c5a4878f17ddbb49bd1741dd7ca298a0ddbe6594/ksp_plugin/plugin.cpp#L365-L386


Note that in the future, we should probably change `LOG_IF` in our glog fork to use `if` rather than `?:`, so that it is possible to narrowly scope `inserted`, thus
```C++
CHECK(bool const inserted = container.insert(...).second; inserted) << ...;
```