### PR TITLE
Ancient history

### DIFF
--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -217,9 +217,9 @@ Iterator* __cdecl principia__PlanetariumPlotPsychohistory(
 }
 
 // Returns an iterator for the rendered past trajectory of the celestial with
-// the given index; the trajectory goes back as far as the history of the vessel
-// with the given GUID, or, if no vessel is provided, up to |max_history_length|
-// seconds before the present time.
+// the given index; the trajectory goes back |max_history_length| seconds before
+// the present time (or to the earliest time available if the relevant |t_min|
+// is more recent).
 Iterator* __cdecl principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
     Planetarium const* const planetarium,
     Plugin const* const plugin,
@@ -243,9 +243,7 @@ Iterator* __cdecl principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
         plugin->GetCelestial(celestial_index).trajectory();
     Instant const first_time = std::max(
         plugin->CurrentTime() - max_history_length * Second,
-        vessel_guid == nullptr
-            ? celestial_trajectory.t_min()
-            : plugin->GetVessel(vessel_guid)->psychohistory().t_min());
+            celestial_trajectory.t_min());
     auto const rp2_lines =
         planetarium->PlotMethod2(celestial_trajectory,
                                  first_time,


### PR DESCRIPTION
Show celestial histories before the beginning of the history of the active vessel.

Prior to this change, seeing long celestial trajectories was easiest to achieve in the tracking station, with no vessel selected.

However, to quote @lpgagnon, the primary reason to look at long celestial trajectories is
> because they're pretty

whereas
> the tracking station is not pretty
> (and, annoyingly, doesn't support F2 to hide the UI)

Long celestial histories can now be seen in map view, along with the shorter history of a vessel. Note that predictions still end where the vessel's does (in the screenshots below, the prediction ends as the vessel collides with Earth, so that the predicted trajectories of Earth and the vessel end at the same point).

### Before
![screenshot37](https://user-images.githubusercontent.com/2284290/71607492-4614e380-2b7a-11ea-9894-015e7bdb1d8b.png)

### After
![screenshot38](https://user-images.githubusercontent.com/2284290/71607498-4d3bf180-2b7a-11ea-8888-409b3a2372d8.png)
![screenshot39](https://user-images.githubusercontent.com/2284290/71607499-4dd48800-2b7a-11ea-9cff-29cc5e6c5bd1.png)
![screenshot40](https://user-images.githubusercontent.com/2284290/71607501-4dd48800-2b7a-11ea-9af4-550a0dda0bf9.png)
![screenshot41](https://user-images.githubusercontent.com/2284290/71607502-4e6d1e80-2b7a-11ea-8c0d-a7ce6df6eb0e.png)

