### PR TITLE
Angular momentum accounting

### DIFF
--- a/ksp_plugin/interface_part.cpp
+++ b/ksp_plugin/interface_part.cpp
@@ -41,14 +41,19 @@ void __cdecl principia__PartIncrementIntrinsicForceWithPosition(
     Plugin* const plugin,
     PartId const part_id,
     XYZ const force_in_kilonewtons,
-    XYZ const position,
+    XYZ const point_of_force_application,
     XYZ const part_position) {
   journal::Method<journal::PartIncrementIntrinsicForceWithPosition> m(
-      {plugin, part_id, force_in_kilonewtons, position, part_position});
+      {plugin,
+       part_id,
+       force_in_kilonewtons,
+       point_of_force_application,
+       part_position});
   CHECK_NOTNULL(plugin)->IncrementPartIntrinsicForceWithPosition(
       part_id,
       Vector<Force, World>(FromXYZ(force_in_kilonewtons) * Kilo(Newton)),
-      World::origin + Displacement<World>(FromXYZ(position) * Metre),
+      World::origin +
+          Displacement<World>(FromXYZ(point_of_force_application) * Metre),
       World::origin + Displacement<World>(FromXYZ(part_position) * Metre));
   return m.Return();
 }

--- a/ksp_plugin/interface_part.cpp
+++ b/ksp_plugin/interface_part.cpp
@@ -41,13 +41,15 @@ void __cdecl principia__PartIncrementIntrinsicForceWithPosition(
     Plugin* const plugin,
     PartId const part_id,
     XYZ const force_in_kilonewtons,
-    XYZ const position) {
+    XYZ const position,
+    XYZ const part_position) {
   journal::Method<journal::PartIncrementIntrinsicForceWithPosition> m(
       {plugin, part_id, force_in_kilonewtons, position});
   CHECK_NOTNULL(plugin)->IncrementPartIntrinsicForceWithPosition(
       part_id,
       Vector<Force, World>(FromXYZ(force_in_kilonewtons) * Kilo(Newton)),
-      World::origin + Displacement<World>(FromXYZ(position) * Metre));
+      World::origin + Displacement<World>(FromXYZ(position) * Metre),
+      World::origin + Displacement<World>(FromXYZ(part_position) * Metre));
   return m.Return();
 }
 

--- a/ksp_plugin/interface_part.cpp
+++ b/ksp_plugin/interface_part.cpp
@@ -44,7 +44,7 @@ void __cdecl principia__PartIncrementIntrinsicForceWithPosition(
     XYZ const position,
     XYZ const part_position) {
   journal::Method<journal::PartIncrementIntrinsicForceWithPosition> m(
-      {plugin, part_id, force_in_kilonewtons, position});
+      {plugin, part_id, force_in_kilonewtons, position, part_position});
   CHECK_NOTNULL(plugin)->IncrementPartIntrinsicForceWithPosition(
       part_id,
       Vector<Force, World>(FromXYZ(force_in_kilonewtons) * Kilo(Newton)),

--- a/ksp_plugin/interface_part.cpp
+++ b/ksp_plugin/interface_part.cpp
@@ -25,31 +25,31 @@ using quantities::si::Newton;
 using quantities::si::Metre;
 using quantities::si::Radian;
 
-void __cdecl principia__PartIncrementIntrinsicForce(
+void __cdecl principia__PartApplyIntrinsicForce(
     Plugin* const plugin,
     PartId const part_id,
     XYZ const force_in_kilonewtons) {
-  journal::Method<journal::PartIncrementIntrinsicForce> m(
+  journal::Method<journal::PartApplyIntrinsicForce> m(
       {plugin, part_id, force_in_kilonewtons});
-  CHECK_NOTNULL(plugin)->IncrementPartIntrinsicForce(
+  CHECK_NOTNULL(plugin)->ApplyPartIntrinsicForce(
       part_id,
       Vector<Force, World>(FromXYZ(force_in_kilonewtons) * Kilo(Newton)));
   return m.Return();
 }
 
-void __cdecl principia__PartIncrementIntrinsicForceWithPosition(
+void __cdecl principia__PartApplyIntrinsicForceAtPosition(
     Plugin* const plugin,
     PartId const part_id,
     XYZ const force_in_kilonewtons,
     XYZ const point_of_force_application,
     XYZ const part_position) {
-  journal::Method<journal::PartIncrementIntrinsicForceWithPosition> m(
+  journal::Method<journal::PartApplyIntrinsicForceAtPosition> m(
       {plugin,
        part_id,
        force_in_kilonewtons,
        point_of_force_application,
        part_position});
-  CHECK_NOTNULL(plugin)->IncrementPartIntrinsicForceWithPosition(
+  CHECK_NOTNULL(plugin)->ApplyPartIntrinsicForceAtPosition(
       part_id,
       Vector<Force, World>(FromXYZ(force_in_kilonewtons) * Kilo(Newton)),
       World::origin +
@@ -58,13 +58,13 @@ void __cdecl principia__PartIncrementIntrinsicForceWithPosition(
   return m.Return();
 }
 
-void __cdecl principia__PartIncrementIntrinsicTorque(
+void __cdecl principia__PartApplyIntrinsicTorque(
     Plugin* const plugin,
     PartId const part_id,
     XYZ const torque_in_kilonewton_metre) {
-  journal::Method<journal::PartIncrementIntrinsicTorque> m(
+  journal::Method<journal::PartApplyIntrinsicTorque> m(
       {plugin, part_id, torque_in_kilonewton_metre});
-  CHECK_NOTNULL(plugin)->IncrementPartIntrinsicTorque(
+  CHECK_NOTNULL(plugin)->ApplyPartIntrinsicTorque(
       part_id,
       Bivector<Torque, World>(FromXYZ(torque_in_kilonewton_metre) *
                               Kilo(Newton) * Metre * Radian));

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -87,7 +87,7 @@ void Part::clear_intrinsic_force() {
   intrinsic_force_ = Vector<Force, Barycentric>{};
 }
 
-void Part::increment_intrinsic_force(
+void Part::apply_intrinsic_force(
     Vector<Force, Barycentric> const& intrinsic_force) {
   intrinsic_force_ += intrinsic_force;
 }
@@ -100,7 +100,7 @@ void Part::clear_intrinsic_torque() {
   intrinsic_torque_ = Bivector<Torque, Barycentric>{};
 }
 
-void Part::increment_intrinsic_torque(
+void Part::apply_intrinsic_torque(
     Bivector<Torque, Barycentric> const& intrinsic_torque) {
   intrinsic_torque_ += intrinsic_torque;
 }
@@ -258,10 +258,10 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
         std::move(deletion_callback));
   }
 
-  part->increment_intrinsic_force(
+  part->apply_intrinsic_force(
       Vector<Force, Barycentric>::ReadFromMessage(message.intrinsic_force()));
   if (!is_pre_frenet) {
-    part->increment_intrinsic_torque(
+    part->apply_intrinsic_torque(
         Bivector<Torque, Barycentric>::ReadFromMessage(
             message.intrinsic_torque()));
   }

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -30,6 +30,7 @@ using quantities::Pow;
 using quantities::SIUnit;
 using quantities::si::Kilogram;
 using quantities::si::Metre;
+using quantities::si::Radian;
 
 Part::Part(
     PartId const part_id,
@@ -107,6 +108,13 @@ void Part::apply_intrinsic_torque(
 
 Bivector<Torque, Barycentric> const& Part::intrinsic_torque() const {
   return intrinsic_torque_;
+}
+
+void Part::ApplyIntrinsicForceWithLeverArm(
+    Vector<Force, Barycentric> const& intrinsic_force,
+    Displacement<Barycentric> const& lever_arm) {
+  apply_intrinsic_force(intrinsic_force);
+  apply_intrinsic_torque(Wedge(lever_arm, intrinsic_force) * Radian);
 }
 
 void Part::set_rigid_motion(

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -63,6 +63,7 @@ PartId Part::part_id() const {
 }
 
 void Part::set_mass(Mass const& mass) {
+  mass_change_ = mass - mass_;
   mass_ = mass;
 }
 
@@ -76,6 +77,10 @@ void Part::set_inertia_tensor(InertiaTensor<RigidPart> const& inertia_tensor) {
 
 InertiaTensor<RigidPart> const& Part::inertia_tensor() const {
   return inertia_tensor_;
+}
+
+Mass const& Part::mass_change() const {
+  return mass_change_;
 }
 
 void Part::clear_intrinsic_force() {

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -71,12 +71,12 @@ class Part final {
   // its engines (or a tractor beam).
   // TODO(phl): Keep track of the point where the force is applied.
   void clear_intrinsic_force();
-  void increment_intrinsic_force(
+  void apply_intrinsic_force(
       Vector<Force, Barycentric> const& intrinsic_force);
   Vector<Force, Barycentric> const& intrinsic_force() const;
 
   void clear_intrinsic_torque();
-  void increment_intrinsic_torque(
+  void apply_intrinsic_torque(
       Bivector<Torque, Barycentric> const& intrinsic_torque);
   Bivector<Torque, Barycentric> const& intrinsic_torque() const;
 

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -64,6 +64,9 @@ class Part final {
   void set_inertia_tensor(InertiaTensor<RigidPart> const& inertia_tensor);
   InertiaTensor<RigidPart> const& inertia_tensor() const;
 
+  // The difference between successive values passed to |set_mass()|.
+  Mass const& mass_change() const;
+
   // Clears, increments or returns the intrinsic force exerted on the part by
   // its engines (or a tractor beam).
   // TODO(phl): Keep track of the point where the force is applied.
@@ -142,6 +145,7 @@ class Part final {
   PartId const part_id_;
   std::string const name_;
   Mass mass_;
+  Mass mass_change_;
   InertiaTensor<RigidPart> inertia_tensor_;
   Vector<Force, Barycentric> intrinsic_force_;
   Bivector<Torque, Barycentric> intrinsic_torque_;

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -27,6 +27,7 @@ namespace internal_part {
 using base::not_null;
 using base::Subset;
 using geometry::Bivector;
+using geometry::Displacement;
 using geometry::InertiaTensor;
 using geometry::Instant;
 using geometry::Position;
@@ -69,7 +70,6 @@ class Part final {
 
   // Clears, increments or returns the intrinsic force exerted on the part by
   // its engines (or a tractor beam).
-  // TODO(phl): Keep track of the point where the force is applied.
   void clear_intrinsic_force();
   void apply_intrinsic_force(
       Vector<Force, Barycentric> const& intrinsic_force);
@@ -79,6 +79,10 @@ class Part final {
   void apply_intrinsic_torque(
       Bivector<Torque, Barycentric> const& intrinsic_torque);
   Bivector<Torque, Barycentric> const& intrinsic_torque() const;
+
+  void ApplyIntrinsicForceWithLeverArm(
+      Vector<Force, Barycentric> const& intrinsic_force,
+      Displacement<Barycentric> const& lever_arm);
 
   // Sets or returns the rigid motion of the part.
   void set_rigid_motion(

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -116,14 +116,13 @@ void PileUp::RecomputeFromParts() {
     intrinsic_force_ += part->intrinsic_force();
 
     RigidMotion<RigidPart, NonRotatingPileUp> const part_motion =
-        actual_part_rigid_motion_[part];
+        FindOrDie(actual_part_rigid_motion_, part);
     DegreesOfFreedom<NonRotatingPileUp> const part_dof =
         part_motion({RigidPart::origin, RigidPart::unmoving});
     intrinsic_torque_ +=
         Wedge(part_dof.position() - NonRotatingPileUp::origin,
               Identity<Barycentric, NonRotatingPileUp>()(
-                  part->intrinsic_force())) *
-            Radian +
+                  part->intrinsic_force())) * Radian +
         Identity<Barycentric, NonRotatingPileUp>()(part->intrinsic_torque());
 
     AngularVelocity<NonRotatingPileUp> const part_angular_velocity =

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -51,6 +51,7 @@ using physics::RigidMotion;
 using quantities::AngularMomentum;
 using quantities::Force;
 using quantities::Mass;
+using quantities::Torque;
 
 // The origin of |NonRotatingPileUp| is the centre of mass of the pile up.
 // Its axes are those of |Barycentric|. It is used to describe the rotational
@@ -162,9 +163,6 @@ class PileUp {
   template<AppendToPartTrajectory append_to_part_trajectory>
   void AppendToPart(DiscreteTrajectory<Barycentric>::Iterator it) const;
 
-  // Updates the mechanical system and intrinsic force from the list of parts.
-  void RecomputeFromParts(std::list<not_null<Part*>> const& parts);
-
   // Wrapped in a |unique_ptr| to be moveable.
   not_null<std::unique_ptr<absl::Mutex>> lock_;
 
@@ -174,9 +172,9 @@ class PileUp {
   Ephemeris<Barycentric>::FixedStepParameters fixed_step_parameters_;
 
   // Recomputed by the parts subset on every change.  Not serialized.
-  std::unique_ptr<MechanicalSystem<Barycentric, NonRotatingPileUp>>
-      mechanical_system_;
+  Mass mass_;
   Vector<Force, Barycentric> intrinsic_force_;
+  Bivector<Torque, NonRotatingPileUp> intrinsic_torque_;
 
   // The |history_| is the past trajectory of the pile-up.  It is normally
   // integrated with a fixed step using |fixed_instance_|, except in the
@@ -193,6 +191,10 @@ class PileUp {
   // the fact that we are trying to predict the future, but since we are not as
   // good as Hari Seldon we only do it over a short period of time.
   DiscreteTrajectory<Barycentric>* psychohistory_ = nullptr;
+
+  // The angular momentum of the pile up with respect to its centre of mass.
+  // TODO(egg): This is not yet serialized.
+  Bivector<AngularMomentum, NonRotatingPileUp> angular_momentum_;
 
   // When present, this instance is used to integrate the trajectory of this
   // pile-up using a fixed-step integrator.  This instance is destroyed

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -175,6 +175,11 @@ class PileUp {
   Mass mass_;
   Vector<Force, Barycentric> intrinsic_force_;
   Bivector<Torque, NonRotatingPileUp> intrinsic_torque_;
+  // The angular momentum change arising from mass loss (or, more generally,
+  // mass changes); consistently with the native behaviour of the game, we
+  // assume that lost mass carries angular momentum in such a way that the
+  // angular velocity of a part remains constant.
+  Bivector<AngularMomentum, NonRotatingPileUp> angular_momentum_change_;
 
   // The |history_| is the past trajectory of the pile-up.  It is normally
   // integrated with a fixed step using |fixed_instance_|, except in the

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -502,13 +502,16 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
 void Plugin::IncrementPartIntrinsicForceWithPosition(
     PartId const part_id,
     Vector<Force, World> const& force,
-    Position<World> const& position) {
+    Position<World> const& position,
+    Position<World> const& part_position) {
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
-  // TODO(egg): Do something with position.
   vessel->part(part_id)->increment_intrinsic_force(
       renderer_->WorldToBarycentric(PlanetariumRotation())(force));
+  vessel->part(part_id)->increment_intrinsic_torque(
+      renderer_->WorldToBarycentric(PlanetariumRotation())(
+          Wedge(position - part_position, force) * Radian));
 }
 
 void Plugin::IncrementPartIntrinsicTorque(

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -491,7 +491,7 @@ void Plugin::InsertOrKeepLoadedPart(
 }
 
 void Plugin::ApplyPartIntrinsicForce(PartId const part_id,
-                                         Vector<Force, World> const& force) {
+                                     Vector<Force, World> const& force) {
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -507,11 +507,11 @@ void Plugin::ApplyPartIntrinsicForceAtPosition(
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
-  vessel->part(part_id)->apply_intrinsic_force(
-      renderer_->WorldToBarycentric(PlanetariumRotation())(force));
-  vessel->part(part_id)->apply_intrinsic_torque(
-      renderer_->WorldToBarycentric(PlanetariumRotation())(
-          Wedge(point_of_force_application - part_position, force) * Radian));
+  OrthogonalMap<World, Barycentric> const world_to_barycentric =
+      renderer_->WorldToBarycentric(PlanetariumRotation());
+  vessel->part(part_id)->ApplyIntrinsicForceWithLeverArm(
+      world_to_barycentric(force),
+      world_to_barycentric(point_of_force_application - part_position));
 }
 
 void Plugin::ApplyPartIntrinsicTorque(

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -490,16 +490,16 @@ void Plugin::InsertOrKeepLoadedPart(
   part->set_inertia_tensor(inertia_tensor);
 }
 
-void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
+void Plugin::ApplyPartIntrinsicForce(PartId const part_id,
                                          Vector<Force, World> const& force) {
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
-  vessel->part(part_id)->increment_intrinsic_force(
+  vessel->part(part_id)->apply_intrinsic_force(
       renderer_->WorldToBarycentric(PlanetariumRotation())(force));
 }
 
-void Plugin::IncrementPartIntrinsicForceWithPosition(
+void Plugin::ApplyPartIntrinsicForceAtPosition(
     PartId const part_id,
     Vector<Force, World> const& force,
     Position<World> const& point_of_force_application,
@@ -507,20 +507,20 @@ void Plugin::IncrementPartIntrinsicForceWithPosition(
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
-  vessel->part(part_id)->increment_intrinsic_force(
+  vessel->part(part_id)->apply_intrinsic_force(
       renderer_->WorldToBarycentric(PlanetariumRotation())(force));
-  vessel->part(part_id)->increment_intrinsic_torque(
+  vessel->part(part_id)->apply_intrinsic_torque(
       renderer_->WorldToBarycentric(PlanetariumRotation())(
           Wedge(point_of_force_application - part_position, force) * Radian));
 }
 
-void Plugin::IncrementPartIntrinsicTorque(
+void Plugin::ApplyPartIntrinsicTorque(
     PartId const part_id,
     Bivector<Torque, World> const& torque) {
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));
-  vessel->part(part_id)->increment_intrinsic_torque(
+  vessel->part(part_id)->apply_intrinsic_torque(
       renderer_->WorldToBarycentric(PlanetariumRotation())(torque));
 }
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -502,7 +502,7 @@ void Plugin::IncrementPartIntrinsicForce(PartId const part_id,
 void Plugin::IncrementPartIntrinsicForceWithPosition(
     PartId const part_id,
     Vector<Force, World> const& force,
-    Position<World> const& position,
+    Position<World> const& point_of_force_application,
     Position<World> const& part_position) {
   CHECK(!initializing_);
   not_null<Vessel*> const vessel = FindOrDie(part_id_to_vessel_, part_id);
@@ -511,7 +511,7 @@ void Plugin::IncrementPartIntrinsicForceWithPosition(
       renderer_->WorldToBarycentric(PlanetariumRotation())(force));
   vessel->part(part_id)->increment_intrinsic_torque(
       renderer_->WorldToBarycentric(PlanetariumRotation())(
-          Wedge(position - part_position, force) * Radian));
+          Wedge(point_of_force_application - part_position, force) * Radian));
 }
 
 void Plugin::IncrementPartIntrinsicTorque(

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -221,7 +221,8 @@ class Plugin {
   virtual void IncrementPartIntrinsicForceWithPosition(
       PartId part_id,
       Vector<Force, World> const& force,
-      Position<World> const& position);
+      Position<World> const& position,
+      Position<World> const& part_position);
   virtual void IncrementPartIntrinsicTorque(
       PartId part_id,
       Bivector<Torque, World> const& torque);

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -221,7 +221,7 @@ class Plugin {
   virtual void IncrementPartIntrinsicForceWithPosition(
       PartId part_id,
       Vector<Force, World> const& force,
-      Position<World> const& position,
+      Position<World> const& point_of_force_application,
       Position<World> const& part_position);
   virtual void IncrementPartIntrinsicTorque(
       PartId part_id,

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -213,23 +213,23 @@ class Plugin {
       RigidMotion<RigidPart, World> const& part_rigid_motion,
       Time const& Δt);
 
-  // Calls |increment_intrinsic_force| and |increment_intrinsic_torque| on the
+  // Calls |apply_intrinsic_force| and |apply_intrinsic_torque| on the
   // relevant part, which must be in a loaded vessel.
-  virtual void IncrementPartIntrinsicForce(
+  virtual void ApplyPartIntrinsicForce(
       PartId part_id,
       Vector<Force, World> const& force);
-  virtual void IncrementPartIntrinsicForceWithPosition(
+  virtual void ApplyPartIntrinsicForceAtPosition(
       PartId part_id,
       Vector<Force, World> const& force,
       Position<World> const& point_of_force_application,
       Position<World> const& part_position);
-  virtual void IncrementPartIntrinsicTorque(
+  virtual void ApplyPartIntrinsicTorque(
       PartId part_id,
       Bivector<Torque, World> const& torque);
 
   // Calls |MakeSingleton| for all parts in loaded vessels, enabling the use of
   // union-find for pile up construction.  This must be called after the calls
-  // to |IncrementPartIntrinsicForce|, and before the calls to
+  // to |ApplyPartIntrinsicForce|, and before the calls to
   // |ReportGroundCollision| or |ReportPartCollision|.
   virtual void PrepareToReportCollisions();
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -178,10 +178,10 @@ public partial class PrincipiaPluginAdapter
   private readonly Dictionary<uint, Part.ForceHolder[]>
       part_id_to_intrinsic_forces_ = new Dictionary<uint, Part.ForceHolder[]>();
 
-      // The degrees of freedom at BetterLateThanNever.  Those are used to insert
-      // new parts with the correct initial state.
-      private readonly Dictionary<uint, QP> part_id_to_degrees_of_freedom_ =
-      new Dictionary<uint, QP>();
+  // The degrees of freedom at BetterLateThanNever.  Those are used to insert
+  // new parts with the correct initial state.
+  private readonly Dictionary<uint, QP> part_id_to_degrees_of_freedom_ =
+  new Dictionary<uint, QP>();
 
   private readonly MapNodePool map_node_pool_;
   private ManeuverNode guidance_node_;
@@ -1010,9 +1010,11 @@ public partial class PrincipiaPluginAdapter
           }
           if (part_id_to_intrinsic_forces_.ContainsKey(part.flightID)) {
             foreach (var force in part_id_to_intrinsic_forces_[part.flightID]) {
-              plugin_.PartIncrementIntrinsicForceWithPosition(part.flightID,
-                                                              (XYZ)force.force,
-                                                              (XYZ)force.pos);
+              plugin_.PartIncrementIntrinsicForceWithPosition(
+                  part.flightID,
+                  (XYZ)force.force,
+                  (XYZ)force.pos,
+                  part_id_to_degrees_of_freedom_[part.flightID].q);
             }
           }
         }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -992,7 +992,7 @@ public partial class PrincipiaPluginAdapter
               (XYZ)(Vector3d)(part.rb.rotation * part.rb.angularVelocity),
               Δt);
           if (part_id_to_intrinsic_torque_.ContainsKey(part.flightID)) {
-            plugin_.PartIncrementIntrinsicTorque(
+            plugin_.PartApplyIntrinsicTorque(
                 part.flightID,
                 (XYZ)part_id_to_intrinsic_torque_[part.flightID]);
           }
@@ -1003,14 +1003,14 @@ public partial class PrincipiaPluginAdapter
             // effects where doing an EVA accelerates the vessel, see #1415.
             // Just say no to stupidity.
             if (!(vessel.isEVA && vessel.evaController.OnALadder)) {
-              plugin_.PartIncrementIntrinsicForce(
+              plugin_.PartApplyIntrinsicForce(
                   part.flightID,
                   (XYZ)part_id_to_intrinsic_force_[part.flightID]);
             }
           }
           if (part_id_to_intrinsic_forces_.ContainsKey(part.flightID)) {
             foreach (var force in part_id_to_intrinsic_forces_[part.flightID]) {
-              plugin_.PartIncrementIntrinsicForceWithPosition(
+              plugin_.PartApplyIntrinsicForceAtPosition(
                   part.flightID,
                   (XYZ)force.force,
                   (XYZ)force.pos,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -181,7 +181,7 @@ public partial class PrincipiaPluginAdapter
   // The degrees of freedom at BetterLateThanNever.  Those are used to insert
   // new parts with the correct initial state.
   private readonly Dictionary<uint, QP> part_id_to_degrees_of_freedom_ =
-  new Dictionary<uint, QP>();
+      new Dictionary<uint, QP>();
 
   private readonly MapNodePool map_node_pool_;
   private ManeuverNode guidance_node_;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1014,7 +1014,7 @@ public partial class PrincipiaPluginAdapter
                   part.flightID,
                   (XYZ)force.force,
                   (XYZ)force.pos,
-                  part_id_to_degrees_of_freedom_[part.flightID].q);
+                  degrees_of_freedom.q);
             }
           }
         }

--- a/ksp_plugin_test/part_test.cpp
+++ b/ksp_plugin_test/part_test.cpp
@@ -36,7 +36,7 @@ class PartTest : public testing::Test {
               RigidMotion<RigidPart, Barycentric>::MakeNonRotatingMotion(
                   degrees_of_freedom_),
               /*deletion_callback=*/nullptr) {
-    part_.increment_intrinsic_force(intrinsic_force_);
+    part_.apply_intrinsic_force(intrinsic_force_);
     part_.AppendToHistory(
         astronomy::J2000,
         {Barycentric::origin +

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -82,7 +82,7 @@ class TestablePileUp : public PileUp {
   using PileUp::NudgeParts;
 
   Mass const& mass() const {
-    return mechanical_system_->mass();
+    return mass_;
   }
 
   Vector<Force, Barycentric> const& intrinsic_force() const {

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -271,9 +271,9 @@ class PileUpTest : public testing::Test {
 // force.
 TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
   MockEphemeris<Barycentric> ephemeris;
-  p1_.increment_intrinsic_force(
+  p1_.apply_intrinsic_force(
       Vector<Force, Barycentric>({1 * Newton, 2 * Newton, 3 * Newton}));
-  p2_.increment_intrinsic_force(
+  p2_.apply_intrinsic_force(
       Vector<Force, Barycentric>({11 * Newton, 21 * Newton, 31 * Newton}));
   EXPECT_CALL(deletion_callback_, Call()).Times(1);
   TestablePileUp pile_up({&p1_, &p2_},
@@ -607,7 +607,7 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
   Vector<Acceleration, Barycentric> const a{{1729 * Metre / Pow<2>(Second),
                                              -168 * Metre / Pow<2>(Second),
                                              504 * Metre / Pow<2>(Second)}};
-  p1_.increment_intrinsic_force(p1_.mass() * a);
+  p1_.apply_intrinsic_force(p1_.mass() * a);
   pile_up.RecomputeFromParts();
   pile_up.AdvanceTime(astronomy::J2000 + 2 * fixed_step);
   pile_up.NudgeParts();
@@ -617,9 +617,9 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
 
 TEST_F(PileUpTest, Serialization) {
   MockEphemeris<Barycentric> ephemeris;
-  p1_.increment_intrinsic_force(
+  p1_.apply_intrinsic_force(
       Vector<Force, Barycentric>({1 * Newton, 2 * Newton, 3 * Newton}));
-  p2_.increment_intrinsic_force(
+  p2_.apply_intrinsic_force(
       Vector<Force, Barycentric>({11 * Newton, 21 * Newton, 31 * Newton}));
   EXPECT_CALL(deletion_callback_, Call()).Times(2);
   TestablePileUp pile_up({&p1_, &p2_},
@@ -661,9 +661,9 @@ TEST_F(PileUpTest, Serialization) {
 
 TEST_F(PileUpTest, SerializationCompatibility) {
   MockEphemeris<Barycentric> ephemeris;
-  p1_.increment_intrinsic_force(
+  p1_.apply_intrinsic_force(
       Vector<Force, Barycentric>({1 * Newton, 2 * Newton, 3 * Newton}));
-  p2_.increment_intrinsic_force(
+  p2_.apply_intrinsic_force(
       Vector<Force, Barycentric>({11 * Newton, 21 * Newton, 31 * Newton}));
   EXPECT_CALL(deletion_callback_, Call()).Times(2);
   TestablePileUp pile_up({&p1_, &p2_},

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1510,9 +1510,9 @@ message NewPlugin {
   optional Return return = 3;
 }
 
-message PartIncrementIntrinsicForce {
+message PartApplyIntrinsicForce {
   extend Method {
-    optional PartIncrementIntrinsicForce extension = 5114;
+    optional PartApplyIntrinsicForce extension = 5114;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
@@ -1522,9 +1522,9 @@ message PartIncrementIntrinsicForce {
   optional In in = 1;
 }
 
-message PartIncrementIntrinsicForceWithPosition {
+message PartApplyIntrinsicForceAtPosition {
   extend Method {
-    optional PartIncrementIntrinsicForceWithPosition extension = 5164;
+    optional PartApplyIntrinsicForceAtPosition extension = 5164;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
@@ -1536,9 +1536,9 @@ message PartIncrementIntrinsicForceWithPosition {
   optional In in = 1;
 }
 
-message PartIncrementIntrinsicTorque {
+message PartApplyIntrinsicTorque {
   extend Method {
-    optional PartIncrementIntrinsicTorque extension = 5165;
+    optional PartApplyIntrinsicTorque extension = 5165;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1530,8 +1530,8 @@ message PartApplyIntrinsicForceAtPosition {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
     required fixed32 part_id = 2;
     required XYZ force_in_kilonewtons = 3;
-    required XYZ position = 4;
-    required XYZ point_of_force_application = 5;
+    required XYZ point_of_force_application = 4;
+    required XYZ part_position = 5;
   }
   optional In in = 1;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1531,7 +1531,7 @@ message PartIncrementIntrinsicForceWithPosition {
     required fixed32 part_id = 2;
     required XYZ force_in_kilonewtons = 3;
     required XYZ position = 4;
-    required XYZ part_position = 5;
+    required XYZ point_of_force_application = 5;
   }
   optional In in = 1;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1531,6 +1531,7 @@ message PartIncrementIntrinsicForceWithPosition {
     required fixed32 part_id = 2;
     required XYZ force_in_kilonewtons = 3;
     required XYZ position = 4;
+    required XYZ part_position = 5;
   }
   optional In in = 1;
 }


### PR DESCRIPTION
Keep track of the angular momentum of a pile up.
For the moment, it is neither exposed nor serialized.