### PR TITLE
Signature

### DIFF
--- a/geometry/geometry.vcxproj
+++ b/geometry/geometry.vcxproj
@@ -46,6 +46,8 @@
     <ClInclude Include="rp2_point_body.hpp" />
     <ClInclude Include="serialization.hpp" />
     <ClInclude Include="serialization_body.hpp" />
+    <ClInclude Include="signature.hpp" />
+    <ClInclude Include="signature_body.hpp" />
     <ClInclude Include="sign_body.hpp" />
     <ClInclude Include="sign.hpp" />
     <ClInclude Include="sphere.hpp" />
@@ -69,6 +71,7 @@
     <ClCompile Include="r3_element_test.cpp" />
     <ClCompile Include="rotation_test.cpp" />
     <ClCompile Include="rp2_point_test.cpp" />
+    <ClCompile Include="signature_test.cpp" />
     <ClCompile Include="sign_test.cpp" />
     <ClCompile Include="symmetric_bilinear_form_test.cpp" />
   </ItemGroup>

--- a/geometry/geometry.vcxproj.filters
+++ b/geometry/geometry.vcxproj.filters
@@ -152,6 +152,12 @@
     <ClInclude Include="interval_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="signature.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="signature_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="sign_test.cpp">
@@ -203,6 +209,9 @@
       <Filter>Test Files</Filter>
     </ClCompile>
     <ClCompile Include="symmetric_bilinear_form_test.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="signature_test.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -26,6 +26,9 @@ FORWARD_DECLARE_FROM(permutation,
 FORWARD_DECLARE_FROM(rotation,
                      TEMPLATE(typename FromFrame, typename ToFrame) class,
                      Rotation);
+FORWARD_DECLARE_FROM(signature,
+                     TEMPLATE(typename FromFrame, typename ToFrame) class,
+                     Signature);
 FORWARD_DECLARE_FROM(symmetric_bilinear_form,
                      TEMPLATE(typename Scalar, typename Frame) class,
                      SymmetricBilinearForm);
@@ -100,6 +103,8 @@ class OrthogonalMap : public LinearMap<FromFrame, ToFrame> {
   friend class internal_permutation::Permutation;
   template<typename From, typename To>
   friend class internal_rotation::Rotation;
+  template<typename From, typename To>
+  friend class internal_signature::Signature;
 
   template<typename From, typename Through, typename To>
   friend OrthogonalMap<From, To> operator*(

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -46,7 +46,7 @@ template<typename FromFrame, typename ToFrame>
 template<typename Scalar>
 Trivector<Scalar, ToFrame> OrthogonalMap<FromFrame, ToFrame>::operator()(
     Trivector<Scalar, FromFrame> const& trivector) const {
-  return determinant_ * trivector;
+  return Trivector<Scalar, ToFrame>(determinant_ * trivector.coordinates());
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -7,8 +7,13 @@ namespace principia {
 namespace geometry {
 namespace internal_signature {
 
-struct deduce_sign_t {};
-constexpr deduce_sign_t deduce_sign_from_handedness{};
+using base::not_constructible;
+
+struct deduce_sign_direct_t final {};
+struct deduce_sign_indirect_t final {};
+
+constexpr deduce_sign_direct_t deduce_sign_for_direct_isometry{};
+constexpr deduce_sign_indirect_t deduce_sign_for_indirect_isometry{};
 
 template<typename FromFrame, typename ToFrame>
 class Signature {
@@ -16,6 +21,9 @@ class Signature {
   static constexpr Sign determinant =
       FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
                                                    : Sign::Negative();
+  using deduce_sign_t = std::conditional_t<determinant.Positive(),
+                                           deduce_sign_direct_t,
+                                           deduce_sign_indirect_t>;
 
   constexpr Signature(Sign x, Sign y, deduce_sign_t z);
   constexpr Signature(Sign x, deduce_sign_t y, Sign z);
@@ -29,7 +37,7 @@ class Signature {
   template<typename F = FromFrame,
            typename T = ToFrame,
            typename = std::enable_if_t<F::handedness != T::handedness>>
-  static constexpr Signature CentralReflection();
+  static constexpr Signature CentralInversion();
 
   constexpr Signature<ToFrame, FromFrame> Inverse() const;
 

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -20,12 +20,10 @@ struct DeduceSignReversingOrientation final {};
 template<typename FromFrame, typename ToFrame>
 class Signature : public LinearMap<FromFrame, ToFrame> {
  public:
-  static constexpr Sign determinant =
-      FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
-                                                   : Sign::Negative();
-  using DeduceSign = std::conditional_t<determinant.is_positive(),
-                                        DeduceSignPreservingOrientation,
-                                        DeduceSignReversingOrientation>;
+  using DeduceSign =
+      std::conditional_t<FromFrame::handedness == ToFrame::handedness,
+                         DeduceSignPreservingOrientation,
+                         DeduceSignReversingOrientation>;
 
   constexpr Signature(Sign x, Sign y, DeduceSign z);
   constexpr Signature(Sign x, DeduceSign y, Sign z);
@@ -83,6 +81,10 @@ class Signature : public LinearMap<FromFrame, ToFrame> {
   Sign x_;
   Sign y_;
   Sign z_;
+
+  static constexpr Sign determinant_ =
+      FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
+                                                   : Sign::Negative();
 
   template<typename From, typename To>
   friend class Signature;

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -8,13 +8,13 @@ namespace principia {
 namespace geometry {
 namespace internal_signature {
 
-using base::not_constructible;
+using base::not_null;
 
 struct DeduceSignPreservingOrientation final {};
 struct DeduceSignReversingOrientation final {};
 
 template<typename FromFrame, typename ToFrame>
-class Signature {
+class Signature : public LinearMap<FromFrame, ToFrame> {
  public:
   static constexpr Sign determinant =
       FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
@@ -26,6 +26,8 @@ class Signature {
   constexpr Signature(Sign x, Sign y, DeduceSign z);
   constexpr Signature(Sign x, DeduceSign y, Sign z);
   constexpr Signature(DeduceSign x, Sign y, Sign z);
+
+  constexpr Sign Determinant() const override;
 
   template<typename F = FromFrame,
            typename T = ToFrame,
@@ -57,7 +59,19 @@ class Signature {
 
   OrthogonalMap<FromFrame, ToFrame> Forget() const;
 
-  // TODO(egg): Serialization.
+  void WriteToMessage(not_null<serialization::LinearMap*> message) const;
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<base::is_serializable_v<F> &&
+                                       base::is_serializable_v<T>>>
+  static Signature ReadFromMessage(serialization::LinearMap const& message);
+
+  void WriteToMessage(not_null<serialization::Signature*> message) const;
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<base::is_serializable_v<F> &&
+                                       base::is_serializable_v<T>>>
+  static Signature ReadFromMessage(serialization::Signature const& message);
 
  private:
   constexpr Signature(Sign x, Sign y, Sign z);

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "geometry/frame.hpp"
 #include "geometry/orthogonal_map.hpp"
@@ -13,6 +13,10 @@ using base::not_null;
 struct DeduceSignPreservingOrientation final {};
 struct DeduceSignReversingOrientation final {};
 
+// A coordinate change whose matrix is a signature matrix, i.e., a diagonal
+// matrix with ±1 on the diagonal.  There are 8 possible signatures: the
+// identity 𝟙, the central inversion -𝟙, the 180° rotations around all three
+// axes, and the reflections across the planes orthogonal to all three axes.
 template<typename FromFrame, typename ToFrame>
 class Signature : public LinearMap<FromFrame, ToFrame> {
  public:

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -7,14 +7,15 @@ namespace principia {
 namespace geometry {
 namespace internal_signature {
 
+struct deduce_sign_t {};
+constexpr deduce_sign_t deduce_sign_from_handedness{};
+
 template<typename FromFrame, typename ToFrame>
 class Signature {
  public:
   static constexpr Sign determinant =
       FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
                                                    : Sign::Negative();
-  struct deduce_sign_t {};
-  static constexpr deduce_sign_t deduce_sign_from_handedness{};
 
   constexpr Signature(Sign x, Sign y, deduce_sign_t z);
   constexpr Signature(Sign x, deduce_sign_t y, Sign z);
@@ -56,6 +57,13 @@ class Signature {
   Sign x_;
   Sign y_;
   Sign z_;
+
+  template<typename From, typename To>
+  friend class Signature;
+
+  template<typename From, typename Through, typename To>
+  friend Signature<From, To> operator*(Signature<Through, To> const& left,
+                                       Signature<From, Through> const& right);
 };
 
 template<typename FromFrame, typename ThroughFrame, typename ToFrame>
@@ -69,6 +77,7 @@ std::ostream& operator<<(std::ostream& out,
 
 }  // namespace internal_signature
 
+using internal_signature::deduce_sign_from_handedness;
 using internal_signature::Signature;
 
 }  // namespace geometry

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "geometry/frame.hpp"
+#include "geometry/sign.hpp"
+
+namespace principia {
+namespace geometry {
+namespace internal_signature {
+
+template<typename FromFrame, typename ToFrame>
+class Signature {
+ public:
+  static constexpr Sign determinant =
+      FromFrame::handedness == ToFrame::handedness ? Sign::Positive()
+                                                   : Sign::Negative();
+  struct deduce_sign_t {};
+  static constexpr deduce_sign_t deduce_sign_from_handedness{};
+
+  constexpr Signature(Sign x, Sign y, deduce_sign_t z);
+  constexpr Signature(Sign x, deduce_sign_t y, Sign z);
+  constexpr Signature(deduce_sign_t x, Sign y, Sign z);
+
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness == T::handedness>>
+  static constexpr Signature Identity();
+
+  template<typename F = FromFrame,
+           typename T = ToFrame,
+           typename = std::enable_if_t<F::handedness != T::handedness>>
+  static constexpr Signature CentralReflection();
+
+  constexpr Signature<ToFrame, FromFrame> Inverse() const;
+
+  template<typename Scalar>
+  Vector<Scalar, ToFrame> operator()(
+      Vector<Scalar, FromFrame> const& vector) const;
+
+  template<typename Scalar>
+  Bivector<Scalar, ToFrame> operator()(
+      Bivector<Scalar, FromFrame> const& bivector) const;
+
+  template<typename Scalar>
+  Trivector<Scalar, ToFrame> operator()(
+      Trivector<Scalar, FromFrame> const& trivector) const;
+
+  template<typename Scalar>
+  SymmetricBilinearForm<Scalar, ToFrame> operator()(
+      SymmetricBilinearForm<Scalar, FromFrame> const& form) const;
+
+  // TODO(egg): Serialization.
+
+ private:
+  constexpr Signature(Sign x, Sign y, Sign z);
+
+  Sign x_;
+  Sign y_;
+  Sign z_;
+};
+
+template<typename FromFrame, typename ThroughFrame, typename ToFrame>
+Signature<FromFrame, ToFrame> operator*(
+    Signature<ThroughFrame, ToFrame> const& left,
+    Signature<FromFrame, ThroughFrame> const& right);
+
+template<typename FromFrame, typename ToFrame>
+std::ostream& operator<<(std::ostream& out,
+                         Signature<FromFrame, ToFrame> const& signature);
+
+}  // namespace internal_signature
+
+using internal_signature::Signature;
+
+}  // namespace geometry
+}  // namespace principia
+
+#include "geometry/signature_body.hpp"

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -10,23 +10,23 @@ template<typename FromFrame, typename ToFrame>
 constexpr Signature<FromFrame, ToFrame>::Signature(Sign const x,
                                                    Sign const y,
                                                    DeduceSign const z)
-    : x_(x), y_(y), z_(x * y * determinant) {}
+    : x_(x), y_(y), z_(x * y * determinant_) {}
 
 template<typename FromFrame, typename ToFrame>
 constexpr Signature<FromFrame, ToFrame>::Signature(Sign const x,
                                                    DeduceSign const y,
                                                    Sign const z)
-    : x_(x), y_(x * determinant * z), z_(z) {}
+    : x_(x), y_(x * determinant_ * z), z_(z) {}
 
 template<typename FromFrame, typename ToFrame>
 constexpr Signature<FromFrame, ToFrame>::Signature(DeduceSign const x,
                                                    Sign const y,
                                                    Sign const z)
-    : x_(determinant * y * z), y_(y), z_(z) {}
+    : x_(determinant_ * y * z), y_(y), z_(z) {}
 
 template<typename FromFrame, typename ToFrame>
 constexpr Sign Signature<FromFrame, ToFrame>::Determinant() const {
-  return determinant;
+  return determinant_;
 }
 
 template<typename FromFrame, typename ToFrame>
@@ -65,16 +65,16 @@ template<typename Scalar>
 Bivector<Scalar, ToFrame> Signature<FromFrame, ToFrame>::operator()(
     Bivector<Scalar, FromFrame> const& bivector) const {
   return Bivector<Scalar, ToFrame>(
-      {determinant * x_ * bivector.coordinates().x,
-       determinant * y_ * bivector.coordinates().y,
-       determinant * z_ * bivector.coordinates().z});
+      {determinant_ * x_ * bivector.coordinates().x,
+       determinant_ * y_ * bivector.coordinates().y,
+       determinant_ * z_ * bivector.coordinates().z});
 }
 
 template<typename FromFrame, typename ToFrame>
 template<typename Scalar>
 Trivector<Scalar, ToFrame> Signature<FromFrame, ToFrame>::operator()(
     Trivector<Scalar, FromFrame> const& trivector) const {
-  return Trivector<Scalar, ToFrame>(determinant * trivector.coordinates());
+  return Trivector<Scalar, ToFrame>(determinant_ * trivector.coordinates());
 }
 
 template<typename FromFrame, typename ToFrame>
@@ -92,18 +92,18 @@ OrthogonalMap<FromFrame, ToFrame> Signature<FromFrame, ToFrame>::Forget()
     // TODO(phl): unsound rotation; this should use |Identity| once we go
     // through an intermediate frame.
     return OrthogonalMap<FromFrame, ToFrame>(
-        determinant, Rotation<FromFrame, ToFrame>(Quaternion(1)));
+        determinant_, Rotation<FromFrame, ToFrame>(Quaternion(1)));
   }
   // The signature is neither +++ nor ---, so dividing it by its determinant
   // yields a 180° rotation around one of the axes (+--, -+-, or --+).
-  R3Element<double> const axis = (determinant * x_).is_positive()
+  R3Element<double> const axis = (determinant_ * x_).is_positive()
                                      ? R3Element<double>{1, 0, 0}
-                                     : (determinant * y_).is_positive()
+                                     : (determinant_ * y_).is_positive()
                                            ? R3Element<double>{0, 1, 0}
                                            : R3Element<double>{0, 0, 1};
   // TODO(phl): unsound rotation.
   return OrthogonalMap<FromFrame, ToFrame>(
-      determinant, Rotation<FromFrame, ToFrame>(Quaternion(0, axis)));
+      determinant_, Rotation<FromFrame, ToFrame>(Quaternion(0, axis)));
 }
 
 template<typename FromFrame, typename ToFrame>
@@ -139,7 +139,7 @@ Signature<FromFrame, ToFrame> Signature<FromFrame, ToFrame>::ReadFromMessage(
   auto const x = Sign::ReadFromMessage(message.x());
   auto const y = Sign::ReadFromMessage(message.y());
   auto const z = Sign::ReadFromMessage(message.z());
-  CHECK_EQ(x * y * z, determinant) << message.DebugString();
+  CHECK_EQ(x * y * z, determinant_) << message.DebugString();
   return Signature(x, y, z);
 }
 

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "geometry/signature.hpp"
 
@@ -95,7 +95,7 @@ OrthogonalMap<FromFrame, ToFrame> Signature<FromFrame, ToFrame>::Forget()
         determinant, Rotation<FromFrame, ToFrame>(Quaternion(1)));
   }
   // The signature is neither +++ nor ---, so dividing it by its determinant
-  // yields a 180� rotation around one of the axes (+--, -+-, or --+).
+  // yields a 180° rotation around one of the axes (+--, -+-, or --+).
   R3Element<double> const axis = (determinant * x_).is_positive()
                                      ? R3Element<double>{1, 0, 0}
                                      : (determinant * y_).is_positive()

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -40,7 +40,7 @@ Signature<FromFrame, ToFrame>::Identity() {
 template<typename FromFrame, typename ToFrame>
 template<typename F, typename T, typename>
 constexpr Signature<FromFrame, ToFrame>
-Signature<FromFrame, ToFrame>::CentralReflection() {
+Signature<FromFrame, ToFrame>::CentralInversion() {
   return Signature(Sign::Negative(), Sign::Negative(), Sign::Negative());
 }
 

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "geometry/signature.hpp"
+
+namespace principia {
+namespace geometry {
+namespace internal_signature {
+
+template<typename FromFrame, typename ToFrame>
+constexpr Signature<FromFrame, ToFrame>::Signature(
+    Sign const x,
+    Sign const y,
+    Signature::deduce_sign_t const z)
+    : x_(x), y_(y), z_(x * y * determinant) {}
+
+template<typename FromFrame, typename ToFrame>
+constexpr Signature<FromFrame, ToFrame>::Signature(
+    Sign const x,
+    Signature::deduce_sign_t const y,
+    Sign const z)
+    : x_(x), y_(x * determinant * z), z_(z) {}
+
+template<typename FromFrame, typename ToFrame>
+constexpr Signature<FromFrame, ToFrame>::Signature(
+    Signature::deduce_sign_t const x,
+    Sign const y,
+    Sign const z)
+    : x_(determinant * y * z), y_(y), z_(z) {}
+
+template<typename FromFrame, typename ToFrame>
+constexpr Signature<ToFrame, FromFrame> Signature<FromFrame, ToFrame>::Inverse()
+    const {
+  return Signature<ToFrame, FromFrame>(x_, y_, z_);
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename F, typename T, typename>
+constexpr Signature<FromFrame, ToFrame>
+Signature<FromFrame, ToFrame>::Identity() {
+  return Signature(Sign::Positive(), Sign::Positive(), Sign::Positive());
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename F, typename T, typename>
+constexpr Signature<FromFrame, ToFrame>
+Signature<FromFrame, ToFrame>::CentralReflection() {
+  return Signature(Sign::Negative(), Sign::Negative(), Sign::Negative());
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename Scalar>
+Vector<Scalar, ToFrame> Signature<FromFrame, ToFrame>::operator()(
+    Vector<Scalar, FromFrame> const& vector) const {
+  return Vector<Scalar, ToFrame>({x_ * vector.coordinates().x,
+                                  y_ * vector.coordinates().y,
+                                  z_ * vector.coordinates().z});
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename Scalar>
+Bivector<Scalar, ToFrame> Signature<FromFrame, ToFrame>::operator()(
+    Bivector<Scalar, FromFrame> const& bivector) const {
+  return Bivector<Scalar, ToFrame>(
+      {determinant * x_ * bivector.coordinates().x,
+       determinant * y_ * bivector.coordinates().y,
+       determinant * z_ * bivector.coordinates().z});
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename Scalar>
+Trivector<Scalar, ToFrame> Signature<FromFrame, ToFrame>::operator()(
+    Trivector<Scalar, FromFrame> const& trivector) const {
+  return Trivector<Scalar, ToFrame>(determinant * trivector.coordinates());
+}
+
+template<typename FromFrame, typename ToFrame>
+template<typename Scalar>
+SymmetricBilinearForm<Scalar, ToFrame> Signature<FromFrame, ToFrame>::
+operator()(SymmetricBilinearForm<Scalar, FromFrame> const& form) const {
+  return SymmetricBilinearForm<Scalar, ToFrame>();
+}
+
+template<typename FromFrame, typename ToFrame>
+constexpr Signature<FromFrame, ToFrame>::Signature(Sign const x,
+                                                   Sign const y,
+                                                   Sign const z)
+    : x_(x), y_(y), z_(z) {}
+
+template<typename FromFrame, typename ThroughFrame, typename ToFrame>
+Signature<FromFrame, ToFrame> operator*(
+    Signature<ThroughFrame, ToFrame> const& left,
+    Signature<FromFrame, ThroughFrame> const& right) {
+  return Signature<FromFrame, ToFrame>(
+      left.x_ * right.x_, left.y_ * right.y_, deduce_sign_from_handedness);
+}
+
+template<typename FromFrame, typename ToFrame>
+std::ostream& operator<<(std::ostream& out,
+                         Signature<FromFrame, ToFrame> const& signature) {
+  return out << "{" << signature.x_ << ", " << signature.y_ << ", "
+             << signature.z_ << "}";
+}
+
+}  // namespace internal_signature
+}  // namespace geometry
+}  // namespace principia

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -7,24 +7,21 @@ namespace geometry {
 namespace internal_signature {
 
 template<typename FromFrame, typename ToFrame>
-constexpr Signature<FromFrame, ToFrame>::Signature(
-    Sign const x,
-    Sign const y,
-    Signature::deduce_sign_t const z)
+constexpr Signature<FromFrame, ToFrame>::Signature(Sign const x,
+                                                   Sign const y,
+                                                   deduce_sign_t const z)
     : x_(x), y_(y), z_(x * y * determinant) {}
 
 template<typename FromFrame, typename ToFrame>
-constexpr Signature<FromFrame, ToFrame>::Signature(
-    Sign const x,
-    Signature::deduce_sign_t const y,
-    Sign const z)
+constexpr Signature<FromFrame, ToFrame>::Signature(Sign const x,
+                                                   deduce_sign_t const y,
+                                                   Sign const z)
     : x_(x), y_(x * determinant * z), z_(z) {}
 
 template<typename FromFrame, typename ToFrame>
-constexpr Signature<FromFrame, ToFrame>::Signature(
-    Signature::deduce_sign_t const x,
-    Sign const y,
-    Sign const z)
+constexpr Signature<FromFrame, ToFrame>::Signature(deduce_sign_t const x,
+                                                   Sign const y,
+                                                   Sign const z)
     : x_(determinant * y * z), y_(y), z_(z) {}
 
 template<typename FromFrame, typename ToFrame>
@@ -91,7 +88,7 @@ Signature<FromFrame, ToFrame> operator*(
     Signature<ThroughFrame, ToFrame> const& left,
     Signature<FromFrame, ThroughFrame> const& right) {
   return Signature<FromFrame, ToFrame>(
-      left.x_ * right.x_, left.y_ * right.y_, deduce_sign_from_handedness);
+      left.x_ * right.x_, left.y_ * right.y_, left.z_ * right.z_);
 }
 
 template<typename FromFrame, typename ToFrame>

--- a/geometry/signature_test.cpp
+++ b/geometry/signature_test.cpp
@@ -195,6 +195,16 @@ TEST_F(SignatureTest, Composition) {
               Eq(reflection(rotation(trivector_))));
 }
 
+TEST_F(SignatureTest, Serialization) {
+  serialization::Signature message;
+
+  PositiveSignature signature(
+      Sign::Positive(), Sign::Negative(), DeduceSignPreservingOrientation{});
+  signature.WriteToMessage(&message);
+  EXPECT_THAT(PositiveSignature::ReadFromMessage(message)(vector_),
+              Eq(signature(vector_)));
+}
+
 TEST_F(SignatureTest, Output) {
   EXPECT_THAT((std::stringstream{}
                << PositiveSignature(Sign::Positive(),

--- a/geometry/signature_test.cpp
+++ b/geometry/signature_test.cpp
@@ -1,0 +1,71 @@
+
+#include "geometry/signature.hpp"
+
+#include <vector>
+
+#include "geometry/frame.hpp"
+#include "geometry/identity.hpp"
+#include "geometry/orthogonal_map.hpp"
+#include "geometry/r3_element.hpp"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "quantities/si.hpp"
+#include "serialization/geometry.pb.h"
+#include "testing_utilities/almost_equals.hpp"
+
+namespace principia {
+
+using quantities::Length;
+using quantities::si::Metre;
+using ::testing::Eq;
+
+namespace geometry {
+
+class SignatureTest : public testing::Test {
+ protected:
+  using R1 = Frame<serialization::Frame::TestTag,
+                  Inertial,
+                  Handedness::Right,
+                   serialization::Frame::TEST1>;
+  using R2 = Frame<serialization::Frame::TestTag,
+                   Inertial,
+                   Handedness::Right,
+                   serialization::Frame::TEST2>;
+  using L = Frame<enum class LTag, Inertial, Handedness::Left>;
+
+  using PositiveSignature = Signature<R1, R2>;
+  using NegativeSignature = Signature<R1, L>;
+
+  SignatureTest()
+      : vector_({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}),
+        bivector_({1.0 * Metre, 2.0 * Metre, 3.0 * Metre}),
+        trivector_(4.0 * Metre) {}
+
+  Vector<Length, R1> vector_;
+  Bivector<Length, R1> bivector_;
+  Trivector<Length, R1> trivector_;
+};
+
+using SignatureDeathTest = SignatureTest;
+
+TEST_F(SignatureTest, Identity) {
+  EXPECT_THAT(PositiveSignature::Identity()(vector_).coordinates(),
+              Eq(vector_.coordinates()));
+  EXPECT_THAT(PositiveSignature::Identity()(bivector_).coordinates(),
+              Eq(bivector_.coordinates()));
+  EXPECT_THAT(PositiveSignature::Identity()(trivector_).coordinates(),
+              Eq(trivector_.coordinates()));
+}
+
+TEST_F(SignatureTest, CentralReflection) {
+  EXPECT_THAT(NegativeSignature::CentralReflection()(vector_).coordinates(),
+              Eq(vector_.coordinates()));
+  EXPECT_THAT(NegativeSignature::CentralReflection()(bivector_).coordinates(),
+              Eq(bivector_.coordinates()));
+  EXPECT_THAT(NegativeSignature::CentralReflection()(trivector_).coordinates(),
+              Eq(trivector_.coordinates()));
+}
+
+}  // namespace geometry
+}  // namespace principia

--- a/geometry/signature_test.cpp
+++ b/geometry/signature_test.cpp
@@ -195,5 +195,14 @@ TEST_F(SignatureTest, Composition) {
               Eq(reflection(rotation(trivector_))));
 }
 
+TEST_F(SignatureTest, Output) {
+  EXPECT_THAT((std::stringstream{}
+               << PositiveSignature(Sign::Positive(),
+                                    Sign::Negative(),
+                                    DeduceSignPreservingOrientation{}))
+                  .str(),
+              Eq("{+, -, -}"));
+}
+
 }  // namespace geometry
 }  // namespace principia

--- a/geometry/signature_test.cpp
+++ b/geometry/signature_test.cpp
@@ -59,12 +59,12 @@ TEST_F(SignatureTest, Identity) {
               Eq(trivector_.coordinates()));
 }
 
-TEST_F(SignatureTest, CentralReflection) {
-  EXPECT_THAT(NegativeSignature::CentralReflection()(vector_).coordinates(),
+TEST_F(SignatureTest, CentralInversion) {
+  EXPECT_THAT(NegativeSignature::CentralInversion()(vector_).coordinates(),
               Eq(-vector_.coordinates()));
-  EXPECT_THAT(NegativeSignature::CentralReflection()(bivector_).coordinates(),
+  EXPECT_THAT(NegativeSignature::CentralInversion()(bivector_).coordinates(),
               Eq(bivector_.coordinates()));
-  EXPECT_THAT(NegativeSignature::CentralReflection()(trivector_).coordinates(),
+  EXPECT_THAT(NegativeSignature::CentralInversion()(trivector_).coordinates(),
               Eq(-trivector_.coordinates()));
 }
 

--- a/serialization/geometry.proto
+++ b/serialization/geometry.proto
@@ -78,7 +78,7 @@ message SymmetricBilinearForm {
 message LinearMap {
   required Frame from_frame = 1;
   required Frame to_frame = 2;
-  extensions 1000 to 1999;  // Last used: 1003.
+  extensions 1000 to 1999;  // Last used: 1004.
 }
 
 message Identity {
@@ -130,6 +130,15 @@ message Rotation {
     optional Rotation extension = 1003;
   }
   required Quaternion quaternion = 1;
+}
+
+message Signature {
+  extend LinearMap {
+    optional Signature extension = 1004;
+  }
+  required Sign x = 1;
+  required Sign y = 2;
+  required Sign z = 3;
 }
 
 // Frames follow.  Note that the names of the enum types are part of the


### PR DESCRIPTION
This pull request introduces `Signature`; it does introduce usages of it.
We should use it in `OrthogonalMap` and `EulerSolver` later on.

`Signature` is handedness-correct.