### PR TITLE
Avoid exit destructors

### DIFF
--- a/base/flags.cpp
+++ b/base/flags.cpp
@@ -8,20 +8,20 @@ namespace principia {
 namespace base {
 
 void Flags::Clear() {
-  flags_.clear();
+  flags().clear();
 }
 
 void Flags::Set(std::string_view const name, std::string_view const value) {
-  flags_.emplace(std::string(name), std::string(value));
+  flags().emplace(std::string(name), std::string(value));
 }
 
 bool Flags::IsPresent(std::string_view const name) {
-  return flags_.find(std::string(name)) != flags_.end();
+  return flags().find(std::string(name)) != flags().end();
 }
 
 bool Flags::IsPresent(std::string_view const name,
                       std::string_view const value) {
-  auto const pair = flags_.equal_range(std::string(name));
+  auto const pair = flags().equal_range(std::string(name));
   std::set<std::string> values;
   for (auto it = pair.first; it != pair.second; ++it) {
     if (it->second == value) {
@@ -32,7 +32,7 @@ bool Flags::IsPresent(std::string_view const name,
 }
 
 std::set<std::string> Flags::Values(std::string_view const name) {
-  auto const pair = flags_.equal_range(std::string(name));
+  auto const pair = flags().equal_range(std::string(name));
   std::set<std::string> values;
   for (auto it = pair.first; it != pair.second; ++it) {
     values.insert(it->second);
@@ -40,7 +40,10 @@ std::set<std::string> Flags::Values(std::string_view const name) {
   return values;
 }
 
-std::multimap<std::string, std::string> Flags::flags_;
+std::multimap<std::string, std::string>& Flags::flags() {
+  static auto* const flags = new std::multimap<std::string, std::string>();
+  return *flags;
+}
 
 }  // namespace base
 }  // namespace principia

--- a/base/flags.hpp
+++ b/base/flags.hpp
@@ -27,7 +27,7 @@ class Flags {
   static std::set<std::string> Values(std::string_view name);
 
  private:
-  static std::multimap<std::string, std::string> flags_;
+  static std::multimap<std::string, std::string>& flags();
 };
 
 }  // namespace base


### PR DESCRIPTION
The Linux test dumps a core at the very end.  Let's avoid static objects at namespace scope.