### PR TITLE
Use manifests instead of DLL paths to find our DLLs

### DIFF
--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -3,14 +3,24 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A3F94607-2666-408F-AF98-0E47D61C98BB}</ProjectGuid>
     <RootNamespace>ksp_plugin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)principia.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)principia.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
-      <AdditionalOptions>-validate_manifest -hashupdate:$(OutDir)</AdditionalOptions>
+      <AdditionalOptions>
+      </AdditionalOptions>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)principia.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)principia.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -9,8 +9,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Manifest>
       <AdditionalManifestFiles>$(ProjectDir)principia.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
-      <AdditionalOptions>
-      </AdditionalOptions>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -3,8 +3,16 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A3F94607-2666-408F-AF98-0E47D61C98BB}</ProjectGuid>
     <RootNamespace>ksp_plugin</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)principia.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)principia.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <AdditionalOptions>-validate_manifest -hashupdate:$(OutDir)</AdditionalOptions>
+    </Manifest>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="celestial.hpp" />
     <ClInclude Include="equator_relevance_threshold.hpp" />
@@ -71,5 +79,8 @@
       <Message>$([System.String]::Format($(PrincipiaGenerateProfilesMessage), %(FullPath)))</Message>
       <Outputs>$(PrincipiaGenerateProfilesOutputs)</Outputs>
     </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="principia.manifest" />
   </ItemGroup>
 </Project>

--- a/ksp_plugin/ksp_plugin.vcxproj.filters
+++ b/ksp_plugin/ksp_plugin.vcxproj.filters
@@ -164,4 +164,7 @@
   <ItemGroup>
     <CustomBuild Include="..\serialization\journal.proto" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="principia.manifest" />
+  </ItemGroup>
 </Project>

--- a/ksp_plugin/principia.manifest
+++ b/ksp_plugin/principia.manifest
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity name="principia.dll" version="2019.08.30.11" type="win32"/>
+  <file name="libglog.dll"/>
+  <file name="libprotobuf.dll"/>
+  <file name="serialization.dll"/>
+</assembly>

--- a/ksp_plugin/principia.manifest
+++ b/ksp_plugin/principia.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity name="principia.dll" version="2019.08.30.11" type="win32"/>
+  <assemblyIdentity name="principia.dll" version="0.0.0.0" type="win32"/>
   <file name="libglog.dll"/>
   <file name="libprotobuf.dll"/>
   <file name="serialization.dll"/>

--- a/ksp_plugin_adapter/loader.cs
+++ b/ksp_plugin_adapter/loader.cs
@@ -50,17 +50,6 @@ internal static class Loader {
     }
     try {
       loaded_principia_dll_ = true;
-      // No kernel32 on *nix, so we throw an exception and immediately resume
-      // after the try block.
-      try {
-        // We dynamically link glog, protobuf, and the serialization DLL on
-        // Windows, so we need that to be in the DLL search path for the main
-        // DLL to load.
-        if (!SetDllDirectory(@"GameData\Principia\x64")) {
-          return "Failed to set DLL directory (error code " +
-                 Marshal.GetLastWin32Error() + ").";
-        }
-      } catch {}
       Log.InitGoogleLogging();
       return null;
     } catch (Exception e) {

--- a/serialization/serialization.manifest
+++ b/serialization/serialization.manifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity name="serialization.dll" version="2019.08.30.11" type="win32"/>
+  <assemblyIdentity name="serialization.dll" version="0.0.0.0" type="win32"/>
   <file name="libprotobuf.dll"/>
 </assembly>

--- a/serialization/serialization.manifest
+++ b/serialization/serialization.manifest
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity name="serialization.dll" version="2019.08.30.11" type="win32"/>
+  <file name="libprotobuf.dll"/>
+</assembly>

--- a/serialization/serialization.vcxproj
+++ b/serialization/serialization.vcxproj
@@ -5,6 +5,21 @@
     <RootNamespace>serialization</RootNamespace>
   </PropertyGroup>
   <Import Project="$(SolutionDir)principia.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)serialization.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)serialization.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_LLVM|x64'">
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)serialization.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="geometry.proto">
       <FileType>Document</FileType>
@@ -93,5 +108,8 @@
     <ClCompile Include="physics.pb.cc" />
     <ClCompile Include="quantities.pb.cc" />
     <ClCompile Include="testing_utilities.pb.cc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="serialization.manifest" />
   </ItemGroup>
 </Project>

--- a/serialization/serialization.vcxproj.filters
+++ b/serialization/serialization.vcxproj.filters
@@ -19,6 +19,7 @@
     <CustomBuild Include="integrators.proto" />
     <CustomBuild Include="astronomy.proto" />
     <CustomBuild Include="journal.proto" />
+    <CustomBuild Include="testing_utilities.proto" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="geometry.pb.h">
@@ -79,6 +80,6 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="testing_utilities.proto" />
+    <Manifest Include="serialization.manifest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix #2297.