### PR TITLE
Do not call C++ with positions, velocities or angular velocities that are NaNs.

### DIFF
--- a/geometry/r3x3_matrix_body.hpp
+++ b/geometry/r3x3_matrix_body.hpp
@@ -162,12 +162,12 @@ R3Element<Quotient<RScalar, Scalar>> R3x3Matrix<Scalar>::Solve(
         max = Abs(A(i, k));
       }
     }
-    CHECK_LE(0, r);
-    CHECK_GT(3, r);
+    CHECK_LE(0, r) << *this << " cannot pivot";
+    CHECK_GT(3, r) << *this << " cannot pivot";
     std::swap(A.rows_[k], A.rows_[r]);
     std::swap(L.rows_[k], L.rows_[r]);
     std::swap(b[k], b[r]);
-    CHECK_NE(Scalar{}, A(k, k));
+    CHECK_NE(Scalar{}, A(k, k)) << *this << " is singular";
 
     for (int j = k; j < 3; ++j) {
       Scalar U_kj = A(k, j);

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -89,7 +89,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Crashes\2507\JOURNAL.20200328-214524)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Crashes\2530\JOURNAL.20200416-093807)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -109,7 +109,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
     auto* extension = method_in.MutableExtension(
         serialization::CatchUpLaggingVessels::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(2014156823824);
+    in->set_plugin(2899402431696);
   }
   serialization::Method method_out_return;
   {

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -63,6 +63,8 @@ class Part final {
 
   PartId part_id() const;
 
+  // When a part is not truthful, all its properties except for name and part_id
+  // are lies and should not be propagated to the game.
   bool truthful() const;
   void make_truthful();
 


### PR DESCRIPTION
It seems that in some cases (maybe when a part is about to be destroyed) KSP gives us NaNs in the positions, velocities, angular velocities, forces and torques.  This change filters out such parts early in the C# code, as if they had no rigid body.

The alternative of letting `NaN`s enter the C++ code would be a nightmare because they would fail every single `CHECK`.

Will hopefully fix #2530.