### PR TITLE
Use the new features of the Frame class

### DIFF
--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -72,9 +72,7 @@ constexpr Time Δt = 45 * Minute;
 
 class KSPResonanceTest : public ::testing::Test {
  protected:
-  using KSP = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST,
-                    Inertial>;
+  using KSP = Frame<enum class KSPTag, KSPTag{}, Inertial>;
 
   using Periods = std::map<not_null<MassiveBody const*>, Time>;
 

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -65,9 +65,7 @@ using ::testing::Lt;
 
 namespace astronomy {
 
-using KSP = Frame<serialization::Frame::TestTag,
-                  serialization::Frame::TEST,
-                  Inertial>;
+using KSP = Frame<enum class KSPTag, KSPTag{}, Inertial>;
 
 class KSPSystem {
  protected:

--- a/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
@@ -58,8 +58,7 @@ namespace integrators {
 
 namespace {
 
-using World = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST, Inertial>;
+using World = Frame<enum class WorldTag, WorldTag{}, Inertial>;
 
 template<typename ODE>
 double HarmonicOscillatorToleranceRatio1D(

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -13,6 +13,7 @@
 #include "base/not_null.hpp"
 #include "base/thread_pool.hpp"
 #include "benchmark/benchmark.h"
+#include "geometry/frame.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/quaternion.hpp"
 #include "geometry/rotation.hpp"
@@ -43,6 +44,7 @@ using base::ThreadPool;
 using geometry::Bivector;
 using geometry::DefinesFrame;
 using geometry::Displacement;
+using geometry::Frame;
 using geometry::Identity;
 using geometry::Instant;
 using geometry::Position;
@@ -435,7 +437,7 @@ void EphemerisL4ProbeBenchmark(Time const integration_duration,
     // plane is the ecliptic realized by the obliquity given by the IAU in 1976
     // (16th general assembly, resolution 10, commission 4, recommendation 1),
     // identifying the ICRS xy plane with the mean equator of J2000.0.
-    struct Ecliptic;
+    using Ecliptic = Frame<enum class EclipticTag>;
 
     Rotation<ICRS, Ecliptic> const equatorial_to_ecliptic(
         23 * Degree + 26 * ArcMinute + 21.448 * ArcSecond,

--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -10,6 +10,7 @@
 #include "astronomy/frames.hpp"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/r3_element.hpp"
@@ -28,6 +29,7 @@ using astronomy::ICRS;
 using astronomy::ITRS;
 using base::not_null;
 using geometry::Displacement;
+using geometry::Frame;
 using geometry::Instant;
 using geometry::R3Element;
 using geometry::Vector;
@@ -75,7 +77,7 @@ GeneralSphericalHarmonicsAccelerationF90(
     FixedMatrix<double, degree + 1, order + 1> const& snm,
     Instant const& t,
     Displacement<Frame> const& r) {
-  struct SurfaceFrame;
+  using SurfaceFrame = geometry::Frame<enum class SurfaceFrameTag>;
   auto const from_surface_frame =
       body->template FromSurfaceFrame<SurfaceFrame>(t);
   auto const to_surface_frame = from_surface_frame.Inverse();

--- a/benchmarks/perspective.cpp
+++ b/benchmarks/perspective.cpp
@@ -25,10 +25,8 @@ using quantities::si::Metre;
 using quantities::si::Radian;
 
 namespace {
-using World = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST1>;
-using Camera = Frame<serialization::Frame::TestTag,
-                     serialization::Frame::TEST2>;
+using World = Frame<enum class WorldTag>;
+using Camera = Frame<enum class CameraTag>;
 }  // namespace
 
 void RandomSegmentsBenchmark(

--- a/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
@@ -58,8 +58,7 @@ namespace integrators {
 
 namespace {
 
-using World = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST, Inertial>;
+using World = Frame<enum class WorldTag, WorldTag{}, Inertial>;
 
 }  // namespace
 

--- a/geometry/affine_map.hpp
+++ b/geometry/affine_map.hpp
@@ -26,6 +26,9 @@ class AffineMap final {
   AffineMap<ToFrame, FromFrame, Scalar, LinearMap> Inverse() const;
   Point<ToVector> operator()(Point<FromVector> const& point) const;
 
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness == T::handedness>>
   static AffineMap Identity();
 
   LinearMap<FromFrame, ToFrame> const& linear_map() const;

--- a/geometry/affine_map_body.hpp
+++ b/geometry/affine_map_body.hpp
@@ -44,6 +44,7 @@ AffineMap<FromFrame, ToFrame, Scalar, LinearMap>::operator()(
 
 template<typename FromFrame, typename ToFrame, typename Scalar,
          template<typename, typename> class LinearMap>
+template<typename F, typename T, typename>
 AffineMap<FromFrame, ToFrame, Scalar, LinearMap>
 AffineMap<FromFrame, ToFrame, Scalar, LinearMap>::Identity() {
   return AffineMap(Point<FromVector>(),

--- a/geometry/barycentre_calculator_test.cpp
+++ b/geometry/barycentre_calculator_test.cpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "gtest/gtest.h"
 #include "quantities/named_quantities.hpp"
@@ -11,6 +12,7 @@
 
 namespace principia {
 
+using geometry::Frame;
 using quantities::Entropy;
 using quantities::KinematicViscosity;
 using quantities::SIUnit;
@@ -20,7 +22,7 @@ namespace geometry {
 
 class BarycentreCalculatorTest : public testing::Test {
  protected:
-  struct World;
+  using World = Frame<enum class WorldTag>;
 
   BarycentreCalculatorTest()
       : b1_({1 * SIUnit<Entropy>(),

--- a/geometry/identity.hpp
+++ b/geometry/identity.hpp
@@ -25,6 +25,9 @@ using base::not_null;
 // The identity map.
 template<typename FromFrame, typename ToFrame>
 class Identity : public LinearMap<FromFrame, ToFrame> {
+  static_assert(FromFrame::handedness == ToFrame::handedness,
+                "Cannot identity frames with different handedness");
+
  public:
   Identity();
 

--- a/geometry/identity_test.cpp
+++ b/geometry/identity_test.cpp
@@ -98,7 +98,7 @@ TEST_F(IdentityTest, Forget) {
 }
 
 TEST_F(IdentityTest, Compose) {
-  struct World3;
+  using World3 = Frame<enum class World3Tag>;
   using Orth12 = OrthogonalMap<World1, World2>;
   using Orth13 = OrthogonalMap<World1, World3>;
   using Orth23 = OrthogonalMap<World2, World3>;

--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -65,6 +65,9 @@ class OrthogonalMap : public LinearMap<FromFrame, ToFrame> {
   template<typename T>
   typename base::Mappable<OrthogonalMap, T>::type operator()(T const& t) const;
 
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness == T::handedness>>
   static OrthogonalMap Identity();
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -63,7 +63,10 @@ OrthogonalMap<FromFrame, ToFrame>::operator()(T const& t) const {
   return base::Mappable<OrthogonalMap, T>::Do(*this, t);
 }
 
+// NOTE(phl): VS2019 wants us to name the types F and T below, even though it is
+// happy with ReadFromMessage below.  You can't explain that.
 template<typename FromFrame, typename ToFrame>
+template<typename F, typename T, typename>
 OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::Identity() {
   return OrthogonalMap(Sign::Positive(),

--- a/geometry/pair_test.cpp
+++ b/geometry/pair_test.cpp
@@ -34,7 +34,7 @@ class PairTest : public testing::Test {
   using World = Frame<serialization::Frame::TestTag,
                       serialization::Frame::TEST, Inertial>;
 
-  struct Universe;
+  using Universe = Frame<enum class UniverseTag>;
 
   PairTest()
       : p1_(P1() + V1({4 * SIUnit<Action>(),

--- a/geometry/permutation.hpp
+++ b/geometry/permutation.hpp
@@ -68,6 +68,9 @@ class Permutation : public LinearMap<FromFrame, ToFrame> {
 
   OrthogonalMap<FromFrame, ToFrame> Forget() const;
 
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness == T::handedness>>
   static Permutation Identity();
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;

--- a/geometry/permutation_body.hpp
+++ b/geometry/permutation_body.hpp
@@ -88,6 +88,7 @@ Permutation<FromFrame, ToFrame>::Forget() const {
 }
 
 template<typename FromFrame, typename ToFrame>
+template<typename F, typename T, typename>
 Permutation<FromFrame, ToFrame> Permutation<FromFrame, ToFrame>::Identity() {
   return Permutation(XYZ);
 }

--- a/geometry/permutation_test.cpp
+++ b/geometry/permutation_test.cpp
@@ -156,7 +156,7 @@ TEST_F(PermutationTest, Forget) {
 }
 
 TEST_F(PermutationTest, Compose) {
-  struct World3;
+  using World3 = Frame<enum class World3Tag>;
   using Orth12 = OrthogonalMap<World1, World2>;
   using Orth13 = OrthogonalMap<World1, World3>;
   using Orth23 = OrthogonalMap<World2, World3>;

--- a/geometry/rotation.hpp
+++ b/geometry/rotation.hpp
@@ -222,6 +222,9 @@ class Rotation : public LinearMap<FromFrame, ToFrame> {
 
   OrthogonalMap<FromFrame, ToFrame> Forget() const;
 
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness == T::handedness>>
   static Rotation Identity();
 
   Quaternion const& quaternion() const;

--- a/geometry/rotation_body.hpp
+++ b/geometry/rotation_body.hpp
@@ -269,6 +269,7 @@ OrthogonalMap<FromFrame, ToFrame> Rotation<FromFrame, ToFrame>::Forget() const {
 }
 
 template<typename FromFrame, typename ToFrame>
+template<typename F, typename T, typename>
 Rotation<FromFrame, ToFrame> Rotation<FromFrame, ToFrame>::Identity() {
   return Rotation(Quaternion(1));
 }

--- a/geometry/rotation_test.cpp
+++ b/geometry/rotation_test.cpp
@@ -383,17 +383,17 @@ TEST_F(RotationTest, EulerAngles) {
   Angle const ω = 100 * Degree;
 
   // The frame in which the above elements are given.
-  struct Reference;
+  using Reference = Frame<enum class ReferenceTag>;
   // |Nodes| shares its z axis with |Reference|, and has the ascending node of
   // the orbit as its positive x direction.
-  struct Nodes;
+  using Nodes = Frame<enum class NodesTag>;
   // |Plane| also has the ascending node of the orbit as its positive x
   // direction, and has the orbital plane as its xy plane (with z being the
   // positive orbit normal).
-  struct Plane;
+  using Plane = Frame<enum class PlaneTag>;
   // |Orbit| has its x axis towards the periapsis, and its z axis towards the
   // positive orbit normal.
-  struct Orbit;
+  using Orbit = Frame<enum class OrbitTag>;
 
   Bivector<double, Reference> const celestial_pole({0, 0, 1});
   Bivector<double, Nodes> const ascending_node({1, 0, 0});
@@ -418,13 +418,13 @@ TEST_F(RotationTest, EulerAngles) {
 }
 
 TEST_F(RotationTest, CardanoAngles) {
-  struct Ground;
+  using Ground = Frame<enum class GroundTag>;
   Vector<double, Ground> north({1, 0, 0});
   Vector<double, Ground> east({0, 1, 0});
   Vector<double, Ground> down({0, 0, 1});
   auto const up = -down;
 
-  struct Aircraft;
+  using Aircraft = Frame<enum class AircraftTag>;
   Vector<double, Aircraft> forward({1, 0, 0});
   Vector<double, Aircraft> right({0, 1, 0});
   Vector<double, Aircraft> bottom({0, 0, 1});

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -30,6 +30,7 @@
 #include "base/unique_ptr_logging.hpp"
 #include "geometry/affine_map.hpp"
 #include "geometry/barycentre_calculator.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/identity.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/permutation.hpp"
@@ -77,6 +78,7 @@ using geometry::BarycentreCalculator;
 using geometry::Bivector;
 using geometry::DefinesFrame;
 using geometry::EulerAngles;
+using geometry::Frame;
 using geometry::Identity;
 using geometry::Normalize;
 using geometry::Permutation;
@@ -1070,7 +1072,7 @@ void Plugin::SetTargetVessel(GUID const& vessel_guid,
 std::unique_ptr<FrameField<World, Navball>> Plugin::NavballFrameField(
     Position<World> const& sun_world_position) const {
 
-  struct RightHandedNavball;
+  using RightHandedNavball = Frame<enum class RightHandedNavballTag>;
 
   // TODO(phl): Clean up this mess!
   class NavballFrameField : public FrameField<World, Navball> {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -312,7 +312,7 @@ Rotation<BodyWorld, World> Plugin::CelestialRotation(
     Index const index) const {
   // |BodyWorld| with its y and z axes swapped (so that z is the polar axis).
   // The basis is right-handed.
-  struct BodyFixed;
+  using BodyFixed = Frame<enum class BodyFixedTag>;
   Permutation<BodyWorld, BodyFixed> const body_mirror(
       Permutation<BodyWorld, BodyFixed>::XZY);
 
@@ -1448,7 +1448,7 @@ void Plugin::UpdatePlanetariumRotation() {
   // axis of |Barycentric| if they coincide).
   // This can be expressed using Euler angles, see figures 1 and 2 of
   // http://astropedia.astrogeology.usgs.gov/download/Docs/WGCCRE/WGCCRE2009reprint.pdf.
-  struct PlanetariumFrame;
+  using PlanetariumFrame = Frame<enum class PlanetariumFrameTag>;
 
   CHECK_NOTNULL(main_body_);
   Rotation<Barycentric, PlanetariumFrame> const to_planetarium(

--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -119,6 +119,11 @@ Renderer::RenderPlottingTrajectoryInWorld(
     Position<World> const& sun_world_position,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
+
+  //   Dinanzi a me non fuor cose create
+  //   se non etterne, e io etterno duro.
+  //   Lasciate ogne speranza, voi ch’intrate.
+  //
   // This function does unnatural things.
   // - It identifies positions in the plotting frame with those of world using
   // the rigid transformation at the current time, instead of transforming each
@@ -133,7 +138,8 @@ Renderer::RenderPlottingTrajectoryInWorld(
   // velocity).
   // The resulting |DegreesOfFreedom| should be seen as no more than a
   // convenient hack to send a plottable position together with a velocity in
-  // the coordinates we want.
+  // the coordinates we want.  In fact, it needs an articial permutation to
+  // avoid a violation of handedness.
   // TODO(phl): This will no longer be needed once we have support for
   // projections; instead of these convenient lies we can simply say that the
   // camera is fixed in the plotting frame and project there; additional data
@@ -149,7 +155,9 @@ Renderer::RenderPlottingTrajectoryInWorld(
     DegreesOfFreedom<World> const world_degrees_of_freedom = {
         from_plotting_frame_to_world_at_current_time(
             navigation_degrees_of_freedom.position()),
-        geometry::Identity<Navigation, World>{}(
+        geometry::Permutation<Navigation, World>(
+            geometry::Permutation<Navigation,
+                                  World>::CoordinatePermutation::YXZ)(
             navigation_degrees_of_freedom.velocity())};
     trajectory->Append(time, world_degrees_of_freedom);
   }

--- a/ksp_plugin_test/interface_flight_plan_test.cpp
+++ b/ksp_plugin_test/interface_flight_plan_test.cpp
@@ -5,6 +5,7 @@
 #include "geometry/identity.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/orthogonal_map.hpp"
+#include "geometry/permutation.hpp"
 #include "geometry/rotation.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -39,6 +40,7 @@ using base::not_null;
 using geometry::AngularVelocity;
 using geometry::Identity;
 using geometry::OrthogonalMap;
+using geometry::Permutation;
 using geometry::RigidTransformation;
 using geometry::Rotation;
 using geometry::Velocity;
@@ -317,7 +319,10 @@ TEST_F(InterfaceFlightPlanTest, FlightPlan) {
       .WillOnce(ReturnRef(navigation_manœuvre));
 
   EXPECT_CALL(renderer, BarycentricToWorldSun(_))
-      .WillOnce(Return(OrthogonalMap<Barycentric, WorldSun>::Identity()));
+      .WillOnce(Return(
+          Permutation<Barycentric, WorldSun>(
+              Permutation<Barycentric, WorldSun>::CoordinatePermutation::YXZ)
+              .Forget()));
   EXPECT_CALL(navigation_manœuvre, FrenetFrame())
       .WillOnce(
           Return(OrthogonalMap<Frenet<Navigation>, Barycentric>::Identity()));

--- a/ksp_plugin_test/interface_planetarium_test.cpp
+++ b/ksp_plugin_test/interface_planetarium_test.cpp
@@ -4,6 +4,7 @@
 #include "geometry/affine_map.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/orthogonal_map.hpp"
+#include "geometry/permutation.hpp"
 #include "geometry/rotation.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -21,6 +22,7 @@ using base::make_not_null_unique;
 using base::not_null;
 using geometry::Instant;
 using geometry::OrthogonalMap;
+using geometry::Permutation;
 using geometry::RigidTransformation;
 using geometry::Rotation;
 using ksp_plugin::Camera;
@@ -55,7 +57,12 @@ TEST_F(InterfacePlanetariumTest, ConstructionDestruction) {
   EXPECT_CALL(*plugin_, PlanetariumRotation())
       .WillRepeatedly(ReturnRef(identity));
   EXPECT_CALL(renderer, WorldToPlotting(_, _, _))
-      .WillOnce(Return(RigidTransformation<World, Navigation>::Identity()));
+      .WillOnce(Return(RigidTransformation<World, Navigation>(
+          World::origin,
+          Navigation::origin,
+          Permutation<World, Navigation>(
+              Permutation<World, Navigation>::CoordinatePermutation::YXZ)
+              .Forget())));
   EXPECT_CALL(*plugin_, FillPlanetarium(_, _, _))
       .WillOnce(FillUniquePtr<2>(new MockPlanetarium));
 

--- a/ksp_plugin_test/manœuvre_test.cpp
+++ b/ksp_plugin_test/manœuvre_test.cpp
@@ -64,7 +64,7 @@ class ManœuvreTest : public ::testing::Test {
  protected:
   using World = Barycentric;
   using Rendering = Frame<serialization::Frame::TestTag,
-                          serialization::Frame::TEST2>;
+                          serialization::Frame::TEST>;
 
   not_null<std::unique_ptr<StrictMock<MockDynamicFrame<World, Rendering>>>>
   MakeMockDynamicFrame() {

--- a/ksp_plugin_test/part_test.cpp
+++ b/ksp_plugin_test/part_test.cpp
@@ -124,21 +124,21 @@ TEST_F(PartTest, Serialization) {
                   .x()
                   .quantity()
                   .magnitude(),
-              AlmostEquals(-4, 0));
+              AlmostEquals(-4, 2));
   EXPECT_THAT(message.rigid_motion()
                   .velocity_of_to_frame_origin()
                   .vector()
                   .y()
                   .quantity()
                   .magnitude(),
-              AlmostEquals(-6, 0));
+              AlmostEquals(-6, 2));
   EXPECT_THAT(message.rigid_motion()
                   .velocity_of_to_frame_origin()
                   .vector()
                   .z()
                   .quantity()
                   .magnitude(),
-              AlmostEquals(-5, 0));
+              AlmostEquals(-5, 2));
   EXPECT_EQ(1, message.prehistory().timeline_size());
   EXPECT_EQ(1, message.prehistory().children_size());
   EXPECT_EQ(1, message.prehistory().children(0).trajectories_size());

--- a/ksp_plugin_test/part_test.cpp
+++ b/ksp_plugin_test/part_test.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 #include "ksp_plugin/frames.hpp"
 #include "physics/inertia_tensor.hpp"
+#include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/matchers.hpp"
 
 namespace principia {
@@ -23,6 +24,7 @@ using quantities::si::Newton;
 using quantities::si::Second;
 using ::testing::_;
 using ::testing::MockFunction;
+using testing_utilities::AlmostEquals;
 using testing_utilities::EqualsProto;
 
 class PartTest : public testing::Test {
@@ -116,27 +118,27 @@ TEST_F(PartTest, Serialization) {
                 .magnitude());
   EXPECT_TRUE(
       message.rigid_motion().velocity_of_to_frame_origin().has_vector());
-  EXPECT_EQ(-4,
-            message.rigid_motion()
-                .velocity_of_to_frame_origin()
-                .vector()
-                .x()
-                .quantity()
-                .magnitude());
-  EXPECT_EQ(-5,
-            message.rigid_motion()
-                .velocity_of_to_frame_origin()
-                .vector()
-                .y()
-                .quantity()
-                .magnitude());
-  EXPECT_EQ(-6,
-            message.rigid_motion()
-                .velocity_of_to_frame_origin()
-                .vector()
-                .z()
-                .quantity()
-                .magnitude());
+  EXPECT_THAT(message.rigid_motion()
+                  .velocity_of_to_frame_origin()
+                  .vector()
+                  .x()
+                  .quantity()
+                  .magnitude(),
+              AlmostEquals(-4, 0));
+  EXPECT_THAT(message.rigid_motion()
+                  .velocity_of_to_frame_origin()
+                  .vector()
+                  .y()
+                  .quantity()
+                  .magnitude(),
+              AlmostEquals(-6, 0));
+  EXPECT_THAT(message.rigid_motion()
+                  .velocity_of_to_frame_origin()
+                  .vector()
+                  .z()
+                  .quantity()
+                  .magnitude(),
+              AlmostEquals(-5, 0));
   EXPECT_EQ(1, message.prehistory().timeline_size());
   EXPECT_EQ(1, message.prehistory().children_size());
   EXPECT_EQ(1, message.prehistory().children(0).trajectories_size());

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -137,7 +137,7 @@ class PileUpTest : public testing::Test {
                       AlmostEquals(Velocity<Barycentric>(
                                        {130.0 / 3.0 * Metre / Second,
                                         40.0 * Metre / Second,
-                                        110.0 / 3.0 * Metre / Second}), 0)));
+                                        110.0 / 3.0 * Metre / Second}), 4)));
 
     EXPECT_THAT(
         pile_up.actual_part_degrees_of_freedom().at(&p1_),
@@ -149,7 +149,7 @@ class PileUpTest : public testing::Test {
                       AlmostEquals(Velocity<RigidPileUp>(
                                        {-100.0 / 3.0 * Metre / Second,
                                         -20.0 * Metre / Second,
-                                        -20.0 / 3.0 * Metre / Second}), 3)));
+                                        -20.0 / 3.0 * Metre / Second}), 5)));
     EXPECT_THAT(
         pile_up.actual_part_degrees_of_freedom().at(&p2_),
         Componentwise(AlmostEquals(RigidPileUp::origin +
@@ -350,7 +350,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
                     AlmostEquals(Velocity<Barycentric>(
                                      {-250.0 / 9.0 * Metre / Second,
                                       400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 1)));
+                                      1010.0 / 9.0 * Metre / Second}), 4)));
   EXPECT_THAT(
       p2_.degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
@@ -361,7 +361,7 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
                     AlmostEquals(Velocity<Barycentric>(
                                      {260.0 / 9.0 * Metre / Second,
                                       430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 0)));
+                                      890.0 / 9.0 * Metre / Second}), 6)));
 }
 
 // Same as above, but without an intrinsic force.
@@ -533,7 +533,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                     AlmostEquals(Velocity<Barycentric>(
                                      {-250.0 / 9.0 * Metre / Second,
                                       400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 1)));
+                                      1010.0 / 9.0 * Metre / Second}), 4)));
   EXPECT_THAT(
       p2_.degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +
@@ -544,7 +544,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                     AlmostEquals(Velocity<Barycentric>(
                                      {260.0 / 9.0 * Metre / Second,
                                       430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 0)));
+                                      890.0 / 9.0 * Metre / Second}), 6)));
 }
 
 TEST_F(PileUpTest, MidStepIntrinsicForce) {
@@ -595,7 +595,8 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
 
   pile_up.AdvanceTime(astronomy::J2000 + 1.5 * fixed_step);
   pile_up.NudgeParts();
-  EXPECT_THAT(p1_.degrees_of_freedom().velocity(), Eq(old_velocity));
+  EXPECT_THAT(p1_.degrees_of_freedom().velocity(),
+              AlmostEquals(old_velocity, 4));
 
   Vector<Acceleration, Barycentric> const a{{1729 * Metre / Pow<2>(Second),
                                              -168 * Metre / Pow<2>(Second),

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -1011,7 +1011,7 @@ TEST_F(PluginTest, VesselInsertionAtInitialization) {
   EXPECT_THAT(
       plugin_->VesselFromParent(SolarSystemFactory::Earth, guid),
       Componentwise(AlmostEquals(satellite_initial_displacement_, 13556),
-                    AlmostEquals(satellite_initial_velocity_, 6)));
+                    AlmostEquals(satellite_initial_velocity_, 36)));
 }
 
 TEST_F(PluginTest, UpdateCelestialHierarchy) {
@@ -1186,12 +1186,12 @@ TEST_F(PluginTest, Frenet) {
   not_null<std::unique_ptr<NavigationFrame>> const geocentric =
       plugin.NewBodyCentredNonRotatingNavigationFrame(
           SolarSystemFactory::Earth);
-  EXPECT_THAT(plugin.VesselTangent(satellite), AlmostEquals(t, 5, 17));
-  EXPECT_THAT(plugin.VesselNormal(satellite), AlmostEquals(n, 3, 11));
+  EXPECT_THAT(plugin.VesselTangent(satellite), AlmostEquals(t, 5, 61));
+  EXPECT_THAT(plugin.VesselNormal(satellite), AlmostEquals(n, 3, 25));
   EXPECT_THAT(plugin.VesselBinormal(satellite), AlmostEquals(b, 0, 15));
   EXPECT_THAT(
       plugin.VesselVelocity(satellite),
-      AlmostEquals(alice_sun_to_world(satellite_initial_velocity_), 7, 19));
+      AlmostEquals(alice_sun_to_world(satellite_initial_velocity_), 7, 83));
 }
 
 }  // namespace internal_plugin

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -178,7 +178,7 @@ TEST_F(VesselTest, PrepareHistory) {
                     AlmostEquals(Velocity<Barycentric>(
                                       {130.0 / 3.0 * Metre / Second,
                                       40.0 * Metre / Second,
-                                      110.0 / 3.0 * Metre / Second}), 0)));
+                                      110.0 / 3.0 * Metre / Second}), 4)));
 }
 
 TEST_F(VesselTest, AdvanceTime) {
@@ -314,7 +314,7 @@ TEST_F(VesselTest, Prediction) {
                     AlmostEquals(Velocity<Barycentric>(
                                       {130.0 / 3.0 * Metre / Second,
                                        40.0 * Metre / Second,
-                                       110.0 / 3.0 * Metre / Second}), 0)));
+                                       110.0 / 3.0 * Metre / Second}), 4)));
   ++it;
   EXPECT_EQ(astronomy::J2000 + 1.0 * Second, it->time);
   EXPECT_THAT(

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -369,9 +369,7 @@ void GenerateKeplerProblemWorkErrorGraphs(double const eccentricity) {
   MassiveBody b1(μ);
   MasslessBody b2;
 
-  using World = geometry::Frame<serialization::Frame::TestTag,
-                                serialization::Frame::TEST,
-                                Inertial>;
+  using World = geometry::Frame<enum class WorldTag, WorldTag{}, Inertial>;
   KeplerianElements<World> elements;
   elements.semimajor_axis = 1 * Metre;
   elements.eccentricity = eccentricity;

--- a/numerics/double_precision_test.cpp
+++ b/numerics/double_precision_test.cpp
@@ -52,8 +52,7 @@ constexpr double ε² = ε * ε;
 constexpr double ε³ = ε² * ε;
 constexpr double ε⁴ = ε³ * ε;
 
-using World = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST>;
+using World = Frame<enum class WorldTag>;
 
 class DoublePrecisionTest : public ::testing::Test {};
 

--- a/numerics/hermite3_test.cpp
+++ b/numerics/hermite3_test.cpp
@@ -41,8 +41,7 @@ namespace numerics {
 
 class Hermite3Test : public ::testing::Test {
  protected:
-  using World = Frame<serialization::Frame::TestTag,
-                      serialization::Frame::TEST1, Inertial>;
+  using World = Frame<enum class WorldTag, WorldTag{}, Inertial>;
 
   Instant const t0_;
 };

--- a/numerics/polynomial_test.cpp
+++ b/numerics/polynomial_test.cpp
@@ -56,7 +56,7 @@ namespace numerics {
 class PolynomialTest : public ::testing::Test {
  protected:
   using World = Frame<serialization::Frame::TestTag,
-                      serialization::Frame::TEST1, Inertial>;
+                      serialization::Frame::TEST, Inertial>;
 
   using P2V = PolynomialInMonomialBasis<Displacement<World>, Time, 2,
                                         HornerEvaluator>;

--- a/physics/body_surface_frame_field_test.cpp
+++ b/physics/body_surface_frame_field_test.cpp
@@ -36,8 +36,7 @@ using ::testing::_;
 
 class BodySurfaceFrameFieldTest : public ::testing::Test {
  protected:
-  using TestFrame = Frame<serialization::Frame::TestTag,
-                              serialization::Frame::TEST>;
+  using TestFrame = Frame<enum class TestFrameTag>;
 
   BodySurfaceFrameFieldTest()
       : body_(MassiveBody::Parameters(1 * Kilogram),

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -4,6 +4,7 @@
 #include "astronomy/epoch.hpp"
 #include "astronomy/frames.hpp"
 #include "astronomy/time_scales.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/r3_element.hpp"
 #include "gmock/gmock.h"
@@ -354,7 +355,7 @@ TEST_F(BodyTest, AllFrames) {
 
 // Check that the rotation of the Earth gives the right solar noon.
 TEST_F(BodyTest, SolarNoon) {
-  struct SurfaceFrame;
+  using SurfaceFrame = Frame<enum class SurfaceFrameTag>;
   SolarSystem<ICRS> solar_system_j2000(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
       SOLUTION_DIR / "astronomy" /

--- a/physics/degrees_of_freedom_test.cpp
+++ b/physics/degrees_of_freedom_test.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "geometry/barycentre_calculator.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -18,6 +19,7 @@ namespace internal_degrees_of_freedom {
 using geometry::Barycentre;
 using geometry::BarycentreCalculator;
 using geometry::Displacement;
+using geometry::Frame;
 using geometry::Position;
 using geometry::Velocity;
 using quantities::Entropy;
@@ -29,7 +31,7 @@ using ::testing::Eq;
 
 class DegreesOfFreedomTest : public testing::Test {
  protected:
-  struct World;
+  using World = Frame<enum class WorldTag>;
 
   DegreesOfFreedomTest()
       : d1_(origin_ + Displacement<World>({1 * SIUnit<Length>(),

--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -32,10 +32,8 @@ using testing_utilities::Componentwise;
 
 namespace {
 
-using Circular =
-    Frame<serialization::Frame::TestTag, serialization::Frame::TEST, Inertial>;
-using Helical =
-    Frame<serialization::Frame::TestTag, serialization::Frame::TEST1, Inertial>;
+using Circular = Frame<enum class CircularTag, CircularTag{}, Inertial>;
+using Helical = Frame<enum class HelicalTag, HelicalTag{}, Inertial>;
 
 Vector<Acceleration, Circular> Gravity(Instant const& t,
                                        Position<Circular> const& q) {

--- a/physics/euler_solver.hpp
+++ b/physics/euler_solver.hpp
@@ -3,6 +3,7 @@
 
 #include <optional>
 
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/r3_element.hpp"
@@ -16,6 +17,7 @@ namespace internal_euler_solver {
 
 using geometry::AngularVelocity;
 using geometry::Bivector;
+using geometry::Frame;
 using geometry::Instant;
 using geometry::R3Element;
 using geometry::Rotation;
@@ -60,13 +62,14 @@ class EulerSolver {
                               Instant const& time) const;
 
  private:
-  struct ℬₜ;
-  struct ℬʹ;
+  using ℬₜ = Frame<enum class ℬₜTag>;
+  using ℬʹ = Frame<enum class ℬʹTag>;
 
   // A frame which is rotated from PrincipalAxesFrame such that the coordinates
   // of m along which we project is positive.  Used for all internal
   // computations.
-  struct PreferredPrincipalAxesFrame;
+  using PreferredPrincipalAxesFrame =
+      Frame<enum class PreferredPrincipalAxesFrameTag>;
 
   using PreferredAngularMomentumBivector =
       Bivector<AngularMomentum, PreferredPrincipalAxesFrame>;

--- a/physics/euler_solver_test.cpp
+++ b/physics/euler_solver_test.cpp
@@ -905,7 +905,7 @@ TEST_F(EulerSolverTest, Toutatis) {
   // axis is our I₃ and their z axis is our I₁, see Table 2.  This appears to
   // contradict Figure 1, but it is consistent with ω₁, ω₂, ω₃ being along their
   // x, y, z axes respectively.
-  struct TakahashiPrincipalAxes;
+  using TakahashiPrincipalAxes = Frame<enum class TakahashiPrincipalAxesTag>;
   using TakahashiAttitudeRotation = Rotation<TakahashiPrincipalAxes, ICRS>;
   using TakahashiPermutation = Permutation<TakahashiPrincipalAxes,
                                            PrincipalAxes>;

--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "base/not_null.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "numerics/polynomial.hpp"
@@ -16,6 +17,7 @@ namespace internal_geopotential {
 
 using base::not_null;
 using geometry::Displacement;
+using geometry::Frame;
 using geometry::Instant;
 using geometry::Vector;
 using numerics::PolynomialInMonomialBasis;
@@ -99,7 +101,7 @@ class Geopotential {
 
  private:
   // The frame of the surface of the celestial.
-  struct SurfaceFrame;
+  using SurfaceFrame = geometry::Frame<enum class SurfaceFrameTag>;
   static const Vector<double, SurfaceFrame> x_;
   static const Vector<double, SurfaceFrame> y_;
 

--- a/physics/hierarchical_system_test.cpp
+++ b/physics/hierarchical_system_test.cpp
@@ -34,9 +34,7 @@ using ::testing::ElementsAre;
 
 class HierarchicalSystemTest : public ::testing::Test {
  protected:
-  using World = Frame<serialization::Frame::TestTag,
-                      serialization::Frame::TEST,
-                      Inertial>;
+  using World = Frame<enum class WorldTag, WorldTag{}, Inertial>;
 };
 
 TEST_F(HierarchicalSystemTest, HierarchicalSystem) {

--- a/physics/inertia_tensor_body.hpp
+++ b/physics/inertia_tensor_body.hpp
@@ -3,6 +3,7 @@
 #include "physics/inertia_tensor.hpp"
 
 #include "geometry/barycentre_calculator.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/identity.hpp"
 #include "geometry/point.hpp"
 #include "geometry/rotation.hpp"
@@ -18,6 +19,7 @@ using geometry::Anticommutator;
 using geometry::Barycentre;
 using geometry::Bivector;
 using geometry::Commutator;
+using geometry::Frame;
 using geometry::Identity;
 using geometry::Rotation;
 using geometry::SymmetricProduct;
@@ -78,7 +80,7 @@ template<typename Frame>
 template<typename PrincipalAxesFrame>
 typename InertiaTensor<Frame>::template PrincipalAxes<PrincipalAxesFrame>
 InertiaTensor<Frame>::Diagonalize() const {
-  struct IntermediateFrame {};
+  using IntermediateFrame = geometry::Frame<enum class IntermediateFrameTag>;
 
   auto const eigensystem = form_.template Diagonalize<IntermediateFrame>();
 

--- a/physics/inertia_tensor_test.cpp
+++ b/physics/inertia_tensor_test.cpp
@@ -74,7 +74,8 @@ class InertiaTensorTest : public ::testing::Test {
   void CheckMomentsOfInertia(
       InertiaTensor<Frame> const& tensor,
       Matcher<R3Element<MomentOfInertia>> const& matcher) {
-    struct PrincipalAxesFrame {};
+    using PrincipalAxesFrame =
+        geometry::Frame<enum class PrincipalAxesFrameTag>;
     auto const principal_axes = tensor.Diagonalize<PrincipalAxesFrame>();
     EXPECT_THAT(principal_axes.moments_of_inertia, matcher);
   }

--- a/physics/jacobi_coordinates_test.cpp
+++ b/physics/jacobi_coordinates_test.cpp
@@ -26,9 +26,7 @@ using ::testing::ElementsAre;
 
 class JacobiCoordinatesTest : public ::testing::Test {
  protected:
-  using World = Frame<serialization::Frame::TestTag,
-                      serialization::Frame::TEST,
-                      Inertial>;
+  using World = Frame<enum class WorldTag, WorldTag{}, Inertial>;
 
   MassiveBody m1_ = MassiveBody(1 * Kilogram);
   MassiveBody m2_ = MassiveBody(2 * Kilogram);

--- a/physics/kepler_orbit_body.hpp
+++ b/physics/kepler_orbit_body.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "base/optional_serialization.hpp"
+#include "geometry/frame.hpp"
 #include "geometry/rotation.hpp"
 #include "numerics/root_finders.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -260,7 +261,7 @@ KeplerOrbit<Frame>::StateVectors(Instant const& t) const {
   }
   CompleteAnomalies(elements);
   Angle const& ν = *elements.true_anomaly;
-  struct OrbitPlane;
+  using OrbitPlane = geometry::Frame<enum class OrbitPlaneTag>;
   Rotation<OrbitPlane, Frame> const from_orbit_plane(
       Ω, i, ω,
       EulerAngles::ZXZ,

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -82,12 +82,25 @@ template<typename FromFrame, typename ToFrame>
 RigidMotion<FromFrame, ToFrame>
 RigidMotion<FromFrame, ToFrame>::MakeNonRotatingMotion(
     DegreesOfFreedom<ToFrame> const& degrees_of_freedom_of_from_frame_origin) {
-  return RigidMotion(RigidTransformation<FromFrame, ToFrame>(
-                         FromFrame::origin,
-                         degrees_of_freedom_of_from_frame_origin.position(),
-                         geometry::Identity<FromFrame, ToFrame>().Forget()),
-                     AngularVelocity<ToFrame>{},
-                     degrees_of_freedom_of_from_frame_origin.velocity());
+  if constexpr (FromFrame::handedness == ToFrame::handedness) {
+    return RigidMotion(RigidTransformation<FromFrame, ToFrame>(
+                           FromFrame::origin,
+                           degrees_of_freedom_of_from_frame_origin.position(),
+                           geometry::Identity<FromFrame, ToFrame>().Forget()),
+                       AngularVelocity<ToFrame>{},
+                       degrees_of_freedom_of_from_frame_origin.velocity());
+  } else {
+    return RigidMotion(
+        RigidTransformation<FromFrame, ToFrame>(
+            FromFrame::origin,
+            degrees_of_freedom_of_from_frame_origin.position(),
+            geometry::Permutation<FromFrame, ToFrame>(
+                geometry::Permutation<FromFrame,
+                                      ToFrame>::CoordinatePermutation::XZY)
+                .Forget()),
+        AngularVelocity<ToFrame>{},
+        degrees_of_freedom_of_from_frame_origin.velocity());
+  }
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -90,6 +90,8 @@ RigidMotion<FromFrame, ToFrame>::MakeNonRotatingMotion(
                        AngularVelocity<ToFrame>{},
                        degrees_of_freedom_of_from_frame_origin.velocity());
   } else {
+    // TODO(phl): This is extremely dubious.  We apply the sun_looking_glass
+    // permutation because we "know" that we have World and RigidPart here.
     return RigidMotion(
         RigidTransformation<FromFrame, ToFrame>(
             FromFrame::origin,

--- a/physics/solar_system_test.cpp
+++ b/physics/solar_system_test.cpp
@@ -102,9 +102,7 @@ TEST_F(SolarSystemTest, RealSolarSystem) {
 }
 
 TEST_F(SolarSystemTest, KSPSystem) {
-  using KSP = Frame<serialization::Frame::TestTag,
-                    serialization::Frame::TEST,
-                    Inertial>;
+  using KSP = Frame<enum class KSPTag, KSPTag{}, Inertial>;
 
   SolarSystem<KSP> solar_system(
       SOLUTION_DIR / "astronomy" / "kerbol_gravity_model.proto.txt",

--- a/testing_utilities/componentwise_test.cpp
+++ b/testing_utilities/componentwise_test.cpp
@@ -3,6 +3,7 @@
 
 #include <limits>
 
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/pair.hpp"
 #include "geometry/r3_element.hpp"
@@ -21,6 +22,7 @@
 namespace principia {
 
 using geometry::Bivector;
+using geometry::Frame;
 using geometry::Pair;
 using geometry::R3Element;
 using geometry::RP2Point;
@@ -42,7 +44,7 @@ using ::testing::_;
 
 namespace testing_utilities {
 
-struct World;
+using World = Frame<enum class WorldTag>;
 
 class ComponentwiseTest : public testing::Test {};
 

--- a/testing_utilities/numerics_test.cpp
+++ b/testing_utilities/numerics_test.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 
+#include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/r3_element.hpp"
 #include "glog/logging.h"
@@ -18,6 +19,7 @@ namespace principia {
 namespace testing_utilities {
 
 using geometry::Bivector;
+using geometry::Frame;
 using geometry::Point;
 using geometry::R3Element;
 using geometry::Trivector;
@@ -29,13 +31,9 @@ using ::testing::Eq;
 using ::testing::Gt;
 using ::testing::Ne;
 
-namespace {
-struct World;
-}  // namespace
-
 class NumericsTest : public testing::Test {
  protected:
-  struct World;
+  using World = Frame<enum class WorldTag>;
 
   R3Element<double> const i_ = {1, 0, 0};
   R3Element<double> const j_ = {0, 1, 0};


### PR DESCRIPTION
* Use non-serializable frames in tests that don't exercise serialization.
* Use non-serializable frames instead of dummy structs for local frames.
* Add SFINAE to the `Identity` class and functions to make it impossible to create an identity that violates handedness.
* Fix the violations.