### PR TITLE
Use the CONSTEXPR_INFINITY macro for new constants

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -155,7 +155,8 @@ inline void noreturn() { std::exit(0); }
 #define CONSTEXPR_CHECK(condition) CHECK(condition)
 
 // Clang for some reason doesn't like FP arithmetic that yields infinities in
-// constexpr code (MSVC and GCC are fine with that).
+// constexpr code (MSVC and GCC are fine with that).  This will be fixed in
+// Clang 9.0.0, all hail zygoloid.
 #if PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL
 #  define CONSTEXPR_INFINITY const
 #else

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -130,10 +130,12 @@ constexpr Q SIUnit() { return Q(1); };
 
 // A positive infinity of |Q|.
 template<typename Q>
-constexpr Q Infinity = SIUnit<Q>() * std::numeric_limits<double>::infinity();
+CONSTEXPR_INFINITY Q Infinity =
+    SIUnit<Q>() * std::numeric_limits<double>::infinity();
 // A quiet NaN of |Q|.
 template<typename Q>
-constexpr Q NaN = SIUnit<Q>() * std::numeric_limits<double>::quiet_NaN();
+CONSTEXPR_INFINITY Q NaN =
+    SIUnit<Q>() * std::numeric_limits<double>::quiet_NaN();
 
 template<typename Q>
 constexpr bool IsFinite(Q const& x);


### PR DESCRIPTION
Clang 8.0.0 has not heard about the new rule, but Clang 9.0.0 has.