### PR TITLE
Templatize on the need for the integral of the third kind

### DIFF
--- a/benchmarks/elliptic_integrals_benchmark.cpp
+++ b/benchmarks/elliptic_integrals_benchmark.cpp
@@ -31,7 +31,7 @@ void BM_EllipticF(benchmark::State& state) {
     mcs.push_back(distribution_mc(random));
   }
 
-  while (state.KeepRunningBatch(size * size * size)) {
+  while (state.KeepRunningBatch(size * size)) {
     Angle f;
     for (Angle const φ : φs) {
       for (double const mc : mcs) {

--- a/benchmarks/elliptic_integrals_benchmark.cpp
+++ b/benchmarks/elliptic_integrals_benchmark.cpp
@@ -23,24 +23,19 @@ void BM_EllipticF(benchmark::State& state) {
 
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> distribution_φ(0.0, π / 2);
-  std::uniform_real_distribution<> distribution_n(0.0, 1.0);
   std::uniform_real_distribution<> distribution_mc(0.0, 1.0);
   std::vector<Angle> φs;
-  std::vector<double> ns;
   std::vector<double> mcs;
   for (int i = 0; i < size; ++i) {
     φs.push_back(distribution_φ(random) * Radian);
-    ns.push_back(distribution_n(random));
     mcs.push_back(distribution_mc(random));
   }
 
   while (state.KeepRunningBatch(size * size * size)) {
     Angle f;
     for (Angle const φ : φs) {
-      for (double const n : ns) {
-        for (double const mc : mcs) {
-          f += EllipticF(φ, mc);
-        }
+      for (double const mc : mcs) {
+        f += EllipticF(φ, mc);
       }
     }
     benchmark::DoNotOptimize(f);

--- a/benchmarks/elliptic_integrals_benchmark.cpp
+++ b/benchmarks/elliptic_integrals_benchmark.cpp
@@ -18,6 +18,35 @@ using quantities::si::Radian;
 
 namespace numerics {
 
+void BM_EllipticF(benchmark::State& state) {
+  constexpr int size = 20;
+
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> distribution_φ(0.0, π / 2);
+  std::uniform_real_distribution<> distribution_n(0.0, 1.0);
+  std::uniform_real_distribution<> distribution_mc(0.0, 1.0);
+  std::vector<Angle> φs;
+  std::vector<double> ns;
+  std::vector<double> mcs;
+  for (int i = 0; i < size; ++i) {
+    φs.push_back(distribution_φ(random) * Radian);
+    ns.push_back(distribution_n(random));
+    mcs.push_back(distribution_mc(random));
+  }
+
+  while (state.KeepRunningBatch(size * size * size)) {
+    Angle f;
+    for (Angle const φ : φs) {
+      for (double const n : ns) {
+        for (double const mc : mcs) {
+          f += EllipticF(φ, mc);
+        }
+      }
+    }
+    benchmark::DoNotOptimize(f);
+  }
+}
+
 void BM_EllipticFEΠ(benchmark::State& state) {
   constexpr int size = 20;
 
@@ -84,6 +113,7 @@ void BM_FukushimaEllipticBDJ(benchmark::State& state) {
   }
 }
 
+BENCHMARK(BM_EllipticF);
 BENCHMARK(BM_EllipticFEΠ);
 BENCHMARK(BM_FukushimaEllipticBDJ);
 

--- a/numerics/elliptic_integrals.cpp
+++ b/numerics/elliptic_integrals.cpp
@@ -54,15 +54,15 @@ struct UnusedResult {
   constexpr UnusedResult(base::uninitialized_t) {}
 };
 
-template<typename T, typename = EnableIfAngleResult<T>>
-inline constexpr bool should_compute = !std::is_same_v<T, UnusedResult const>;
-
 inline constexpr UnusedResult unused{uninitialized};
 
 template<typename T>
 using EnableIfAngleResult =
     std::enable_if_t<std::is_same_v<T, UnusedResult const> ||
                      std::is_same_v<T, Angle>>;
+
+template<typename T, typename = EnableIfAngleResult<T>>
+inline constexpr bool should_compute = !std::is_same_v<T, UnusedResult const>;
 
 // Computes Emde’s complete elliptic integrals of the second kind B(m) and D(m),
 // as well as Fukushima’s complete elliptic integral of the third kind J(n, m),

--- a/numerics/elliptic_integrals.hpp
+++ b/numerics/elliptic_integrals.hpp
@@ -51,6 +51,9 @@ void FukushimaEllipticBDJ(Angle const& φ,
                           Angle& D_φǀm,
                           Angle& J_φ_nǀm);
 
+// Same as above, but does not compute J.
+void FukushimaEllipticBD(Angle const& φ, double mc, Angle& B_φǀm, Angle& D_φǀm);
+
 // Returns the incomplete elliptic integral of the first kind F(φ|m), where
 // m = 1 - mc.
 Angle EllipticF(Angle const& φ, double mc);
@@ -62,6 +65,10 @@ Angle EllipticE(Angle const& φ, double mc);
 // Returns the incomplete elliptic integral of the third kind Π(φ, n|m), where
 // m = 1 - mc.
 Angle EllipticΠ(Angle const& φ, double n, double mc);
+
+// Computes the incomplete elliptic integrals the first and second kinds F(φ|m)
+// and E(φ|m), where m = 1 - mc.
+void EllipticFE(Angle const& φ, double mc, Angle& F_φǀm, Angle& E_φǀm);
 
 // Computes the incomplete elliptic integrals of all three kinds F(φ|m), E(φ|m),
 // and Π(φ, n|m), where m = 1 - mc.


### PR DESCRIPTION
This makes it possible to compute F and E without computing J when Π is not needed.

Before:
```
Run on (4 X 2808 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 262K (x2)
  L3 Unified 4194K (x1)
------------------------------------------------------
Benchmark               Time           CPU Iterations
------------------------------------------------------
BM_EllipticF          233 ns        228 ns    2951600
BM_EllipticFEΠ        235 ns        230 ns    2992000
```
After:
```
Run on (4 X 2808 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 262K (x2)
  L3 Unified 4194K (x1)
------------------------------------------------------
Benchmark               Time           CPU Iterations
------------------------------------------------------
BM_EllipticF          133 ns        123 ns    4072800
BM_EllipticFEΠ        239 ns        230 ns    2992000
```