### PR TITLE
Make the discrete trajectory iterators more STL-like

### DIFF
--- a/Principia.sln.DotSettings
+++ b/Principia.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:Int64 x:Key="/Default/CodeEditing/NullCheckPatterns/PatternTypeNamesToPriority/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ENullChecking_002EIfThenThrowPattern/@EntryIndexedValue">500</s:Int64>
 	<s:Int64 x:Key="/Default/CodeEditing/NullCheckPatterns/PatternTypeNamesToPriority/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ENullChecking_002EPatternMatchingIfThenThrowPattern/@EntryIndexedValue">200</s:Int64>
 	<s:Int64 x:Key="/Default/CodeEditing/NullCheckPatterns/PatternTypeNamesToPriority/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ENullChecking_002EThrowExpressionNullCheckPattern/@EntryIndexedValue">1000</s:Int64>
+	<s:Boolean x:Key="/Default/CodeEditing/TypingAssist/HandleTab/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeEditing/TypingAssist/SmartBackspace/@EntryValue">OFF</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AccessToStaticMemberViaDerivedType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EnforceDoWhileStatementBraces/@EntryIndexedValue">WARNING</s:String>
@@ -140,6 +141,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/Editor/StructuralNavigationIsEnabled/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/ExcludedFiles/FileMasksToSkip/=_002A_002Ecpp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/ExcludedFiles/FileMasksToSkip/=_002A_002Ehpp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/ParameterNameHintsOptions/ShowParameterNameHints/@EntryValue">False</s:Boolean>

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -108,21 +108,21 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
   StandardProduct3::SatelliteIdentifier const lageos2_id{
       StandardProduct3::SatelliteGroup::General, 52};
 
-  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->begin()->time,
-           initial_ilrsb.orbit(lageos2_id).front()->begin()->time);
+  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->front().time,
+           initial_ilrsb.orbit(lageos2_id).front()->front().time);
 
   Instant const initial_time =
-      initial_ilrsa.orbit(lageos2_id).front()->begin()->time;
+      initial_ilrsa.orbit(lageos2_id).front()->front().time;
   DegreesOfFreedom<ITRS> const initial_dof_ilrsa =
-      initial_ilrsa.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
+      initial_ilrsa.orbit(lageos2_id).front()->front().degrees_of_freedom;
 
   DegreesOfFreedom<ITRS> const initial_dof_ilrsb =
-      initial_ilrsb.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
+      initial_ilrsb.orbit(lageos2_id).front()->front().degrees_of_freedom;
 
   Instant const final_time =
-      final_ilrsa.orbit(lageos2_id).front()->begin()->time;
+      final_ilrsa.orbit(lageos2_id).front()->front().time;
   DegreesOfFreedom<ITRS> const expected_final_dof =
-      final_ilrsa.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
+      final_ilrsa.orbit(lageos2_id).front()->front().degrees_of_freedom;
 
   ephemeris_->Prolong(final_time);
 

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -156,13 +156,13 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
     return flow_lageos2(secondary_lageos2_trajectory);
   });
   bundle.Join();
-  EXPECT_THAT(primary_lageos2_trajectory.rbegin().time(), Eq(final_time));
-  EXPECT_THAT(secondary_lageos2_trajectory.rbegin().time(), Eq(final_time));
+  EXPECT_THAT(primary_lageos2_trajectory.back().time, Eq(final_time));
+  EXPECT_THAT(secondary_lageos2_trajectory.back().time, Eq(final_time));
 
   auto const primary_actual_final_dof = itrs_.ToThisFrameAtTime(final_time)(
-      primary_lageos2_trajectory.rbegin().degrees_of_freedom());
+      primary_lageos2_trajectory.back().degrees_of_freedom);
   auto const secondary_actual_final_dof = itrs_.ToThisFrameAtTime(final_time)(
-      secondary_lageos2_trajectory.rbegin().degrees_of_freedom());
+      secondary_lageos2_trajectory.back().degrees_of_freedom);
 
   // Absolute error in position.
   EXPECT_THAT(AbsoluteError(primary_actual_final_dof.position(),

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -108,21 +108,21 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
   StandardProduct3::SatelliteIdentifier const lageos2_id{
       StandardProduct3::SatelliteGroup::General, 52};
 
-  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->begin().time(),
-           initial_ilrsb.orbit(lageos2_id).front()->begin().time());
+  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->begin()->time,
+           initial_ilrsb.orbit(lageos2_id).front()->begin()->time);
 
   Instant const initial_time =
-      initial_ilrsa.orbit(lageos2_id).front()->begin().time();
+      initial_ilrsa.orbit(lageos2_id).front()->begin()->time;
   DegreesOfFreedom<ITRS> const initial_dof_ilrsa =
-      initial_ilrsa.orbit(lageos2_id).front()->begin().degrees_of_freedom();
+      initial_ilrsa.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
 
   DegreesOfFreedom<ITRS> const initial_dof_ilrsb =
-      initial_ilrsb.orbit(lageos2_id).front()->begin().degrees_of_freedom();
+      initial_ilrsb.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
 
   Instant const final_time =
-      final_ilrsa.orbit(lageos2_id).front()->begin().time();
+      final_ilrsa.orbit(lageos2_id).front()->begin()->time;
   DegreesOfFreedom<ITRS> const expected_final_dof =
-      final_ilrsa.orbit(lageos2_id).front()->begin().degrees_of_freedom();
+      final_ilrsa.orbit(lageos2_id).front()->begin()->degrees_of_freedom;
 
   ephemeris_->Prolong(final_time);
 

--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -108,21 +108,21 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
   StandardProduct3::SatelliteIdentifier const lageos2_id{
       StandardProduct3::SatelliteGroup::General, 52};
 
-  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->Begin().time(),
-           initial_ilrsb.orbit(lageos2_id).front()->Begin().time());
+  CHECK_EQ(initial_ilrsa.orbit(lageos2_id).front()->begin().time(),
+           initial_ilrsb.orbit(lageos2_id).front()->begin().time());
 
   Instant const initial_time =
-      initial_ilrsa.orbit(lageos2_id).front()->Begin().time();
+      initial_ilrsa.orbit(lageos2_id).front()->begin().time();
   DegreesOfFreedom<ITRS> const initial_dof_ilrsa =
-      initial_ilrsa.orbit(lageos2_id).front()->Begin().degrees_of_freedom();
+      initial_ilrsa.orbit(lageos2_id).front()->begin().degrees_of_freedom();
 
   DegreesOfFreedom<ITRS> const initial_dof_ilrsb =
-      initial_ilrsb.orbit(lageos2_id).front()->Begin().degrees_of_freedom();
+      initial_ilrsb.orbit(lageos2_id).front()->begin().degrees_of_freedom();
 
   Instant const final_time =
-      final_ilrsa.orbit(lageos2_id).front()->Begin().time();
+      final_ilrsa.orbit(lageos2_id).front()->begin().time();
   DegreesOfFreedom<ITRS> const expected_final_dof =
-      final_ilrsa.orbit(lageos2_id).front()->Begin().degrees_of_freedom();
+      final_ilrsa.orbit(lageos2_id).front()->begin().degrees_of_freedom();
 
   ephemeris_->Prolong(final_time);
 
@@ -156,13 +156,13 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
     return flow_lageos2(secondary_lageos2_trajectory);
   });
   bundle.Join();
-  EXPECT_THAT(primary_lageos2_trajectory.last().time(), Eq(final_time));
-  EXPECT_THAT(secondary_lageos2_trajectory.last().time(), Eq(final_time));
+  EXPECT_THAT(primary_lageos2_trajectory.rbegin().time(), Eq(final_time));
+  EXPECT_THAT(secondary_lageos2_trajectory.rbegin().time(), Eq(final_time));
 
   auto const primary_actual_final_dof = itrs_.ToThisFrameAtTime(final_time)(
-      primary_lageos2_trajectory.last().degrees_of_freedom());
+      primary_lageos2_trajectory.rbegin().degrees_of_freedom());
   auto const secondary_actual_final_dof = itrs_.ToThisFrameAtTime(final_time)(
-      secondary_lageos2_trajectory.last().degrees_of_freedom());
+      secondary_lageos2_trajectory.rbegin().degrees_of_freedom());
 
   // Absolute error in position.
   EXPECT_THAT(AbsoluteError(primary_actual_final_dof.position(),

--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -160,12 +160,12 @@ class OrbitAnalysisTest : public ::testing::Test {
           sp3.orbit(sp3_orbit.satellite);
       CHECK_EQ(orbit.size(), 1);
       auto const& arc = *orbit.front();
-      for (auto it = arc.Begin(); it != arc.End(); ++it) {
-        ephemeris_->Prolong(it.time());
+      for (auto const& [time, degrees_of_freedom] : arc) {
+        ephemeris_->Prolong(time);
         result->Append(
-            it.time(),
-            gcrs.ToThisFrameAtTime(it.time())(
-                itrs.FromThisFrameAtTime(it.time())(it.degrees_of_freedom())));
+            time,
+            gcrs.ToThisFrameAtTime(time)(
+                itrs.FromThisFrameAtTime(time)(degrees_of_freedom)));
       }
     }
     return result;

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -31,16 +31,16 @@ Angle CelestialLongitude(Position<PrimaryCentred> const& q) {
 template<typename Iterator, typename Inertial>
 Angle PlanetocentricLongitude(Iterator const& it,
                               RotatingBody<Inertial> const& primary) {
-  return CelestialLongitude(it.degrees_of_freedom().position()) -
-         primary.AngleAt(it.time()) - π / 2 * Radian;
+  return CelestialLongitude(it->degrees_of_freedom.position()) -
+         primary.AngleAt(it->time) - π / 2 * Radian;
 }
 
 // The resulting angle is not normalized.
 template<typename Iterator>
 Angle MeanSolarTime(Iterator const& it,
                     OrbitGroundTrack::MeanSun const& mean_sun) {
-  Time const t = it.time() - mean_sun.epoch;
-  return π * Radian + CelestialLongitude(it.degrees_of_freedom().position()) -
+  Time const t = it->time - mean_sun.epoch;
+  return π * Radian + CelestialLongitude(it->degrees_of_freedom.position()) -
          (mean_sun.mean_longitude_at_epoch +
           (2 * π * Radian * t / mean_sun.year));
 }

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -51,7 +51,7 @@ Interval<Angle> MeanSolarTimesOfNodes(
     OrbitGroundTrack::MeanSun const& mean_sun) {
   Interval<Angle> mean_solar_times;
   std::optional<Angle> mean_solar_time;
-  for (auto node = nodes.Begin(); node != nodes.End(); ++node) {
+  for (auto node = nodes.begin(); node != nodes.end(); ++node) {
     if (mean_solar_time.has_value()) {
       mean_solar_time =
           UnwindFrom(*mean_solar_time, MeanSolarTime(node, mean_sun));
@@ -71,8 +71,8 @@ Interval<Angle> ReducedLongitudesOfEquatorialCrossings(
     std::optional<Angle>& initial_offset) {
   Interval<Angle> reduced_longitudes;
   std::optional<Angle> reduced_longitude;
-  for (auto [node, n] = std::make_pair(nodes.Begin(), 0);  // NOLINT
-       node != nodes.End();
+  for (auto [node, n] = std::make_pair(nodes.begin(), 0);  // NOLINT
+       node != nodes.end();
        ++node, ++n) {
     Angle const planetocentric_longitude =
         PlanetocentricLongitude(node, primary);
@@ -103,8 +103,8 @@ OrbitGroundTrack OrbitGroundTrack::ForTrajectory(
   DiscreteTrajectory<PrimaryCentred> ascending_nodes;
   DiscreteTrajectory<PrimaryCentred> descending_nodes;
   OrbitGroundTrack ground_track;
-  ComputeNodes(trajectory.Begin(),
-               trajectory.End(),
+  ComputeNodes(trajectory.begin(),
+               trajectory.end(),
                Vector<double, PrimaryCentred>({0, 0, 1}),
                /*max_points=*/std::numeric_limits<int>::max(),
                ascending_nodes,

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -52,7 +52,8 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
         "trajectory does not span one sidereal period: sidereal period is " +
             DebugString(orbital_elements.sidereal_period_) +
             ", trajectory spans " +
-            DebugString(trajectory.last().time() - trajectory.Begin().time()));
+            DebugString(trajectory.rbegin().time() -
+                        trajectory.begin().time()));
   }
   orbital_elements.mean_classical_elements_ =
       ToClassicalElements(orbital_elements.mean_equinoctial_elements_);
@@ -113,12 +114,12 @@ OrbitalElements::OsculatingEquinoctialElements(
   DegreesOfFreedom<PrimaryCentred> const primary_dof{
       PrimaryCentred::origin, Velocity<PrimaryCentred>{}};
   std::vector<EquinoctialElements> result;
-  for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
+  for (auto const& [time, degrees_of_freedom] : trajectory) {
     auto const osculating_elements =
         KeplerOrbit<PrimaryCentred>(primary,
                                     secondary,
-                                    it.degrees_of_freedom() - primary_dof,
-                                    it.time())
+                                    degrees_of_freedom - primary_dof,
+                                    time)
             .elements_at_epoch();
     double const& e = *osculating_elements.eccentricity;
     Angle const& ϖ = *osculating_elements.longitude_of_periapsis;
@@ -128,7 +129,7 @@ OrbitalElements::OsculatingEquinoctialElements(
     double const tg_½i = Tan(i / 2);
     double const cotg_½i = 1 / tg_½i;
     result.push_back(
-        {/*.t = */ it.time(),
+        {/*.t = */ time,
          /*.a = */ *osculating_elements.semimajor_axis,
          /*.h = */ e * Sin(ϖ),
          /*.k = */ e * Cos(ϖ),

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -53,7 +53,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
             DebugString(orbital_elements.sidereal_period_) +
             ", trajectory spans " +
             DebugString(trajectory.back().time -
-                        trajectory.begin()->time));
+                        trajectory.front().time));
   }
   orbital_elements.mean_classical_elements_ =
       ToClassicalElements(orbital_elements.mean_equinoctial_elements_);

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -53,7 +53,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
             DebugString(orbital_elements.sidereal_period_) +
             ", trajectory spans " +
             DebugString(trajectory.back().time -
-                        trajectory.begin().time()));
+                        trajectory.begin()->time));
   }
   orbital_elements.mean_classical_elements_ =
       ToClassicalElements(orbital_elements.mean_equinoctial_elements_);

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -52,7 +52,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
         "trajectory does not span one sidereal period: sidereal period is " +
             DebugString(orbital_elements.sidereal_period_) +
             ", trajectory spans " +
-            DebugString(trajectory.rbegin().time() -
+            DebugString(trajectory.back().time -
                         trajectory.begin().time()));
   }
   orbital_elements.mean_classical_elements_ =

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -112,10 +112,8 @@ class OrbitalElementsTest : public ::testing::Test {
         },
         /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max());
     auto result = make_not_null_unique<DiscreteTrajectory<GCRS>>();
-    for (auto it = icrs_trajectory.Begin(); it != icrs_trajectory.End(); ++it) {
-      result->Append(
-          it.time(),
-          gcrs.ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+    for (auto const& [time, degrees_of_freedom] : icrs_trajectory) {
+      result->Append(time, gcrs.ToThisFrameAtTime(time)(degrees_of_freedom));
     }
     return result;
   }

--- a/astronomy/standard_product_3.cpp
+++ b/astronomy/standard_product_3.cpp
@@ -38,7 +38,7 @@ not_null<std::unique_ptr<DiscreteTrajectory<ITRS>>> ComputeVelocities(
   CHECK_GE(arc.Size(), n);
   std::array<Instant, n> times;
   std::array<Position<ITRS>, n> positions;
-  auto it = arc.Begin();
+  auto it = arc.begin();
   for (int k = 0; k < n; ++k, ++it) {
     // TODO(egg): we should check when reading the file that the times are
     // equally spaced at the interval declared in columns 25-38 of SP3
@@ -59,7 +59,7 @@ not_null<std::unique_ptr<DiscreteTrajectory<ITRS>>> ComputeVelocities(
              offset)});
     // At every iteration, either |offset| advances, or the |positions|
     // window shifts and |it| advances.
-    if (offset < (n - 1) / 2 || it == arc.End()) {
+    if (offset < (n - 1) / 2 || it == arc.end()) {
       ++offset;
     } else {
       std::move(positions.begin() + 1, positions.end(), positions.begin());

--- a/astronomy/standard_product_3.cpp
+++ b/astronomy/standard_product_3.cpp
@@ -43,8 +43,8 @@ not_null<std::unique_ptr<DiscreteTrajectory<ITRS>>> ComputeVelocities(
     // TODO(egg): we should check when reading the file that the times are
     // equally spaced at the interval declared in columns 25-38 of SP3
     // line two.
-    times[k] = it.time();
-    positions[k] = it.degrees_of_freedom().position();
+    times[k] = it->time;
+    positions[k] = it->degrees_of_freedom.position();
   }
   // We use a central difference formula wherever possible, so we keep
   // |offset| at (n - 1) / 2 except at the beginning and end of the arc.
@@ -64,8 +64,8 @@ not_null<std::unique_ptr<DiscreteTrajectory<ITRS>>> ComputeVelocities(
     } else {
       std::move(positions.begin() + 1, positions.end(), positions.begin());
       std::move(times.begin() + 1, times.end(), times.begin());
-      times.back() = it.time();
-      positions.back()  = it.degrees_of_freedom().position();
+      times.back() = it->time;
+      positions.back()  = it->degrees_of_freedom.position();
       ++it;
     }
   }

--- a/astronomy/standard_product_3_test.cpp
+++ b/astronomy/standard_product_3_test.cpp
@@ -364,14 +364,14 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
   for (auto const& satellite : sp3.satellites()) {
     for (not_null<DiscreteTrajectory<ITRS> const*> const arc :
          sp3.orbit(satellite)) {
-      auto it = arc->Begin();
+      auto it = arc->begin();
       for (int i = 0;; ++i) {
         DiscreteTrajectory<ICRS> integrated_arc;
         ephemeris_->Prolong(it.time());
         integrated_arc.Append(
             it.time(),
             itrs_.FromThisFrameAtTime(it.time())(it.degrees_of_freedom()));
-        if (++it == arc->End()) {
+        if (++it == arc->end()) {
           break;
         }
       ephemeris_->FlowWithAdaptiveStep(
@@ -387,7 +387,7 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
                 /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
             /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max());
       DegreesOfFreedom<ICRS> actual =
-          integrated_arc.last().degrees_of_freedom();
+          integrated_arc.rbegin().degrees_of_freedom();
       DegreesOfFreedom<ICRS> expected =
           itrs_.FromThisFrameAtTime(it.time())(it.degrees_of_freedom());
       EXPECT_THAT(AbsoluteError(expected.position(), actual.position()),

--- a/astronomy/standard_product_3_test.cpp
+++ b/astronomy/standard_product_3_test.cpp
@@ -387,7 +387,7 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
                 /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
             /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max());
       DegreesOfFreedom<ICRS> actual =
-          integrated_arc.rbegin().degrees_of_freedom();
+          integrated_arc.back().degrees_of_freedom;
       DegreesOfFreedom<ICRS> expected =
           itrs_.FromThisFrameAtTime(it.time())(it.degrees_of_freedom());
       EXPECT_THAT(AbsoluteError(expected.position(), actual.position()),

--- a/astronomy/standard_product_3_test.cpp
+++ b/astronomy/standard_product_3_test.cpp
@@ -367,17 +367,17 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
       auto it = arc->begin();
       for (int i = 0;; ++i) {
         DiscreteTrajectory<ICRS> integrated_arc;
-        ephemeris_->Prolong(it.time());
+        ephemeris_->Prolong(it->time);
         integrated_arc.Append(
-            it.time(),
-            itrs_.FromThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+            it->time,
+            itrs_.FromThisFrameAtTime(it->time)(it->degrees_of_freedom));
         if (++it == arc->end()) {
           break;
         }
       ephemeris_->FlowWithAdaptiveStep(
             &integrated_arc,
             Ephemeris<ICRS>::NoIntrinsicAcceleration,
-            it.time(),
+            it->time,
             Ephemeris<ICRS>::AdaptiveStepParameters(
                 EmbeddedExplicitRungeKuttaNyströmIntegrator<
                     DormandالمكاوىPrince1986RKN434FM,
@@ -389,7 +389,7 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
       DegreesOfFreedom<ICRS> actual =
           integrated_arc.back().degrees_of_freedom;
       DegreesOfFreedom<ICRS> expected =
-          itrs_.FromThisFrameAtTime(it.time())(it.degrees_of_freedom());
+          itrs_.FromThisFrameAtTime(it->time)(it->degrees_of_freedom);
       EXPECT_THAT(AbsoluteError(expected.position(), actual.position()),
                   Lt(25 * Metre))
           << "orbit of satellite " << satellite << " flowing from point " << i;

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -75,17 +75,17 @@ class ApsidesBenchmark : public benchmark::Fixture {
     auto const ilrsa_lageos2_trajectory_itrs =
         ilrsa_lageos2_sp3.orbit(lageos2_id).front();
     auto const begin = ilrsa_lageos2_trajectory_itrs->begin();
-    ephemeris_->Prolong(begin.time());
+    ephemeris_->Prolong(begin->time);
 
     BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_, earth_);
     ilrsa_lageos2_trajectory_icrs_ = new DiscreteTrajectory<ICRS>;
     ilrsa_lageos2_trajectory_icrs_->Append(
-        begin.time(),
-        itrs.FromThisFrameAtTime(begin.time())(begin.degrees_of_freedom()));
+        begin->time,
+        itrs.FromThisFrameAtTime(begin->time)(begin->degrees_of_freedom));
     ephemeris_->FlowWithAdaptiveStep(
         ilrsa_lageos2_trajectory_icrs_,
         Ephemeris<ICRS>::NoIntrinsicAcceleration,
-        begin.time() + 1 * JulianYear,
+        begin->time + 1 * JulianYear,
         Ephemeris<ICRS>::AdaptiveStepParameters(
             EmbeddedExplicitRungeKuttaNyströmIntegrator<
                 DormandالمكاوىPrince1986RKN434FM,

--- a/benchmarks/apsides.cpp
+++ b/benchmarks/apsides.cpp
@@ -74,7 +74,7 @@ class ApsidesBenchmark : public benchmark::Fixture {
 
     auto const ilrsa_lageos2_trajectory_itrs =
         ilrsa_lageos2_sp3.orbit(lageos2_id).front();
-    auto const begin = ilrsa_lageos2_trajectory_itrs->Begin();
+    auto const begin = ilrsa_lageos2_trajectory_itrs->begin();
     ephemeris_->Prolong(begin.time());
 
     BodySurfaceDynamicFrame<ICRS, ITRS> const itrs(ephemeris_, earth_);
@@ -98,12 +98,10 @@ class ApsidesBenchmark : public benchmark::Fixture {
     BodyCentredNonRotatingDynamicFrame<ICRS, GCRS> const gcrs(ephemeris_,
                                                               earth_);
     ilrsa_lageos2_trajectory_gcrs_ = new DiscreteTrajectory<GCRS>;
-    for (auto it = ilrsa_lageos2_trajectory_icrs_->Begin();
-         it != ilrsa_lageos2_trajectory_icrs_->End();
-         ++it) {
+    for (auto const& [time, degrees_of_freedom] :
+         *ilrsa_lageos2_trajectory_icrs_) {
       ilrsa_lageos2_trajectory_gcrs_->Append(
-          it.time(),
-          gcrs.ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+          time, gcrs.ToThisFrameAtTime(time)(degrees_of_freedom));
     }
   }
 
@@ -137,8 +135,8 @@ BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
     DiscreteTrajectory<ICRS> apoapsides;
     DiscreteTrajectory<ICRS> periapsides;
     ComputeApsides(*earth_trajectory_,
-                   ilrsa_lageos2_trajectory_icrs_->Begin(),
-                   ilrsa_lageos2_trajectory_icrs_->End(),
+                   ilrsa_lageos2_trajectory_icrs_->begin(),
+                   ilrsa_lageos2_trajectory_icrs_->end(),
                    /*max_points=*/std::numeric_limits<int>::max(),
                    apoapsides,
                    periapsides);
@@ -151,8 +149,8 @@ BENCHMARK_F(ApsidesBenchmark, ComputeNodes)(benchmark::State& state) {
   for (auto _ : state) {
     DiscreteTrajectory<GCRS> ascending;
     DiscreteTrajectory<GCRS> descending;
-    ComputeNodes(ilrsa_lageos2_trajectory_gcrs_->Begin(),
-                 ilrsa_lageos2_trajectory_gcrs_->End(),
+    ComputeNodes(ilrsa_lageos2_trajectory_gcrs_->begin(),
+                 ilrsa_lageos2_trajectory_gcrs_->end(),
                  Vector<double, GCRS>({0, 0, 1}),
                  /*max_points=*/std::numeric_limits<int>::max(),
                  ascending,

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -104,11 +104,11 @@ ApplyDynamicFrame(
   }
 
   // Render the trajectory at current time in |Rendering|.
-  Instant const& current_time = intermediate_trajectory.last().time();
+  Instant const& current_time = intermediate_trajectory.rbegin().time();
   DiscreteTrajectory<Rendering>::Iterator initial_it =
-      intermediate_trajectory.Begin();
+      intermediate_trajectory.begin();
   DiscreteTrajectory<Rendering>::Iterator const intermediate_end =
-      intermediate_trajectory.End();
+      intermediate_trajectory.end();
   auto to_rendering_frame_at_current_time =
       dynamic_frame->FromThisFrameAtTime(current_time).rigid_transformation();
   if (initial_it != intermediate_end) {
@@ -168,8 +168,8 @@ void BM_BodyCentredNonRotatingDynamicFrame(benchmark::State& state) {
   while (state.KeepRunning()) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
-                               probe_trajectory.Begin(),
-                               probe_trajectory.End());
+                               probe_trajectory.begin(),
+                               probe_trajectory.end());
   }
 }
 
@@ -218,8 +218,8 @@ void BM_BarycentricRotatingDynamicFrame(benchmark::State& state) {
   while (state.KeepRunning()) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
-                               probe_trajectory.Begin(),
-                               probe_trajectory.End());
+                               probe_trajectory.begin(),
+                               probe_trajectory.end());
   }
 }
 

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -104,7 +104,7 @@ ApplyDynamicFrame(
   }
 
   // Render the trajectory at current time in |Rendering|.
-  Instant const& current_time = intermediate_trajectory.rbegin().time();
+  Instant const& current_time = intermediate_trajectory.back().time;
   DiscreteTrajectory<Rendering>::Iterator initial_it =
       intermediate_trajectory.begin();
   DiscreteTrajectory<Rendering>::Iterator const intermediate_end =

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -99,8 +99,8 @@ ApplyDynamicFrame(
   DiscreteTrajectory<Rendering> intermediate_trajectory;
   for (auto it = begin; it != end; ++it) {
     intermediate_trajectory.Append(
-        it.time(),
-        dynamic_frame->ToThisFrameAtTime(it.time())(it.degrees_of_freedom()));
+        it->time,
+        dynamic_frame->ToThisFrameAtTime(it->time)(it->degrees_of_freedom));
   }
 
   // Render the trajectory at current time in |Rendering|.
@@ -116,9 +116,9 @@ ApplyDynamicFrame(
          ++final_it, final_it != intermediate_end;
          initial_it = final_it) {
       result.emplace_back(to_rendering_frame_at_current_time(
-                              initial_it.degrees_of_freedom().position()),
+                              initial_it->degrees_of_freedom.position()),
                           to_rendering_frame_at_current_time(
-                              final_it.degrees_of_freedom().position()));
+                              final_it->degrees_of_freedom.position()));
     }
   }
   return result;

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -98,9 +98,10 @@ ApplyDynamicFrame(
   // Compute the trajectory in the rendering frame.
   DiscreteTrajectory<Rendering> intermediate_trajectory;
   for (auto it = begin; it != end; ++it) {
+    auto const& [time, degrees_of_freedom] = *it;
     intermediate_trajectory.Append(
-        it->time,
-        dynamic_frame->ToThisFrameAtTime(it->time)(it->degrees_of_freedom));
+        time,
+        dynamic_frame->ToThisFrameAtTime(time)(degrees_of_freedom));
   }
 
   // Render the trajectory at current time in |Rendering|.

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -228,13 +228,13 @@ void BM_EphemerisLEOProbe(benchmark::State& state) {
                      *ephemeris,
                      SolarSystemFactory::name(SolarSystemFactory::Sun)).
                          EvaluatePosition(final_time) -
-                 trajectory.rbegin().degrees_of_freedom().position()).
+                 trajectory.back().degrees_of_freedom.position()).
                      Norm();
     earth_error = (at_спутник_1_launch->trajectory(
                        *ephemeris,
                        SolarSystemFactory::name(SolarSystemFactory::Earth)).
                            EvaluatePosition(final_time) -
-                   trajectory.rbegin().degrees_of_freedom().position()).
+                   trajectory.back().degrees_of_freedom.position()).
                        Norm();
     steps = trajectory.Size();
     state.ResumeTiming();
@@ -298,13 +298,13 @@ void BM_EphemerisTranslunarSpaceProbe(benchmark::State& state) {
                      *ephemeris,
                      SolarSystemFactory::name(SolarSystemFactory::Sun)).
                          EvaluatePosition(final_time) -
-                 trajectory.rbegin().degrees_of_freedom().position()).
+                 trajectory.back().degrees_of_freedom.position()).
                      Norm();
     earth_error = (at_спутник_1_launch->trajectory(
                        *ephemeris,
                        SolarSystemFactory::name(SolarSystemFactory::Earth)).
                            EvaluatePosition(final_time) -
-                   trajectory.rbegin().degrees_of_freedom().position()).
+                   trajectory.back().degrees_of_freedom.position()).
                        Norm();
     steps = trajectory.Size();
     state.ResumeTiming();
@@ -392,7 +392,7 @@ void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
     Length const earth_distance =
         (at_спутник_1_launch->trajectory(*ephemeris, earth_name).
              EvaluatePosition(final_time) -
-         trajectory.rbegin().degrees_of_freedom().position()).Norm();
+         trajectory.back().degrees_of_freedom.position()).Norm();
     ss << earth_distance << " ";
   }
   state.SetLabel(ss.str());
@@ -486,13 +486,13 @@ void EphemerisL4ProbeBenchmark(Time const integration_duration,
              *ephemeris,
              SolarSystemFactory::name(
                  SolarSystemFactory::Sun)).EvaluatePosition(final_time) -
-         trajectory->rbegin().degrees_of_freedom().position()).Norm();
+         trajectory->back().degrees_of_freedom.position()).Norm();
     earth_error =
         (at_спутник_1_launch->trajectory(
              *ephemeris,
              SolarSystemFactory::name(
                  SolarSystemFactory::Earth)).EvaluatePosition(final_time) -
-         trajectory->rbegin().degrees_of_freedom().position()).Norm();
+         trajectory->back().degrees_of_freedom.position()).Norm();
     steps = trajectory->Size();
     state.ResumeTiming();
   }

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -228,13 +228,13 @@ void BM_EphemerisLEOProbe(benchmark::State& state) {
                      *ephemeris,
                      SolarSystemFactory::name(SolarSystemFactory::Sun)).
                          EvaluatePosition(final_time) -
-                 trajectory.last().degrees_of_freedom().position()).
+                 trajectory.rbegin().degrees_of_freedom().position()).
                      Norm();
     earth_error = (at_спутник_1_launch->trajectory(
                        *ephemeris,
                        SolarSystemFactory::name(SolarSystemFactory::Earth)).
                            EvaluatePosition(final_time) -
-                   trajectory.last().degrees_of_freedom().position()).
+                   trajectory.rbegin().degrees_of_freedom().position()).
                        Norm();
     steps = trajectory.Size();
     state.ResumeTiming();
@@ -298,13 +298,13 @@ void BM_EphemerisTranslunarSpaceProbe(benchmark::State& state) {
                      *ephemeris,
                      SolarSystemFactory::name(SolarSystemFactory::Sun)).
                          EvaluatePosition(final_time) -
-                 trajectory.last().degrees_of_freedom().position()).
+                 trajectory.rbegin().degrees_of_freedom().position()).
                      Norm();
     earth_error = (at_спутник_1_launch->trajectory(
                        *ephemeris,
                        SolarSystemFactory::name(SolarSystemFactory::Earth)).
                            EvaluatePosition(final_time) -
-                   trajectory.last().degrees_of_freedom().position()).
+                   trajectory.rbegin().degrees_of_freedom().position()).
                        Norm();
     steps = trajectory.Size();
     state.ResumeTiming();
@@ -392,7 +392,7 @@ void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
     Length const earth_distance =
         (at_спутник_1_launch->trajectory(*ephemeris, earth_name).
              EvaluatePosition(final_time) -
-         trajectory.last().degrees_of_freedom().position()).Norm();
+         trajectory.rbegin().degrees_of_freedom().position()).Norm();
     ss << earth_distance << " ";
   }
   state.SetLabel(ss.str());
@@ -486,13 +486,13 @@ void EphemerisL4ProbeBenchmark(Time const integration_duration,
              *ephemeris,
              SolarSystemFactory::name(
                  SolarSystemFactory::Sun)).EvaluatePosition(final_time) -
-         trajectory->last().degrees_of_freedom().position()).Norm();
+         trajectory->rbegin().degrees_of_freedom().position()).Norm();
     earth_error =
         (at_спутник_1_launch->trajectory(
              *ephemeris,
              SolarSystemFactory::name(
                  SolarSystemFactory::Earth)).EvaluatePosition(final_time) -
-         trajectory->last().degrees_of_freedom().position()).Norm();
+         trajectory->rbegin().degrees_of_freedom().position()).Norm();
     steps = trajectory->Size();
     state.ResumeTiming();
   }

--- a/benchmarks/planetarium_plot_methods.cpp
+++ b/benchmarks/planetarium_plot_methods.cpp
@@ -190,8 +190,8 @@ void RunBenchmark(benchmark::State& state,
   // This is the time of a lunar eclipse in January 2000.
   constexpr Instant now = "2000-01-21T04:41:30,5"_TT;
   while (state.KeepRunning()) {
-    lines = planetarium.PlotMethod2(satellites.goes_8_trajectory().Begin(),
-                                    satellites.goes_8_trajectory().End(),
+    lines = planetarium.PlotMethod2(satellites.goes_8_trajectory().begin(),
+                                    satellites.goes_8_trajectory().end(),
                                     now,
                                     /*reverse=*/false);
     total_lines += lines.size();

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -76,7 +76,7 @@ Instant FlightPlan::initial_time() const {
 }
 
 Instant FlightPlan::actual_final_time() const {
-  return segments_.back()->rbegin().time();
+  return segments_.back()->back().time;
 }
 
 Instant FlightPlan::desired_final_time() const {
@@ -121,7 +121,7 @@ void FlightPlan::ForgetBefore(Instant const& time,
   // we only look at coasts.
   std::optional<int> first_to_keep;
   for (int i = 0; i < segments_.size(); i += 2) {
-    if (time <= segments_[i]->rbegin().time()) {
+    if (time <= segments_[i]->back().time) {
       first_to_keep = i;
       break;
     }

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -138,8 +138,8 @@ void FlightPlan::ForgetBefore(Instant const& time,
       segments_[*first_to_keep]->DetachFork();
   new_first_coast->ForgetBefore(time);
   root_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();
-  root_->Append(new_first_coast->begin()->time,
-                new_first_coast->begin()->degrees_of_freedom);
+  root_->Append(new_first_coast->front().time,
+                new_first_coast->front().degrees_of_freedom);
   root_->AttachFork(std::move(new_first_coast));
 
   // Remove from the vectors the trajectories and manœuvres that we don't want

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -76,7 +76,7 @@ Instant FlightPlan::initial_time() const {
 }
 
 Instant FlightPlan::actual_final_time() const {
-  return segments_.back()->last().time();
+  return segments_.back()->rbegin().time();
 }
 
 Instant FlightPlan::desired_final_time() const {
@@ -121,7 +121,7 @@ void FlightPlan::ForgetBefore(Instant const& time,
   // we only look at coasts.
   std::optional<int> first_to_keep;
   for (int i = 0; i < segments_.size(); i += 2) {
-    if (time <= segments_[i]->last().time()) {
+    if (time <= segments_[i]->rbegin().time()) {
       first_to_keep = i;
       break;
     }
@@ -138,8 +138,8 @@ void FlightPlan::ForgetBefore(Instant const& time,
       segments_[*first_to_keep]->DetachFork();
   new_first_coast->ForgetBefore(time);
   root_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();
-  root_->Append(new_first_coast->Begin().time(),
-                new_first_coast->Begin().degrees_of_freedom());
+  root_->Append(new_first_coast->begin().time(),
+                new_first_coast->begin().degrees_of_freedom());
   root_->AttachFork(std::move(new_first_coast));
 
   // Remove from the vectors the trajectories and manœuvres that we don't want
@@ -149,7 +149,7 @@ void FlightPlan::ForgetBefore(Instant const& time,
   manœuvres_.erase(manœuvres_.cbegin(),
                    manœuvres_.cbegin() + *first_to_keep / 2);
 
-  auto const root_begin = root_->Begin();
+  auto const root_begin = root_->begin();
   initial_time_ = root_begin.time();
   initial_degrees_of_freedom_ = root_begin.degrees_of_freedom();
 }
@@ -241,14 +241,14 @@ void FlightPlan::GetSegment(
   CHECK_LE(0, index);
   CHECK_LT(index, number_of_segments());
   begin = segments_[index]->Fork();
-  end = segments_[index]->End();
+  end = segments_[index]->end();
 }
 
 void FlightPlan::GetAllSegments(
     DiscreteTrajectory<Barycentric>::Iterator& begin,
     DiscreteTrajectory<Barycentric>::Iterator& end) const {
   begin = segments_.back()->Find(segments_.front()->Fork().time());
-  end = segments_.back()->End();
+  end = segments_.back()->end();
   CHECK(begin != end);
 }
 

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -138,8 +138,8 @@ void FlightPlan::ForgetBefore(Instant const& time,
       segments_[*first_to_keep]->DetachFork();
   new_first_coast->ForgetBefore(time);
   root_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();
-  root_->Append(new_first_coast->begin().time(),
-                new_first_coast->begin().degrees_of_freedom());
+  root_->Append(new_first_coast->begin()->time,
+                new_first_coast->begin()->degrees_of_freedom);
   root_->AttachFork(std::move(new_first_coast));
 
   // Remove from the vectors the trajectories and manœuvres that we don't want
@@ -150,8 +150,8 @@ void FlightPlan::ForgetBefore(Instant const& time,
                    manœuvres_.cbegin() + *first_to_keep / 2);
 
   auto const root_begin = root_->begin();
-  initial_time_ = root_begin.time();
-  initial_degrees_of_freedom_ = root_begin.degrees_of_freedom();
+  initial_time_ = root_begin->time;
+  initial_degrees_of_freedom_ = root_begin->degrees_of_freedom;
 }
 
 Status FlightPlan::RemoveLast() {
@@ -247,7 +247,7 @@ void FlightPlan::GetSegment(
 void FlightPlan::GetAllSegments(
     DiscreteTrajectory<Barycentric>::Iterator& begin,
     DiscreteTrajectory<Barycentric>::Iterator& end) const {
-  begin = segments_.back()->Find(segments_.front()->Fork().time());
+  begin = segments_.back()->Find(segments_.front()->Fork()->time);
   end = segments_.back()->end();
   CHECK(begin != end);
 }
@@ -446,7 +446,7 @@ void FlightPlan::AddLastSegment() {
 }
 
 void FlightPlan::ResetLastSegment() {
-  segments_.back()->ForgetAfter(segments_.back()->Fork().time());
+  segments_.back()->ForgetAfter(segments_.back()->Fork()->time);
   if (anomalous_segments_ == 1) {
     anomalous_segments_ = 0;
   }

--- a/ksp_plugin/interface_external.cpp
+++ b/ksp_plugin/interface_external.cpp
@@ -201,9 +201,9 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
       plugin->NewBodyCentredNonRotatingNavigationFrame(central_body_index);
   DiscreteTrajectory<Navigation> coast;
   for (auto it = coast_begin; it != coast_end; ++it) {
-    coast.Append(it.time(),
-                 body_centred_inertial->ToThisFrameAtTime(it.time())(
-                     it.degrees_of_freedom()));
+    coast.Append(it->time,
+                 body_centred_inertial->ToThisFrameAtTime(it->time)(
+                     it->degrees_of_freedom));
   }
 
   Instant const current_time = plugin->CurrentTime();
@@ -228,7 +228,7 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
       from_world_body_centred_inertial.rigid_transformation()(
           FromXYZ<Position<World>>(world_body_centred_reference_position));
   DiscreteTrajectory<Navigation> immobile_reference;
-  immobile_reference.Append(coast.begin().time(),
+  immobile_reference.Append(coast.begin()->time,
                             {reference_position, Velocity<Navigation>{}});
   if (coast.Size() > 1) {
     immobile_reference.Append(coast.back().time,
@@ -244,18 +244,18 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
                  periapsides);
   if (periapsides.Empty()) {
     bool const begin_is_nearest =
-        (coast.begin().degrees_of_freedom().position() -
+        (coast.begin()->degrees_of_freedom.position() -
          reference_position).Norm²() <
         (coast.back().degrees_of_freedom.position() -
          reference_position).Norm²();
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            begin_is_nearest ? coast.begin().degrees_of_freedom()
+            begin_is_nearest ? coast.begin()->degrees_of_freedom
                              : coast.back().degrees_of_freedom));
   } else {
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            periapsides.begin().degrees_of_freedom()));
+            periapsides.begin()->degrees_of_freedom));
   }
   return m.Return(OK());
 }

--- a/ksp_plugin/interface_external.cpp
+++ b/ksp_plugin/interface_external.cpp
@@ -231,7 +231,7 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
   immobile_reference.Append(coast.begin().time(),
                             {reference_position, Velocity<Navigation>{}});
   if (coast.Size() > 1) {
-    immobile_reference.Append(coast.rbegin().time(),
+    immobile_reference.Append(coast.back().time,
                               {reference_position, Velocity<Navigation>{}});
   }
   DiscreteTrajectory<Navigation> apoapsides;
@@ -246,12 +246,12 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
     bool const begin_is_nearest =
         (coast.begin().degrees_of_freedom().position() -
          reference_position).Norm²() <
-        (coast.rbegin().degrees_of_freedom().position() -
+        (coast.back().degrees_of_freedom.position() -
          reference_position).Norm²();
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
             begin_is_nearest ? coast.begin().degrees_of_freedom()
-                             : coast.rbegin().degrees_of_freedom()));
+                             : coast.back().degrees_of_freedom));
   } else {
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(

--- a/ksp_plugin/interface_external.cpp
+++ b/ksp_plugin/interface_external.cpp
@@ -228,7 +228,7 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
       from_world_body_centred_inertial.rigid_transformation()(
           FromXYZ<Position<World>>(world_body_centred_reference_position));
   DiscreteTrajectory<Navigation> immobile_reference;
-  immobile_reference.Append(coast.begin()->time,
+  immobile_reference.Append(coast.front().time,
                             {reference_position, Velocity<Navigation>{}});
   if (coast.Size() > 1) {
     immobile_reference.Append(coast.back().time,
@@ -244,18 +244,18 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
                  periapsides);
   if (periapsides.Empty()) {
     bool const begin_is_nearest =
-        (coast.begin()->degrees_of_freedom.position() -
+        (coast.front().degrees_of_freedom.position() -
          reference_position).Norm²() <
         (coast.back().degrees_of_freedom.position() -
          reference_position).Norm²();
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            begin_is_nearest ? coast.begin()->degrees_of_freedom
+            begin_is_nearest ? coast.front().degrees_of_freedom
                              : coast.back().degrees_of_freedom));
   } else {
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            periapsides.begin()->degrees_of_freedom));
+            periapsides.front().degrees_of_freedom));
   }
   return m.Return(OK());
 }

--- a/ksp_plugin/interface_external.cpp
+++ b/ksp_plugin/interface_external.cpp
@@ -228,34 +228,34 @@ Status principia__ExternalGetNearestPlannedCoastDegreesOfFreedom(
       from_world_body_centred_inertial.rigid_transformation()(
           FromXYZ<Position<World>>(world_body_centred_reference_position));
   DiscreteTrajectory<Navigation> immobile_reference;
-  immobile_reference.Append(coast.Begin().time(),
+  immobile_reference.Append(coast.begin().time(),
                             {reference_position, Velocity<Navigation>{}});
   if (coast.Size() > 1) {
-    immobile_reference.Append(coast.last().time(),
+    immobile_reference.Append(coast.rbegin().time(),
                               {reference_position, Velocity<Navigation>{}});
   }
   DiscreteTrajectory<Navigation> apoapsides;
   DiscreteTrajectory<Navigation> periapsides;
   ComputeApsides(/*reference=*/immobile_reference,
-                 coast.Begin(),
-                 coast.End(),
+                 coast.begin(),
+                 coast.end(),
                  /*max_points=*/std::numeric_limits<int>::max(),
                  apoapsides,
                  periapsides);
   if (periapsides.Empty()) {
     bool const begin_is_nearest =
-        (coast.Begin().degrees_of_freedom().position() -
+        (coast.begin().degrees_of_freedom().position() -
          reference_position).Norm²() <
-        (coast.last().degrees_of_freedom().position() -
+        (coast.rbegin().degrees_of_freedom().position() -
          reference_position).Norm²();
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            begin_is_nearest ? coast.Begin().degrees_of_freedom()
-                             : coast.last().degrees_of_freedom()));
+            begin_is_nearest ? coast.begin().degrees_of_freedom()
+                             : coast.rbegin().degrees_of_freedom()));
   } else {
     *world_body_centred_nearest_degrees_of_freedom =
         ToQP(to_world_body_centred_inertial(
-            periapsides.Begin().degrees_of_freedom()));
+            periapsides.begin().degrees_of_freedom()));
   }
   return m.Return(OK());
 }

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -448,7 +448,7 @@ Iterator* principia__FlightPlanRenderedSegment(
           FromXYZ<Position<World>>(sun_world_position),
           plugin->PlanetariumRotation());
   if (index % 2 == 1 && !rendered_trajectory->Empty() &&
-      rendered_trajectory->begin()->time != begin->time) {
+      rendered_trajectory->front().time != begin->time) {
     // TODO(egg): this is ugly; we should centralize rendering.
     // If this is a burn and we cannot render the beginning of the burn, we
     // render none of it, otherwise we try to render the Frenet trihedron at the

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -448,7 +448,7 @@ Iterator* principia__FlightPlanRenderedSegment(
           FromXYZ<Position<World>>(sun_world_position),
           plugin->PlanetariumRotation());
   if (index % 2 == 1 && !rendered_trajectory->Empty() &&
-      rendered_trajectory->begin().time() != begin.time()) {
+      rendered_trajectory->begin()->time != begin->time) {
     // TODO(egg): this is ugly; we should centralize rendering.
     // If this is a burn and we cannot render the beginning of the burn, we
     // render none of it, otherwise we try to render the Frenet trihedron at the

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -448,7 +448,7 @@ Iterator* principia__FlightPlanRenderedSegment(
           FromXYZ<Position<World>>(sun_world_position),
           plugin->PlanetariumRotation());
   if (index % 2 == 1 && !rendered_trajectory->Empty() &&
-      rendered_trajectory->Begin().time() != begin.time()) {
+      rendered_trajectory->begin().time() != begin.time()) {
     // TODO(egg): this is ugly; we should centralize rendering.
     // If this is a burn and we cannot render the beginning of the burn, we
     // render none of it, otherwise we try to render the Frenet trihedron at the

--- a/ksp_plugin/interface_iterator.cpp
+++ b/ksp_plugin/interface_iterator.cpp
@@ -46,7 +46,7 @@ QP principia__IteratorGetDiscreteTrajectoryQP(Iterator const* const iterator) {
       dynamic_cast<TypedIterator<DiscreteTrajectory<World>> const*>(iterator));
   return m.Return(typed_iterator->Get<QP>(
       [](DiscreteTrajectory<World>::Iterator const& iterator) -> QP {
-        return ToQP(iterator.degrees_of_freedom());
+        return ToQP(iterator->degrees_of_freedom);
       }));
 }
 
@@ -59,7 +59,7 @@ double principia__IteratorGetDiscreteTrajectoryTime(
   auto const plugin = typed_iterator->plugin();
   return m.Return(typed_iterator->Get<double>(
       [plugin](DiscreteTrajectory<World>::Iterator const& iterator) -> double {
-        return ToGameTime(*plugin, iterator.time());
+        return ToGameTime(*plugin, iterator->time);
       }));
 }
 
@@ -71,7 +71,7 @@ XYZ principia__IteratorGetDiscreteTrajectoryXYZ(
       dynamic_cast<TypedIterator<DiscreteTrajectory<World>> const*>(iterator));
   return m.Return(typed_iterator->Get<XYZ>(
       [](DiscreteTrajectory<World>::Iterator const& iterator) -> XYZ {
-        return ToXYZ(iterator.degrees_of_freedom().position());
+        return ToXYZ(iterator->degrees_of_freedom.position());
       }));
 }
 

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -179,7 +179,7 @@ Iterator* principia__PlanetariumPlotPrediction(
   auto const rp2_lines = PlotMethodN(*planetarium,
                                      method,
                                      prediction.Fork(),
-                                     prediction.End(),
+                                     prediction.end(),
                                      plugin->CurrentTime(),
                                      /*reverse=*/false);
   return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
@@ -205,8 +205,8 @@ Iterator* principia__PlanetariumPlotPsychohistory(
     auto const& psychohistory = plugin->GetVessel(vessel_guid)->psychohistory();
     auto const rp2_lines = PlotMethodN(*planetarium,
                                        method,
-                                       psychohistory.Begin(),
-                                       psychohistory.End(),
+                                       psychohistory.begin(),
+                                       psychohistory.end(),
                                        plugin->CurrentTime(),
                                        /*reverse=*/true);
     return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -153,7 +153,7 @@ Iterator* principia__PlanetariumPlotFlightPlanSegment(
   // start and we fail.
   if (index % 2 == 0 ||
       segment_begin == segment_end ||
-      segment_begin.time() >= plugin->renderer().GetPlottingFrame()->t_min()) {
+      segment_begin->time >= plugin->renderer().GetPlottingFrame()->t_min()) {
      rp2_lines = PlotMethodN(*planetarium,
                              method,
                              segment_begin,

--- a/ksp_plugin/interface_renderer.cpp
+++ b/ksp_plugin/interface_renderer.cpp
@@ -49,7 +49,7 @@ void principia__RenderedPredictionApsides(Plugin const* const plugin,
   std::unique_ptr<DiscreteTrajectory<World>> rendered_periapsides;
   plugin->ComputeAndRenderApsides(celestial_index,
                                   prediction.Fork(),
-                                  prediction.End(),
+                                  prediction.end(),
                                   FromXYZ<Position<World>>(sun_world_position),
                                   max_points,
                                   rendered_apoapsides,
@@ -77,7 +77,7 @@ void principia__RenderedPredictionClosestApproaches(
   std::unique_ptr<DiscreteTrajectory<World>> rendered_closest_approaches;
   plugin->ComputeAndRenderClosestApproaches(
       prediction.Fork(),
-      prediction.End(),
+      prediction.end(),
       FromXYZ<Position<World>>(sun_world_position),
       max_points,
       rendered_closest_approaches);
@@ -101,7 +101,7 @@ void principia__RenderedPredictionNodes(Plugin const* const plugin,
   std::unique_ptr<DiscreteTrajectory<World>> rendered_ascending;
   std::unique_ptr<DiscreteTrajectory<World>> rendered_descending;
   plugin->ComputeAndRenderNodes(prediction.Fork(),
-                                prediction.End(),
+                                prediction.end(),
                                 FromXYZ<Position<World>>(sun_world_position),
                                 max_points,
                                 rendered_ascending,

--- a/ksp_plugin/iterators_body.hpp
+++ b/ksp_plugin/iterators_body.hpp
@@ -44,7 +44,7 @@ inline TypedIterator<DiscreteTrajectory<World>>::TypedIterator(
     not_null<std::unique_ptr<DiscreteTrajectory<World>>> trajectory,
     not_null<Plugin const*> const plugin)
     : trajectory_(std::move(trajectory)),
-      iterator_(trajectory_->Begin()),
+      iterator_(trajectory_->begin()),
       plugin_(plugin) {
   CHECK(trajectory_->is_root());
 }
@@ -53,12 +53,12 @@ template<typename Interchange>
 Interchange TypedIterator<DiscreteTrajectory<World>>::Get(
     std::function<Interchange(
         DiscreteTrajectory<World>::Iterator const&)> const& convert) const {
-  CHECK(iterator_ != trajectory_->End());
+  CHECK(iterator_ != trajectory_->end());
   return convert(iterator_);
 }
 
 inline bool TypedIterator<DiscreteTrajectory<World>>::AtEnd() const {
-  return iterator_ == trajectory_->End();
+  return iterator_ == trajectory_->end();
 }
 
 inline void TypedIterator<DiscreteTrajectory<World>>::Increment() {
@@ -66,7 +66,7 @@ inline void TypedIterator<DiscreteTrajectory<World>>::Increment() {
 }
 
 inline void TypedIterator<DiscreteTrajectory<World>>::Reset() {
-  iterator_ = trajectory_->Begin();
+  iterator_ = trajectory_->begin();
 }
 
 inline int TypedIterator<DiscreteTrajectory<World>>::Size() const {

--- a/ksp_plugin/manœuvre_body.hpp
+++ b/ksp_plugin/manœuvre_body.hpp
@@ -207,7 +207,7 @@ OrthogonalMap<Frenet<Frame>, InertialFrame>
   typename DiscreteTrajectory<InertialFrame>::Iterator const it =
       coasting_trajectory_->Find(initial_time());
   CHECK(it != coasting_trajectory_->end());
-  return ComputeFrenetFrame(initial_time(), it.degrees_of_freedom());
+  return ComputeFrenetFrame(initial_time(), it->degrees_of_freedom);
 }
 
 template<typename InertialFrame, typename Frame>

--- a/ksp_plugin/manœuvre_body.hpp
+++ b/ksp_plugin/manœuvre_body.hpp
@@ -206,7 +206,7 @@ OrthogonalMap<Frenet<Frame>, InertialFrame>
   CHECK_NOTNULL(coasting_trajectory_);
   typename DiscreteTrajectory<InertialFrame>::Iterator const it =
       coasting_trajectory_->Find(initial_time());
-  CHECK(it != coasting_trajectory_->End());
+  CHECK(it != coasting_trajectory_->end());
   return ComputeFrenetFrame(initial_time(), it.degrees_of_freedom());
 }
 

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -86,7 +86,7 @@ DiscreteTrajectory<Barycentric>::Iterator Part::history_begin() {
 }
 
 DiscreteTrajectory<Barycentric>::Iterator Part::history_end() {
-  return history_->End();
+  return history_->end();
 }
 
 DiscreteTrajectory<Barycentric>::Iterator Part::psychohistory_begin() {
@@ -102,7 +102,7 @@ DiscreteTrajectory<Barycentric>::Iterator Part::psychohistory_end() {
   if (psychohistory_ == nullptr) {
     psychohistory_ = history_->NewForkAtLast();
   }
-  return psychohistory_->End();
+  return psychohistory_->end();
 }
 
 void Part::AppendToHistory(
@@ -189,8 +189,8 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
         /*forks=*/{});
     // The |prehistory_| and |history_| have been created by the constructor
     // above.  Construct the various trajectories from the |tail|.
-    for (auto it = tail->Begin(); it != tail->End(); ++it) {
-      if (it == tail->last() && !message.tail_is_authoritative()) {
+    for (auto it = tail->begin(); it != tail->end(); ++it) {
+      if (it == tail->rbegin() && !message.tail_is_authoritative()) {
         part->AppendToPsychohistory(it.time(), it.degrees_of_freedom());
       } else {
         part->AppendToHistory(it.time(), it.degrees_of_freedom());

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -189,11 +189,13 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
         /*forks=*/{});
     // The |prehistory_| and |history_| have been created by the constructor
     // above.  Construct the various trajectories from the |tail|.
-    for (auto it = tail->begin(); it != tail->end(); ++it) {
-      if (it == tail->rbegin() && !message.tail_is_authoritative()) {
-        part->AppendToPsychohistory(it.time(), it.degrees_of_freedom());
+    for (auto it = tail->begin(); it != tail->end();) {
+      auto const& [time, degrees_of_freedom] = *it;
+      ++it;
+      if (it == tail->end() && !message.tail_is_authoritative()) {
+        part->AppendToPsychohistory(time, degrees_of_freedom);
       } else {
-        part->AppendToHistory(it.time(), it.degrees_of_freedom());
+        part->AppendToHistory(time, degrees_of_freedom);
       }
     }
   } else {

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -205,7 +205,7 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
     // Fork a psychohistory for compatibility if there is a non-authoritative
     // point.
     if (pile_up->history_->Size() == 2) {
-      Instant const history_begin_time = pile_up->history_->begin()->time;
+      Instant const history_begin_time = pile_up->history_->front().time;
       pile_up->psychohistory_ =
           pile_up->history_->NewForkWithCopy(history_begin_time);
       pile_up->history_->ForgetAfter(history_begin_time);

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -107,7 +107,7 @@ void PileUp::SetPartApparentDegreesOfFreedom(
 
 void PileUp::NudgeParts() const {
   auto const actual_centre_of_mass =
-      psychohistory_->last().degrees_of_freedom();
+      psychohistory_->rbegin().degrees_of_freedom();
 
   RigidMotion<Barycentric, RigidPileUp> const barycentric_to_pile_up{
       RigidTransformation<Barycentric, RigidPileUp>{
@@ -126,7 +126,7 @@ void PileUp::NudgeParts() const {
 Status PileUp::DeformAndAdvanceTime(Instant const& t) {
   absl::MutexLock l(lock_.get());
   Status status;
-  if (psychohistory_->last().time() < t) {
+  if (psychohistory_->rbegin().time() < t) {
     DeformPileUpIfNeeded();
     status = AdvanceTime(t);
     NudgeParts();
@@ -205,7 +205,7 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
     // Fork a psychohistory for compatibility if there is a non-authoritative
     // point.
     if (pile_up->history_->Size() == 2) {
-      Instant const history_begin_time = pile_up->history_->Begin().time();
+      Instant const history_begin_time = pile_up->history_->begin().time();
       pile_up->psychohistory_ =
           pile_up->history_->NewForkWithCopy(history_begin_time);
       pile_up->history_->ForgetAfter(history_begin_time);
@@ -321,7 +321,7 @@ Status PileUp::AdvanceTime(Instant const& t) {
   CHECK_NOTNULL(psychohistory_);
 
   Status status;
-  auto const history_last = history_->last();
+  auto const history_last = history_->rbegin();
   if (intrinsic_force_ == Vector<Force, Barycentric>{}) {
     // Remove the fork.
     history_->DeleteFork(psychohistory_);
@@ -331,10 +331,10 @@ Status PileUp::AdvanceTime(Instant const& t) {
           Ephemeris<Barycentric>::NoIntrinsicAccelerations,
           fixed_step_parameters_);
     }
-    CHECK_LT(history_->last().time(), t);
+    CHECK_LT(history_->rbegin().time(), t);
     status = ephemeris_->FlowWithFixedStep(t, *fixed_instance_);
     psychohistory_ = history_->NewForkAtLast();
-    if (history_->last().time() < t) {
+    if (history_->rbegin().time() < t) {
       // Do not clear the |fixed_instance_| here, we will use it for the next
       // fixed-step integration.
       status.Update(
@@ -352,7 +352,7 @@ Status PileUp::AdvanceTime(Instant const& t) {
     // We make the |psychohistory_|, if any, authoritative, i.e. append it to
     // the end of the |history_|. We integrate on top of it, and it gets
     // appended authoritatively to the part tails.
-    auto const psychohistory_end = psychohistory_->End();
+    auto const psychohistory_end = psychohistory_->end();
     auto it = psychohistory_->Fork();
     for (++it; it != psychohistory_end; ++it) {
       history_->Append(it.time(), it.degrees_of_freedom());
@@ -379,8 +379,8 @@ Status PileUp::AdvanceTime(Instant const& t) {
 
   // Append the |history_| authoritatively to the parts' tails and the
   // |psychohistory_| non-authoritatively.
-  auto const history_end = history_->End();
-  auto const psychohistory_end = psychohistory_->End();
+  auto const history_end = history_->end();
+  auto const psychohistory_end = psychohistory_->end();
   auto it = history_last;
   for (++it; it != history_end; ++it) {
     AppendToPart<&Part::AppendToHistory>(it);

--- a/ksp_plugin/planetarium.cpp
+++ b/ksp_plugin/planetarium.cpp
@@ -149,8 +149,8 @@ RP2Lines<Length, Camera> Planetarium::PlotMethod2(
       Pow<2>(parameters_.tan_angular_resolution_);
   auto const plottable_spheres = ComputePlottableSpheres(now);
   auto const& trajectory = *begin.trajectory();
-  auto const begin_time = std::max(begin.time(), plotting_frame_->t_min());
-  auto const last_time = std::min(last.time(), plotting_frame_->t_max());
+  auto const begin_time = std::max(begin->time, plotting_frame_->t_min());
+  auto const last_time = std::min(last->time, plotting_frame_->t_max());
   auto const final_time = reverse ? begin_time : last_time;
   auto previous_time = reverse ? last_time : begin_time;
   Sign const direction = reverse ? Sign(-1) : Sign(1);
@@ -275,22 +275,22 @@ Segments<Navigation> Planetarium::ComputePlottableSegments(
     return all_segments;
   }
   auto it1 = begin;
-  Instant t1 = it1.time();
+  Instant t1 = it1->time;
   RigidMotion<Barycentric, Navigation> rigid_motion_at_t1 =
       plotting_frame_->ToThisFrameAtTime(t1);
   Position<Navigation> p1 =
-      rigid_motion_at_t1(it1.degrees_of_freedom()).position();
+      rigid_motion_at_t1(it1->degrees_of_freedom).position();
 
   auto it2 = it1;
   while (++it2 != end) {
     // Processing one segment of the trajectory.
-    Instant const t2 = it2.time();
+    Instant const t2 = it2->time;
 
     // Transform the degrees of freedom to the plotting frame.
     RigidMotion<Barycentric, Navigation> const rigid_motion_at_t2 =
         plotting_frame_->ToThisFrameAtTime(t2);
     Position<Navigation> const p2 =
-        rigid_motion_at_t2(it2.degrees_of_freedom()).position();
+        rigid_motion_at_t2(it2->degrees_of_freedom).position();
 
     // Find the part of the segment that is behind the focal plane.  We don't
     // care about things that are in front of the focal plane.

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -729,7 +729,7 @@ void Plugin::CatchUpLaggingVessels(VesselSet& collided_vessels) {
   // Update the vessels.
   for (auto const& pair : vessels_) {
     Vessel& vessel = *pair.second;
-    if (vessel.psychohistory().last().time() < current_time_) {
+    if (vessel.psychohistory().rbegin().time() < current_time_) {
       if (Contains(collided_vessels, &vessel)) {
         vessel.DisableDownsampling();
       }
@@ -804,7 +804,7 @@ RelativeDegreesOfFreedom<AliceSun> Plugin::VesselFromParent(
     vessel->set_parent(parent);
   }
   RelativeDegreesOfFreedom<Barycentric> const barycentric_result =
-      vessel->psychohistory().last().degrees_of_freedom() -
+      vessel->psychohistory().rbegin().degrees_of_freedom() -
       vessel->parent()->current_degrees_of_freedom(current_time_);
   RelativeDegreesOfFreedom<AliceSun> const result =
       PlanetariumRotation()(barycentric_result);
@@ -852,7 +852,7 @@ void Plugin::UpdatePrediction(GUID const& vessel_guid) const {
   if (renderer_->HasTargetVessel()) {
     Vessel& target_vessel = renderer_->GetTargetVessel();
     target_vessel.RefreshPrediction();
-    vessel.RefreshPrediction(target_vessel.prediction().last().time());
+    vessel.RefreshPrediction(target_vessel.prediction().rbegin().time());
   } else {
     vessel.RefreshPrediction();
   }
@@ -889,14 +889,14 @@ void Plugin::ComputeAndRenderApsides(
                  periapsides_trajectory);
   apoapsides = renderer_->RenderBarycentricTrajectoryInWorld(
                    current_time_,
-                   apoapsides_trajectory.Begin(),
-                   apoapsides_trajectory.End(),
+                   apoapsides_trajectory.begin(),
+                   apoapsides_trajectory.end(),
                    sun_world_position,
                    PlanetariumRotation());
   periapsides = renderer_->RenderBarycentricTrajectoryInWorld(
                     current_time_,
-                    periapsides_trajectory.Begin(),
-                    periapsides_trajectory.End(),
+                    periapsides_trajectory.begin(),
+                    periapsides_trajectory.end(),
                     sun_world_position,
                     PlanetariumRotation());
 }
@@ -920,8 +920,8 @@ void Plugin::ComputeAndRenderClosestApproaches(
   closest_approaches =
       renderer_->RenderBarycentricTrajectoryInWorld(
           current_time_,
-          periapsides_trajectory.Begin(),
-          periapsides_trajectory.End(),
+          periapsides_trajectory.begin(),
+          periapsides_trajectory.end(),
           sun_world_position,
           PlanetariumRotation());
 }
@@ -956,8 +956,8 @@ void Plugin::ComputeAndRenderNodes(
   DiscreteTrajectory<Navigation> ascending_trajectory;
   DiscreteTrajectory<Navigation> descending_trajectory;
   // The so-called North is orthogonal to the plane of the trajectory.
-  ComputeNodes(trajectory_in_plotting->Begin(),
-               trajectory_in_plotting->End(),
+  ComputeNodes(trajectory_in_plotting->begin(),
+               trajectory_in_plotting->end(),
                Vector<double, Navigation>({0, 0, 1}),
                max_points,
                ascending_trajectory,
@@ -966,14 +966,14 @@ void Plugin::ComputeAndRenderNodes(
 
   ascending = renderer_->RenderPlottingTrajectoryInWorld(
                   current_time_,
-                  ascending_trajectory.Begin(),
-                  ascending_trajectory.End(),
+                  ascending_trajectory.begin(),
+                  ascending_trajectory.end(),
                   sun_world_position,
                   PlanetariumRotation());
   descending = renderer_->RenderPlottingTrajectoryInWorld(
                    current_time_,
-                   descending_trajectory.Begin(),
-                   descending_trajectory.End(),
+                   descending_trajectory.begin(),
+                   descending_trajectory.end(),
                    sun_world_position,
                    PlanetariumRotation());
 }
@@ -1195,7 +1195,7 @@ Velocity<World> Plugin::UnmanageableVesselVelocity(
 
 Velocity<World> Plugin::VesselVelocity(GUID const& vessel_guid) const {
   Vessel const& vessel = *FindOrDie(vessels_, vessel_guid);
-  auto const& last = vessel.psychohistory().last();
+  auto const& last = vessel.psychohistory().rbegin();
   return VesselVelocity(last.time(), last.degrees_of_freedom());
 }
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -729,7 +729,7 @@ void Plugin::CatchUpLaggingVessels(VesselSet& collided_vessels) {
   // Update the vessels.
   for (auto const& pair : vessels_) {
     Vessel& vessel = *pair.second;
-    if (vessel.psychohistory().rbegin().time() < current_time_) {
+    if (vessel.psychohistory().back().time < current_time_) {
       if (Contains(collided_vessels, &vessel)) {
         vessel.DisableDownsampling();
       }
@@ -804,7 +804,7 @@ RelativeDegreesOfFreedom<AliceSun> Plugin::VesselFromParent(
     vessel->set_parent(parent);
   }
   RelativeDegreesOfFreedom<Barycentric> const barycentric_result =
-      vessel->psychohistory().rbegin().degrees_of_freedom() -
+      vessel->psychohistory().back().degrees_of_freedom -
       vessel->parent()->current_degrees_of_freedom(current_time_);
   RelativeDegreesOfFreedom<AliceSun> const result =
       PlanetariumRotation()(barycentric_result);
@@ -852,7 +852,7 @@ void Plugin::UpdatePrediction(GUID const& vessel_guid) const {
   if (renderer_->HasTargetVessel()) {
     Vessel& target_vessel = renderer_->GetTargetVessel();
     target_vessel.RefreshPrediction();
-    vessel.RefreshPrediction(target_vessel.prediction().rbegin().time());
+    vessel.RefreshPrediction(target_vessel.prediction().back().time);
   } else {
     vessel.RefreshPrediction();
   }
@@ -1195,8 +1195,8 @@ Velocity<World> Plugin::UnmanageableVesselVelocity(
 
 Velocity<World> Plugin::VesselVelocity(GUID const& vessel_guid) const {
   Vessel const& vessel = *FindOrDie(vessels_, vessel_guid);
-  auto const& last = vessel.psychohistory().rbegin();
-  return VesselVelocity(last.time(), last.degrees_of_freedom());
+  auto const back = vessel.psychohistory().back();
+  return VesselVelocity(back.time, back.degrees_of_freedom);
 }
 
 Instant Plugin::GameEpoch() const {

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -193,19 +193,18 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
 OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
     Vessel const& vessel,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  auto const last = vessel.psychohistory().rbegin();
-  Instant const& time = last.time();
+  auto const back = vessel.psychohistory().back();
   DegreesOfFreedom<Barycentric> const& barycentric_degrees_of_freedom =
-      last.degrees_of_freedom();
+      back.degrees_of_freedom;
   DegreesOfFreedom<Navigation> const plotting_frame_degrees_of_freedom =
-      BarycentricToPlotting(time)(barycentric_degrees_of_freedom);
+      BarycentricToPlotting(back.time)(barycentric_degrees_of_freedom);
   Rotation<Frenet<Navigation>, Navigation> const
       frenet_frame_to_plotting_frame =
           GetPlottingFrame()->FrenetFrame(
-              time,
+              back.time,
               plotting_frame_degrees_of_freedom);
 
-  return PlottingToWorld(time, planetarium_rotation) *
+  return PlottingToWorld(back.time, planetarium_rotation) *
          frenet_frame_to_plotting_frame.Forget();
 }
 
@@ -213,13 +212,13 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
     Vessel const& vessel,
     NavigationFrame const& navigation_frame,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  auto const last = vessel.psychohistory().rbegin();
-  auto const to_navigation = navigation_frame.ToThisFrameAtTime(last.time());
+  auto const back = vessel.psychohistory().back();
+  auto const to_navigation = navigation_frame.ToThisFrameAtTime(back.time);
   auto const from_navigation = to_navigation.orthogonal_map().Inverse();
   auto const frenet_frame =
       navigation_frame.FrenetFrame(
-          last.time(),
-          to_navigation(last.degrees_of_freedom())).Forget();
+          back.time,
+          to_navigation(back.degrees_of_freedom)).Forget();
   return BarycentricToWorld(planetarium_rotation) * from_navigation *
          frenet_frame;
 }

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -96,7 +96,7 @@ Renderer::RenderBarycentricTrajectoryInPlotting(
     DiscreteTrajectory<Barycentric>::Iterator const& end) const {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<Navigation>>();
   for (auto it = begin; it != end; ++it) {
-    Instant const& t = it.time();
+    Instant const& t = it->time;
     if (target_) {
       auto const& prediction = target_->vessel->prediction();
       if (t < prediction.t_min()) {
@@ -105,7 +105,7 @@ Renderer::RenderBarycentricTrajectoryInPlotting(
         break;
       }
     }
-    trajectory->Append(t, BarycentricToPlotting(t)(it.degrees_of_freedom()));
+    trajectory->Append(t, BarycentricToPlotting(t)(it->degrees_of_freedom));
   }
   return trajectory;
 }
@@ -143,13 +143,13 @@ Renderer::RenderPlottingTrajectoryInWorld(
           PlottingToWorld(time, sun_world_position, planetarium_rotation);
   for (auto it = begin; it != end; ++it) {
     DegreesOfFreedom<Navigation> const& navigation_degrees_of_freedom =
-        it.degrees_of_freedom();
+        it->degrees_of_freedom;
     DegreesOfFreedom<World> const world_degrees_of_freedom = {
         from_plotting_frame_to_world_at_current_time(
             navigation_degrees_of_freedom.position()),
         geometry::Identity<Navigation, World>{}(
             navigation_degrees_of_freedom.velocity())};
-    trajectory->Append(it.time(), world_degrees_of_freedom);
+    trajectory->Append(it->time, world_degrees_of_freedom);
   }
   return trajectory;
 }

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -96,16 +96,16 @@ Renderer::RenderBarycentricTrajectoryInPlotting(
     DiscreteTrajectory<Barycentric>::Iterator const& end) const {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<Navigation>>();
   for (auto it = begin; it != end; ++it) {
-    Instant const& t = it->time;
+    auto const& [time, degrees_of_freedom] = *it;
     if (target_) {
       auto const& prediction = target_->vessel->prediction();
-      if (t < prediction.t_min()) {
+      if (time < prediction.t_min()) {
         continue;
-      } else if (t > prediction.t_max()) {
+      } else if (time > prediction.t_max()) {
         break;
       }
     }
-    trajectory->Append(t, BarycentricToPlotting(t)(it->degrees_of_freedom));
+    trajectory->Append(time, BarycentricToPlotting(time)(degrees_of_freedom));
   }
   return trajectory;
 }
@@ -142,14 +142,15 @@ Renderer::RenderPlottingTrajectoryInWorld(
       from_plotting_frame_to_world_at_current_time =
           PlottingToWorld(time, sun_world_position, planetarium_rotation);
   for (auto it = begin; it != end; ++it) {
+    auto const& [time, degrees_of_freedom] = *it;
     DegreesOfFreedom<Navigation> const& navigation_degrees_of_freedom =
-        it->degrees_of_freedom;
+        degrees_of_freedom;
     DegreesOfFreedom<World> const world_degrees_of_freedom = {
         from_plotting_frame_to_world_at_current_time(
             navigation_degrees_of_freedom.position()),
         geometry::Identity<Navigation, World>{}(
             navigation_degrees_of_freedom.velocity())};
-    trajectory->Append(it->time, world_degrees_of_freedom);
+    trajectory->Append(time, world_degrees_of_freedom);
   }
   return trajectory;
 }

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -83,8 +83,8 @@ Renderer::RenderBarycentricTrajectoryInWorld(
       RenderBarycentricTrajectoryInPlotting(begin, end);
   auto trajectory_in_world =
       RenderPlottingTrajectoryInWorld(time,
-                                      trajectory_in_plotting_frame->Begin(),
-                                      trajectory_in_plotting_frame->End(),
+                                      trajectory_in_plotting_frame->begin(),
+                                      trajectory_in_plotting_frame->end(),
                                       sun_world_position,
                                       planetarium_rotation);
   return trajectory_in_world;
@@ -193,7 +193,7 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
 OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
     Vessel const& vessel,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  auto const last = vessel.psychohistory().last();
+  auto const last = vessel.psychohistory().rbegin();
   Instant const& time = last.time();
   DegreesOfFreedom<Barycentric> const& barycentric_degrees_of_freedom =
       last.degrees_of_freedom();
@@ -213,7 +213,7 @@ OrthogonalMap<Frenet<Navigation>, World> Renderer::FrenetToWorld(
     Vessel const& vessel,
     NavigationFrame const& navigation_frame,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  auto const last = vessel.psychohistory().last();
+  auto const last = vessel.psychohistory().rbegin();
   auto const to_navigation = navigation_frame.ToThisFrameAtTime(last.time());
   auto const from_navigation = to_navigation.orthogonal_map().Inverse();
   auto const frenet_frame =

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -74,8 +74,8 @@ Vessel::~Vessel() {
       absl::MutexLock l(&prognosticator_lock_);
       prognosticator_parameters_ =
           PrognosticatorParameters{Ephemeris<Barycentric>::Guard(ephemeris_),
-                                   psychohistory_->rbegin().time(),
-                                   psychohistory_->rbegin().degrees_of_freedom(),
+                                   psychohistory_->back().time,
+                                   psychohistory_->back().degrees_of_freedom,
                                    prediction_adaptive_step_parameters_,
                                    /*shutdown=*/true};
     }
@@ -262,7 +262,7 @@ void Vessel::ForgetBefore(Instant const& time) {
   // Make sure that the history keeps at least one point and don't change the
   // psychohistory or prediction.  We cannot use the parts because they may have
   // been moved to the future already.
-  history_->ForgetBefore(std::min(time, history_->rbegin().time()));
+  history_->ForgetBefore(std::min(time, history_->back().time));
   if (flight_plan_ != nullptr) {
     flight_plan_->ForgetBefore(time, [this]() { flight_plan_.reset(); });
   }
@@ -275,11 +275,11 @@ void Vessel::CreateFlightPlan(
         flight_plan_adaptive_step_parameters,
     Ephemeris<Barycentric>::GeneralizedAdaptiveStepParameters const&
         flight_plan_generalized_adaptive_step_parameters) {
-  auto const history_last = history_->rbegin();
+  auto const history_back = history_->back();
   flight_plan_ = std::make_unique<FlightPlan>(
       initial_mass,
-      /*initial_time=*/history_last.time(),
-      /*initial_degrees_of_freedom=*/history_last.degrees_of_freedom(),
+      /*initial_time=*/history_back.time,
+      /*initial_degrees_of_freedom=*/history_back.degrees_of_freedom,
       final_time,
       ephemeris_,
       flight_plan_adaptive_step_parameters,
@@ -305,8 +305,8 @@ void Vessel::RefreshPrediction() {
   // this code might have to change.
   prognosticator_parameters_ =
       PrognosticatorParameters{Ephemeris<Barycentric>::Guard(ephemeris_),
-                               psychohistory_->rbegin().time(),
-                               psychohistory_->rbegin().degrees_of_freedom(),
+                               psychohistory_->back().time,
+                               psychohistory_->back().degrees_of_freedom,
                                prediction_adaptive_step_parameters_,
                                /*shutdown=*/false};
   if (synchronous_) {
@@ -396,13 +396,15 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
                                                          /*forks=*/{});
     // The |history_| has been created by the constructor above.  Reconstruct
     // it from the |psychohistory|.
-    for (auto it = psychohistory->begin(); it != psychohistory->end(); ++it) {
-      if (it == psychohistory->rbegin() &&
+    for (auto it = psychohistory->begin(); it != psychohistory->end();) {
+      auto const& [time, degrees_of_freedom] = *it;
+      ++it;
+      if (it == psychohistory->end() &&
           !message.psychohistory_is_authoritative()) {
         vessel->psychohistory_ = vessel->history_->NewForkAtLast();
-        vessel->psychohistory_->Append(it.time(), it.degrees_of_freedom());
+        vessel->psychohistory_->Append(time, degrees_of_freedom);
       } else {
-        vessel->history_->Append(it.time(), it.degrees_of_freedom());
+        vessel->history_->Append(time, degrees_of_freedom);
       }
     }
     if (message.psychohistory_is_authoritative()) {
@@ -420,7 +422,7 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
         /*forks=*/{&vessel->psychohistory_, &vessel->prediction_});
     // Necessary after Εὔδοξος because the ephemeris has not been prolonged
     // during deserialization.  Doesn't hurt prior to Εὔδοξος.
-    ephemeris->Prolong(vessel->prediction_->rbegin().time());
+    ephemeris->Prolong(vessel->prediction_->back().time);
   }
 
   if (is_pre_陈景润) {
@@ -530,7 +532,7 @@ Status Vessel::FlowPrognostication(
   }
   LOG_IF(INFO, !status.ok())
       << "Prognostication from " << prognosticator_parameters.first_time
-      << " finished at " << prognostication->rbegin().time() << " with "
+      << " finished at " << prognostication->back().time << " with "
       << status.ToString() << " for " << ShortDebugString();
   return status;
 }
@@ -594,7 +596,7 @@ void Vessel::AppendToVesselTrajectory(
 
 void Vessel::AttachPrediction(
     not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> trajectory) {
-  trajectory->ForgetBefore(psychohistory_->rbegin().time());
+  trajectory->ForgetBefore(psychohistory_->back().time);
   if (trajectory->Empty()) {
     prediction_ = psychohistory_->NewForkAtLast();
   } else {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -566,7 +566,7 @@ void Vessel::AppendToVesselTrajectory(
     auto const& it0 = its[0];
     bool const at_end_of_part_trajectory = it0 == ends[0];
     Instant const first_time = at_end_of_part_trajectory ? Instant()
-                                                         : it0.time();
+                                                         : it0->time;
 
     // Loop over the parts at a given time.
     BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass> calculator;
@@ -576,8 +576,8 @@ void Vessel::AppendToVesselTrajectory(
       auto& it = its[i];
       CHECK_EQ(at_end_of_part_trajectory, it == ends[i]);
       if (!at_end_of_part_trajectory) {
-        calculator.Add(it.degrees_of_freedom(), part.mass());
-        CHECK_EQ(first_time, it.time());
+        calculator.Add(it->degrees_of_freedom, part.mass());
+        CHECK_EQ(first_time, it->time);
         ++it;
       }
       ++i;

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -199,8 +199,8 @@ TEST_F(FlightPlanTest, Singular) {
                 Velocity<Barycentric>()});
   flight_plan_ = std::make_unique<FlightPlan>(
       /*initial_mass=*/1 * Kilogram,
-      /*initial_time=*/root_.rbegin().time(),
-      /*initial_degrees_of_freedom=*/root_.rbegin().degrees_of_freedom(),
+      /*initial_time=*/root_.back().time,
+      /*initial_degrees_of_freedom=*/root_.back().degrees_of_freedom,
       /*final_time=*/singularity + 100 * Second,
       ephemeris_.get(),
       Ephemeris<Barycentric>::AdaptiveStepParameters(

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -101,8 +101,8 @@ class FlightPlanTest : public testing::Test {
                                          0 * Metre / Second})});
     flight_plan_ = std::make_unique<FlightPlan>(
         /*initial_mass=*/1 * Kilogram,
-        /*initial_time=*/root_.begin()->time,
-        /*initial_degrees_of_freedom=*/root_.begin()->degrees_of_freedom,
+        /*initial_time=*/root_.front().time,
+        /*initial_degrees_of_freedom=*/root_.front().degrees_of_freedom,
         /*desired_final_time=*/t0_ + 1.5 * Second,
         ephemeris_.get(),
         Ephemeris<Barycentric>::AdaptiveStepParameters(
@@ -184,7 +184,7 @@ TEST_F(FlightPlanTest, Singular) {
   Length const x0 = 1 * Metre;
   Instant const singularity = t0_ + π * Sqrt(Pow<3>(x0 / 2) / μ);
   flight_plan_.reset();
-  root_.ForgetAfter(root_.begin()->time);
+  root_.ForgetAfter(root_.front().time);
   // NOTE(egg): In order for to avoid singular Frenet frames NaNing everything,
   // we offset our test particle by 100 ε.  The resulting system is still
   // extremely stiff, indeed the integrator detects a singularity at the exact

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -101,8 +101,8 @@ class FlightPlanTest : public testing::Test {
                                          0 * Metre / Second})});
     flight_plan_ = std::make_unique<FlightPlan>(
         /*initial_mass=*/1 * Kilogram,
-        /*initial_time=*/root_.Begin().time(),
-        /*initial_degrees_of_freedom=*/root_.Begin().degrees_of_freedom(),
+        /*initial_time=*/root_.begin().time(),
+        /*initial_degrees_of_freedom=*/root_.begin().degrees_of_freedom(),
         /*desired_final_time=*/t0_ + 1.5 * Second,
         ephemeris_.get(),
         Ephemeris<Barycentric>::AdaptiveStepParameters(
@@ -184,7 +184,7 @@ TEST_F(FlightPlanTest, Singular) {
   Length const x0 = 1 * Metre;
   Instant const singularity = t0_ + π * Sqrt(Pow<3>(x0 / 2) / μ);
   flight_plan_.reset();
-  root_.ForgetAfter(root_.Begin().time());
+  root_.ForgetAfter(root_.begin().time());
   // NOTE(egg): In order for to avoid singular Frenet frames NaNing everything,
   // we offset our test particle by 100 ε.  The resulting system is still
   // extremely stiff, indeed the integrator detects a singularity at the exact
@@ -199,8 +199,8 @@ TEST_F(FlightPlanTest, Singular) {
                 Velocity<Barycentric>()});
   flight_plan_ = std::make_unique<FlightPlan>(
       /*initial_mass=*/1 * Kilogram,
-      /*initial_time=*/root_.last().time(),
-      /*initial_degrees_of_freedom=*/root_.last().degrees_of_freedom(),
+      /*initial_time=*/root_.rbegin().time(),
+      /*initial_degrees_of_freedom=*/root_.rbegin().degrees_of_freedom(),
       /*final_time=*/singularity + 100 * Second,
       ephemeris_.get(),
       Ephemeris<Barycentric>::AdaptiveStepParameters(

--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -360,8 +360,8 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
   segment->Append(t0_ + 1 * Second, immobile_origin);
   segment->Append(t0_ + 2 * Second, immobile_origin);
   EXPECT_CALL(flight_plan, GetSegment(3, _, _))
-      .WillOnce(DoAll(SetArgReferee<1>(segment->Begin()),
-                      SetArgReferee<2>(segment->End())));
+      .WillOnce(DoAll(SetArgReferee<1>(segment->begin()),
+                      SetArgReferee<2>(segment->end())));
   EXPECT_CALL(renderer,
               FillRenderedBarycentricTrajectoryInWorld(_, _, _, _, _, _))
       .WillOnce(FillUniquePtr<5>(rendered_trajectory.release()));

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -110,7 +110,7 @@ class PileUpTest : public testing::Test {
     EXPECT_EQ(3 * Kilogram, pile_up.mass());
 
     EXPECT_THAT(
-        pile_up.psychohistory()->rbegin().degrees_of_freedom(),
+        pile_up.psychohistory()->back().degrees_of_freedom,
         Componentwise(AlmostEquals(Barycentric::origin +
                                        Displacement<Barycentric>(
                                            {13.0 / 3.0 * Metre,
@@ -307,7 +307,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
                                       890.0 / 9.0 * Metre / Second}), 0)));
   EXPECT_EQ(1, pile_up.psychohistory()->Size());
   EXPECT_THAT(
-      pile_up.psychohistory()->rbegin().degrees_of_freedom(),
+      pile_up.psychohistory()->back().degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.0 * Metre,
@@ -490,7 +490,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       140.2 * Metre / Second,
                                       310.2 / 3.0 * Metre / Second}), 0)));
   EXPECT_THAT(
-      pile_up.psychohistory()->rbegin().degrees_of_freedom(),
+      pile_up.psychohistory()->back().degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.0 * Metre,

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -479,7 +479,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       890.0 / 9.0 * Metre / Second}), 0)));
   EXPECT_EQ(2, pile_up.psychohistory()->Size());
   EXPECT_THAT(
-      pile_up.psychohistory()->begin()->degrees_of_freedom,
+      pile_up.psychohistory()->front().degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.2 * Metre,

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -282,7 +282,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
   EXPECT_EQ(++p1_.history_begin(), p1_.history_end());
   EXPECT_EQ(p1_.psychohistory_begin(), p1_.psychohistory_end());
   EXPECT_THAT(
-      p1_.history_begin().degrees_of_freedom(),
+      p1_.history_begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {-25.0 / 9.0 * Metre,
@@ -295,7 +295,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
   EXPECT_EQ(++p2_.history_begin(), p2_.history_end());
   EXPECT_EQ(p2_.psychohistory_begin(), p2_.psychohistory_end());
   EXPECT_THAT(
-      p2_.history_begin().degrees_of_freedom(),
+      p2_.history_begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {26.0 / 9.0 * Metre,
@@ -408,7 +408,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
   EXPECT_EQ(++(++p1_.history_begin()), p1_.history_end());
   EXPECT_EQ(++p1_.psychohistory_begin(), p1_.psychohistory_end());
   EXPECT_THAT(
-      p1_.history_begin().degrees_of_freedom(),
+      p1_.history_begin()->degrees_of_freedom,
       Componentwise(
           AlmostEquals(Barycentric::origin +
                            Displacement<Barycentric>({-24.1 / 9.0 * Metre,
@@ -420,7 +420,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                               1010.3 / 9.0 * Metre / Second}),
                        1)));
   EXPECT_THAT(
-      (++p1_.history_begin()).degrees_of_freedom(),
+      (++p1_.history_begin())->degrees_of_freedom,
       Componentwise(
           AlmostEquals(Barycentric::origin +
                            Displacement<Barycentric>({-23.2 / 9.0 * Metre,
@@ -432,7 +432,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                               1010.6 / 9.0 * Metre / Second}),
                        1)));
   EXPECT_THAT(
-      p1_.psychohistory_begin().degrees_of_freedom(),
+      p1_.psychohistory_begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {-25.0 / 9.0 * Metre,
@@ -445,7 +445,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
   EXPECT_EQ(++(++p2_.history_begin()), p2_.history_end());
   EXPECT_EQ(++p2_.psychohistory_begin(), p2_.psychohistory_end());
   EXPECT_THAT(
-      p2_.history_begin().degrees_of_freedom(),
+      p2_.history_begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {26.9 / 9.0 * Metre,
@@ -456,7 +456,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       430.3 / 3.0 * Metre / Second,
                                       890.3 / 9.0 * Metre / Second}), 1)));
   EXPECT_THAT(
-      (++p2_.history_begin()).degrees_of_freedom(),
+      (++p2_.history_begin())->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {27.8 / 9.0 * Metre,
@@ -467,7 +467,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       430.6 / 3.0 * Metre / Second,
                                       890.6 / 9.0 * Metre / Second}), 1)));
   EXPECT_THAT(
-      p2_.psychohistory_begin().degrees_of_freedom(),
+      p2_.psychohistory_begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {26.0 / 9.0 * Metre,
@@ -479,7 +479,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       890.0 / 9.0 * Metre / Second}), 0)));
   EXPECT_EQ(2, pile_up.psychohistory()->Size());
   EXPECT_THAT(
-      pile_up.psychohistory()->begin().degrees_of_freedom(),
+      pile_up.psychohistory()->begin()->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.2 * Metre,

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -110,7 +110,7 @@ class PileUpTest : public testing::Test {
     EXPECT_EQ(3 * Kilogram, pile_up.mass());
 
     EXPECT_THAT(
-        pile_up.psychohistory()->last().degrees_of_freedom(),
+        pile_up.psychohistory()->rbegin().degrees_of_freedom(),
         Componentwise(AlmostEquals(Barycentric::origin +
                                        Displacement<Barycentric>(
                                            {13.0 / 3.0 * Metre,
@@ -307,7 +307,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
                                       890.0 / 9.0 * Metre / Second}), 0)));
   EXPECT_EQ(1, pile_up.psychohistory()->Size());
   EXPECT_THAT(
-      pile_up.psychohistory()->last().degrees_of_freedom(),
+      pile_up.psychohistory()->rbegin().degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.0 * Metre,
@@ -479,7 +479,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       890.0 / 9.0 * Metre / Second}), 0)));
   EXPECT_EQ(2, pile_up.psychohistory()->Size());
   EXPECT_THAT(
-      pile_up.psychohistory()->Begin().degrees_of_freedom(),
+      pile_up.psychohistory()->begin().degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.2 * Metre,
@@ -490,7 +490,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                                       140.2 * Metre / Second,
                                       310.2 / 3.0 * Metre / Second}), 0)));
   EXPECT_THAT(
-      pile_up.psychohistory()->last().degrees_of_freedom(),
+      pile_up.psychohistory()->rbegin().degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
                                      Displacement<Barycentric>(
                                          {1.0 * Metre,

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -278,7 +278,7 @@ TEST_F(PlanetariumTest, RealSolarSystem) {
   auto const rp2_lines =
       planetarium.PlotMethod2(discrete_trajectory->begin(),
                               discrete_trajectory->end(),
-                              discrete_trajectory->rbegin().time(),
+                              discrete_trajectory->back().time,
                               /*reverse=*/false);
 
   EXPECT_EQ(2, rp2_lines.size());

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -152,8 +152,8 @@ TEST_F(PlanetariumTest, PlotMethod0) {
   Planetarium planetarium(
       parameters, perspective_, &ephemeris_, &plotting_frame_);
   auto const rp2_lines =
-      planetarium.PlotMethod0(discrete_trajectory->Begin(),
-                              discrete_trajectory->End(),
+      planetarium.PlotMethod0(discrete_trajectory->begin(),
+                              discrete_trajectory->end(),
                               t0_ + 10 * Second,
                               /*reverse=*/false);
 
@@ -193,8 +193,8 @@ TEST_F(PlanetariumTest, PlotMethod1) {
   Planetarium planetarium(
       parameters, perspective_, &ephemeris_, &plotting_frame_);
   auto const rp2_lines =
-      planetarium.PlotMethod1(discrete_trajectory->Begin(),
-                              discrete_trajectory->End(),
+      planetarium.PlotMethod1(discrete_trajectory->begin(),
+                              discrete_trajectory->end(),
                               t0_ + 10 * Second,
                               /*reverse=*/false);
 
@@ -224,8 +224,8 @@ TEST_F(PlanetariumTest, PlotMethod2) {
   Planetarium planetarium(
       parameters, perspective_, &ephemeris_, &plotting_frame_);
   auto const rp2_lines =
-      planetarium.PlotMethod2(discrete_trajectory->Begin(),
-                              discrete_trajectory->End(),
+      planetarium.PlotMethod2(discrete_trajectory->begin(),
+                              discrete_trajectory->end(),
                               t0_ + 10 * Second,
                               /*reverse=*/false);
 
@@ -276,9 +276,9 @@ TEST_F(PlanetariumTest, RealSolarSystem) {
                           ephemeris.get(),
                           plotting_frame.get());
   auto const rp2_lines =
-      planetarium.PlotMethod2(discrete_trajectory->Begin(),
-                              discrete_trajectory->End(),
-                              discrete_trajectory->last().time(),
+      planetarium.PlotMethod2(discrete_trajectory->begin(),
+                              discrete_trajectory->end(),
+                              discrete_trajectory->rbegin().time(),
                               /*reverse=*/false);
 
   EXPECT_EQ(2, rp2_lines.size());

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -391,17 +391,17 @@ TEST_F(PluginIntegrationTest, BarycentricRotatingNavigationIntegration) {
   auto it2 = it1;
   ++it2;
   while (it2 != rendered_trajectory->end()) {
-    EXPECT_THAT((it0.degrees_of_freedom().position() -
-                 it2.degrees_of_freedom().position())
+    EXPECT_THAT((it0->degrees_of_freedom.position() -
+                 it2->degrees_of_freedom.position())
                     .Norm(),
-                Gt(((it0.degrees_of_freedom().position() -
-                     it1.degrees_of_freedom().position())
+                Gt(((it0->degrees_of_freedom.position() -
+                     it1->degrees_of_freedom.position())
                         .Norm() +
-                    (it1.degrees_of_freedom().position() -
-                     it2.degrees_of_freedom().position())
+                    (it1->degrees_of_freedom.position() -
+                     it2->degrees_of_freedom.position())
                         .Norm()) /
                    1.5))
-        << it0.time();
+        << it0->time;
     ++it0;
     ++it1;
     ++it2;
@@ -729,7 +729,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
   for (auto it = rendered_prediction->begin();
        it != rendered_prediction->end();
        ++it, ++index) {
-    auto const& position = it.degrees_of_freedom().position();
+    auto const& position = it->degrees_of_freedom.position();
     EXPECT_THAT(AbsoluteError((position - World::origin).Norm(), 1 * Metre),
                 Lt(0.5 * Milli(Metre)));
     if (index >= 5) {

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -738,7 +738,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
     }
   }
   EXPECT_THAT(AbsoluteError(
-                  rendered_prediction->rbegin().degrees_of_freedom().position(),
+                  rendered_prediction->back().degrees_of_freedom.position(),
                   Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre}) +
                       World::origin),
               IsNear(29_⑴ * Milli(Metre)));

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -846,12 +846,12 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeWithFlightPlan) {
   plugin_->CatchUpLaggingVessels(collided_vessels);
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 3));
   EXPECT_LE(HistoryTime(time, 3), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().begin()->time);
+  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().front().time);
   EXPECT_EQ(1, satellite->flight_plan().number_of_manœuvres());
   EXPECT_EQ(1 * Newton, satellite->flight_plan().GetManœuvre(0).thrust());
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 5));
   EXPECT_LE(HistoryTime(time, 5), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().begin()->time);
+  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().front().time);
   EXPECT_EQ(0, satellite->flight_plan().number_of_manœuvres());
 }
 

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -846,12 +846,12 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeWithFlightPlan) {
   plugin_->CatchUpLaggingVessels(collided_vessels);
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 3));
   EXPECT_LE(HistoryTime(time, 3), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().begin().time());
+  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().begin()->time);
   EXPECT_EQ(1, satellite->flight_plan().number_of_manœuvres());
   EXPECT_EQ(1 * Newton, satellite->flight_plan().GetManœuvre(0).thrust());
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 5));
   EXPECT_LE(HistoryTime(time, 5), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().begin().time());
+  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().begin()->time);
   EXPECT_EQ(0, satellite->flight_plan().number_of_manœuvres());
 }
 

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -846,12 +846,12 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeWithFlightPlan) {
   plugin_->CatchUpLaggingVessels(collided_vessels);
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 3));
   EXPECT_LE(HistoryTime(time, 3), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().Begin().time());
+  EXPECT_LE(HistoryTime(time, 3), satellite->psychohistory().begin().time());
   EXPECT_EQ(1, satellite->flight_plan().number_of_manœuvres());
   EXPECT_EQ(1 * Newton, satellite->flight_plan().GetManœuvre(0).thrust());
   plugin_->ForgetAllHistoriesBefore(HistoryTime(time, 5));
   EXPECT_LE(HistoryTime(time, 5), satellite->flight_plan().initial_time());
-  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().Begin().time());
+  EXPECT_LE(HistoryTime(time, 5), satellite->psychohistory().begin().time());
   EXPECT_EQ(0, satellite->flight_plan().number_of_manœuvres());
 }
 
@@ -937,7 +937,7 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeAfterPredictionFork) {
       plugin_->renderer().RenderBarycentricTrajectoryInWorld(
           plugin_->CurrentTime(),
           prediction.Fork(),
-          prediction.End(),
+          prediction.end(),
           World::origin,
           plugin_->PlanetariumRotation());
 }

--- a/ksp_plugin_test/renderer_test.cpp
+++ b/ksp_plugin_test/renderer_test.cpp
@@ -144,17 +144,15 @@ TEST_F(RendererTest, RenderBarycentricTrajectoryInPlottingWithoutTargetVessel) {
 
   auto const rendered_trajectory =
       renderer_.RenderBarycentricTrajectoryInPlotting(
-          trajectory_to_render.Begin(),
-          trajectory_to_render.End());
+          trajectory_to_render.begin(),
+          trajectory_to_render.end());
 
   EXPECT_EQ(10, rendered_trajectory->Size());
   int index = 0;
-  for (auto it = rendered_trajectory->Begin();
-       it != rendered_trajectory->End();
-       ++it) {
-    EXPECT_EQ(t0_ + index * Second, it.time());
+  for (auto const& [time, degrees_of_freedom] : *rendered_trajectory) {
+    EXPECT_EQ(t0_ + index * Second, time);
     EXPECT_THAT(
-        it.degrees_of_freedom(),
+        degrees_of_freedom,
         Componentwise(
             AlmostEquals(Navigation::origin +
                              Displacement<Navigation>({6 * index * Metre,
@@ -228,21 +226,19 @@ TEST_F(RendererTest, RenderBarycentricTrajectoryInPlottingWithTargetVessel) {
   renderer_.SetTargetVessel(&vessel, &celestial_, &ephemeris);
   auto const rendered_trajectory =
       renderer_.RenderBarycentricTrajectoryInPlotting(
-          trajectory_to_render.Begin(),
-          trajectory_to_render.End());
+          trajectory_to_render.begin(),
+          trajectory_to_render.end());
 
   EXPECT_EQ(5, rendered_trajectory->Size());
   int index = 3;
-  for (auto it = rendered_trajectory->Begin();
-       it != rendered_trajectory->End();
-       ++it) {
-    EXPECT_EQ(t0_ + index * Second, it.time());
+  for (auto const& [time, degrees_of_freedom] : *rendered_trajectory) {
+    EXPECT_EQ(t0_ + index * Second, time);
     // The degrees of freedom are computed using a real dynamic frame, not a
     // mock.  No point in re-doing the computation here, we just check that the
     // numbers are reasonable.
-    EXPECT_LT((it.degrees_of_freedom().position() - Navigation::origin).Norm(),
+    EXPECT_LT((degrees_of_freedom.position() - Navigation::origin).Norm(),
               42 * Metre);
-    EXPECT_LT(it.degrees_of_freedom().velocity().Norm(), 6 * Metre / Second);
+    EXPECT_LT(degrees_of_freedom.velocity().Norm(), 6 * Metre / Second);
     ++index;
   }
 }
@@ -286,23 +282,21 @@ TEST_F(RendererTest, RenderPlottingTrajectoryInWorldWithoutTargetVessel) {
 
   auto const rendered_trajectory =
       renderer_.RenderPlottingTrajectoryInWorld(rendering_time,
-                                                trajectory_to_render.Begin(),
-                                                trajectory_to_render.End(),
+                                                trajectory_to_render.begin(),
+                                                trajectory_to_render.end(),
                                                 sun_world_position,
                                                 planetarium_rotation);
 
   EXPECT_EQ(10, rendered_trajectory->Size());
   int index = 0;
-  for (auto it = rendered_trajectory->Begin();
-       it != rendered_trajectory->End();
-       ++it) {
-    EXPECT_EQ(t0_ + index * Second, it.time());
+  for (auto const& [time, degrees_of_freedom] : *rendered_trajectory) {
+    EXPECT_EQ(t0_ + index * Second, time);
     // The degrees of freedom are computed using real geometrical transforms.
     // No point in re-doing the computation here, we just check that the numbers
     // are reasonable.
-    EXPECT_LT((it.degrees_of_freedom().position() - World::origin).Norm(),
+    EXPECT_LT((degrees_of_freedom.position() - World::origin).Norm(),
               452 * Metre);
-    EXPECT_LT(it.degrees_of_freedom().velocity().Norm(), 9 * Metre / Second);
+    EXPECT_LT(degrees_of_freedom.velocity().Norm(), 9 * Metre / Second);
     ++index;
   }
 }

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -211,8 +211,8 @@ TEST_F(VesselTest, AdvanceTime) {
   EXPECT_EQ(3, vessel_.psychohistory().Size());
   auto it = vessel_.psychohistory().begin();
   ++it;
-  EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it.time());
-  EXPECT_THAT(it.degrees_of_freedom(),
+  EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it->time);
+  EXPECT_THAT(it->degrees_of_freedom,
               Componentwise(AlmostEquals(Barycentric::origin +
                                          Displacement<Barycentric>(
                                              {13.3 / 3.0 * Metre,
@@ -223,8 +223,8 @@ TEST_F(VesselTest, AdvanceTime) {
                                        40.1 * Metre / Second,
                                        110.3 / 3.0 * Metre / Second}), 1)));
   ++it;
-  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it.time());
-  EXPECT_THAT(it.degrees_of_freedom(),
+  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it->time);
+  EXPECT_THAT(it->degrees_of_freedom,
               Componentwise(AlmostEquals(Barycentric::origin +
                                          Displacement<Barycentric>(
                                              {13.6 / 3.0 * Metre,
@@ -282,9 +282,9 @@ TEST_F(VesselTest, Prediction) {
 
   EXPECT_EQ(2, vessel_.prediction().Size());
   auto it = vessel_.prediction().begin();
-  EXPECT_EQ(astronomy::J2000, it.time());
+  EXPECT_EQ(astronomy::J2000, it->time);
   EXPECT_THAT(
-      it.degrees_of_freedom(),
+      it->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                       Displacement<Barycentric>(
                                           {13.0 / 3.0 * Metre,
@@ -295,9 +295,9 @@ TEST_F(VesselTest, Prediction) {
                                        40.0 * Metre / Second,
                                        110.0 / 3.0 * Metre / Second}), 0)));
   ++it;
-  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it.time());
+  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it->time);
   EXPECT_THAT(
-      it.degrees_of_freedom(),
+      it->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                       Displacement<Barycentric>(
                                           {14.0 / 3.0 * Metre,
@@ -354,11 +354,11 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
 
   auto it = vessel_.prediction().begin();
   ++it;
-  EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it.time());
+  EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it->time);
   ++it;
-  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it.time());
+  EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it->time);
   EXPECT_THAT(
-      it.degrees_of_freedom(),
+      it->degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                       Displacement<Barycentric>(
                                           {5.0 * Metre,

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -146,9 +146,9 @@ TEST_F(VesselTest, PrepareHistory) {
 
   EXPECT_EQ(1, vessel_.psychohistory().Size());
   EXPECT_EQ(astronomy::J2000 + 1 * Second,
-            vessel_.psychohistory().rbegin().time());
+            vessel_.psychohistory().back().time);
   EXPECT_THAT(
-      vessel_.psychohistory().rbegin().degrees_of_freedom(),
+      vessel_.psychohistory().back().degrees_of_freedom,
       Componentwise(AlmostEquals(Barycentric::origin +
                                       Displacement<Barycentric>(
                                           {13.0 / 3.0 * Metre,
@@ -278,7 +278,7 @@ TEST_F(VesselTest, Prediction) {
     vessel_.RefreshPrediction(astronomy::J2000 + 1 * Second);
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
-  } while (vessel_.prediction().rbegin().time() == astronomy::J2000);
+  } while (vessel_.prediction().back().time == astronomy::J2000);
 
   EXPECT_EQ(2, vessel_.prediction().Size());
   auto it = vessel_.prediction().begin();

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -146,9 +146,9 @@ TEST_F(VesselTest, PrepareHistory) {
 
   EXPECT_EQ(1, vessel_.psychohistory().Size());
   EXPECT_EQ(astronomy::J2000 + 1 * Second,
-            vessel_.psychohistory().last().time());
+            vessel_.psychohistory().rbegin().time());
   EXPECT_THAT(
-      vessel_.psychohistory().last().degrees_of_freedom(),
+      vessel_.psychohistory().rbegin().degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
                                       Displacement<Barycentric>(
                                           {13.0 / 3.0 * Metre,
@@ -209,7 +209,7 @@ TEST_F(VesselTest, AdvanceTime) {
   vessel_.AdvanceTime();
 
   EXPECT_EQ(3, vessel_.psychohistory().Size());
-  auto it = vessel_.psychohistory().Begin();
+  auto it = vessel_.psychohistory().begin();
   ++it;
   EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it.time());
   EXPECT_THAT(it.degrees_of_freedom(),
@@ -278,10 +278,10 @@ TEST_F(VesselTest, Prediction) {
     vessel_.RefreshPrediction(astronomy::J2000 + 1 * Second);
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
-  } while (vessel_.prediction().last().time() == astronomy::J2000);
+  } while (vessel_.prediction().rbegin().time() == astronomy::J2000);
 
   EXPECT_EQ(2, vessel_.prediction().Size());
-  auto it = vessel_.prediction().Begin();
+  auto it = vessel_.prediction().begin();
   EXPECT_EQ(astronomy::J2000, it.time());
   EXPECT_THAT(
       it.degrees_of_freedom(),
@@ -352,7 +352,7 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
     std::this_thread::sleep_for(100ms);
   } while (vessel_.prediction().Size() != 3);
 
-  auto it = vessel_.prediction().Begin();
+  auto it = vessel_.prediction().begin();
   ++it;
   EXPECT_EQ(astronomy::J2000 + 0.5 * Second, it.time());
   ++it;

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -41,14 +41,14 @@ void ComputeApsides(Trajectory<Frame> const& reference,
   Instant const t_min = reference.t_min();
   Instant const t_max = reference.t_max();
   for (auto it = begin; it != end; ++it) {
-    Instant const& time = it.time();
+    Instant const& time = it->time;
     if (time < t_min) {
       continue;
     }
     if (time > t_max) {
       break;
     }
-    DegreesOfFreedom<Frame> const degrees_of_freedom = it.degrees_of_freedom();
+    DegreesOfFreedom<Frame> const degrees_of_freedom = it->degrees_of_freedom;
     DegreesOfFreedom<Frame> const body_degrees_of_freedom =
         reference.EvaluateDegreesOfFreedom(time);
     RelativeDegreesOfFreedom<Frame> const relative =
@@ -142,8 +142,8 @@ void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
   std::optional<Speed> previous_z_speed;
 
   for (auto it = begin; it != end; ++it) {
-    Instant const time = it.time();
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = it.degrees_of_freedom();
+    Instant const time = it->time;
+    DegreesOfFreedom<Frame> const& degrees_of_freedom = it->degrees_of_freedom;
     Length const z =
         (degrees_of_freedom.position() - Frame::origin).coordinates().z;
     Speed const z_speed = degrees_of_freedom.velocity().coordinates().z;

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -41,14 +41,13 @@ void ComputeApsides(Trajectory<Frame> const& reference,
   Instant const t_min = reference.t_min();
   Instant const t_max = reference.t_max();
   for (auto it = begin; it != end; ++it) {
-    Instant const& time = it->time;
+    auto const& [time, degrees_of_freedom] = *it;
     if (time < t_min) {
       continue;
     }
     if (time > t_max) {
       break;
     }
-    DegreesOfFreedom<Frame> const degrees_of_freedom = it->degrees_of_freedom;
     DegreesOfFreedom<Frame> const body_degrees_of_freedom =
         reference.EvaluateDegreesOfFreedom(time);
     RelativeDegreesOfFreedom<Frame> const relative =
@@ -142,8 +141,7 @@ void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
   std::optional<Speed> previous_z_speed;
 
   for (auto it = begin; it != end; ++it) {
-    Instant const time = it->time;
-    DegreesOfFreedom<Frame> const& degrees_of_freedom = it->degrees_of_freedom;
+    auto const& [time, degrees_of_freedom] = *it;
     Length const z =
         (degrees_of_freedom.position() - Frame::origin).coordinates().z;
     Speed const z_speed = degrees_of_freedom.velocity().coordinates().z;

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -107,17 +107,16 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
   DiscreteTrajectory<World> apoapsides;
   DiscreteTrajectory<World> periapsides;
   ComputeApsides(*ephemeris.trajectory(b),
-                 trajectory.Begin(),
-                 trajectory.End(),
+                 trajectory.begin(),
+                 trajectory.end(),
                  /*max_points=*/std::numeric_limits<int>::max(),
                  apoapsides,
                  periapsides);
 
   std::optional<Instant> previous_time;
   std::map<Instant, DegreesOfFreedom<World>> all_apsides;
-  for (auto it = apoapsides.Begin(); it != apoapsides.End(); ++it) {
-    Instant const time = it.time();
-    all_apsides.emplace(time, it.degrees_of_freedom());
+  for (auto const& [time, degrees_of_freedom] : apoapsides) {
+    all_apsides.emplace(time, degrees_of_freedom);
     if (previous_time) {
       EXPECT_THAT(time - *previous_time, AlmostEquals(T, 118, 2824));
     }
@@ -125,9 +124,8 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
   }
 
   previous_time = std::nullopt;
-  for (auto it = periapsides.Begin(); it != periapsides.End(); ++it) {
-    Instant const time = it.time();
-    all_apsides.emplace(time, it.degrees_of_freedom());
+  for (auto const& [time, degrees_of_freedom] : periapsides) {
+    all_apsides.emplace(time, degrees_of_freedom);
     if (previous_time) {
       EXPECT_THAT(time - *previous_time, AlmostEquals(T, 134, 257));
     }
@@ -204,17 +202,16 @@ TEST_F(ApsidesTest, ComputeNodes) {
 
   DiscreteTrajectory<World> ascending_nodes;
   DiscreteTrajectory<World> descending_nodes;
-  ComputeNodes(trajectory.Begin(),
-               trajectory.End(),
+  ComputeNodes(trajectory.begin(),
+               trajectory.end(),
                north,
                /*max_points=*/std::numeric_limits<int>::max(),
                ascending_nodes,
                descending_nodes);
 
   std::optional<Instant> previous_time;
-  for (auto it = ascending_nodes.Begin(); it != ascending_nodes.End(); ++it) {
-    Instant const time = it.time();
-    EXPECT_THAT((it.degrees_of_freedom().position() - World::origin)
+  for (auto const& [time, degrees_of_freedom] : ascending_nodes) {
+    EXPECT_THAT((degrees_of_freedom.position() - World::origin)
                     .coordinates()
                     .ToSpherical()
                     .longitude,
@@ -226,10 +223,9 @@ TEST_F(ApsidesTest, ComputeNodes) {
   }
 
   previous_time = std::nullopt;
-  for (auto it = descending_nodes.Begin(); it != descending_nodes.End(); ++it) {
-    Instant const time = it.time();
+  for (auto const& [time, degrees_of_freedom] : descending_nodes) {
     EXPECT_THAT(
-        (it.degrees_of_freedom().position() - World::origin)
+        (degrees_of_freedom.position() - World::origin)
                 .coordinates()
                 .ToSpherical()
                 .longitude,
@@ -246,8 +242,8 @@ TEST_F(ApsidesTest, ComputeNodes) {
   DiscreteTrajectory<World> south_ascending_nodes;
   DiscreteTrajectory<World> south_descending_nodes;
   Vector<double, World> const mostly_south({1, 1, -1});
-  ComputeNodes(trajectory.Begin(),
-               trajectory.End(),
+  ComputeNodes(trajectory.begin(),
+               trajectory.end(),
                mostly_south,
                /*max_points=*/std::numeric_limits<int>::max(),
                south_ascending_nodes,
@@ -255,11 +251,11 @@ TEST_F(ApsidesTest, ComputeNodes) {
   EXPECT_THAT(south_ascending_nodes.Size(), Eq(10));
   EXPECT_THAT(south_descending_nodes.Size(), Eq(10));
 
-  for (auto south_ascending_it  = south_ascending_nodes.Begin(),
-            ascending_it        = ascending_nodes.Begin(),
-            south_descending_it = south_descending_nodes.Begin(),
-            descending_it       = descending_nodes.Begin();
-       south_ascending_it != south_ascending_nodes.End();
+  for (auto south_ascending_it  = south_ascending_nodes.begin(),
+            ascending_it        = ascending_nodes.begin(),
+            south_descending_it = south_descending_nodes.begin(),
+            descending_it       = descending_nodes.begin();
+       south_ascending_it != south_ascending_nodes.end();
        ++south_ascending_it,
        ++ascending_it,
        ++south_descending_it,

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -260,12 +260,12 @@ TEST_F(ApsidesTest, ComputeNodes) {
        ++ascending_it,
        ++south_descending_it,
        ++descending_it) {
-    EXPECT_THAT(south_ascending_it.degrees_of_freedom(),
-                Eq(descending_it.degrees_of_freedom()));
-    EXPECT_THAT(south_ascending_it.time(), Eq(descending_it.time()));
-    EXPECT_THAT(south_descending_it.degrees_of_freedom(),
-                Eq(ascending_it.degrees_of_freedom()));
-    EXPECT_THAT(south_descending_it.time(), Eq(ascending_it.time()));
+    EXPECT_THAT(south_ascending_it->degrees_of_freedom,
+                Eq(descending_it->degrees_of_freedom));
+    EXPECT_THAT(south_ascending_it->time, Eq(descending_it->time));
+    EXPECT_THAT(south_descending_it->degrees_of_freedom,
+                Eq(ascending_it->degrees_of_freedom));
+    EXPECT_THAT(south_descending_it->time, Eq(ascending_it->time));
   }
 }
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -46,7 +46,13 @@ class DiscreteTrajectoryIterator
   Instant const& time() const;
   DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
 
-  std::pair<Instant const, DegreesOfFreedom<Frame>> const& operator*() const;
+  struct reference {
+    Instant const& time;
+    DegreesOfFreedom<Frame> const& degrees_of_freedom;
+  };
+
+  reference operator*() const;
+  std::optional<reference> operator->() const;
 
  protected:
   not_null<DiscreteTrajectoryIterator*> that() override;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -46,6 +46,8 @@ class DiscreteTrajectoryIterator
   Instant const& time() const;
   DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
 
+  std::pair<Instant const, DegreesOfFreedom<Frame>> const& operator*() const;
+
  protected:
   not_null<DiscreteTrajectoryIterator*> that() override;
   not_null<DiscreteTrajectoryIterator const*> that() const override;
@@ -83,12 +85,6 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   DiscreteTrajectory(DiscreteTrajectory&&) = delete;
   DiscreteTrajectory& operator=(DiscreteTrajectory const&) = delete;
   DiscreteTrajectory& operator=(DiscreteTrajectory&&) = delete;
-
-  // Returns an iterator at the last point of the trajectory.  Complexity is
-  // O(1).  The trajectory must not be empty.
-  // TODO(phl): This is really RBegin, but Forkable doesn't have reverse
-  // iterators.
-  Iterator last() const;
 
   // Creates a new child trajectory forked at time |time|, and returns it.  The
   // child trajectory shares its data with the current trajectory for times less
@@ -148,7 +144,7 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
 
   // Implementation of the interface |Trajectory|.
 
-  // The bounds are the times of |Begin()| and |last()| if this trajectory is
+  // The bounds are the times of |begin()| and |rbegin()| if this trajectory is
   // nonempty, otherwise they are infinities of the appropriate signs.
   Instant t_min() const override;
   Instant t_max() const override;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -43,9 +43,6 @@ class DiscreteTrajectoryIterator
     : public ForkableIterator<DiscreteTrajectory<Frame>,
                               DiscreteTrajectoryIterator<Frame>> {
  public:
-  Instant const& time() const;
-  DegreesOfFreedom<Frame> const& degrees_of_freedom() const;
-
   struct reference {
     Instant const& time;
     DegreesOfFreedom<Frame> const& degrees_of_freedom;

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -173,7 +173,7 @@ void DiscreteTrajectory<Frame>::Append(
 
   if (!timeline_.empty() && timeline_.cbegin()->first == time) {
     LOG(WARNING) << "Append at existing time " << time
-                 << ", time range = [" << this->begin()->time << ", "
+                 << ", time range = [" << this->front().time << ", "
                  << back().time << "]";
     return;
   }
@@ -288,7 +288,7 @@ void DiscreteTrajectory<Frame>::ClearDownsampling() {
 
 template<typename Frame>
 Instant DiscreteTrajectory<Frame>::t_min() const {
-  return this->Empty() ? InfiniteFuture : this->begin()->time;
+  return this->Empty() ? InfiniteFuture : this->front().time;
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -104,10 +104,7 @@ class DiscreteTrajectoryTest : public testing::Test {
   std::map<Instant, Position<World>> Positions(
       DiscreteTrajectory<World> const& trajectory) const {
     std::map<Instant, Position<World>> result;
-    for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
-      Instant const& time = it.time();
-      DegreesOfFreedom<World> const& degrees_of_freedom =
-          it.degrees_of_freedom();
+    for (auto const& [time, degrees_of_freedom] : trajectory) {
       result.emplace_hint(result.end(), time, degrees_of_freedom.position());
     }
     return result;
@@ -116,10 +113,7 @@ class DiscreteTrajectoryTest : public testing::Test {
   std::map<Instant, Velocity<World>> Velocities(
       DiscreteTrajectory<World> const& trajectory) const {
     std::map<Instant, Velocity<World>> result;
-    for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
-      Instant const& time = it.time();
-      DegreesOfFreedom<World> const& degrees_of_freedom =
-          it.degrees_of_freedom();
+    for (auto const& [time, degrees_of_freedom] : trajectory) {
       result.emplace_hint(result.end(), time, degrees_of_freedom.velocity());
     }
     return result;
@@ -127,8 +121,8 @@ class DiscreteTrajectoryTest : public testing::Test {
 
   std::list<Instant> Times(DiscreteTrajectory<World> const& trajectory) const {
     std::list<Instant> result;
-    for (auto it = trajectory.Begin(); it != trajectory.End(); ++it) {
-      result.push_back(it.time());
+    for (auto const& [time, degrees_of_freedom] : trajectory) {
+      result.push_back(time);
     }
     return result;
   }
@@ -247,11 +241,11 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   not_null<DiscreteTrajectory<World>*> const fork1 =
       massive_trajectory_->NewForkWithCopy(t3_);
   not_null<DiscreteTrajectory<World>*> const fork2 =
-      fork1->NewForkWithCopy(fork1->last().time());
+      fork1->NewForkWithCopy(fork1->rbegin().time());
   not_null<DiscreteTrajectory<World>*> const fork3 =
-      fork2->NewForkWithCopy(fork1->last().time());
-  EXPECT_EQ(t3_, massive_trajectory_->last().time());
-  EXPECT_EQ(t3_, fork1->last().time());
+      fork2->NewForkWithCopy(fork1->rbegin().time());
+  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
+  EXPECT_EQ(t3_, fork1->rbegin().time());
 
   std::map<Instant, Position<World>> positions = Positions(*fork2);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork2);
@@ -261,13 +255,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   std::vector<Instant> after;
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -282,13 +276,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
-       it != fork2->End();
+       it != fork2->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -303,13 +297,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
-       it != fork1->End();
+       it != fork1->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -323,14 +317,14 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork3->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork3->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork3->last().time());
+  EXPECT_EQ(q3_, fork3->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork3->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork3->rbegin().time());
 
   fork2->Append(t4_, d4_);
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
-       it != fork2->End();
+       it != fork2->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -339,7 +333,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   fork3->Append(t4_, d4_);
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -347,7 +341,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t2_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -364,8 +358,8 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
       fork1->NewForkAtLast();
   not_null<DiscreteTrajectory<World>*> const fork3 =
       fork2->NewForkAtLast();
-  EXPECT_EQ(t3_, massive_trajectory_->last().time());
-  EXPECT_EQ(t3_, fork1->last().time());
+  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
+  EXPECT_EQ(t3_, fork1->rbegin().time());
 
   std::map<Instant, Position<World>> positions = Positions(*fork2);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork2);
@@ -375,13 +369,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   std::vector<Instant> after;
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -396,13 +390,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
-       it != fork2->End();
+       it != fork2->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -417,13 +411,13 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->last().time());
+  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork2->rbegin().time());
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
-       it != fork1->End();
+       it != fork1->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -437,14 +431,14 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork3->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork3->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork3->last().time());
+  EXPECT_EQ(q3_, fork3->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, fork3->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, fork3->rbegin().time());
 
   fork2->Append(t4_, d4_);
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
-       it != fork2->End();
+       it != fork2->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -453,7 +447,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   fork3->Append(t4_, d4_);
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -461,7 +455,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t2_);
-       it != fork3->End();
+       it != fork3->end();
        ++it) {
     after.push_back(it.time());
   }
@@ -596,9 +590,9 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   EXPECT_THAT(positions, ElementsAre(Pair(t1_, q1_), Pair(t2_, q2_)));
   EXPECT_THAT(velocities, ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_));
-  EXPECT_EQ(q2_, fork->last().degrees_of_freedom().position());
-  EXPECT_EQ(p2_, fork->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t2_, fork->last().time());
+  EXPECT_EQ(q2_, fork->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p2_, fork->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t2_, fork->rbegin().time());
 
   positions = Positions(*massive_trajectory_);
   velocities = Velocities(*massive_trajectory_);
@@ -779,7 +773,7 @@ TEST_F(DiscreteTrajectoryTest, TrajectorySerializationSuccess) {
 
 TEST_F(DiscreteTrajectoryDeathTest, LastError) {
   EXPECT_DEATH({
-    massive_trajectory_->last();
+    massive_trajectory_->rbegin();
   }, "parent_.*non NULL");
 }
 
@@ -787,27 +781,27 @@ TEST_F(DiscreteTrajectoryTest, LastSuccess) {
   massive_trajectory_->Append(t1_, d1_);
   massive_trajectory_->Append(t2_, d2_);
   massive_trajectory_->Append(t3_, d3_);
-  EXPECT_EQ(q3_, massive_trajectory_->last().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, massive_trajectory_->last().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, massive_trajectory_->last().time());
+  EXPECT_EQ(q3_, massive_trajectory_->rbegin().degrees_of_freedom().position());
+  EXPECT_EQ(p3_, massive_trajectory_->rbegin().degrees_of_freedom().velocity());
+  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
 }
 
 TEST_F(DiscreteTrajectoryDeathTest, IteratorError) {
   EXPECT_DEATH({
-    DiscreteTrajectory<World>::Iterator it = massive_trajectory_->last();
+    DiscreteTrajectory<World>::Iterator it = massive_trajectory_->rbegin();
   }, "parent_.*non NULL");
 }
 
 TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
-  DiscreteTrajectory<World>::Iterator it = massive_trajectory_->Begin();
-  EXPECT_TRUE(it == massive_trajectory_->End());
+  DiscreteTrajectory<World>::Iterator it = massive_trajectory_->begin();
+  EXPECT_TRUE(it == massive_trajectory_->end());
 
   massless_trajectory_->Append(t1_, d1_);
   massless_trajectory_->Append(t2_, d2_);
   massless_trajectory_->Append(t3_, d3_);
 
-  it = massless_trajectory_->Begin();
-  EXPECT_FALSE(it == massless_trajectory_->End());
+  it = massless_trajectory_->begin();
+  EXPECT_FALSE(it == massless_trajectory_->end());
   EXPECT_EQ(t1_, it.time());
   EXPECT_EQ(d1_, it.degrees_of_freedom());
   ++it;
@@ -817,14 +811,14 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(t3_, it.time());
   EXPECT_EQ(d3_, it.degrees_of_freedom());
   ++it;
-  EXPECT_TRUE(it == massless_trajectory_->End());
+  EXPECT_TRUE(it == massless_trajectory_->end());
 
   not_null<DiscreteTrajectory<World>*> const fork =
       massless_trajectory_->NewForkWithCopy(t2_);
   fork->Append(t4_, d4_);
 
-  it = fork->Begin();
-  EXPECT_FALSE(it == fork->End());
+  it = fork->begin();
+  EXPECT_FALSE(it == fork->end());
   EXPECT_EQ(t1_, it.time());
   EXPECT_EQ(d1_, it.degrees_of_freedom());
   ++it;
@@ -837,7 +831,7 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
   EXPECT_EQ(t4_, it.time());
   EXPECT_EQ(d4_, it.degrees_of_freedom());
   ++it;
-  EXPECT_TRUE(it == fork->End());
+  EXPECT_TRUE(it == fork->end());
 }
 
 TEST_F(DiscreteTrajectoryTest, QuadrilateralCircle) {
@@ -898,9 +892,9 @@ TEST_F(DiscreteTrajectoryTest, Downsampling) {
   EXPECT_THAT(circle.Size(), Eq(1001));
   EXPECT_THAT(downsampled_circle.Size(), Eq(77));
   std::vector<Length> errors;
-  for (auto it = circle.Begin(); it != circle.End(); ++it) {
-    errors.push_back((downsampled_circle.EvaluatePosition(it.time()) -
-                      it.degrees_of_freedom().position()).Norm());
+  for (auto const& [time, degrees_of_freedom] : circle) {
+    errors.push_back((downsampled_circle.EvaluatePosition(time) -
+                      degrees_of_freedom.position()).Norm());
   }
   EXPECT_THAT(errors, Each(Lt(1 * Milli(Metre))));
   EXPECT_THAT(errors, Contains(Gt(9 * Micro(Metre))))
@@ -946,8 +940,8 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingSerialization) {
   }
   EXPECT_THAT(circle.Size(), Eq(77));
   EXPECT_THAT(deserialized_circle->Size(), Eq(circle.Size()));
-  for (auto it1 = circle.Begin(), it2 = deserialized_circle->Begin();
-       it1 != circle.End();
+  for (auto it1 = circle.begin(), it2 = deserialized_circle->begin();
+       it1 != circle.end();
        ++it1, ++it2) {
     EXPECT_EQ(it1.time(), it2.time());
     EXPECT_EQ(it1.degrees_of_freedom(), it2.degrees_of_freedom());
@@ -977,7 +971,7 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingForgetAfter) {
     forgotten_circle.Append(t, dof);
   }
   forgotten_circle.ForgetAfter(t0_ + 5 * Second);
-  t = forgotten_circle.last().time();
+  t = forgotten_circle.rbegin().time();
   for (t += 10 * Milli(Second); t <= t0_ + 10 * Second;
        t += 10 * Milli(Second)) {
     DegreesOfFreedom<World> const dof =
@@ -992,9 +986,9 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingForgetAfter) {
   EXPECT_THAT(circle.Size(), Eq(77));
   EXPECT_THAT(forgotten_circle.Size(), Eq(circle.Size()));
   std::vector<Length> errors;
-  for (auto it = forgotten_circle.Begin(); it != forgotten_circle.End(); ++it) {
-    errors.push_back((circle.Find(it.time()).degrees_of_freedom().position() -
-                      it.degrees_of_freedom().position()).Norm());
+  for (auto const [time, degrees_of_freedom] : forgotten_circle) {
+    errors.push_back((circle.Find(time).degrees_of_freedom().position() -
+                      degrees_of_freedom.position()).Norm());
   }
   EXPECT_THAT(errors, Each(Eq(0 * Metre)));
 }

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -263,7 +263,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_));
 
@@ -284,7 +284,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
        it != fork2->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_));
 
@@ -305,7 +305,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
        it != fork1->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -326,7 +326,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
        it != fork2->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -335,7 +335,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -343,7 +343,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t2_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t2_, t3_, t4_));
 }
@@ -377,7 +377,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_));
 
@@ -398,7 +398,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
        it != fork2->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_));
 
@@ -419,7 +419,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
        it != fork1->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -440,7 +440,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
        it != fork2->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -449,7 +449,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t3_, t4_));
 
@@ -457,7 +457,7 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t2_);
        it != fork3->end();
        ++it) {
-    after.push_back(it.time());
+    after.push_back(it->time);
   }
   EXPECT_THAT(after, ElementsAre(t2_, t3_, t4_));
 }
@@ -710,9 +710,9 @@ TEST_F(DiscreteTrajectoryTest, TrajectorySerializationSuccess) {
                                                      {&deserialized_fork1,
                                                       &deserialized_fork3,
                                                       &deserialized_fork2});
-  EXPECT_EQ(t2_, deserialized_fork1->Fork().time());
-  EXPECT_EQ(t2_, deserialized_fork2->Fork().time());
-  EXPECT_EQ(t3_, deserialized_fork3->Fork().time());
+  EXPECT_EQ(t2_, deserialized_fork1->Fork()->time);
+  EXPECT_EQ(t2_, deserialized_fork2->Fork()->time);
+  EXPECT_EQ(t3_, deserialized_fork3->Fork()->time);
   message.Clear();
   deserialized_trajectory->WriteToMessage(&message,
                                           {deserialized_fork1,
@@ -802,14 +802,14 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
 
   it = massless_trajectory_->begin();
   EXPECT_FALSE(it == massless_trajectory_->end());
-  EXPECT_EQ(t1_, it.time());
-  EXPECT_EQ(d1_, it.degrees_of_freedom());
+  EXPECT_EQ(t1_, it->time);
+  EXPECT_EQ(d1_, it->degrees_of_freedom);
   ++it;
-  EXPECT_EQ(t2_, it.time());
-  EXPECT_EQ(d2_, it.degrees_of_freedom());
+  EXPECT_EQ(t2_, it->time);
+  EXPECT_EQ(d2_, it->degrees_of_freedom);
   ++it;
-  EXPECT_EQ(t3_, it.time());
-  EXPECT_EQ(d3_, it.degrees_of_freedom());
+  EXPECT_EQ(t3_, it->time);
+  EXPECT_EQ(d3_, it->degrees_of_freedom);
   ++it;
   EXPECT_TRUE(it == massless_trajectory_->end());
 
@@ -819,17 +819,17 @@ TEST_F(DiscreteTrajectoryTest, IteratorSuccess) {
 
   it = fork->begin();
   EXPECT_FALSE(it == fork->end());
-  EXPECT_EQ(t1_, it.time());
-  EXPECT_EQ(d1_, it.degrees_of_freedom());
+  EXPECT_EQ(t1_, it->time);
+  EXPECT_EQ(d1_, it->degrees_of_freedom);
   ++it;
-  EXPECT_EQ(t2_, it.time());
-  EXPECT_EQ(d2_, it.degrees_of_freedom());
+  EXPECT_EQ(t2_, it->time);
+  EXPECT_EQ(d2_, it->degrees_of_freedom);
   ++it;
-  EXPECT_EQ(t3_, it.time());
-  EXPECT_EQ(d3_, it.degrees_of_freedom());
+  EXPECT_EQ(t3_, it->time);
+  EXPECT_EQ(d3_, it->degrees_of_freedom);
   ++it;
-  EXPECT_EQ(t4_, it.time());
-  EXPECT_EQ(d4_, it.degrees_of_freedom());
+  EXPECT_EQ(t4_, it->time);
+  EXPECT_EQ(d4_, it->degrees_of_freedom);
   ++it;
   EXPECT_TRUE(it == fork->end());
 }
@@ -943,8 +943,8 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingSerialization) {
   for (auto it1 = circle.begin(), it2 = deserialized_circle->begin();
        it1 != circle.end();
        ++it1, ++it2) {
-    EXPECT_EQ(it1.time(), it2.time());
-    EXPECT_EQ(it1.degrees_of_freedom(), it2.degrees_of_freedom());
+    EXPECT_EQ(it1->time, it2->time);
+    EXPECT_EQ(it1->degrees_of_freedom, it2->degrees_of_freedom);
   }
 }
 
@@ -987,7 +987,7 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingForgetAfter) {
   EXPECT_THAT(forgotten_circle.Size(), Eq(circle.Size()));
   std::vector<Length> errors;
   for (auto const [time, degrees_of_freedom] : forgotten_circle) {
-    errors.push_back((circle.Find(time).degrees_of_freedom().position() -
+    errors.push_back((circle.Find(time)->degrees_of_freedom.position() -
                       degrees_of_freedom.position()).Norm());
   }
   EXPECT_THAT(errors, Each(Eq(0 * Metre)));

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -241,11 +241,11 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   not_null<DiscreteTrajectory<World>*> const fork1 =
       massive_trajectory_->NewForkWithCopy(t3_);
   not_null<DiscreteTrajectory<World>*> const fork2 =
-      fork1->NewForkWithCopy(fork1->rbegin().time());
+      fork1->NewForkWithCopy(fork1->back().time);
   not_null<DiscreteTrajectory<World>*> const fork3 =
-      fork2->NewForkWithCopy(fork1->rbegin().time());
-  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
-  EXPECT_EQ(t3_, fork1->rbegin().time());
+      fork2->NewForkWithCopy(fork1->back().time);
+  EXPECT_EQ(t3_, massive_trajectory_->back().time);
+  EXPECT_EQ(t3_, fork1->back().time);
 
   std::map<Instant, Position<World>> positions = Positions(*fork2);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork2);
@@ -255,9 +255,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   std::vector<Instant> after;
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
@@ -276,9 +276,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
@@ -297,9 +297,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
@@ -317,9 +317,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkWithCopyAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork3->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork3->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork3->rbegin().time());
+  EXPECT_EQ(q3_, fork3->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork3->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork3->back().time);
 
   fork2->Append(t4_, d4_);
   after.clear();
@@ -358,8 +358,8 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
       fork1->NewForkAtLast();
   not_null<DiscreteTrajectory<World>*> const fork3 =
       fork2->NewForkAtLast();
-  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
-  EXPECT_EQ(t3_, fork1->rbegin().time());
+  EXPECT_EQ(t3_, massive_trajectory_->back().time);
+  EXPECT_EQ(t3_, fork1->back().time);
 
   std::map<Instant, Position<World>> positions = Positions(*fork2);
   std::map<Instant, Velocity<World>> velocities = Velocities(*fork2);
@@ -369,9 +369,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   std::vector<Instant> after;
   for (DiscreteTrajectory<World>::Iterator it = fork3->Find(t3_);
@@ -390,9 +390,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork2->Find(t3_);
@@ -411,9 +411,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork2->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork2->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork2->rbegin().time());
+  EXPECT_EQ(q3_, fork2->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork2->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork2->back().time);
 
   after.clear();
   for (DiscreteTrajectory<World>::Iterator it = fork1->Find(t3_);
@@ -431,9 +431,9 @@ TEST_F(DiscreteTrajectoryTest, NewForkAtLast) {
   EXPECT_THAT(velocities,
               ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_), Pair(t3_, p3_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_, t3_));
-  EXPECT_EQ(q3_, fork3->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, fork3->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, fork3->rbegin().time());
+  EXPECT_EQ(q3_, fork3->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, fork3->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, fork3->back().time);
 
   fork2->Append(t4_, d4_);
   after.clear();
@@ -590,9 +590,9 @@ TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   EXPECT_THAT(positions, ElementsAre(Pair(t1_, q1_), Pair(t2_, q2_)));
   EXPECT_THAT(velocities, ElementsAre(Pair(t1_, p1_), Pair(t2_, p2_)));
   EXPECT_THAT(times, ElementsAre(t1_, t2_));
-  EXPECT_EQ(q2_, fork->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p2_, fork->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t2_, fork->rbegin().time());
+  EXPECT_EQ(q2_, fork->back().degrees_of_freedom.position());
+  EXPECT_EQ(p2_, fork->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t2_, fork->back().time);
 
   positions = Positions(*massive_trajectory_);
   velocities = Velocities(*massive_trajectory_);
@@ -773,7 +773,7 @@ TEST_F(DiscreteTrajectoryTest, TrajectorySerializationSuccess) {
 
 TEST_F(DiscreteTrajectoryDeathTest, LastError) {
   EXPECT_DEATH({
-    massive_trajectory_->rbegin();
+    massive_trajectory_->back();
   }, "parent_.*non NULL");
 }
 
@@ -781,14 +781,14 @@ TEST_F(DiscreteTrajectoryTest, LastSuccess) {
   massive_trajectory_->Append(t1_, d1_);
   massive_trajectory_->Append(t2_, d2_);
   massive_trajectory_->Append(t3_, d3_);
-  EXPECT_EQ(q3_, massive_trajectory_->rbegin().degrees_of_freedom().position());
-  EXPECT_EQ(p3_, massive_trajectory_->rbegin().degrees_of_freedom().velocity());
-  EXPECT_EQ(t3_, massive_trajectory_->rbegin().time());
+  EXPECT_EQ(q3_, massive_trajectory_->back().degrees_of_freedom.position());
+  EXPECT_EQ(p3_, massive_trajectory_->back().degrees_of_freedom.velocity());
+  EXPECT_EQ(t3_, massive_trajectory_->back().time);
 }
 
 TEST_F(DiscreteTrajectoryDeathTest, IteratorError) {
   EXPECT_DEATH({
-    DiscreteTrajectory<World>::Iterator it = massive_trajectory_->rbegin();
+    DiscreteTrajectory<World>::Iterator it = --massive_trajectory_->end();
   }, "parent_.*non NULL");
 }
 
@@ -971,7 +971,7 @@ TEST_F(DiscreteTrajectoryTest, DownsamplingForgetAfter) {
     forgotten_circle.Append(t, dof);
   }
   forgotten_circle.ForgetAfter(t0_ + 5 * Second);
-  t = forgotten_circle.rbegin().time();
+  t = forgotten_circle.back().time;
   for (t += 10 * Milli(Second); t <= t0_ + 10 * Second;
        t += 10 * Milli(Second)) {
     DegreesOfFreedom<World> const dof =

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -432,10 +432,10 @@ Ephemeris<Frame>::NewInstance(
   };
 
   CHECK(!trajectories.empty());
-  Instant const trajectory_last_time = (*trajectories.begin())->last().time();
+  Instant const trajectory_last_time = (*trajectories.begin())->rbegin().time();
   problem.initial_state.time = DoublePrecision<Instant>(trajectory_last_time);
   for (auto const& trajectory : trajectories) {
-    auto const trajectory_last = trajectory->last();
+    auto const trajectory_last = trajectory->rbegin();
     auto const last_degrees_of_freedom = trajectory_last.degrees_of_freedom();
     CHECK_EQ(trajectory_last.time(), trajectory_last_time);
     problem.initial_state.positions.emplace_back(
@@ -1155,7 +1155,7 @@ Status Ephemeris<Frame>::FlowODEWithAdaptiveStep(
     Instant const& t,
     ODEAdaptiveStepParameters<ODE> const& parameters,
     std::int64_t max_ephemeris_steps) {
-  Instant const& trajectory_last_time = trajectory->last().time();
+  Instant const& trajectory_last_time = trajectory->rbegin().time();
   if (trajectory_last_time == t) {
     return Status::OK;
   }
@@ -1176,7 +1176,7 @@ Status Ephemeris<Frame>::FlowODEWithAdaptiveStep(
   IntegrationProblem<ODE> problem;
   problem.equation.compute_acceleration = std::move(compute_acceleration);
 
-  auto const trajectory_last = trajectory->last();
+  auto const trajectory_last = trajectory->rbegin();
   auto const last_degrees_of_freedom = trajectory_last.degrees_of_freedom();
   problem.initial_state = {{last_degrees_of_freedom.position()},
                            {last_degrees_of_freedom.velocity()},

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -546,7 +546,7 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMasslessBody(
     not_null<DiscreteTrajectory<Frame>*> const trajectory,
     Instant const& t) const {
   auto const it = trajectory->Find(t);
-  DegreesOfFreedom<Frame> const& degrees_of_freedom = it.degrees_of_freedom();
+  DegreesOfFreedom<Frame> const& degrees_of_freedom = it->degrees_of_freedom;
   return ComputeGravitationalAccelerationOnMasslessBody(
              degrees_of_freedom.position(), t);
 }

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -432,12 +432,12 @@ Ephemeris<Frame>::NewInstance(
   };
 
   CHECK(!trajectories.empty());
-  Instant const trajectory_last_time = (*trajectories.begin())->rbegin().time();
+  auto const trajectory_last_time = (*trajectories.begin())->back().time;
   problem.initial_state.time = DoublePrecision<Instant>(trajectory_last_time);
   for (auto const& trajectory : trajectories) {
-    auto const trajectory_last = trajectory->rbegin();
-    auto const last_degrees_of_freedom = trajectory_last.degrees_of_freedom();
-    CHECK_EQ(trajectory_last.time(), trajectory_last_time);
+    auto const& trajectory_back = trajectory->back();
+    auto const last_degrees_of_freedom = trajectory_back.degrees_of_freedom;
+    CHECK_EQ(trajectory_back.time, trajectory_last_time);
     problem.initial_state.positions.emplace_back(
         last_degrees_of_freedom.position());
     problem.initial_state.velocities.emplace_back(
@@ -1155,7 +1155,7 @@ Status Ephemeris<Frame>::FlowODEWithAdaptiveStep(
     Instant const& t,
     ODEAdaptiveStepParameters<ODE> const& parameters,
     std::int64_t max_ephemeris_steps) {
-  Instant const& trajectory_last_time = trajectory->rbegin().time();
+  Instant const& trajectory_last_time = trajectory->back().time;
   if (trajectory_last_time == t) {
     return Status::OK;
   }
@@ -1176,11 +1176,11 @@ Status Ephemeris<Frame>::FlowODEWithAdaptiveStep(
   IntegrationProblem<ODE> problem;
   problem.equation.compute_acceleration = std::move(compute_acceleration);
 
-  auto const trajectory_last = trajectory->rbegin();
-  auto const last_degrees_of_freedom = trajectory_last.degrees_of_freedom();
+  auto const trajectory_back = trajectory->back();
+  auto const last_degrees_of_freedom = trajectory_back.degrees_of_freedom;
   problem.initial_state = {{last_degrees_of_freedom.position()},
                            {last_degrees_of_freedom.velocity()},
-                           trajectory_last.time()};
+                           trajectory_back.time};
 
   typename AdaptiveStepSizeIntegrator<ODE>::Parameters const
       integrator_parameters(

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -1017,11 +1017,11 @@ TEST_P(EphemerisTest, ComputeApsidesContinuousTrajectory) {
   for (auto it1 = apoapsides1.begin(), it2 = apoapsides2.begin();
        it1 != apoapsides1.end() && it2 != apoapsides2.end();
        ++it1, ++it2) {
-    Instant const time = it1.time();
+    Instant const time = it1->time;
     all_times.emplace(time);
     Displacement<ICRS> const displacement =
-        it1.degrees_of_freedom().position() -
-        it2.degrees_of_freedom().position();
+        it1->degrees_of_freedom.position() -
+        it2->degrees_of_freedom.position();
     EXPECT_LT(AbsoluteError(displacement.Norm(), (1 + e) * a),
               1.9e-5 * fitting_tolerance);
     if (previous_time) {
@@ -1035,11 +1035,11 @@ TEST_P(EphemerisTest, ComputeApsidesContinuousTrajectory) {
   for (auto it1 = periapsides1.begin(), it2 = periapsides2.begin();
        it1 != periapsides1.end() && it2 != periapsides2.end();
        ++it1, ++it2) {
-    Instant const time = it1.time();
+    Instant const time = it1->time;
     all_times.emplace(time);
     Displacement<ICRS> const displacement =
-        it1.degrees_of_freedom().position() -
-        it2.degrees_of_freedom().position();
+        it1->degrees_of_freedom.position() -
+        it2->degrees_of_freedom.position();
     EXPECT_LT(AbsoluteError(displacement.Norm(), (1 - e) * a),
               5.3e-3 * fitting_tolerance);
     if (previous_time) {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -242,7 +242,7 @@ TEST_P(EphemerisTest, FlowWithAdaptiveStepSpecialCase) {
   EXPECT_OK(ephemeris.FlowWithAdaptiveStep(
       &trajectory,
       Ephemeris<ICRS>::NoIntrinsicAcceleration,
-      trajectory.rbegin().time(),
+      trajectory.back().time,
       Ephemeris<ICRS>::AdaptiveStepParameters(
           EmbeddedExplicitRungeKuttaNyströmIntegrator<
               DormandالمكاوىPrince1986RKN434FM,
@@ -488,10 +488,10 @@ TEST_P(EphemerisTest, EarthProbe) {
               AlmostEquals(1.00 * period * v_earth, 633, 635));
   EXPECT_THAT(earth_positions[100].coordinates().y, Eq(q_earth));
 
-  Length const q_probe = (trajectory.rbegin().degrees_of_freedom().position() -
+  Length const q_probe = (trajectory.back().degrees_of_freedom.position() -
                           ICRS::origin).coordinates().y;
   Speed const v_probe =
-      trajectory.rbegin().degrees_of_freedom().velocity().coordinates().x;
+      trajectory.back().degrees_of_freedom.velocity().coordinates().x;
   std::vector<Displacement<ICRS>> probe_positions;
   for (auto const& [time, degrees_of_freedom] : trajectory) {
     probe_positions.push_back(degrees_of_freedom.position() - ICRS::origin);
@@ -509,7 +509,7 @@ TEST_P(EphemerisTest, EarthProbe) {
               Eq(q_probe));
 
   Instant const old_t_max = ephemeris.t_max();
-  EXPECT_THAT(trajectory.rbegin().time(), Lt(old_t_max));
+  EXPECT_THAT(trajectory.back().time, Lt(old_t_max));
   EXPECT_THAT(ephemeris.FlowWithAdaptiveStep(
                   &trajectory,
                   intrinsic_acceleration,
@@ -524,7 +524,7 @@ TEST_P(EphemerisTest, EarthProbe) {
                   /*max_ephemeris_steps=*/0),
               StatusIs(Error::DEADLINE_EXCEEDED));
   EXPECT_THAT(ephemeris.t_max(), Eq(old_t_max));
-  EXPECT_THAT(trajectory.rbegin().time(), Eq(old_t_max));
+  EXPECT_THAT(trajectory.back().time, Eq(old_t_max));
 }
 
 // The Earth and two massless probes, similar to the previous test but flowing
@@ -617,15 +617,15 @@ TEST_P(EphemerisTest, EarthTwoProbes) {
   EXPECT_THAT(earth_positions[100].coordinates().y, Eq(q_earth));
 
   Length const q_probe1 =
-      (trajectory1.rbegin().degrees_of_freedom().position() -
+      (trajectory1.back().degrees_of_freedom.position() -
        ICRS::origin).coordinates().y;
   Length const q_probe2 =
-      (trajectory2.rbegin().degrees_of_freedom().position() -
+      (trajectory2.back().degrees_of_freedom.position() -
        ICRS::origin).coordinates().y;
   Speed const v_probe1 =
-      trajectory1.rbegin().degrees_of_freedom().velocity().coordinates().x;
+      trajectory1.back().degrees_of_freedom.velocity().coordinates().x;
   Speed const v_probe2 =
-      trajectory2.rbegin().degrees_of_freedom().velocity().coordinates().x;
+      trajectory2.back().degrees_of_freedom.velocity().coordinates().x;
   std::vector<Displacement<ICRS>> probe1_positions;
   std::vector<Displacement<ICRS>> probe2_positions;
   for (auto const& [time, degrees_of_freedom] : trajectory1) {
@@ -752,7 +752,7 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMasslessBody) {
       Ephemeris<ICRS>::unlimited_max_ephemeris_steps);
 
   Speed const v_elephant_y =
-      trajectory.rbegin().degrees_of_freedom().velocity().coordinates().y;
+      trajectory.back().degrees_of_freedom.velocity().coordinates().y;
   std::vector<Displacement<ICRS>> elephant_positions;
   std::vector<Vector<Acceleration, ICRS>> elephant_accelerations;
   for (auto const& [time, degrees_of_freedom] : trajectory) {

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -135,7 +135,6 @@ class Forkable {
   It3rator begin() const;
   It3rator end() const;
 
-  //TODO(phl):Test this
   typename It3rator::reference front() const;
   typename It3rator::reference back() const;
 

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -135,8 +135,9 @@ class Forkable {
   It3rator begin() const;
   It3rator end() const;
 
-  It3rator rbegin() const;
-  // TODO(phl): Add rend.
+  //TODO(phl):Test this
+  typename It3rator::reference front() const;
+  typename It3rator::reference back() const;
 
   It3rator Find(Instant const& time) const;
   It3rator LowerBound(Instant const& time) const;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -74,7 +74,7 @@ class ForkableIterator {
   virtual not_null<It3rator const*> that() const = 0;
 
   // Returns the point in the timeline that is denoted by this iterator.
-  TimelineConstIterator current() const;
+  TimelineConstIterator const& current() const;
 
  private:
   // We want a single representation for an end iterator.  In various places
@@ -132,8 +132,11 @@ class Forkable {
   not_null<Tr4jectory const*> parent() const;
   not_null<Tr4jectory*> parent();
 
-  It3rator Begin() const;
-  It3rator End() const;
+  It3rator begin() const;
+  It3rator end() const;
+
+  It3rator rbegin() const;
+  // TODO(phl): Add rend.
 
   It3rator Find(Instant const& time) const;
   It3rator LowerBound(Instant const& time) const;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -101,7 +101,7 @@ It3rator& ForkableIterator<Tr4jectory, It3rator>::operator--() {
 }
 
 template<typename Tr4jectory, typename It3rator>
-typename ForkableIterator<Tr4jectory, It3rator>::TimelineConstIterator
+typename ForkableIterator<Tr4jectory, It3rator>::TimelineConstIterator const&
 ForkableIterator<Tr4jectory, It3rator>::current() const {
   return current_;
 }
@@ -175,19 +175,24 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator>::parent() {
 }
 
 template<typename Tr4jectory, typename It3rator>
-It3rator Forkable<Tr4jectory, It3rator>::Begin() const {
+It3rator Forkable<Tr4jectory, It3rator>::begin() const {
   not_null<Tr4jectory const*> ancestor = root();
   return Wrap(ancestor, ancestor->timeline_begin());
 }
 
 template<typename Tr4jectory, typename It3rator>
-It3rator Forkable<Tr4jectory, It3rator>::End() const {
+It3rator Forkable<Tr4jectory, It3rator>::end() const {
   not_null<Tr4jectory const*> const ancestor = that();
   It3rator iterator;
   iterator.ancestry_.push_front(ancestor);
   iterator.current_ = ancestor->timeline_end();
   iterator.CheckNormalizedIfEnd();
   return iterator;
+}
+
+template<typename Tr4jectory, typename It3rator>
+It3rator Forkable<Tr4jectory, It3rator>::rbegin() const {
+  return --end();
 }
 
 template<typename Tr4jectory, typename It3rator>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -191,8 +191,13 @@ It3rator Forkable<Tr4jectory, It3rator>::end() const {
 }
 
 template<typename Tr4jectory, typename It3rator>
-It3rator Forkable<Tr4jectory, It3rator>::rbegin() const {
-  return --end();
+typename It3rator::reference Forkable<Tr4jectory, It3rator>::front() const {
+  return *begin();
+}
+
+template<typename Tr4jectory, typename It3rator>
+typename It3rator::reference Forkable<Tr4jectory, It3rator>::back() const {
+  return *--end();
 }
 
 template<typename Tr4jectory, typename It3rator>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -192,11 +192,13 @@ It3rator Forkable<Tr4jectory, It3rator>::end() const {
 
 template<typename Tr4jectory, typename It3rator>
 typename It3rator::reference Forkable<Tr4jectory, It3rator>::front() const {
+  // TODO(phl): This can be implemented more efficiently.
   return *begin();
 }
 
 template<typename Tr4jectory, typename It3rator>
 typename It3rator::reference Forkable<Tr4jectory, It3rator>::back() const {
+  // TODO(phl): This can be implemented more efficiently.
   return *--end();
 }
 

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -32,6 +32,7 @@ class FakeTrajectoryIterator
     : public ForkableIterator<FakeTrajectory, FakeTrajectoryIterator> {
  public:
   using ForkableIterator<FakeTrajectory, FakeTrajectoryIterator>::current;
+  using reference = std::list<Instant>::reference;
 
  protected:
   not_null<FakeTrajectoryIterator*> that() override;

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -163,7 +163,7 @@ class ForkableTest : public testing::Test {
       Instant const& time) {
     std::vector<Instant> after;
     for (FakeTrajectory::Iterator it = trajectory->Find(time);
-         it != trajectory->End();
+         it != trajectory->end();
          ++it) {
       after.push_back(*it.current());
     }
@@ -172,7 +172,7 @@ class ForkableTest : public testing::Test {
 
   static Instant const& LastTime(
       not_null<FakeTrajectory const*> const trajectory) {
-    FakeTrajectory::Iterator it = trajectory->End();
+    FakeTrajectory::Iterator it = trajectory->end();
     --it;
     return *it.current();
   }
@@ -180,8 +180,8 @@ class ForkableTest : public testing::Test {
   static std::vector<Instant> Times(
       not_null<FakeTrajectory const*> const trajectory) {
     std::vector<Instant> times;
-    for (FakeTrajectory::Iterator it = trajectory->Begin();
-         it != trajectory->End();
+    for (FakeTrajectory::Iterator it = trajectory->begin();
+         it != trajectory->end();
          ++it) {
       times.push_back(*it.current());
     }
@@ -483,7 +483,7 @@ TEST_F(ForkableTest, CheckNoForksBeforeSuccess) {
 
 TEST_F(ForkableDeathTest, IteratorDecrementError) {
   EXPECT_DEATH({
-    auto it = trajectory_.End();
+    auto it = trajectory_.end();
     --it;
   }, "parent_.*non NULL");
 }
@@ -492,7 +492,7 @@ TEST_F(ForkableTest, IteratorDecrementNoForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
-  auto it = trajectory_.End();
+  auto it = trajectory_.end();
   --it;
   EXPECT_EQ(t3_, *it.current());
   --it;
@@ -507,7 +507,7 @@ TEST_F(ForkableTest, IteratorDecrementForkSuccess) {
   auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
-  auto it = fork->End();
+  auto it = fork->end();
   --it;
   EXPECT_EQ(t3_, *it.current());
   --it;
@@ -521,17 +521,17 @@ TEST_F(ForkableTest, IteratorDecrementMultipleForksSuccess) {
   auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
   auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
   fork2->push_back(t3_);
-  auto it = fork3->End();
+  auto it = fork3->end();
   --it;
   EXPECT_EQ(t2_, *it.current());
   --it;
   EXPECT_EQ(t1_, *it.current());
-  EXPECT_EQ(it, fork3->Begin());
+  EXPECT_EQ(it, fork3->begin());
 }
 
 TEST_F(ForkableDeathTest, IteratorIncrementError) {
   EXPECT_DEATH({
-    auto it = trajectory_.Begin();
+    auto it = trajectory_.begin();
     ++it;
   }, "current.*!=.*end");
 }
@@ -540,7 +540,7 @@ TEST_F(ForkableTest, IteratorIncrementNoForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
-  auto it = trajectory_.Begin();
+  auto it = trajectory_.begin();
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t2_, *it.current());
@@ -554,12 +554,12 @@ TEST_F(ForkableTest, IteratorIncrementForkSuccess) {
   auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
-  auto it = fork->Begin();
+  auto it = fork->begin();
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t3_, *it.current());
   ++it;
-  EXPECT_EQ(it, fork->End());
+  EXPECT_EQ(it, fork->end());
 }
 
 TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
@@ -568,23 +568,23 @@ TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
   auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
   auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
   auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
-  auto it = fork3->Begin();
+  auto it = fork3->begin();
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t2_, *it.current());
   ++it;
-  EXPECT_EQ(it, fork3->End());
+  EXPECT_EQ(it, fork3->end());
   fork3->push_back(t3_);
   --it;
   EXPECT_EQ(t3_, *it.current());
-  it = fork3->Begin();
+  it = fork3->begin();
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t2_, *it.current());
   ++it;
   EXPECT_EQ(t3_, *it.current());
   ++it;
-  EXPECT_EQ(it, fork3->End());
+  EXPECT_EQ(it, fork3->end());
 }
 
 #if !defined(_DEBUG)
@@ -593,8 +593,8 @@ TEST_F(ForkableTest, IteratorEndEquality) {
   trajectory_.push_back(t2_);
   auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t1_));
   auto fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  auto it1 = fork1->End();
-  auto it2 = fork2->End();
+  auto it1 = fork1->end();
+  auto it2 = fork2->end();
   EXPECT_NE(it1, it2);
 }
 #endif
@@ -613,76 +613,76 @@ TEST_F(ForkableTest, Root) {
 }
 
 TEST_F(ForkableTest, IteratorBeginSuccess) {
-  auto it = trajectory_.Begin();
-  EXPECT_EQ(it, trajectory_.End());
+  auto it = trajectory_.begin();
+  EXPECT_EQ(it, trajectory_.end());
 
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
 
-  it = trajectory_.Begin();
-  EXPECT_NE(it, trajectory_.End());
+  it = trajectory_.begin();
+  EXPECT_NE(it, trajectory_.end());
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t2_, *it.current());
   ++it;
   EXPECT_EQ(t3_, *it.current());
   ++it;
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
       trajectory_.NewFork(trajectory_.timeline_find(t2_));
   fork->push_back(t4_);
 
-  it = fork->Begin();
-  EXPECT_NE(it, fork->End());
+  it = fork->begin();
+  EXPECT_NE(it, fork->end());
   EXPECT_EQ(t1_, *it.current());
   ++it;
   EXPECT_EQ(t2_, *it.current());
   ++it;
   EXPECT_EQ(t4_, *it.current());
   ++it;
-  EXPECT_EQ(it, fork->End());
+  EXPECT_EQ(it, fork->end());
 }
 
 TEST_F(ForkableTest, IteratorFindSuccess) {
   auto it = trajectory_.Find(t0_);
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
 
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
 
   it = trajectory_.Find(t0_);
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
   it = trajectory_.Find(t1_);
-  EXPECT_NE(it, trajectory_.End());
+  EXPECT_NE(it, trajectory_.end());
   EXPECT_EQ(t1_, *it.current());
   it = trajectory_.Find(t2_);
   EXPECT_EQ(t2_, *it.current());
   it = trajectory_.Find(t4_);
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
       trajectory_.NewFork(trajectory_.timeline_find(t2_));
   fork->push_back(t4_);
 
   it = fork->Find(t0_);
-  EXPECT_EQ(it, fork->End());
+  EXPECT_EQ(it, fork->end());
   it = fork->Find(t1_);
-  EXPECT_NE(it, fork->End());
+  EXPECT_NE(it, fork->end());
   EXPECT_EQ(t1_, *it.current());
   it = fork->Find(t2_);
   EXPECT_EQ(t2_, *it.current());
   it = fork->Find(t4_);
   EXPECT_EQ(t4_, *it.current());
   it = fork->Find(t4_ + 1 * Second);
-  EXPECT_EQ(it, fork->End());
+  EXPECT_EQ(it, fork->end());
 }
 
 TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   auto it = trajectory_.LowerBound(t0_);
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
 
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
@@ -695,7 +695,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   it = trajectory_.LowerBound(t2_);
   EXPECT_EQ(t2_, *it.current());
   it = trajectory_.LowerBound(t4_);
-  EXPECT_EQ(it, trajectory_.End());
+  EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork1 =
       trajectory_.NewFork(trajectory_.timeline_find(t2_));
@@ -704,7 +704,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   it = fork1->LowerBound(t0_);
   EXPECT_EQ(t1_, *it.current());
   it = fork1->LowerBound(t1_);
-  EXPECT_NE(it, fork1->End());
+  EXPECT_NE(it, fork1->end());
   EXPECT_EQ(t1_, *it.current());
   it = fork1->LowerBound(t2_);
   EXPECT_EQ(t2_, *it.current());
@@ -716,7 +716,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   it = fork1->LowerBound(t4_);
   EXPECT_EQ(t4_, *it.current());
   it = fork1->LowerBound(t4_ + 1 * Second);
-  EXPECT_EQ(it, fork1->End());
+  EXPECT_EQ(it, fork1->end());
 
   not_null<FakeTrajectory*> const fork2 =
       fork1->NewFork(fork1->timeline_find(t2_));


### PR DESCRIPTION
1. Change the names to `begin` and `end` to help with range for loops.
1. Add operators `*` and `->`.
1. Expose a small struct with fields `time` and `degrees_of_freedom` and remove the selector functions by the same name.
1. Add `front` and `back` and use them wherever possible.

Fix #2263.