### PR TITLE
Display the flight planner and the orbit analyser in the tracking station

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -23,6 +23,9 @@ class FlightPlanner : SupervisedWindowRenderer {
   }
 
   public void RenderButton() {
+    // NOTE(phl): This logic is replicated in OrbitAnalyser.  Might want to
+    // invest in an intermediate subclass of SupervisedWindowRenderer to factor
+    // it out.
     if (UnityEngine.GUILayout.Button("Flight plan...")) {
       Toggle();
     }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -25,17 +25,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   }
 
   public void RenderButton() {
-    // NOTE(phl): This logic is replicated in OrbitAnalyser.  Might want to
-    // invest in an intermediate subclass of SupervisedWindowRenderer to factor
-    // it out.
-    if (UnityEngine.GUILayout.Button("Flight plan...")) {
-      Toggle();
-    }
-    // Override the state of the toggle if there is no predicted vessel.
-    string vessel_guid = predicted_vessel?.id.ToString();
-    if (vessel_guid == null) {
-      Hide();
-    }
+    RenderButton("Flight plan...");
   }
 
   public bool show_guidance => show_guidance_;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -322,7 +322,11 @@ public partial class PrincipiaPluginAdapter
   }
 
   private Vessel PredictedVessel() {
-    Vessel vessel = FlightGlobals.ActiveVessel ?? space_tracking?.SelectedVessel;
+    if (!PluginRunning()) {
+      return null;
+    }
+    Vessel vessel =
+        FlightGlobals.ActiveVessel ?? space_tracking?.SelectedVessel;
     string vessel_guid = vessel?.id.ToString();
     if (vessel_guid != null && plugin_.HasVessel(vessel_guid)) {
       return vessel;
@@ -1591,7 +1595,7 @@ public partial class PrincipiaPluginAdapter
     // The only timing that satisfies these constraints is BetterLateThanNever
     // in LateUpdate.
     string main_vessel_guid = PredictedVessel()?.id.ToString();
-    if (MapView.MapIsEnabled && main_vessel_guid != null && PluginRunning()) {
+    if (MapView.MapIsEnabled && main_vessel_guid != null) {
       XYZ sun_world_position = (XYZ)Planetarium.fetch.Sun.position;
       RenderPredictionMarkers(main_vessel_guid, sun_world_position);
       string target_id =

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -300,8 +300,8 @@ public partial class PrincipiaPluginAdapter
     }
 
     map_node_pool_ = new MapNodePool();
-    flight_planner_ = new FlightPlanner(this);
-    orbit_analyser_ = new OrbitAnalyser(this);
+    flight_planner_ = new FlightPlanner(this, PredictedVessel);
+    orbit_analyser_ = new OrbitAnalyser(this, PredictedVessel);
     plotting_frame_selector_ = new ReferenceFrameSelector(this,
                                                           UpdateRenderingFrame,
                                                           "Plotting frame");
@@ -322,7 +322,13 @@ public partial class PrincipiaPluginAdapter
   }
 
   private Vessel PredictedVessel() {
-    return FlightGlobals.ActiveVessel ?? space_tracking?.SelectedVessel;
+    Vessel vessel = FlightGlobals.ActiveVessel ?? space_tracking?.SelectedVessel;
+    string vessel_guid = vessel?.id.ToString();
+    if (vessel_guid != null && plugin_.HasVessel(vessel_guid)) {
+      return vessel;
+    } else {
+      return null;
+    }
   }
 
   private delegate void BodyProcessor(CelestialBody body);
@@ -392,9 +398,7 @@ public partial class PrincipiaPluginAdapter
   private void UpdatePredictions() {
     Vessel main_vessel = PredictedVessel();
     bool ready_to_draw_active_vessel_trajectory =
-        main_vessel != null &&
-        MapView.MapIsEnabled &&
-        plugin_.HasVessel(main_vessel.id.ToString());
+        main_vessel != null && MapView.MapIsEnabled;
 
     if (ready_to_draw_active_vessel_trajectory) {
       plugin_.UpdatePrediction(main_vessel.id.ToString());
@@ -1587,8 +1591,7 @@ public partial class PrincipiaPluginAdapter
     // The only timing that satisfies these constraints is BetterLateThanNever
     // in LateUpdate.
     string main_vessel_guid = PredictedVessel()?.id.ToString();
-    if (MapView.MapIsEnabled && main_vessel_guid != null &&
-        PluginRunning() && plugin_.HasVessel(main_vessel_guid)) {
+    if (MapView.MapIsEnabled && main_vessel_guid != null && PluginRunning()) {
       XYZ sun_world_position = (XYZ)Planetarium.fetch.Sun.position;
       RenderPredictionMarkers(main_vessel_guid, sun_world_position);
       string target_id =
@@ -1968,9 +1971,6 @@ public partial class PrincipiaPluginAdapter
       RemoveStockTrajectoriesIfNeeded(vessel);
     }
     string main_vessel_guid = PredictedVessel()?.id.ToString();
-    if (main_vessel_guid != null && !plugin_.HasVessel(main_vessel_guid)) {
-      main_vessel_guid = null;
-    }
     if (MapView.MapIsEnabled) {
       XYZ sun_world_position = (XYZ)Planetarium.fetch.Sun.position;
       using (DisposablePlanetarium planetarium =

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -3,26 +3,23 @@
 namespace principia {
 namespace ksp_plugin_adapter {
 
-internal class MainWindow : SupervisedWindowRenderer {
+internal class MainWindow : VesselSupervisedWindowRenderer {
   // Update this section before each release.
   private const string next_release_name_ = "Fubini";
   private const int next_release_lunation_number_ = 251;
   private readonly DateTimeOffset next_release_date_ =
       new DateTimeOffset(2020, 04, 23, 02, 26, 00, TimeSpan.Zero);
 
-  public delegate Vessel PredictedVessel();
-
   public MainWindow(PrincipiaPluginAdapter adapter,
                     FlightPlanner flight_planner,
                     OrbitAnalyser orbit_analyser,
                     ReferenceFrameSelector plotting_frame_selector,
                     PredictedVessel predicted_vessel)
-      : base(adapter) {
+      : base(adapter, predicted_vessel) {
     adapter_ = adapter;
     flight_planner_ = flight_planner;
     orbit_analyser_ = orbit_analyser;
     plotting_frame_selector_ = plotting_frame_selector;
-    predicted_vessel_ = predicted_vessel;
     Show();
   }
 
@@ -371,11 +368,9 @@ internal class MainWindow : SupervisedWindowRenderer {
   }
 
   private void RenderPredictionSettings() {
-    vessel_ = predicted_vessel_();
-
     AdaptiveStepParameters? adaptive_step_parameters = null;
-    string vessel_guid = vessel_?.id.ToString();
-    if (vessel_guid != null && plugin.HasVessel(vessel_guid)) {
+    string vessel_guid = predicted_vessel?.id.ToString();
+    if (vessel_guid != null) {
       adaptive_step_parameters =
           plugin.VesselGetPredictionAdaptiveStepParameters(vessel_guid);
       prediction_length_tolerance_index_ = Array.FindIndex(
@@ -508,7 +503,6 @@ internal class MainWindow : SupervisedWindowRenderer {
   private readonly FlightPlanner flight_planner_;
   private readonly OrbitAnalyser orbit_analyser_;
   private readonly ReferenceFrameSelector plotting_frame_selector_;
-  private readonly PredictedVessel predicted_vessel_;
 
   private bool selecting_target_celestial_ = false;
 
@@ -531,8 +525,6 @@ internal class MainWindow : SupervisedWindowRenderer {
   private bool must_record_journal_ = false;
   // Whether a journal is currently being recorded.
   private static bool journaling_ = false;
-
-  private Vessel vessel_;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -171,9 +171,10 @@ internal static class Formatters {
   }
 }
 
-internal class OrbitAnalyser : SupervisedWindowRenderer {
-  public OrbitAnalyser(PrincipiaPluginAdapter adapter)
-      : base(adapter, UnityEngine.GUILayout.MinWidth(0)) {
+internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
+  public OrbitAnalyser(PrincipiaPluginAdapter adapter,
+                       PredictedVessel predicted_vessel)
+      : base(adapter, predicted_vessel, UnityEngine.GUILayout.MinWidth(0)) {
     adapter_ = adapter;
   }
 
@@ -185,18 +186,17 @@ internal class OrbitAnalyser : SupervisedWindowRenderer {
       Toggle();
     }
     // Override the state of the toggle if there is no active vessel.
-    string vessel_guid = vessel_?.id.ToString();
-    if (vessel_guid == null || !plugin.HasVessel(vessel_guid)) {
+    string vessel_guid = predicted_vessel?.id.ToString();
+    if (vessel_guid == null) {
       Hide();
-      vessel_ = FlightGlobals.ActiveVessel;
     }
   }
 
   protected override string Title => "Orbit analysis";
 
   protected override void RenderWindow(int window_id) {
-    string vessel_guid = vessel_?.id.ToString();
-    if (vessel_guid == null || !plugin.HasVessel(vessel_guid)) {
+    string vessel_guid = predicted_vessel?.id.ToString();
+    if (vessel_guid == null) {
       return;
     }
 
@@ -211,13 +211,13 @@ internal class OrbitAnalyser : SupervisedWindowRenderer {
       float five_lines = multiline_style.CalcHeight(
           new UnityEngine.GUIContent("1\n2\n3\n4\n5"), Width(1));
       UnityEngine.GUILayout.Label(
-          $@"Analysing orbit of {vessel_.vesselName} with respect to {
+          $@"Analysing orbit of {predicted_vessel.vesselName} with respect to {
             primary.NameWithArticle()}...",
           multiline_style,
           UnityEngine.GUILayout.Height(two_lines));
 
       OrbitAnalysis analysis = plugin.VesselRefreshAnalysis(
-          vessel_.id.ToString(),
+          predicted_vessel.id.ToString(),
           primary.flightGlobalsIndex,
           mission_duration_.value,
           autodetect_recurrence_ ? null : (int?)revolutions_per_cycle_,
@@ -278,7 +278,7 @@ internal class OrbitAnalyser : SupervisedWindowRenderer {
         multiline_style = Style.Warning(multiline_style);
       }
       string analysis_description =
-          $@"Orbit of {vessel_.vesselName} with respect to {
+          $@"Orbit of {predicted_vessel.vesselName} with respect to {
             primary.NameWithArticle()} over {
             mission_duration.FormatDuration(show_seconds : false)}:{"\n"}{
             duration_in_revolutions}";
@@ -426,7 +426,6 @@ internal class OrbitAnalyser : SupervisedWindowRenderer {
       field_width      : 5) {
       value = 7 * 24 * 60 * 60
   };
-  private Vessel vessel_;
   private bool autodetect_recurrence_ = true;
   private int revolutions_per_cycle_ = 1;
   private int days_per_cycle_ = 1;

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -179,17 +179,7 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
   }
 
   public void RenderButton() {
-    // NOTE(phl): This logic is replicated in FlightPlanner.  Might want to
-    // invest in an intermediate subclass of SupervisedWindowRenderer to factor
-    // it out.
-    if (UnityEngine.GUILayout.Button("Orbit analysis...")) {
-      Toggle();
-    }
-    // Override the state of the toggle if there is no active vessel.
-    string vessel_guid = predicted_vessel?.id.ToString();
-    if (vessel_guid == null) {
-      Hide();
-    }
+    RenderButton("Orbit analysis...");
   }
 
   protected override string Title => "Orbit analysis";

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -283,6 +283,17 @@ internal abstract class
     predicted_vessel_ = predicted_vessel;
   }
 
+  // A helper for implementing the RenderButton() method of the subclasses.
+  protected void RenderButton(string text) {
+    if (UnityEngine.GUILayout.Button(text)) {
+      Toggle();
+    }
+    // Override the state of the toggle if there is no predicted vessel.
+    if (predicted_vessel == null) {
+      Hide();
+    }
+  }
+
   protected Vessel predicted_vessel => predicted_vessel_();
 
   private readonly PredictedVessel predicted_vessel_;

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -85,7 +85,7 @@ internal class ScalingRenderer {
   private readonly float unit_;
 }
 
-// A class that gather all the mechanisms for rendering entired windows.  It
+// A class that gather all the mechanisms for rendering entire windows.  It
 // deals with skins, input locking, sizing, placement, and hiding.  It also
 // persists the position and size of the window.
 internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -85,7 +85,13 @@ internal class ScalingRenderer {
   private readonly float unit_;
 }
 
+// A class that gather all the mechanisms for rendering entired windows.  It
+// deals with skins, input locking, sizing, placement, and hiding.  It also
+// persists the position and size of the window.
 internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
+  protected abstract string Title { get; }
+  protected abstract void RenderWindow(int window_id);
+
   protected BaseWindowRenderer(UnityEngine.GUILayoutOption[] options) {
     UnityEngine.GUILayoutOption[] default_options = {GUILayoutMinWidth(20)};
     options_ = options.Length == 0 ? default_options : options;
@@ -217,9 +223,6 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
     node.SetValue("y", rectangle_.y, createIfNotFound : true);
   }
 
-  protected abstract string Title { get; }
-  protected abstract void RenderWindow(int window_id);
-
   private static readonly ControlTypes PrincipiaLock =
       ControlTypes.ALLBUTCAMERAS &
       ~ControlTypes.ALL_SHIP_CONTROLS;
@@ -235,6 +238,8 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   private UnityEngine.Rect rectangle_;
 }
 
+// The supervisor of a window decides when to clear input locks, when to render
+// the window and when to delete it.
 internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   public interface ISupervisor {
     event Action LockClearing;
@@ -260,6 +265,30 @@ internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   private readonly ISupervisor supervisor_;
 }
 
+// A supervised window that displays properties of a vessel, given by a
+// delegate.  The delegate must return a nonnull value if and only if there is
+// a currently selected/active vessel *and* it is known to the plugin.
+// Subclasses must access the vessel through the predicted_vessel property and
+// should not cache it.
+internal abstract class
+    VesselSupervisedWindowRenderer : SupervisedWindowRenderer {
+  public delegate Vessel PredictedVessel();
+
+  protected VesselSupervisedWindowRenderer(ISupervisor supervisor,
+                                           PredictedVessel predicted_vessel,
+                                           params UnityEngine.GUILayoutOption[]
+                                               options) : base(
+      supervisor,
+      options) {
+    predicted_vessel_ = predicted_vessel;
+  }
+
+  protected Vessel predicted_vessel => predicted_vessel_();
+
+  private readonly PredictedVessel predicted_vessel_;
+}
+
+// A window without a supervisor is effectively modal.
 internal abstract class UnsupervisedWindowRenderer : BaseWindowRenderer {
   protected UnsupervisedWindowRenderer(
       params UnityEngine.GUILayoutOption[] options) : base(options) {}


### PR DESCRIPTION
These two seem to make the tracking station much more useful.

The implementation involves a bit of code restructuring where we use `PredictedVessel` systematically in many places that were using `ActiveVessel`.  Overall this factors out a bit of logic and fixes a buglet where the orbit analyser in the tracking station would show a stump of a window.

There is a remaining know issue for a Kerbal in EVA: if a flight plan is constructed in the tracking station, that flight plan is lost when switching to the map view.  That's because the Kerbal becomes unready for a couple of frames.  It doesn't happen in the other direction.  We call this "the invariants of KSP".  The ultimate fix would be to keep some of the state of unmanaged vessels, but that's a long term effort.

Fix #2531.