### PR TITLE
A more stable angular momentum correction.

### DIFF
--- a/ksp_plugin/interface_part.cpp
+++ b/ksp_plugin/interface_part.cpp
@@ -112,20 +112,17 @@ void __cdecl principia__PartSetApparentRigidMotion(
     PartId const part_id,
     QP const degrees_of_freedom,
     WXYZ const rotation,
-    XYZ const angular_velocity,
-    QP const main_body_degrees_of_freedom) {
+    XYZ const angular_velocity) {
   journal::Method<journal::PartSetApparentRigidMotion> m(
       {plugin,
        part_id,
        degrees_of_freedom,
        rotation,
-       angular_velocity,
-       main_body_degrees_of_freedom});
+       angular_velocity});
   CHECK_NOTNULL(plugin);
   plugin->SetPartApparentRigidMotion(
       part_id,
-      MakePartRigidMotion(degrees_of_freedom, rotation, angular_velocity),
-      FromQP<DegreesOfFreedom<World>>(main_body_degrees_of_freedom));
+      MakePartRigidMotion(degrees_of_freedom, rotation, angular_velocity));
   return m.Return();
 }
 

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -195,5 +195,24 @@ XYZ __cdecl principia__VesselVelocity(Plugin const* const plugin,
   return m.Return(ToXYZ(plugin->VesselVelocity(vessel_guid)));
 }
 
+void __cdecl principia__SetAngularMomentumConservation(
+    bool const conserve) {
+  journal::Method<journal::SetAngularMomentumConservation> m({conserve});
+  ksp_plugin::PileUp::conserve_angular_momentum = conserve;
+  return m.Return();
+}
+
+char const* __cdecl principia__VesselGetPileUpTrace(
+    Plugin const* const plugin,
+    char const* const vessel_guid) {
+  journal::Method<journal::VesselGetPileUpTrace> m({plugin, vessel_guid});
+  CHECK_NOTNULL(plugin);
+  char const* trace;
+  plugin->GetVessel(vessel_guid)->ForSomePart([&trace](ksp_plugin::Part& part) {
+    trace = part.containing_pile_up()->trace.data();
+  });
+  return m.Return(trace);
+}
+
 }  // namespace interface
 }  // namespace principia

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -196,9 +196,14 @@ XYZ __cdecl principia__VesselVelocity(Plugin const* const plugin,
 }
 
 void __cdecl principia__SetAngularMomentumConservation(
-    bool const conserve) {
-  journal::Method<journal::SetAngularMomentumConservation> m({conserve});
-  ksp_plugin::PileUp::conserve_angular_momentum = conserve;
+    bool const correct_orientation,
+    bool const correct_angular_velocity,
+    bool const thresholding) {
+  journal::Method<journal::SetAngularMomentumConservation> m(
+      {correct_orientation, correct_angular_velocity, thresholding});
+  ksp_plugin::PileUp::correct_orientation = correct_orientation;
+  ksp_plugin::PileUp::correct_angular_velocity = correct_angular_velocity;
+  ksp_plugin::PileUp::thresholding = thresholding;
   return m.Return();
 }
 

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -443,8 +443,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // We apply a rigid rotational correction to the motions of the parts coming
   // from the game (the apparent motions) so as to enforce the conservation of
   // the angular momentum (|angular_momentum_| is authoritative).
-  // Mapping L_apparent to L_actual by a rigid motion leaves can be done in many
-  // ways.
+  // Mapping L_apparent to L_actual by a rigid motion can be done in many ways.
   // We prefer doing some of that correction by a change of attitude, rather
   // than a solely by a change in angular velocity, since, under isotropic
   // conditions, a change in attitude does not alter the physical system (an in

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -477,6 +477,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   auto const α =
       2 * quantities::ArcTan(q.imaginary_part().Norm(), q.real_part());
 
+  // TODO(egg): Use the real Δt.
   if (thresholding && α > ω / (50 * quantities::si::Hertz)) {
     r_apparent = Rotation<ApparentPileUp, EquivalentRigidPileUp>::Identity();
     r_actual = Rotation<NonRotatingPileUp, EquivalentRigidPileUp>::Identity();

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -22,8 +22,8 @@ using base::make_not_null_unique;
 using geometry::AngularVelocity;
 using geometry::BarycentreCalculator;
 using geometry::Bivector;
-using geometry::Frame;
 using geometry::Commutator;
+using geometry::Frame;
 using geometry::Identity;
 using geometry::NonRotating;
 using geometry::Normalize;
@@ -445,7 +445,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // the angular momentum (|angular_momentum_| is authoritative).
   // Mapping L_apparent to L_actual by a rigid motion can be done in many ways.
   // We prefer doing some of that correction by a change of attitude, rather
-  // than a solely by a change in angular velocity, since, under isotropic
+  // than solely by a change in angular velocity, since, under isotropic
   // conditions, a change in attitude does not alter the physical system (and in
   // particular it does not mess with symplectic integration).  We thus try to
   // map L̂_apparent to L̂_actual, by rotation around the correction axis defined
@@ -457,7 +457,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // is 0.  We remedy to that by only performing an attitude correction if its
   // angle would be less than ω Δt, where ω is the smaller of the two equivalent
   // angular frequencies |L_actual / I| and |L_apparent / I|.
-  // As a result, as either L tends towards 0, so does the greatest attitude
+  // As a result, as either L tends towards 0, so does the largest attitude
   // correction that we allow.
   // If the attitude correction would exceed this threshold, we leave the
   // attitude unchanged, and the correction in angular momentum is effected
@@ -533,8 +533,9 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // α is the angle of the tentative attitude correction.
   Angle const α =
       2 * quantities::ArcTan(q.imaginary_part().Norm(), q.real_part());
-  AngularFrequency const ω = std::min(apparent_equivalent_angular_velocity.Norm(),
-                          actual_equivalent_angular_velocity.Norm());
+  AngularFrequency const ω =
+      std::min(apparent_equivalent_angular_velocity.Norm(),
+               actual_equivalent_angular_velocity.Norm());
   Time const Δt = t - psychohistory_->back().time;
   if (thresholding && α > ω * Δt) {
     // The attitude correction is too large.  Preserve attitude.
@@ -558,7 +559,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
               EquivalentRigidPileUp::origin,
               apparent_pile_up_equivalent_rotation.Forget<OrthogonalMap>()),
           correct_angular_velocity ? apparent_equivalent_angular_velocity
-                                    : ApparentPileUp::nonrotating,
+                                   : ApparentPileUp::nonrotating,
           ApparentPileUp::unmoving);
   RigidMotion<NonRotatingPileUp, EquivalentRigidPileUp> const
       actual_pile_up_equivalent_motion(
@@ -567,7 +568,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
               EquivalentRigidPileUp::origin,
               actual_pile_up_equivalent_rotation.Forget<OrthogonalMap>()),
           correct_angular_velocity ? actual_equivalent_angular_velocity
-                                    : NonRotatingPileUp::nonrotating,
+                                   : NonRotatingPileUp::nonrotating,
           NonRotatingPileUp::unmoving);
   RigidMotion<ApparentBubble, NonRotatingPileUp> const
       apparent_bubble_to_pile_up_motion =
@@ -590,11 +591,11 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
     << "norm: " << apparent_angular_momentum.Norm() << "\n"
     << "Actual: " << angular_momentum_ << "\n"
     << "norm: " << angular_momentum_.Norm() << "\n"
-    << u8"|Lap-Lac|: "
+    << "|Lap-Lac|: "
     << (angular_momentum_ - Identity<ApparentPileUp, NonRotatingPileUp>()(
                                 apparent_angular_momentum))
            .Norm() << "\n"
-    << u8"|Lap|-|Lac|: "
+    << "|Lap|-|Lac|: "
     << angular_momentum_.Norm() - apparent_angular_momentum.Norm() << "\n"
     << u8"∡Lap, Lac: "
     << geometry::AngleBetween(angular_momentum_,

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -1,6 +1,7 @@
 ﻿
 #include "ksp_plugin/pile_up.hpp"
 
+#include <algorithm>
 #include <functional>
 #include <list>
 #include <map>

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -744,7 +744,6 @@ PileUpFuture::PileUpFuture(not_null<PileUp const*> const pile_up,
 bool PileUp::correct_orientation = true;
 bool PileUp::correct_angular_velocity = true;
 bool PileUp::thresholding = true;
-bool PileUp::trust_the_game_under_the_threshold = true;
 
 }  // namespace internal_pile_up
 }  // namespace ksp_plugin

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -446,10 +446,10 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // Mapping L_apparent to L_actual by a rigid motion can be done in many ways.
   // We prefer doing some of that correction by a change of attitude, rather
   // than a solely by a change in angular velocity, since, under isotropic
-  // conditions, a change in attitude does not alter the physical system (an in
-  // particular it does not mess with symplectic integration). We thus try to
+  // conditions, a change in attitude does not alter the physical system (and in
+  // particular it does not mess with symplectic integration).  We thus try to
   // map L̂_apparent to L̂_actual, by rotation around the correction axis defined
-  // above, which is perpendicular to both, and imparting the appropriate
+  // above, which is perpendicular to both, and to impart the appropriate
   // angular velocity correction to correct the norm of L.
   // This amounts to trusting the direction of the angular momentum with respect
   // to the vessel as given to us by the game.

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -98,7 +98,6 @@ class PileUp {
   static bool correct_orientation;
   static bool correct_angular_velocity;
   static bool thresholding;
-  static bool trust_the_game_under_the_threshold;
 
   // This class is moveable.
   PileUp(PileUp&& pile_up) = default;

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -94,6 +94,9 @@ class PileUp {
 
   virtual ~PileUp();
 
+  std::string trace;
+  static bool conserve_angular_momentum;
+
   // This class is moveable.
   PileUp(PileUp&& pile_up) = default;
   PileUp& operator=(PileUp&& pile_up) = default;

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -95,7 +95,10 @@ class PileUp {
   virtual ~PileUp();
 
   std::string trace;
-  static bool conserve_angular_momentum;
+  static bool correct_orientation;
+  static bool correct_angular_velocity;
+  static bool thresholding;
+  static bool trust_the_game_under_the_threshold;
 
   // This class is moveable.
   PileUp(PileUp&& pile_up) = default;

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -656,15 +656,14 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
 
 void Plugin::SetPartApparentRigidMotion(
     PartId const part_id,
-    RigidMotion<RigidPart, World> const& rigid_motion,
-    DegreesOfFreedom<World> const& main_body_degrees_of_freedom) {
+    RigidMotion<RigidPart, World> const& rigid_motion) {
   // As a reference frame, |ApparentBubble| differs from |World| only by having
   // the same axes as |Barycentric| and being nonrotating.  However, there is
-  // another semantic distinction: |Apparent| coordinates are uncorrected data
-  // from the game, given immediately after its physics step; before
-  // using them, we must correct them in accordance with the data computed by
-  // the pile up.  This correction overrides the origin of position and
-  // velocity, so we need not worry about the current definition of
+  // another semantic distinction: |Apparent...| coordinates are uncorrected
+  // data from the game, given immediately after its physics step; before using
+  // them, we must correct them in accordance with the data computed by the pile
+  // up.  This correction overrides the origin of position and velocity, so we
+  // need not worry about the current definition of
   // |{World::origin, World::unmoving}| as we do when getting the actual degrees
   // of freedom (via |Plugin::BarycentricToWorld|).
   RigidMotion<World, ApparentBubble> world_to_apparent_bubble{

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -658,8 +658,15 @@ void Plugin::SetPartApparentRigidMotion(
     PartId const part_id,
     RigidMotion<RigidPart, World> const& rigid_motion,
     DegreesOfFreedom<World> const& main_body_degrees_of_freedom) {
-  // Define |ApparentBubble| as the reference frame with the axes of
-  // |Barycentric| centred on the current main body.
+  // As a reference frame, |ApparentBubble| differs from |World| only by having
+  // the same axes as |Barycentric| and being nonrotating.  However, there is
+  // another semantic distinction: |Apparent| coordinates are uncorrected data
+  // from the game, given immediately after its physics step; before
+  // using them, we must correct them in accordance with the data computed by
+  // the pile up.  This correction overrides the origin of position and
+  // velocity, so we need not worry about the current definition of
+  // |{World::origin, World::unmoving}| as we do when getting the actual degrees
+  // of freedom (via |Plugin::BarycentricToWorld|).
   RigidMotion<World, ApparentBubble> world_to_apparent_bubble{
       RigidTransformation<World, ApparentBubble>{
           World::origin,

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -662,13 +662,13 @@ void Plugin::SetPartApparentRigidMotion(
   // |Barycentric| centred on the current main body.
   RigidMotion<World, ApparentBubble> world_to_apparent_bubble{
       RigidTransformation<World, ApparentBubble>{
-          main_body_degrees_of_freedom.position(),
+          World::origin,
           ApparentBubble::origin,
           OrthogonalMap<Barycentric, ApparentBubble>::Identity() *
               renderer_->WorldToBarycentric(PlanetariumRotation())},
       renderer_->BarycentricToWorld(PlanetariumRotation())(
           -angular_velocity_of_world_),
-      main_body_degrees_of_freedom.velocity()};
+      World::unmoving};
 
   not_null<Vessel*> vessel = FindOrDie(part_id_to_vessel_, part_id);
   CHECK(is_loaded(vessel));

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -254,8 +254,7 @@ class Plugin {
   // part.  This part must be in a loaded vessel.
   virtual void SetPartApparentRigidMotion(
       PartId part_id,
-      RigidMotion<RigidPart, World> const& rigid_motion,
-      DegreesOfFreedom<World> const& main_body_degrees_of_freedom);
+      RigidMotion<RigidPart, World> const& rigid_motion);
 
   // Returns the motion of the given part in |World|, assuming that
   // the origin of |World| is fixed at the centre of mass of the

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1238,8 +1238,7 @@ public partial class PrincipiaPluginAdapter
                 new QP{q = (XYZ)(Vector3d)part.rb.position,
                        p = (XYZ)(Vector3d)part.rb.velocity},
                 (WXYZ)(UnityEngine.QuaternionD)part.rb.rotation,
-                (XYZ)(Vector3d)part.rb.angularVelocity,
-                main_body_degrees_of_freedom);
+                (XYZ)(Vector3d)part.rb.angularVelocity);
         }
       }
     }

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -239,10 +239,6 @@ internal class MainWindow : SupervisedWindowRenderer {
     }
     UnityEngine.GUI.DragWindow();
   }
-  
-  static bool correct_orientation = true;
-  static bool correct_angular_velocity = true;
-  static bool thresholding = true;
 
   private void RenderKSPFeatures() {
     correct_orientation = UnityEngine.GUILayout.Toggle(
@@ -518,6 +514,13 @@ internal class MainWindow : SupervisedWindowRenderer {
       field_width      : 5) {
       value = 7 * 24 * 60 * 60
   };
+
+  // These flags exist to facilitate investigation of #2519.
+  // They must not be serialized: their non-default values can lead to absurd
+  // behaviour.
+  private static bool correct_orientation = true;
+  private static bool correct_angular_velocity = true;
+  private static bool thresholding = true;
 
   private static readonly double[] prediction_length_tolerances_ =
       {1e-3, 1e-2, 1e0, 1e1, 1e2, 1e3, 1e4};

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -239,14 +239,23 @@ internal class MainWindow : SupervisedWindowRenderer {
     }
     UnityEngine.GUI.DragWindow();
   }
-
-  static bool conserve = true;
+  
+  static bool correct_orientation = true;
+  static bool correct_angular_velocity = true;
+  static bool thresholding = true;
 
   private void RenderKSPFeatures() {
-    conserve = UnityEngine.GUILayout.Toggle(
-        conserve,
-        "Enforce angular momentum conservation out of warp");
-    Interface.SetAngularMomentumConservation(conserve);
+    correct_orientation = UnityEngine.GUILayout.Toggle(
+        correct_orientation,
+        "Correct orientation");
+    correct_angular_velocity = UnityEngine.GUILayout.Toggle(
+        correct_angular_velocity,
+        "Correct angular velocity");
+    thresholding = UnityEngine.GUILayout.Toggle(
+        thresholding,
+        "Only correct orientation above ω threshold");
+    Interface.SetAngularMomentumConservation(
+        correct_orientation, correct_angular_velocity, thresholding);
     string trace = null;
     if (FlightGlobals.ActiveVessel != null &&
         plugin.HasVessel(FlightGlobals.ActiveVessel.id.ToString())) {

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -253,7 +253,7 @@ internal class MainWindow : SupervisedWindowRenderer {
         "Correct angular velocity");
     thresholding = UnityEngine.GUILayout.Toggle(
         thresholding,
-        "Only correct orientation above ω threshold");
+        "Only correct orientation slower than ω");
     Interface.SetAngularMomentumConservation(
         correct_orientation, correct_angular_velocity, thresholding);
     string trace = null;

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -240,7 +240,22 @@ internal class MainWindow : SupervisedWindowRenderer {
     UnityEngine.GUI.DragWindow();
   }
 
+  static bool conserve = true;
+
   private void RenderKSPFeatures() {
+    conserve = UnityEngine.GUILayout.Toggle(
+        conserve,
+        "Enforce angular momentum conservation out of warp");
+    Interface.SetAngularMomentumConservation(conserve);
+    string trace = null;
+    if (FlightGlobals.ActiveVessel != null &&
+        plugin.HasVessel(FlightGlobals.ActiveVessel.id.ToString())) {
+      trace = plugin.VesselGetPileUpTrace(
+          FlightGlobals.ActiveVessel.id.ToString());
+    }
+    UnityEngine.GUILayout.TextArea(
+        trace ?? "No managed active vessel",
+        style : Style.Multiline(UnityEngine.GUI.skin.textArea));
     display_patched_conics = UnityEngine.GUILayout.Toggle(
         value : display_patched_conics,
         text  : "Display patched conics (do not use for flight planning!)");

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -225,6 +225,32 @@ message Method {
   extensions 5000 to 5999;  // Last used: 5168.
 }
 
+message SetAngularMomentumConservation {
+  extend Method {
+    optional SetAngularMomentumConservation extension = 5999;
+  }
+  message In {
+    required bool conserve = 1;
+  }
+  optional In in = 1;
+}
+
+message VesselGetPileUpTrace {
+  extend Method {
+    optional VesselGetPileUpTrace extension = 5998;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+  }
+  message Return {
+    required string result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
 message AdvanceTime {
   extend Method {
     optional AdvanceTime extension = 5019;

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1635,7 +1635,6 @@ message PartSetApparentRigidMotion {
     required QP degrees_of_freedom = 3;
     required WXYZ rotation = 5;
     required XYZ angular_velocity = 6;
-    required QP main_body_degrees_of_freedom = 4;
   }
   optional In in = 1;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -230,7 +230,9 @@ message SetAngularMomentumConservation {
     optional SetAngularMomentumConservation extension = 5999;
   }
   message In {
-    required bool conserve = 1;
+    required bool correct_orientation = 1;
+    required bool correct_angular_velocity = 2;
+    required bool thresholding = 3;
   }
   optional In in = 1;
 }


### PR DESCRIPTION
This appears to significantly improve the behaviour reported in #2519.

It is not perfect. In the save from https://github.com/mockingbirdnest/Principia/issues/2519#issuecomment-612605437, while we get no uncontrolled spin-up, we get more oscillations than in stock, slowing the rocket down, so that it reaches the water without burning up.

Note that this adds back some traces and toggles for debugging. They will be hidden in a separate pull request (but I would like to keep the plumbing around for now; we may not be quite done with this issue yet).