### PR TITLE
Change EulerSolver to take the principal axes frame as a template parameter

### DIFF
--- a/physics/euler_solver.hpp
+++ b/physics/euler_solver.hpp
@@ -1,19 +1,16 @@
 ﻿
 #pragma once
 
-#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/r3_element.hpp"
 #include "quantities/named_quantities.hpp"
-#include "serialization/geometry.pb.h"
 
 namespace principia {
 namespace physics {
 namespace internal_euler_solver {
 
 using geometry::Bivector;
-using geometry::Frame;
 using geometry::Instant;
 using geometry::R3Element;
 using quantities::Angle;
@@ -31,11 +28,9 @@ using quantities::NaN;
 //   In case (ii) λ should be defined as -σ λ₁.
 //   In case (iii) the first coordinate should include a factor σ (not σʹ) and
 //   λ should be defined as σ σʹ λ₂ (where λ₂ is the common value of λ₁ and λ₃).
+template<typename PrincipalAxesFrame>
 class EulerSolver {
  public:
-  using PrincipalAxesFrame = Frame<serialization::Frame::PhysicsTag,
-                                   serialization::Frame::PRINCIPAL_AXES,
-                                   /*frame_is_inertial*/ false>;
   using AngularMomentumBivector = Bivector<AngularMomentum, PrincipalAxesFrame>;
 
   // Constructs a solver for a body with the given moments_of_inertia in its
@@ -85,3 +80,5 @@ using internal_euler_solver::EulerSolver;
 
 }  // namespace physics
 }  // namespace principia
+
+#include "physics/euler_solver_body.hpp"

--- a/physics/euler_solver_body.hpp
+++ b/physics/euler_solver_body.hpp
@@ -1,8 +1,11 @@
 ﻿
+#pragma once
+
 #include "physics/euler_solver.hpp"
 
 #include <algorithm>
 
+#include "geometry/grassmann.hpp"
 #include "numerics/elliptic_functions.hpp"
 #include "numerics/elliptic_integrals.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -30,7 +33,8 @@ using quantities::Time;
 using quantities::si::Joule;
 using quantities::si::Radian;
 
-EulerSolver::EulerSolver(
+template<typename PrincipalAxesFrame>
+EulerSolver<PrincipalAxesFrame>::EulerSolver(
     R3Element<MomentOfInertia> const& moments_of_inertia,
     AngularMomentumBivector const& initial_angular_momentum,
     Instant const& initial_time)
@@ -110,7 +114,9 @@ EulerSolver::EulerSolver(
   }
 }
 
-EulerSolver::AngularMomentumBivector EulerSolver::AngularMomentumAt(
+template<typename PrincipalAxesFrame>
+typename EulerSolver<PrincipalAxesFrame>::AngularMomentumBivector
+EulerSolver<PrincipalAxesFrame>::AngularMomentumAt(
     Instant const& time) const {
   Time const Δt = time - initial_time_;
   switch (formula_) {

--- a/physics/physics.vcxproj
+++ b/physics/physics.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="dynamic_frame.hpp" />
     <ClInclude Include="dynamic_frame_body.hpp" />
     <ClInclude Include="euler_solver.hpp" />
+    <ClInclude Include="euler_solver_body.hpp" />
     <ClInclude Include="geopotential.hpp" />
     <ClInclude Include="geopotential_body.hpp" />
     <ClInclude Include="protector.hpp" />
@@ -80,7 +81,6 @@
     <ClCompile Include="degrees_of_freedom_test.cpp" />
     <ClCompile Include="discrete_trajectory_test.cpp" />
     <ClCompile Include="dynamic_frame_test.cpp" />
-    <ClCompile Include="euler_solver.cpp" />
     <ClCompile Include="euler_solver_test.cpp" />
     <ClCompile Include="geopotential_test.cpp" />
     <ClCompile Include="hierarchical_system_test.cpp" />

--- a/physics/physics.vcxproj.filters
+++ b/physics/physics.vcxproj.filters
@@ -182,6 +182,9 @@
     <ClInclude Include="euler_solver.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="euler_solver_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="degrees_of_freedom_test.cpp">
@@ -255,9 +258,6 @@
     </ClCompile>
     <ClCompile Include="protector_test.cpp">
       <Filter>Test Files</Filter>
-    </ClCompile>
-    <ClCompile Include="euler_solver.cpp">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="euler_solver_test.cpp">
       <Filter>Test Files</Filter>


### PR DESCRIPTION
1. This is the pattern used by the other classes in physics, e.g. the dynamic frames.
1. We might want to have different principal axes frames for different vessels, for instance.
1. The current pattern would look weird once we take the inertial frame as a template parameter for solving the Arnold equation.