### PR TITLE
Celestial trajectory plotting

### DIFF
--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -1,6 +1,8 @@
 
 #include "ksp_plugin/interface.hpp"
 
+#include <algorithm>
+
 #include "geometry/affine_map.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
@@ -225,7 +227,11 @@ Iterator* principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
     char const* const vessel_guid,
     double const max_history_length) {
   journal::Method<journal::PlanetariumPlotCelestialTrajectoryForPsychohistory>
-      m({planetarium, plugin, celestial_index, vessel_guid, max_history_length});
+      m({planetarium,
+         plugin,
+         celestial_index,
+         vessel_guid,
+         max_history_length});
   CHECK_NOTNULL(plugin);
   CHECK_NOTNULL(planetarium);
 
@@ -253,7 +259,8 @@ Iterator* principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
 // Returns an iterator for the rendered future trajectory of the celestial with
 // the given index; the trajectory goes as far as the furthest of the final time
 // of the prediction or that of the flight plan.
-Iterator* principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
+Iterator*
+principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
     Planetarium const* const planetarium,
     Plugin const* const plugin,
     int const celestial_index,

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -214,6 +214,10 @@ Iterator* principia__PlanetariumPlotPsychohistory(
   }
 }
 
+// Returns an iterator for the rendered past trajectory of the celestial with
+// the given index; the trajectory goes back as far as the history of the vessel
+// with the given GUID, or, if no vessel is provided, up to |max_history_length|
+// seconds before the present time.
 Iterator* principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
     Planetarium const* const planetarium,
     Plugin const* const plugin,
@@ -235,7 +239,7 @@ Iterator* principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
         plugin->CurrentTime() - max_history_length * Second,
         vessel_guid == nullptr
             ? celestial_trajectory.t_min()
-            : plugin->GetVessel(vessel_guid)->psychohistory().front().time);
+            : plugin->GetVessel(vessel_guid)->psychohistory().t_min());
     auto const rp2_lines =
         planetarium->PlotMethod2(celestial_trajectory,
                                  first_time,
@@ -246,6 +250,9 @@ Iterator* principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
   }
 }
 
+// Returns an iterator for the rendered future trajectory of the celestial with
+// the given index; the trajectory goes as far as the furthest of the final time
+// of the prediction or that of the flight plan.
 Iterator* principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
     Planetarium const* const planetarium,
     Plugin const* const plugin,
@@ -262,7 +269,7 @@ Iterator* principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan
     return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
   } else {
     auto const& vessel = *plugin->GetVessel(vessel_guid);
-    Instant const prediction_final_time = vessel.prediction().back().time;
+    Instant const prediction_final_time = vessel.prediction().t_max();
     Instant const final_time =
         vessel.has_flight_plan()
             ? std::max(vessel.flight_plan().actual_final_time(),

--- a/ksp_plugin/planetarium.cpp
+++ b/ksp_plugin/planetarium.cpp
@@ -138,21 +138,30 @@ RP2Lines<Length, Camera> Planetarium::PlotMethod2(
     DiscreteTrajectory<Barycentric>::Iterator const& end,
     Instant const& now,
     bool const reverse) const {
-  RP2Lines<Length, Camera> lines;
   if (begin == end) {
-    return lines;
+    return {};
   }
   auto last = end;
   --last;
-
-  double const tan²_angular_resolution =
-      Pow<2>(parameters_.tan_angular_resolution_);
-  auto const plottable_spheres = ComputePlottableSpheres(now);
   auto const& trajectory = *begin.trajectory();
   auto const begin_time = std::max(begin->time, plotting_frame_->t_min());
   auto const last_time = std::min(last->time, plotting_frame_->t_max());
-  auto const final_time = reverse ? begin_time : last_time;
-  auto previous_time = reverse ? last_time : begin_time;
+  return PlotMethod2(trajectory, begin_time, last_time, now, reverse);
+}
+
+RP2Lines<Length, Camera> Planetarium::PlotMethod2(
+    Trajectory<Barycentric> const& trajectory,
+    Instant const& first_time,
+    Instant const& last_time,
+    Instant const& now,
+    bool reverse) const {
+  RP2Lines<Length, Camera> lines;
+  auto const plottable_spheres = ComputePlottableSpheres(now);
+  double const tan²_angular_resolution =
+      Pow<2>(parameters_.tan_angular_resolution_);
+  auto const final_time = reverse ? first_time : last_time;
+  auto previous_time = reverse ? last_time : first_time;
+
   Sign const direction = reverse ? Sign(-1) : Sign(1);
   if (direction * (final_time - previous_time) <= Time{}) {
     return lines;

--- a/ksp_plugin/planetarium.cpp
+++ b/ksp_plugin/planetarium.cpp
@@ -154,7 +154,7 @@ RP2Lines<Length, Camera> Planetarium::PlotMethod2(
     Instant const& first_time,
     Instant const& last_time,
     Instant const& now,
-    bool reverse) const {
+    bool const reverse) const {
   RP2Lines<Length, Camera> lines;
   auto const plottable_spheres = ComputePlottableSpheres(now);
   double const tan²_angular_resolution =

--- a/ksp_plugin/planetarium.hpp
+++ b/ksp_plugin/planetarium.hpp
@@ -83,12 +83,16 @@ class Planetarium {
       Instant const& now,
       bool reverse) const;
 
+  // A method that plots the cubic Hermite spline interpolating the trajectory,
+  // using an adaptive step size to keep the error between the straight segments
+  // and the actual spline below and close to the angular resolution.
   RP2Lines<Length, Camera> PlotMethod2(
       DiscreteTrajectory<Barycentric>::Iterator const& begin,
       DiscreteTrajectory<Barycentric>::Iterator const& end,
       Instant const& now,
       bool reverse) const;
 
+  // The same method, operating on the |Trajectory| interface.
   RP2Lines<Length, Camera> PlotMethod2(
       Trajectory<Barycentric> const& trajectory,
       Instant const& first_time,

--- a/ksp_plugin/planetarium.hpp
+++ b/ksp_plugin/planetarium.hpp
@@ -34,6 +34,7 @@ using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
 using physics::Ephemeris;
 using physics::RigidMotion;
+using physics::Trajectory;
 using quantities::Angle;
 using quantities::Length;
 
@@ -85,6 +86,13 @@ class Planetarium {
   RP2Lines<Length, Camera> PlotMethod2(
       DiscreteTrajectory<Barycentric>::Iterator const& begin,
       DiscreteTrajectory<Barycentric>::Iterator const& end,
+      Instant const& now,
+      bool reverse) const;
+
+  RP2Lines<Length, Camera> PlotMethod2(
+      Trajectory<Barycentric> const& trajectory,
+      Instant const& first_time,
+      Instant const& last_time,
       Instant const& now,
       bool reverse) const;
 

--- a/ksp_plugin_adapter/gl_lines.cs
+++ b/ksp_plugin_adapter/gl_lines.cs
@@ -109,8 +109,9 @@ internal static class GLLines {
               rp2_line_iterator.IteratorGetRP2LineXY());
           if (previous_rp2_point.HasValue) {
             if (style == Style.Faded) {
-              colour.a = 1 - (float)(4 * index) / (float)(5 * size);
-              UnityEngine.GL.Color(colour);
+              var faded_colour = colour;
+              faded_colour.a *= 1 - (float)(4 * index) / (float)(5 * size);
+              UnityEngine.GL.Color(faded_colour);
             }
             if (style != Style.Dashed || index % 2 == 1) {
               UnityEngine.GL.Vertex3((float)previous_rp2_point.Value.x,

--- a/ksp_plugin_adapter/gl_lines.cs
+++ b/ksp_plugin_adapter/gl_lines.cs
@@ -110,6 +110,8 @@ internal static class GLLines {
           if (previous_rp2_point.HasValue) {
             if (style == Style.Faded) {
               var faded_colour = colour;
+              // Fade from the opacity of |colour| (when index = 0) down to 1/4
+              // of that opacity.
               faded_colour.a *= 1 - (float)(4 * index) / (float)(5 * size);
               UnityEngine.GL.Color(faded_colour);
             }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1803,49 +1803,8 @@ public partial class PrincipiaPluginAdapter
       using (DisposablePlanetarium planetarium =
                 GLLines.NewPlanetarium(plugin_, sun_world_position)) {
         GLLines.Draw(() => {
-          // Celestial trajectories.
-          foreach (CelestialBody celestial in FlightGlobals.Bodies) {
-            if (plotting_frame_selector_.FixedBodies().Contains(celestial)) {
-              continue;
-            }
-            var colour = celestial.MapObject?.uiNode?.VisualIconData.color ??
-                XKCDColors.SunshineYellow;
-            if (colour.a != 1) {
-              // When zoomed into a planetary system, the trajectory of the
-              // planet is hidden in stock (because KSP then draws most things
-              // in the reference frame centred on that planet).
-              // Here we still want to display the trajectory of the primary,
-              // e.g., if we are drawing the trajectories of the Jovian system
-              // in the heliocentric frame.
-              foreach (CelestialBody child in celestial.orbitingBodies) {
-                colour.a = Math.Max(
-                    child.MapObject?.uiNode?.VisualIconData.color.a ?? 1,
-                    colour.a);
-              }
-            }
-            if (colour.a == 0) {
-              continue;
-            }
-            using (DisposableIterator rp2_lines_iterator =
-                      planetarium.PlanetariumPlotCelestialTrajectoryForPsychohistory(
-                          plugin_,
-                          celestial.flightGlobalsIndex,
-                          main_vessel_guid,
-                          main_window_.history_length)) {
-              GLLines.PlotRP2Lines(rp2_lines_iterator,
-                                   colour,
-                                   GLLines.Style.Faded);
-            }
-            if (main_vessel_guid != null) {
-              using (DisposableIterator rp2_lines_iterator =
-                        planetarium.PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
-                            plugin_, celestial.flightGlobalsIndex, main_vessel_guid)) {
-                GLLines.PlotRP2Lines(rp2_lines_iterator,
-                                     colour,
-                                     GLLines.Style.Solid);
-              }
-            }
-          }
+          PlotCelestialTrajectories(planetarium, main_vessel_guid);
+
           // Vessel trajectories.
           if (main_vessel_guid == null) {
             return;
@@ -1956,6 +1915,52 @@ public partial class PrincipiaPluginAdapter
             }
           }
         });
+      }
+    }
+  }
+
+  private void PlotCelestialTrajectories(DisposablePlanetarium planetarium,
+                                         string main_vessel_guid) {
+    foreach (CelestialBody celestial in FlightGlobals.Bodies) {
+      if (plotting_frame_selector_.FixedBodies().Contains(celestial)) {
+        continue;
+      }
+      var colour = celestial.MapObject?.uiNode?.VisualIconData.color ??
+          XKCDColors.SunshineYellow;
+      if (colour.a != 1) {
+        // When zoomed into a planetary system, the trajectory of the
+        // planet is hidden in stock (because KSP then draws most things
+        // in the reference frame centred on that planet).
+        // Here we still want to display the trajectory of the primary,
+        // e.g., if we are drawing the trajectories of the Jovian system
+        // in the heliocentric frame.
+        foreach (CelestialBody child in celestial.orbitingBodies) {
+          colour.a = Math.Max(
+              child.MapObject?.uiNode?.VisualIconData.color.a ?? 1,
+              colour.a);
+        }
+      }
+      if (colour.a == 0) {
+        continue;
+      }
+      using (DisposableIterator rp2_lines_iterator =
+                planetarium.PlanetariumPlotCelestialTrajectoryForPsychohistory(
+                    plugin_,
+                    celestial.flightGlobalsIndex,
+                    main_vessel_guid,
+                    main_window_.history_length)) {
+        GLLines.PlotRP2Lines(rp2_lines_iterator,
+                              colour,
+                              GLLines.Style.Faded);
+      }
+      if (main_vessel_guid != null) {
+        using (DisposableIterator rp2_lines_iterator =
+                  planetarium.PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
+                      plugin_, celestial.flightGlobalsIndex, main_vessel_guid)) {
+          GLLines.PlotRP2Lines(rp2_lines_iterator,
+                                colour,
+                                GLLines.Style.Solid);
+        }
       }
     }
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -862,8 +862,6 @@ public partial class PrincipiaPluginAdapter
           (FlightGlobals.currentMainBody
                ?? FlightGlobals.GetHomeBody()).flightGlobalsIndex);
 
-      plugin_.ForgetAllHistoriesBefore(plugin_.CurrentTime() -
-                                       main_window_.history_length);
       // TODO(egg): Set the degrees of freedom of the origin of |World| (by
       // toying with Krakensbane and FloatingOrigin) here.
 
@@ -1814,7 +1812,10 @@ public partial class PrincipiaPluginAdapter
                 XKCDColors.SunshineYellow;
             using (DisposableIterator rp2_lines_iterator =
                       planetarium.PlanetariumPlotCelestialTrajectoryForPsychohistory(
-                          plugin_, celestial.flightGlobalsIndex, main_vessel_guid)) {
+                          plugin_,
+                          celestial.flightGlobalsIndex,
+                          main_vessel_guid,
+                          main_window_.history_length)) {
               GLLines.PlotRP2Lines(rp2_lines_iterator,
                                    colour,
                                    GLLines.Style.Faded);
@@ -1838,7 +1839,8 @@ public partial class PrincipiaPluginAdapter
                     planetarium.PlanetariumPlotPsychohistory(
                         plugin_,
                         чебышёв_plotting_method_,
-                        main_vessel_guid)) {
+                        main_vessel_guid,
+                        main_window_.history_length)) {
             GLLines.PlotRP2Lines(rp2_lines_iterator,
                                  XKCDColors.Lime,
                                  GLLines.Style.Faded);
@@ -1862,7 +1864,8 @@ public partial class PrincipiaPluginAdapter
                       planetarium.PlanetariumPlotPsychohistory(
                           plugin_,
                           чебышёв_plotting_method_,
-                          target_id)) {
+                          target_id,
+                          main_window_.history_length)) {
               GLLines.PlotRP2Lines(rp2_lines_iterator,
                                    XKCDColors.Goldenrod,
                                    GLLines.Style.Faded);

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1808,8 +1808,11 @@ public partial class PrincipiaPluginAdapter
             if (plotting_frame_selector_.FixedBodies().Contains(celestial)) {
               continue;
             }
-            var colour = celestial.orbitDriver?.Renderer.nodeColor ??
+            var colour = celestial.MapObject?.uiNode?.VisualIconData.color ??
                 XKCDColors.SunshineYellow;
+            if (colour.a == 0) {
+              continue;
+            }
             using (DisposableIterator rp2_lines_iterator =
                       planetarium.PlanetariumPlotCelestialTrajectoryForPsychohistory(
                           plugin_,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1810,6 +1810,19 @@ public partial class PrincipiaPluginAdapter
             }
             var colour = celestial.MapObject?.uiNode?.VisualIconData.color ??
                 XKCDColors.SunshineYellow;
+            if (colour.a != 1) {
+              // When zoomed into a planetary system, the trajectory of the
+              // planet is hidden in stock (because KSP then draws most things
+              // in the reference frame centred on that planet).
+              // Here we still want to display the trajectory of the primary,
+              // e.g., if we are drawing the trajectories of the Jovian system
+              // in the heliocentric frame.
+              foreach (CelestialBody child in celestial.orbitingBodies) {
+                colour.a = Math.Max(
+                    child.MapObject?.uiNode?.VisualIconData.color.a ?? 1,
+                    colour.a);
+              }
+            }
             if (colour.a == 0) {
               continue;
             }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -213,7 +213,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5160.
+  extensions 5000 to 5999;  // Last used: 5162.
 }
 
 message AdvanceTime {
@@ -1558,6 +1558,48 @@ message PlanetariumDelete {
   }
   optional In in = 1;
   optional Out out = 2;
+}
+
+message PlanetariumPlotCelestialTrajectoryForPsychohistory {
+  extend Method {
+    optional PlanetariumPlotCelestialTrajectoryForPsychohistory extension = 5161;
+  }
+  message In {
+    required fixed64 planetarium = 1 [(pointer_to) = "Planetarium const",
+                                      (disposable) = "DisposablePlanetarium",
+                                      (is_subject) = true];
+    required fixed64 plugin = 2 [(pointer_to) = "Plugin const"];
+    required int32 celestial_index = 3;
+    optional string vessel_guid = 4;
+  }
+  message Return {
+    required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",
+                                    (disposable) = "DisposableIterator",
+                                    (is_produced) = true];
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
+message PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan {
+  extend Method {
+    optional PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan extension = 5162;
+  }
+  message In {
+    required fixed64 planetarium = 1 [(pointer_to) = "Planetarium const",
+                                      (disposable) = "DisposablePlanetarium",
+                                      (is_subject) = true];
+    required fixed64 plugin = 2 [(pointer_to) = "Plugin const"];
+    required int32 celestial_index = 3;
+    required string vessel_guid = 4;
+  }
+  message Return {
+    required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",
+                                    (disposable) = "DisposableIterator",
+                                    (is_produced) = true];
+  }
+  optional In in = 1;
+  optional Return return = 3;
 }
 
 message PlanetariumPlotFlightPlanSegment {

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1571,6 +1571,7 @@ message PlanetariumPlotCelestialTrajectoryForPsychohistory {
     required fixed64 plugin = 2 [(pointer_to) = "Plugin const"];
     required int32 celestial_index = 3;
     optional string vessel_guid = 4;
+    required double max_history_length = 5;
   }
   message Return {
     required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",
@@ -1656,6 +1657,7 @@ message PlanetariumPlotPsychohistory {
     required fixed64 plugin = 2 [(pointer_to) = "Plugin const"];
     required int32 method = 3;
     required string vessel_guid = 4;
+    required double max_history_length = 5;
   }
   message Return {
     required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",


### PR DESCRIPTION
This pull request makes the `Max history length` setting hide history, instead of forgetting it. It does not introduce a separate setting to forget the history; we may want to add that if people complain about performance issues.

Fix #942.
Fix #2164.

All hail retrobop:
![screenshot18](https://user-images.githubusercontent.com/2284290/68534430-dda54500-0334-11ea-8de5-455cad1c56b5.png)

Epicycles:
![screenshot20](https://user-images.githubusercontent.com/2284290/68534738-34604e00-0338-11ea-8489-afdd0bd94ba3.png)

Short histories:
![screenshot21](https://user-images.githubusercontent.com/2284290/68550294-f891bb00-0401-11ea-9739-8d8a27fc4b20.png)
![screenshot22](https://user-images.githubusercontent.com/2284290/68550295-f891bb00-0401-11ea-827e-513174acd070.png)

Miscellaneous screenshots:
![screenshot11](https://user-images.githubusercontent.com/2284290/68534052-8dc47f00-0330-11ea-963b-cc68e4162483.png)
![screenshot12](https://user-images.githubusercontent.com/2284290/68534053-8dc47f00-0330-11ea-8f65-1e0504b38bd7.png)
![screenshot13](https://user-images.githubusercontent.com/2284290/68534054-8e5d1580-0330-11ea-9aa9-8523cde21cd5.png)
![screenshot14](https://user-images.githubusercontent.com/2284290/68534055-8e5d1580-0330-11ea-8a3c-56d770e79e08.png)
![screenshot15](https://user-images.githubusercontent.com/2284290/68534056-8e5d1580-0330-11ea-84a5-6f00a3a4aed4.png)
![screenshot16](https://user-images.githubusercontent.com/2284290/68534057-8e5d1580-0330-11ea-8cb5-69d24832bc3c.png)
![screenshot17](https://user-images.githubusercontent.com/2284290/68534058-8ef5ac00-0330-11ea-9f73-ce1877f933d4.png)
