### PR TITLE
Separate the nominal recurrence from OrbitGroundTrack

### DIFF
--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -46,7 +46,9 @@ class OrbitGroundTrack {
     Interval<Angle> longitudes_reduced_to_pass(int pass_index) const;
 
    private:
-    explicit EquatorCrossingLongitudes(OrbitRecurrence const& nominal_recurrence);
+    explicit EquatorCrossingLongitudes(
+        OrbitRecurrence const& nominal_recurrence);
+
     OrbitRecurrence nominal_recurrence_;
     Interval<Angle> ascending_longitudes_reduced_to_pass_1_;
     Interval<Angle> descending_longitudes_reduced_to_pass_2_;

--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -84,6 +84,11 @@ class OrbitGroundTrack {
 
   std::vector<Angle> longitudes_of_equator_crossings_of_ascending_passes_;
   std::vector<Angle> longitudes_of_equator_crossings_of_descending_passes_;
+  // Whether |longitudes_of_equator_crossings_of_descending_passes_.front()| is
+  // the longitude of the pass preceding
+  // |longitudes_of_equator_crossings_of_ascending_passes_.front()|, rather than
+  // the following one.
+  bool first_descending_pass_before_first_ascending_pass_;
   std::optional<Interval<Angle>> mean_solar_times_of_ascending_nodes_;
   std::optional<Interval<Angle>> mean_solar_times_of_descending_nodes_;
 };

--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include <optional>
+#include <vector>
 
 #include "astronomy/orbit_recurrence.hpp"
 #include "astronomy/orbital_elements.hpp"
@@ -45,7 +46,7 @@ class OrbitGroundTrack {
     Interval<Angle> longitudes_reduced_to_pass(int const pass_index) const;
 
    private:
-    EquatorCrossingLongitudes(OrbitRecurrence const& nominal_recurrence);
+    explicit EquatorCrossingLongitudes(OrbitRecurrence const& nominal_recurrence);
     OrbitRecurrence nominal_recurrence_;
     Interval<Angle> ascending_longitudes_reduced_to_pass_1_;
     Interval<Angle> descending_longitudes_reduced_to_pass_2_;

--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -43,7 +43,7 @@ class OrbitGroundTrack {
     // the pass with the given index.  This provides both an indication of how
     // well the orbit follows the nominal recurrence grid, and where that grid
     // is located.
-    Interval<Angle> longitudes_reduced_to_pass(int const pass_index) const;
+    Interval<Angle> longitudes_reduced_to_pass(int pass_index) const;
 
    private:
     explicit EquatorCrossingLongitudes(OrbitRecurrence const& nominal_recurrence);

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -3,6 +3,7 @@
 #include "astronomy/orbit_ground_track.hpp"
 
 #include <limits>
+#include <vector>
 
 #include "physics/apsides.hpp"
 

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -91,7 +91,7 @@ inline Interval<Angle> ReducedLongitudesOfEquatorialCrossings(
   return reduced_longitudes;
 }
 
-Interval<Angle>
+inline Interval<Angle>
 OrbitGroundTrack::EquatorCrossingLongitudes::longitudes_reduced_to_pass(
     int const pass_index) const {
   // |shift| applies the number of equatorial shifts corresponding to the pass


### PR DESCRIPTION
The slow part of OrbitGroundTrack is the computation of the nodes; analysing how well pre-computed nodes follow a particular nominal recurrence grid is fast enough that it can be done in the UI thread, and this makes the analyser more convenient to use.