### PR TITLE
Extend the flight plan when the last manœuvre is moved forward or extended

### DIFF
--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -173,8 +173,17 @@ Status FlightPlan::Replace(NavigationManœuvre::Burn const& burn,
   if (manœuvre.IsSingular()) {
     return Singular();
   }
-  if (!manœuvre.FitsBetween(start_of_previous_coast(index),
-                            start_of_next_burn(index))) {
+  if (index == number_of_manœuvres() - 1) {
+    // This is the last manœuvre.  If it doesn't fit just because the flight
+    // plan is too short, extend the flight plan.
+    if (manœuvre.IsAfter(start_of_previous_coast(index))) {
+      desired_final_time_ =
+          std::max(desired_final_time_, manœuvre.final_time());
+    } else {
+      return DoesNotFit();
+    }
+  } else if (!manœuvre.FitsBetween(start_of_previous_coast(index),
+                                   start_of_next_burn(index))) {
     return DoesNotFit();
   }
 

--- a/ksp_plugin/manœuvre.hpp
+++ b/ksp_plugin/manœuvre.hpp
@@ -119,6 +119,9 @@ class Manœuvre {
   // Returns true if ‖Δv‖ is NaN or infinite.
   bool IsSingular() const;
 
+  // Returrns true if and only if time < initial_time;
+  bool IsAfter(Instant const& time) const;
+
   // Returns true if and only if [initial_time, final_time] ⊆ ]begin, end[.
   bool FitsBetween(Instant const& begin, Instant const& end) const;
 

--- a/ksp_plugin/manœuvre_body.hpp
+++ b/ksp_plugin/manœuvre_body.hpp
@@ -153,14 +153,19 @@ Instant Manœuvre<InertialFrame, Frame>::final_time() const {
 }
 
 template<typename InertialFrame, typename Frame>
-bool Manœuvre<InertialFrame, Frame>::FitsBetween(Instant const& begin,
-                                                 Instant const& end) const {
-  return begin < initial_time() && final_time() < end;
+bool Manœuvre<InertialFrame, Frame>::IsSingular() const {
+  return !IsFinite(Δv().Norm²());
 }
 
 template<typename InertialFrame, typename Frame>
-bool Manœuvre<InertialFrame, Frame>::IsSingular() const {
-  return !IsFinite(Δv().Norm²());
+bool Manœuvre<InertialFrame, Frame>::IsAfter(Instant const& time) const {
+  return time < initial_time();
+}
+
+template<typename InertialFrame, typename Frame>
+bool Manœuvre<InertialFrame, Frame>::FitsBetween(Instant const& begin,
+                                                 Instant const& end) const {
+  return begin < initial_time() && final_time() < end;
 }
 
 template<typename InertialFrame, typename Frame>

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -77,7 +77,7 @@ class FlightPlanner : SupervisedWindowRenderer {
       RenderFlightPlan(vessel_guid);
     } else if (UnityEngine.GUILayout.Button("Create flight plan")) {
       plugin.FlightPlanCreate(vessel_guid,
-                              plugin.CurrentTime() + 1000,
+                              plugin.CurrentTime() + 3600,
                               vessel_.GetTotalMass());
       final_time_.value = plugin.FlightPlanGetDesiredFinalTime(vessel_guid);
       Shrink();

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -149,9 +149,11 @@ class FlightPlanner : SupervisedWindowRenderer {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                           final_time_.value);
         UpdateStatus(status, null);
-        final_time_.value =
-            plugin.FlightPlanGetDesiredFinalTime(vessel_guid);
       }
+      // Always refresh the final time from C++ as it may have changed because
+      // the last burn changed.
+      final_time_.value =
+          plugin.FlightPlanGetDesiredFinalTime(vessel_guid);
 
       FlightPlanAdaptiveStepParameters parameters =
           plugin.FlightPlanGetAdaptiveStepParameters(vessel_guid);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -246,7 +246,8 @@ class FlightPlanner : SupervisedWindowRenderer {
               plugin.FlightPlanGetManoeuvre(vessel_guid, i + 1).
                   burn.initial_time);
         }
-        final_times.Add(plugin.FlightPlanGetActualFinalTime(vessel_guid));
+        // Allow extending the flight plan.
+        final_times.Add(double.PositiveInfinity);
         int number_of_anomalous_manœuvres =
             plugin.FlightPlanNumberOfAnomalousManoeuvres(vessel_guid);
 

--- a/ksp_plugin_test/flight_plan_test.cpp
+++ b/ksp_plugin_test/flight_plan_test.cpp
@@ -411,18 +411,12 @@ TEST_F(FlightPlanTest, Replace) {
       flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
           final_mass();
   EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
-  EXPECT_THAT(flight_plan_->Replace(MakeThirdBurn(), /*index=*/0),
-              StatusIs(FlightPlan::does_not_fit));
-  EXPECT_EQ(old_final_mass,
-            flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
-                final_mass());
-  EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
-  flight_plan_->SetDesiredFinalTime(t0_ + 42 * Second);
   EXPECT_OK(flight_plan_->Replace(MakeThirdBurn(), /*index=*/0));
   EXPECT_GT(old_final_mass,
             flight_plan_->GetManœuvre(flight_plan_->number_of_manœuvres() - 1).
                 final_mass());
   EXPECT_EQ(1, flight_plan_->number_of_manœuvres());
+  EXPECT_LT(t0_ + 1.7 * Second, flight_plan_->desired_final_time());
 }
 
 TEST_F(FlightPlanTest, Segments) {


### PR DESCRIPTION
Also changed the default flight plan length to 1 hour from 1000 seconds (?).

Fix #852.