### PR TITLE
Normalize the quaternions that we get from Unity

### DIFF
--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -10,6 +10,11 @@
 #include "serialization/geometry.pb.h"
 
 namespace principia {
+
+namespace physics {
+class RigidMotionTest;
+}  // namespace physics
+
 namespace geometry {
 
 FORWARD_DECLARE_FROM(identity,
@@ -91,6 +96,9 @@ class OrthogonalMap : public LinearMap<FromFrame, ToFrame> {
       OrthogonalMap<From, Through> const& right);
 
   friend class OrthogonalMapTest;
+
+  // TODO(phl): This friendship could be avoided if we had symmetries.
+  friend class physics::RigidMotionTest;
 };
 
 template<typename FromFrame, typename ThroughFrame, typename ToFrame>

--- a/geometry/quaternion.hpp
+++ b/geometry/quaternion.hpp
@@ -21,6 +21,9 @@ class Quaternion final {
   double real_part() const;
   R3Element<double> const& imaginary_part() const;
 
+  double Norm() const;
+  double Norm²() const;
+
   Quaternion Conjugate() const;
   Quaternion Inverse() const;
 
@@ -55,10 +58,13 @@ Quaternion operator*(double left, Quaternion const& right);
 Quaternion operator*(Quaternion const& left, double right);
 Quaternion operator/(Quaternion const& left, double right);
 
+Quaternion Normalize(Quaternion const& quaternion);
+
 std::ostream& operator<<(std::ostream& out, Quaternion const& quaternion);
 
 }  // namespace internal_quaternion
 
+using internal_quaternion::Normalize;
 using internal_quaternion::Quaternion;
 
 }  // namespace geometry

--- a/geometry/quaternion_body.hpp
+++ b/geometry/quaternion_body.hpp
@@ -4,10 +4,13 @@
 #include "geometry/quaternion.hpp"
 
 #include "geometry/r3_element.hpp"
+#include "quantities/quantities.hpp"
 
 namespace principia {
 namespace geometry {
 namespace internal_quaternion {
+
+using quantities::DebugString;
 
 inline Quaternion::Quaternion() : real_part_(0) {}
 
@@ -141,10 +144,10 @@ inline Quaternion operator/(Quaternion const& left, double const right) {
 
 inline std::ostream& operator<<(std::ostream& out,
                                 Quaternion const& quaternion) {
-  return out << quaternion.real_part() << " + "
-             << quaternion.imaginary_part().x << " i + "
-             << quaternion.imaginary_part().y << " j + "
-             << quaternion.imaginary_part().z << " k";
+  return out << DebugString(quaternion.real_part()) << " + "
+             << DebugString(quaternion.imaginary_part().x) << " i + "
+             << DebugString(quaternion.imaginary_part().y) << " j + "
+             << DebugString(quaternion.imaginary_part().z) << " k";
 }
 
 }  // namespace internal_quaternion

--- a/geometry/quaternion_body.hpp
+++ b/geometry/quaternion_body.hpp
@@ -4,6 +4,7 @@
 #include "geometry/quaternion.hpp"
 
 #include "geometry/r3_element.hpp"
+#include "quantities/elementary_functions.hpp"
 #include "quantities/quantities.hpp"
 
 namespace principia {
@@ -11,6 +12,7 @@ namespace geometry {
 namespace internal_quaternion {
 
 using quantities::DebugString;
+using quantities::Sqrt;
 
 inline Quaternion::Quaternion() : real_part_(0) {}
 
@@ -29,6 +31,14 @@ inline double Quaternion::real_part() const {
 inline R3Element<double> const&
 Quaternion::imaginary_part() const {
   return imaginary_part_;
+}
+
+inline double Quaternion::Norm() const {
+  return Sqrt(Norm²());
+}
+
+inline double Quaternion::Norm²() const {
+  return real_part_ * real_part_ + imaginary_part_.Norm²();
 }
 
 inline Quaternion Quaternion::Conjugate() const {
@@ -140,6 +150,10 @@ inline Quaternion operator*(Quaternion const& left, double const right) {
 inline Quaternion operator/(Quaternion const& left, double const right) {
   return Quaternion(left.real_part() / right,
                     left.imaginary_part() / right);
+}
+
+inline Quaternion Normalize(Quaternion const& quaternion) {
+  return quaternion / quaternion.Norm();
 }
 
 inline std::ostream& operator<<(std::ostream& out,

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -345,7 +345,12 @@ inline RelativeDegreesOfFreedom<World> FromQP(QP const& qp) {
 }
 
 inline Quaternion FromWXYZ(WXYZ const& wxyz) {
-  return Quaternion{wxyz.w, {wxyz.x, wxyz.y, wxyz.z}};
+  // It is critical to normalize the quaternion that we receive from Unity: it
+  // is normalized in *single* precision, which is fine for KSP where the moving
+  // origin of World ensures that coordinates are never very large.  But in the
+  // C++ code we do some computations in Barycentric, which typically results in
+  // large coordinates for which we need normalization in *double* precision.
+  return Normalize(Quaternion{wxyz.w, {wxyz.x, wxyz.y, wxyz.z}});
 }
 
 inline R3Element<double> FromXYZ(XYZ const& xyz) {


### PR DESCRIPTION
... otherwise we accumulate errors when converting to the Barycentric frame.

Fix #2389.