### PR TITLE
Fix miscellaneous bugs with camera rotation

### DIFF
--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -274,7 +274,7 @@ Rotation<CameraReference, World> Renderer::CameraReferenceRotation(
   auto const result =
       OrthogonalMap<WorldSun, World>::Identity() *
       sun_looking_glass.Inverse().Forget() * planetarium_rotation.Forget() *
-      plotting_frame_->FromThisFrameAtTime(time).orthogonal_map() *
+      GetPlottingFrame()->FromThisFrameAtTime(time).orthogonal_map() *
       celestial_mirror.Forget();
   CHECK(result.Determinant().is_positive());
   return result.rotation();

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1664,12 +1664,14 @@ public partial class PrincipiaPluginAdapter
                                   .selected_celestial.flightGlobalsIndex);
       if (plotting_frame_selector_.target_override != target_vessel) {
         navball_changed_ = true;
+        should_transfer_camera_coordinates_ = true;
         plotting_frame_selector_.target_override = target_vessel;
       }
     } else {
       plugin_.ClearTargetVessel();
       if (plotting_frame_selector_.target_override != null) {
         navball_changed_ = true;
+        should_transfer_camera_coordinates_ = true;
         plotting_frame_selector_.target_override = null;
       }
     }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -766,6 +766,11 @@ public partial class PrincipiaPluginAdapter
                                          : roll_change_per_frame;
       }
     }
+    // We cannot run between the |PlanetariumCamera| and |ScaledSpace|
+    // |LateUpdate|s, but we need the ScaledSpace one to run after us to put the
+    // scaled origin where the scaled camera is.  Manually running another
+    // |LateUpdate| on ScaledSpace works, albeit ugly.
+    ScaledSpace.Instance.SendMessage("LateUpdate");
   }
 
   private void LateUpdate() {

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -744,17 +744,22 @@ public partial class PrincipiaPluginAdapter
       should_transfer_camera_coordinates_ = false;
     }
     previous_camera_reference_rotation_ = reference_rotation;
-    PlanetariumCamera.fetch.GetPivot().rotation =
-        reference_rotation *
-        (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
-        camera_roll;
-    // The galaxy camera also renders the galaxy cube outside map view; it
-    // should not be rotated there.
+    // Both the scaled space and galaxy cameras are used in the flight scene as
+    // well as map view; they should not be reoriented there.
     if (MapView.MapIsEnabled) {
+      PlanetariumCamera.fetch.GetPivot().rotation =
+          reference_rotation *
+          (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
+          camera_roll;
       ScaledCamera.Instance.galaxyCamera.transform.rotation =
           reference_rotation *
           (UnityEngine.QuaternionD)ScaledCamera.Instance.galaxyCamera.transform.rotation *
           camera_roll;
+      // We cannot run between the |PlanetariumCamera| and |ScaledSpace|
+      // |LateUpdate|s, but we need the ScaledSpace one to run after us to put the
+      // scaled origin where the scaled camera is.  Manually running another
+      // |LateUpdate| on ScaledSpace works, albeit ugly.
+      ScaledSpace.Instance.SendMessage("LateUpdate");
     }
     if (camera_roll_ != 0) {
       // TODO(egg): Should we be doing this in LateUpdate?
@@ -766,11 +771,6 @@ public partial class PrincipiaPluginAdapter
                                          : roll_change_per_frame;
       }
     }
-    // We cannot run between the |PlanetariumCamera| and |ScaledSpace|
-    // |LateUpdate|s, but we need the ScaledSpace one to run after us to put the
-    // scaled origin where the scaled camera is.  Manually running another
-    // |LateUpdate| on ScaledSpace works, albeit ugly.
-    ScaledSpace.Instance.SendMessage("LateUpdate");
   }
 
   private void LateUpdate() {


### PR DESCRIPTION
##### The EVE clouds were broken.
This is probably because the hemisphere on which clouds are drawn is chosen in the shader based on the position of the planet, which is computed with respect to the galaxy camera, rather than the scaled camera:
https://github.com/rbray89/EnvironmentalVisualEnhancements/blob/0c6fdac386c0fe6da20ddabea25f4fe60ca25b1b/Atmosphere/CloudsPQS.cs#L218-L224.
Normally, both cameras are at the origin, because `ScaledSpace` shifts positions accordingly, so this does not matter; since we adjusted the cameras after `ScaledSpace` ran, we moved the scaled space camera (but not the galaxy camera) away from the origin.
This may arguably be a bug in EVE (that position should be computed using the scaled space camera, since this is the one that renders), but it is probably a bad idea to violate the KSP invariant.

Run `ScaledSpace.LateUpdate()` by hand.

##### We were updating the scaled space orientation even outside map view.
I am not completely sure whether this had effects or whether the blinking that I experienced was from something else, but scaled space exists in the flight scene too (for distant planets), so we should not mess with it there.

##### `plotting_frame_` is not `GetPlottingFrame()`.
The C++ was using `plotting_frame_`, which is the last non-target plotting frame, instead of `GetPlottingFrame()`, which is the plotting frame; this meant that, when using the target frame, the camera was following a different frame.