### PR TITLE
Use a custom timing to adjust the planetarium camera.

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -83,17 +83,7 @@ public partial class PrincipiaPluginAdapter
 
   private bool time_is_advancing_;
 
-  // True if a discontinuous change to the camera reference rotation occurred
-  // (due to a change in plotting frame), in which case we need special handling
-  // to keep the motion of the camera continuous.
-  bool should_transfer_camera_coordinates_ = false;
-  // The camera reference rotation applied during the previous frame; this is
-  // used when transfering camera coordinates to preserve continuity.
-  UnityEngine.QuaternionD previous_camera_reference_rotation_;
-  // The roll of the camera; this is set when transferring camera coordinates to
-  // preserve continuity of orientation, and gradually brought down to 0 so that
-  // the camera is horizontal in the new reference frame.
-  double camera_roll_ = 0;
+  private PlanetariumCameraAdjuster planetarium_camera_adjuster_;
 
   private RenderingActions map_renderer_;
   private RenderingActions galaxy_cube_rotator_;
@@ -590,6 +580,10 @@ public partial class PrincipiaPluginAdapter
                                  JaiFailliAttendre);
     // Timing4, 19.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.Late, Late);
+    // Custom timing, 301.
+    planetarium_camera_adjuster_ =
+        gameObject.AddComponent<PlanetariumCameraAdjuster>();
+    planetarium_camera_adjuster_.adapter = this;
     // Timing5, 8008.
     TimingManager.FixedUpdateAdd(TimingManager.TimingStage.BetterLateThanNever,
                                  BetterLateThanNever);
@@ -699,77 +693,6 @@ public partial class PrincipiaPluginAdapter
       WindowsRendering();
     } else {
       LockClearing();
-    }
-  }
-
-  private void OrientPlanetariumCamera() {
-    const double degree = Math.PI / 180;
-    var reference_rotation =
-        (UnityEngine.QuaternionD)plugin_.CameraReferenceRotation();
-    var camera_roll = UnityEngine.QuaternionD.AngleAxis(camera_roll_ / degree,
-                                                        Vector3d.forward);
-    if (should_transfer_camera_coordinates_) {
-      UnityEngine.QuaternionD previous_referenced_pivot =
-          previous_camera_reference_rotation_ *
-          (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
-          camera_roll;
-      // Note that we use a single-precision quaternion here because the
-      // double-precision one that comes with KSP does not implement Euler
-      // angles.
-      UnityEngine.Quaternion new_dereferenced_pivot =
-          UnityEngine.QuaternionD.Inverse(reference_rotation) *
-          previous_referenced_pivot;
-      double new_heading = (new_dereferenced_pivot.eulerAngles.y -
-                            Planetarium.InverseRotAngle) * degree;
-      double new_pitch = new_dereferenced_pivot.eulerAngles.x * degree;
-      // The camera cannot be given nonzero roll by camera controls, but we
-      // smoothly bring its roll to 0 over the course of a few frames to make
-      // the change in orientation continuous, and thus easier to follow:
-      // instantly flipping can be confusing if it is a large change, e.g. Earth
-      // equator to Uranus equator.
-      camera_roll_ =
-          ((new_dereferenced_pivot.eulerAngles.z + 180) % 360 - 180) * degree;
-      // Unity has a very mad Euler angle convention that has pitch in
-      // [0, π/2] ∪ [3π/2, 2π].
-      if (new_pitch > Math.PI) {
-        new_pitch -= 2 * Math.PI;
-      }
-      PlanetariumCamera.fetch.camHdg = (float)new_heading;
-      PlanetariumCamera.fetch.camPitch = (float)new_pitch;
-      // Use the old reference rotation for this frame: since the change to
-      // camera heading and pitch has yet to take effect, the new one would
-      // result in a weird orientation for one frame.  Similarly, we keep the
-      // existing |camera_roll|.
-      reference_rotation = previous_camera_reference_rotation_;
-      should_transfer_camera_coordinates_ = false;
-    }
-    previous_camera_reference_rotation_ = reference_rotation;
-    // Both the scaled space and galaxy cameras are used in the flight scene as
-    // well as map view; they should not be reoriented there.
-    if (MapView.MapIsEnabled) {
-      PlanetariumCamera.fetch.GetPivot().rotation =
-          reference_rotation *
-          (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
-          camera_roll;
-      ScaledCamera.Instance.galaxyCamera.transform.rotation =
-          reference_rotation *
-          (UnityEngine.QuaternionD)ScaledCamera.Instance.galaxyCamera.transform.rotation *
-          camera_roll;
-      // We cannot run between the |PlanetariumCamera| and |ScaledSpace|
-      // |LateUpdate|s, but we need the ScaledSpace one to run after us to put the
-      // scaled origin where the scaled camera is.  Manually running another
-      // |LateUpdate| on ScaledSpace works, albeit ugly.
-      ScaledSpace.Instance.SendMessage("LateUpdate");
-    }
-    if (camera_roll_ != 0) {
-      // TODO(egg): Should we be doing this in LateUpdate?
-      const double roll_change_per_frame = 0.1 /*radians*/;
-      if (Math.Abs(camera_roll_) < roll_change_per_frame) {
-        camera_roll_ = 0;
-      } else {
-        camera_roll_ += camera_roll_ > 0 ? -roll_change_per_frame
-                                         : roll_change_per_frame;
-      }
     }
   }
 
@@ -1495,9 +1418,6 @@ public partial class PrincipiaPluginAdapter
   }
 
   private void BetterLateThanNeverLateUpdate() {
-    // We need to correct the orientation of the cameras after KSP has set it
-    // (and before we update the map nodes below).
-    OrientPlanetariumCamera();
     // While we draw the trajectories directly (and thus do so after everything
     // else has been rendered), we rely on the game to render its map nodes.
     // Since the screen position is determined in |MapNode.NodeUpdate|, it must
@@ -1521,10 +1441,6 @@ public partial class PrincipiaPluginAdapter
         RenderFlightPlanMarkers(main_vessel_guid, sun_world_position);
       }
     }
-    foreach (var node in KSP.UI.Screens.Mapview.MapNode.AllMapNodes) {
-      node.NodeUpdate();
-    }
-    // TODO(egg): redundant NodeUpdate calls.
     map_node_pool_.Update();
   }
 
@@ -1664,14 +1580,14 @@ public partial class PrincipiaPluginAdapter
                                   .selected_celestial.flightGlobalsIndex);
       if (plotting_frame_selector_.target_override != target_vessel) {
         navball_changed_ = true;
-        should_transfer_camera_coordinates_ = true;
+        planetarium_camera_adjuster_.should_transfer_camera_coordinates = true;
         plotting_frame_selector_.target_override = target_vessel;
       }
     } else {
       plugin_.ClearTargetVessel();
       if (plotting_frame_selector_.target_override != null) {
         navball_changed_ = true;
-        should_transfer_camera_coordinates_ = true;
+        planetarium_camera_adjuster_.should_transfer_camera_coordinates = true;
         plotting_frame_selector_.target_override = null;
       }
     }
@@ -2219,7 +2135,7 @@ public partial class PrincipiaPluginAdapter
     }
     navball_changed_ = true;
     reset_rsas_target_ = true;
-    should_transfer_camera_coordinates_ = true;
+    planetarium_camera_adjuster_.should_transfer_camera_coordinates = true;
   }
 
   private static void InitializeIntegrators(

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -125,6 +125,7 @@
     <Compile Include="main_window.cs" />
     <Compile Include="map_node_pool.cs" />
     <Compile Include="orbit_analyser.cs" />
+    <Compile Include="planetarium_camera_adjuster.cs" />
     <Compile Include="rendering_actions.cs" />
     <Compile Include="null_extensions.cs" />
     <Compile Include="optional_marshaler.cs" />

--- a/ksp_plugin_adapter/planetarium_camera_adjuster.cs
+++ b/ksp_plugin_adapter/planetarium_camera_adjuster.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace principia {
+namespace ksp_plugin_adapter {
+
+// Immediately after |PlanetariumCamera| (300).  In particular, before the next
+// one, |ScaledSpace| (500), which moves scaled space so that the camera is at
+// the origin.  If the adjustment is not performed before |ScaledSpace| runs,
+// EnvironmentalVisualEnhancements will draw clouds on an incorrect hemisphere
+// (not the camera-facing one).
+// Note that KSP provides no timing between 300 and 500, so we have to do this
+// ourselves.
+[UnityEngine.DefaultExecutionOrder(301)]
+public class PlanetariumCameraAdjuster : UnityEngine.MonoBehaviour {
+  private void LateUpdate() {
+    if (!adapter.PluginRunning()) {
+      return;
+    }
+    const double degree = Math.PI / 180;
+    var reference_rotation =
+        (UnityEngine.QuaternionD)adapter.Plugin().CameraReferenceRotation();
+    var camera_roll = UnityEngine.QuaternionD.AngleAxis(camera_roll_ / degree,
+                                                        Vector3d.forward);
+    if (should_transfer_camera_coordinates) {
+      UnityEngine.QuaternionD previous_referenced_pivot =
+          previous_camera_reference_rotation_ *
+          (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
+          camera_roll;
+      // Note that we use a single-precision quaternion here because the
+      // double-precision one that comes with KSP does not implement Euler
+      // angles.
+      UnityEngine.Quaternion new_dereferenced_pivot =
+          UnityEngine.QuaternionD.Inverse(reference_rotation) *
+          previous_referenced_pivot;
+      double new_heading = (new_dereferenced_pivot.eulerAngles.y -
+                            Planetarium.InverseRotAngle) * degree;
+      double new_pitch = new_dereferenced_pivot.eulerAngles.x * degree;
+      // The camera cannot be given nonzero roll by camera controls, but we
+      // smoothly bring its roll to 0 over the course of a few frames to make
+      // the change in orientation continuous, and thus easier to follow:
+      // instantly flipping can be confusing if it is a large change, e.g. Earth
+      // equator to Uranus equator.
+      camera_roll_ =
+          ((new_dereferenced_pivot.eulerAngles.z + 180) % 360 - 180) * degree;
+      // Unity has a very mad Euler angle convention that has pitch in
+      // [0, π/2] ∪ [3π/2, 2π].
+      if (new_pitch > Math.PI) {
+        new_pitch -= 2 * Math.PI;
+      }
+      PlanetariumCamera.fetch.camHdg = (float)new_heading;
+      PlanetariumCamera.fetch.camPitch = (float)new_pitch;
+      // Use the old reference rotation for this frame: since the change to
+      // camera heading and pitch has yet to take effect, the new one would
+      // result in a weird orientation for one frame.  Similarly, we keep the
+      // existing |camera_roll|.
+      reference_rotation = previous_camera_reference_rotation_;
+      should_transfer_camera_coordinates = false;
+    }
+    previous_camera_reference_rotation_ = reference_rotation;
+    // Both the scaled space and galaxy cameras are used in the flight scene as
+    // well as map view; they should not be reoriented there.
+    if (MapView.MapIsEnabled) {
+      PlanetariumCamera.fetch.GetPivot().rotation =
+          reference_rotation *
+          (UnityEngine.QuaternionD)PlanetariumCamera.fetch.GetPivot().rotation *
+          camera_roll;
+      ScaledCamera.Instance.galaxyCamera.transform.rotation =
+          reference_rotation *
+          (UnityEngine.QuaternionD)ScaledCamera.Instance.galaxyCamera.transform.rotation *
+          camera_roll;
+    }
+    if (camera_roll_ != 0) {
+      // TODO(egg): Should we be doing this in LateUpdate?
+      const double roll_change_per_frame = 0.1 /*radians*/;
+      if (Math.Abs(camera_roll_) < roll_change_per_frame) {
+        camera_roll_ = 0;
+      } else {
+        camera_roll_ += camera_roll_ > 0 ? -roll_change_per_frame
+                                         : roll_change_per_frame;
+      }
+    }
+  }
+
+  // True if a discontinuous change to the camera reference rotation occurred
+  // (due to a change in plotting frame), in which case we need special handling
+  // to keep the motion of the camera continuous.
+  public bool should_transfer_camera_coordinates { private get; set; }
+
+  // The camera reference rotation applied during the previous frame; this is
+  // used when transfering camera coordinates to preserve continuity.
+  private UnityEngine.QuaternionD previous_camera_reference_rotation_;
+  // The roll of the camera; this is set when transferring camera coordinates to
+  // preserve continuity of orientation, and gradually brought down to 0 so that
+  // the camera is horizontal in the new reference frame.
+  private double camera_roll_ = 0;
+
+  public PrincipiaPluginAdapter adapter { private get; set; }
+}
+
+}  // namespace ksp_plugin_adapter
+}  // namespace principia


### PR DESCRIPTION
Fix #2401.

The `LateUpdate` of the new file is essentially the old `OrientPlanetariumCamera`. Some of the remainder of the diff is removing workarounds for timing-induced issues; it may be more to compare the adapter with its state prior to #2393: https://github.com/mockingbirdnest/Principia/compare/14ee57622a1064f4518f6f6e1c8c4e3f89cb3fcc...eggrobin:camera-rotation?expand=1#diff-c8666bccb01bd25d11f7ae5e0b5f2d1f.