### PR TITLE
Do not provide a defaulted reference_radius if no geopotential is present

### DIFF
--- a/ksp_plugin_adapter/config_node_parsers.cs
+++ b/ksp_plugin_adapter/config_node_parsers.cs
@@ -85,7 +85,9 @@ internal static class ConfigNodeParsers {
             (body.angularV + " rad/s"),
         reference_radius        =
             node?.GetAtMostOneValue("reference_radius") ??
-            (j2 != null || geopotential != null ? body.Radius + " m" : null),
+            (j2 != null || (geopotential?.Length ?? 0) != 0
+                 ? body.Radius + " m"
+                 : null),
         j2                      = j2,
         geopotential            = geopotential
     };


### PR DESCRIPTION
See #2429 and its fix, #2430: if a [`principia_gravity_model.body`](https://github.com/mockingbirdnest/Principia/wiki/Principia-configuration-files#principia_gravity_model.body) node has no [`geopotential_row`](https://github.com/mockingbirdnest/Principia/wiki/Principia-configuration-files#principia_gravity_model.body.geopotential_row), `geopotential` is an empty array rather than a null in the affected code. This meant that we would provide a defaulted `reference_radius` to the C++, which would fail with
```
Check failed: body.has_j2() || body.has_geopotential() == body.has_reference_radius() (0 vs. 1)
```
even though the constraint
> either `reference_radius` is absent, or one of `j2` and `geopotential_row` is present;

was satisfied by the configuration.
