### PR TITLE
Add a new class, ExpressIn, to help with type erasure of quantities in Mathematica output

### DIFF
--- a/base/traits.hpp
+++ b/base/traits.hpp
@@ -6,6 +6,17 @@ namespace principia {
 namespace base {
 namespace internal_traits {
 
+template<typename... Ts>
+constexpr bool all_different_v = false;
+
+template<>
+constexpr bool all_different_v<> = true;
+
+template<typename T0, typename... Ts>
+constexpr bool all_different_v<T0, Ts...> =
+    (!std::is_same_v<T0, Ts> && ...) && all_different_v<Ts...>;
+
+
 template<template<typename...> typename T, typename U>
 struct is_instance_of : std::false_type {};
 
@@ -55,6 +66,8 @@ template<typename T>
 inline constexpr bool is_serializable_v =
     internal_traits::has_sfinae_read_from_message<T>::value ||
     internal_traits::has_unconditional_read_from_message<T>::value;
+
+using internal_traits::all_different_v;
 
 }  // namespace base
 }  // namespace principia

--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -28,6 +28,7 @@ class ErrorAnalysisTest : public ::testing::Test {
  protected:
 };
 
+#if !defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
   GenerateSimpleHarmonicMotionWorkErrorGraphs();
   // Circular.
@@ -126,6 +127,7 @@ TEST_F(ErrorAnalysisTest, DISABLED_LocalErrorAnalysis) {
       ParseQuantity<Time>(flags["granularity"].value_or("1 d")),
       ParseQuantity<Time>(flags["duration"].value_or("500 d")));
 }
+#endif
 
 }  // namespace mathematica
 }  // namespace principia

--- a/mathematica/local_error_analysis.cpp
+++ b/mathematica/local_error_analysis.cpp
@@ -83,7 +83,7 @@ void LocalErrorAnalyser::WriteLocalErrors(
   }
   OFStream file(path);
   file << Assign("bodyNames", solar_system_->names());
-  file << Assign("errors", ExpressIn(Metre, errors));
+  file << Assign("errors", ToMathematica(errors, ExpressIn(Metre)));
 }
 
 not_null<std::unique_ptr<Ephemeris<ICRS>>> LocalErrorAnalyser::ForkEphemeris(

--- a/mathematica/local_error_analysis.cpp
+++ b/mathematica/local_error_analysis.cpp
@@ -83,7 +83,7 @@ void LocalErrorAnalyser::WriteLocalErrors(
   }
   OFStream file(path);
   file << Assign("bodyNames", solar_system_->names());
-  file << Assign("errors", ToMathematica(errors, ExpressIn(Metre)));
+  file << Assign("errors", errors, ExpressIn(Metre));
 }
 
 not_null<std::unique_ptr<Ephemeris<ICRS>>> LocalErrorAnalyser::ForkEphemeris(

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -67,7 +67,7 @@ class ExpressIn {
         std::is_same_v<Qs, LuminousIntensity> || std::is_same_v<Qs, Angle>) ||
        ...));
 
-  ExpressIn(Qs const&... qs);
+  ExpressIn(Qs const&... qs);  // NOLINT(runtime/explicit)
 
   template<typename Q>
   double operator()(Q const& q) const;

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -12,6 +12,7 @@
 #include "geometry/r3_element.hpp"
 #include "numerics/fixed_arrays.hpp"
 #include "physics/degrees_of_freedom.hpp"
+#include "quantities/elementary_functions.hpp"
 #include "quantities/quantities.hpp"
 
 namespace principia {
@@ -25,8 +26,20 @@ using geometry::R3Element;
 using geometry::Vector;
 using numerics::FixedVector;
 using physics::DegreesOfFreedom;
+using quantities::Amount;
+using quantities::Angle;
+using quantities::Current;
+using quantities::Exponentiation;
+using quantities::Length;
+using quantities::LuminousIntensity;
+using quantities::Mass;
+using quantities::Pow;
 using quantities::Quantity;
 using quantities::Quotient;
+using quantities::Temperature;
+using quantities::Time;
+
+class ExpressIn2;
 
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
@@ -59,6 +72,13 @@ std::string ToMathematica(Quaternion const& quaternion);
 template<typename D>
 std::string ToMathematica(Quantity<D> const& quantity);
 
+template<typename D>
+std::string ToMathematica(Quantity<D> const& quantity);
+
+template<typename D>
+std::string ToMathematica(Quantity<D> const& quantity,
+                          const ExpressIn2& express_in);
+
 template<typename S, typename F>
 std::string ToMathematica(Vector<S, F> const& vector);
 
@@ -89,6 +109,73 @@ std::string ToMathematica(std::string const& str);
 // TODO(egg): escape things properly.
 std::string Escape(std::string const& str);
 
+class ExpressIn2 {
+ public:
+  template<typename... Q>
+  ExpressIn2(Q const&... q) {
+    if (sizeof...(Q) > 0) {
+      FillUnits(q...);
+    }
+  }
+
+  template<typename Q>
+  double operator()(Q const& q) const {
+    return Divide<Q::Dimensions::Length>(
+        Divide<Q::Dimensions::Mass>(
+            Divide<Q::Dimensions::Time>(
+                Divide<Q::Dimensions::Current>(
+                    Divide<Q::Dimensions::Temperature>(
+                        Divide<Q::Dimensions::Amount>(
+                            Divide<Q::Dimensions::LuminousIntensity>(
+                                Divide<Q::Dimensions::Angle>(
+                                    q, std::get<std::optional<Angle>>(units_)),
+                                std::get<std::optional<LuminousIntensity>>(
+                                    units_)),
+                            std::get<std::optional<Amount>>(units_)),
+                        std::get<std::optional<Temperature>>(units_)),
+                    std::get<std::optional<Current>>(units_)),
+                std::get<std::optional<Time>>(units_)),
+            std::get<std::optional<Mass>>(units_)),
+        std::get<std::optional<Length>>(units_));
+  }
+
+ private:
+  template<std::int64_t exponent, typename QLeft, typename QRight>
+  static Quotient<QLeft, Exponentiation<QRight, exponent>> Divide(
+      QLeft const& q_left,
+      std::optional<QRight> const& q_right) {
+    if constexpr (exponent == 0) {
+      return q_left;
+    } else {
+      CHECK(q_right.has_value()) << "Missing unit to decompose " << q_left;
+      return q_left / Pow<exponent>(q_right.value());
+    }
+  }
+
+
+  template<typename QHead, typename... QTail>
+  void FillUnits(QHead const& qhead, QTail const&... qtail) {
+    // The following will fail to compile if QHead is not one of the units in
+    // units_.
+    auto& unit = std::get<std::optional<QHead>>(units_);
+    CHECK(!unit.has_value()) << qhead << " is a redundant specification";
+    unit = qhead;
+    if constexpr (sizeof...(QTail) > 0) {
+      FillUnits(qtail...);
+    }
+  }
+
+  std::tuple<std::optional<Length>,
+             std::optional<Mass>,
+             std::optional<Time>,
+             std::optional<Current>,
+             std::optional<Temperature>,
+             std::optional<Amount>,
+             std::optional<LuminousIntensity>,
+             std::optional<Angle>>
+      units_;
+};
+
 // TODO(phl): This doesn't work well for complex structures like orbital
 // elements or trajectory iterators.  Surely we can do better.
 template<typename T>
@@ -115,6 +202,7 @@ using internal_mathematica::Apply;
 using internal_mathematica::Assign;
 using internal_mathematica::Escape;
 using internal_mathematica::ExpressIn;
+using internal_mathematica::ExpressIn2;
 using internal_mathematica::Option;
 using internal_mathematica::PlottableDataset;
 using internal_mathematica::ToMathematica;

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -43,14 +43,11 @@ using quantities::Time;
 template<typename... Qs>
 class ExpressIn2 {
  public:
-  ExpressIn2() {}
+  // static_assert
 
-  template<typename = std::enable_if_t<(sizeof...(Qs) > 0)>>
-  ExpressIn2(Qs const&... qs) : units_(std::make_tuple(qs...)) {
-    // static_assert
-  }
+  static constexpr bool is_default = sizeof...(Qs) == 0;
 
-  bool is_default() const { return !units_.has_value(); }
+  ExpressIn2(Qs const&... qs) : units_(std::make_tuple(qs...)) {}
 
   template<typename Q>
   double operator()(Q const& q) const {
@@ -71,57 +68,74 @@ class ExpressIn2 {
     if constexpr (exponent == 0) {
       return q2;
     } else {
-      return q2 / Pow<exponent>(std::get<Q1>(units_.value()));
+      return q2 / Pow<exponent>(std::get<Q1>(units_));
     }
   }
 
-  std::optional<std::tuple<Qs...>> units_;
+  std::tuple<Qs...> units_;
 };
 
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
 
-template<typename T>
-std::string Option(std::string const& name, T const& right);
+template<typename T, typename... Qs>
+std::string Option(std::string const& name,
+                   T const& right,
+                   ExpressIn2<Qs...> express_in = {});
 
-template<typename T>
-std::string Assign(std::string const& name, T const& right);
+template<typename T, typename... Qs>
+std::string Assign(std::string const& name,
+                   T const& right,
+                   ExpressIn2<Qs...> express_in = {});
 
-template<typename T, typename U>
-std::string PlottableDataset(std::vector<T> const& x, std::vector<U> const& y);
+template<typename T, typename U, typename... Qs>
+std::string PlottableDataset(std::vector<T> const& x,
+                             std::vector<U> const& y,
+                             ExpressIn2<Qs...> express_in = {});
 
-template<typename T>
-std::string ToMathematica(std::vector<T> const& list);
+template<typename T, typename... Qs>
+std::string ToMathematica(std::vector<T> const& list,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename It>
-std::string ToMathematica(It begin, It end);
+template<typename It, typename... Qs>
+std::string ToMathematica(It begin, It end,
+                          ExpressIn2<Qs...> express_in = {});
 
-std::string ToMathematica(double const& real);
+template<typename... Qs>
+std::string ToMathematica(double real,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename T, int size>
-std::string ToMathematica(FixedVector<T, size> const& fixed_vector);
+template<typename T, int size, typename... Qs>
+std::string ToMathematica(FixedVector<T, size> const& fixed_vector,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename T>
-std::string ToMathematica(R3Element<T> const& r3_element);
+template<typename T, typename... Qs>
+std::string ToMathematica(R3Element<T> const& r3_element,
+                          ExpressIn2<Qs...> express_in = {});
 
-std::string ToMathematica(Quaternion const& quaternion);
+template<typename... Qs>
+std::string ToMathematica(Quaternion const& quaternion,
+                          ExpressIn2<Qs...> express_in = {});
 
 template<typename D, typename... Qs>
-std::string ToMathematica(
-    Quantity<D> const& quantity,
-    ExpressIn2<Qs...> express_in = {});
+std::string ToMathematica(Quantity<D> const& quantity,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename S, typename F>
-std::string ToMathematica(Vector<S, F> const& vector);
+template<typename S, typename F, typename... Qs>
+std::string ToMathematica(Vector<S, F> const& vector,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename S, typename F>
-std::string ToMathematica(Bivector<S, F> const& bivector);
+template<typename S, typename F, typename... Qs>
+std::string ToMathematica(Bivector<S, F> const& bivector,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename V>
-std::string ToMathematica(Point<V> const& point);
+template<typename V, typename... Qs>
+std::string ToMathematica(Point<V> const& point,
+                          ExpressIn2<Qs...> express_in = {});
 
-template<typename F>
-std::string ToMathematica(DegreesOfFreedom<F> const& degrees_of_freedom);
+template<typename F, typename... Qs>
+std::string ToMathematica(DegreesOfFreedom<F> const& degrees_of_freedom,
+                          ExpressIn2<Qs...> express_in = {});
 
 template<typename... Types>
 std::string ToMathematica(std::tuple<Types...> const& tuple);
@@ -131,11 +145,15 @@ template<typename R,
          typename = std::void_t<decltype(std::declval<R>().degrees_of_freedom)>>
 std::string ToMathematica(R ref);
 
+template<typename... Qs>
 std::string ToMathematica(
-    astronomy::OrbitalElements::EquinoctialElements const& elements);
+    astronomy::OrbitalElements::EquinoctialElements const& elements,
+    ExpressIn2<Qs...> express_in = {});
 
 // Returns its argument.
-std::string ToMathematica(std::string const& str);
+template<typename... Qs>
+std::string ToMathematica(std::string const& str,
+                          ExpressIn2<Qs...> express_in = {});
 
 // Wraps the string in quotes.
 // TODO(egg): escape things properly.

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -42,7 +42,7 @@ using quantities::Time;
 
 // A helper class for type erasure of quantities.  It may be used with the
 // functions on this class to remove the dimensions of quantities (we know that
-// Mathematica is sluggish when processing quantities.  Usage:
+// Mathematica is sluggish when processing quantities).  Usage:
 //
 //   ToMathematica(... , ExpressIn(Metre, Second, Degree));
 //
@@ -135,8 +135,10 @@ std::string ToMathematica(std::tuple<Types...> const& tuple);
 
 template<typename R,
          typename = std::void_t<decltype(std::declval<R>().time)>,
-         typename = std::void_t<decltype(std::declval<R>().degrees_of_freedom)>>
-std::string ToMathematica(R ref);
+         typename = std::void_t<decltype(std::declval<R>().degrees_of_freedom)>,
+         typename... Qs>
+std::string ToMathematica(R ref,
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename... Qs>
 std::string ToMathematica(

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -40,37 +40,30 @@ using quantities::Quotient;
 using quantities::Temperature;
 using quantities::Time;
 
+// A helper class for type erasure of quantities.  It may be used with the
+// functions on this class to remove the dimensions of quantities (we know that
+// Mathematica is sluggish when processing quantities.  Usage:
+//
+//   ToMathematica(... , ExpressIn(Metre, Second, Degree));
+//
+// The construction parameters must be for the base units of the SI.  They may
+// be in any order.  If not enough parameters are specified for complete type
+// erasure of the argument, compilation fails.
 template<typename... Qs>
-class ExpressIn2 {
+class ExpressIn {
  public:
   // static_assert
 
   static constexpr bool is_default = sizeof...(Qs) == 0;
 
-  ExpressIn2(Qs const&... qs) : units_(std::make_tuple(qs...)) {}
+  ExpressIn(Qs const&... qs);
 
   template<typename Q>
-  double operator()(Q const& q) const {
-    return Divide<Q::Dimensions::Length, Length>(
-        Divide<Q::Dimensions::Mass, Mass>(
-            Divide<Q::Dimensions::Time, Time>(
-                Divide<Q::Dimensions::Current, Current>(
-                    Divide<Q::Dimensions::Temperature, Temperature>(
-                        Divide<Q::Dimensions::Amount, Amount>(
-                            Divide<Q::Dimensions::LuminousIntensity,
-                                   LuminousIntensity>(
-                                Divide<Q::Dimensions::Angle, Angle>(q))))))));
-  }
+  double operator()(Q const& q) const;
 
- //private:
+ private:
   template<std::int64_t exponent, typename Q1, typename Q2>
-  Quotient<Q2, Exponentiation<Q1, exponent>> Divide(Q2 const& q2) const {
-    if constexpr (exponent == 0) {
-      return q2;
-    } else {
-      return q2 / Pow<exponent>(std::get<Q1>(units_));
-    }
-  }
+  Quotient<Q2, Exponentiation<Q1, exponent>> Divide(Q2 const& q2) const;
 
   std::tuple<Qs...> units_;
 };
@@ -81,61 +74,61 @@ std::string Apply(std::string const& function,
 template<typename T, typename... Qs>
 std::string Option(std::string const& name,
                    T const& right,
-                   ExpressIn2<Qs...> express_in = {});
+                   ExpressIn<Qs...> express_in = {});
 
 template<typename T, typename... Qs>
 std::string Assign(std::string const& name,
                    T const& right,
-                   ExpressIn2<Qs...> express_in = {});
+                   ExpressIn<Qs...> express_in = {});
 
 template<typename T, typename U, typename... Qs>
 std::string PlottableDataset(std::vector<T> const& x,
                              std::vector<U> const& y,
-                             ExpressIn2<Qs...> express_in = {});
+                             ExpressIn<Qs...> express_in = {});
 
 template<typename T, typename... Qs>
 std::string ToMathematica(std::vector<T> const& list,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename It, typename... Qs>
 std::string ToMathematica(It begin, It end,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename... Qs>
 std::string ToMathematica(double real,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename T, int size, typename... Qs>
 std::string ToMathematica(FixedVector<T, size> const& fixed_vector,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename T, typename... Qs>
 std::string ToMathematica(R3Element<T> const& r3_element,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename... Qs>
 std::string ToMathematica(Quaternion const& quaternion,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename D, typename... Qs>
 std::string ToMathematica(Quantity<D> const& quantity,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename S, typename F, typename... Qs>
 std::string ToMathematica(Vector<S, F> const& vector,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename S, typename F, typename... Qs>
 std::string ToMathematica(Bivector<S, F> const& bivector,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename V, typename... Qs>
 std::string ToMathematica(Point<V> const& point,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename F, typename... Qs>
 std::string ToMathematica(DegreesOfFreedom<F> const& degrees_of_freedom,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename... Types>
 std::string ToMathematica(std::tuple<Types...> const& tuple);
@@ -148,36 +141,16 @@ std::string ToMathematica(R ref);
 template<typename... Qs>
 std::string ToMathematica(
     astronomy::OrbitalElements::EquinoctialElements const& elements,
-    ExpressIn2<Qs...> express_in = {});
+    ExpressIn<Qs...> express_in = {});
 
 // Returns its argument.
 template<typename... Qs>
 std::string ToMathematica(std::string const& str,
-                          ExpressIn2<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in = {});
 
 // Wraps the string in quotes.
 // TODO(egg): escape things properly.
 std::string Escape(std::string const& str);
-
-// TODO(phl): This doesn't work well for complex structures like orbital
-// elements or trajectory iterators.  Surely we can do better.
-template<typename T>
-struct RemoveUnit;
-
-template<typename T>
-typename RemoveUnit<T>::Unitless ExpressIn(
-    typename RemoveUnit<T>::Unit const& unit,
-    T const& value);
-
-template<typename V>
-typename RemoveUnit<Point<V>>::Unitless ExpressIn(
-    typename RemoveUnit<Point<V>>::Unit const& unit,
-    Point<V> const& value);
-
-template<typename T>
-typename RemoveUnit<std::vector<T>>::Unitless ExpressIn(
-    typename RemoveUnit<std::vector<T>>::Unit const& unit,
-    std::vector<T> const& values);
 
 }  // namespace internal_mathematica
 
@@ -185,7 +158,6 @@ using internal_mathematica::Apply;
 using internal_mathematica::Assign;
 using internal_mathematica::Escape;
 using internal_mathematica::ExpressIn;
-using internal_mathematica::ExpressIn2;
 using internal_mathematica::Option;
 using internal_mathematica::PlottableDataset;
 using internal_mathematica::ToMathematica;

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -1,9 +1,9 @@
 ﻿
 #pragma once
 
-#include <optional>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "astronomy/orbital_elements.hpp"
@@ -43,20 +43,28 @@ using quantities::Temperature;
 using quantities::Time;
 
 // A helper class for type erasure of quantities.  It may be used with the
-// functions on this file to remove the dimensions of quantities (we know that
+// functions in this file to remove the dimensions of quantities (we know that
 // Mathematica is sluggish when processing quantities).  Usage:
 //
 //   ToMathematica(... , ExpressIn(Metre, Second, Degree));
 //
-// The construction parameters must be for the base units of the SI.  They may
-// be in any order.  If not enough parameters are specified for complete type
-// erasure of the argument, compilation fails.
+// The construction parameters must be for the base SI units.  They may be in
+// any order.  If not enough parameters are specified for complete type erasure
+// of the argument, compilation fails.
 template<typename... Qs>
 class ExpressIn {
  public:
-  // static_assert
-
   static constexpr bool is_default = sizeof...(Qs) == 0;
+
+  // Check that only base SI units are specified.  If a unit is specified
+  // multiple times, the calls to std::get in operator() won't compile.
+  static_assert(
+      is_default ||
+      ((std::is_same_v<Qs, Length> || std::is_same_v<Qs, Mass> ||
+        std::is_same_v<Qs, Time> || std::is_same_v<Qs, Current> ||
+        std::is_same_v<Qs, Temperature> || std::is_same_v<Qs, Amount> ||
+        std::is_same_v<Qs, LuminousIntensity> || std::is_same_v<Qs, Angle>) ||
+       ...));
 
   ExpressIn(Qs const&... qs);
 

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -1,6 +1,7 @@
 ﻿
 #pragma once
 
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -39,7 +40,71 @@ using quantities::Quotient;
 using quantities::Temperature;
 using quantities::Time;
 
-class ExpressIn2;
+class ExpressIn2 {
+public:
+  template<typename... Q>
+  explicit ExpressIn2(Q const&... q) {
+    FillUnits(q...);
+  }
+
+  template<typename Q>
+  double operator()(Q const& q) const {
+    return Divide<Q::Dimensions::Length>(
+        Divide<Q::Dimensions::Mass>(
+            Divide<Q::Dimensions::Time>(
+                Divide<Q::Dimensions::Current>(
+                    Divide<Q::Dimensions::Temperature>(
+                        Divide<Q::Dimensions::Amount>(
+                            Divide<Q::Dimensions::LuminousIntensity>(
+                                Divide<Q::Dimensions::Angle>(
+                                    q, std::get<std::optional<Angle>>(units_)),
+                                std::get<std::optional<LuminousIntensity>>(
+                                    units_)),
+                            std::get<std::optional<Amount>>(units_)),
+                        std::get<std::optional<Temperature>>(units_)),
+                    std::get<std::optional<Current>>(units_)),
+                std::get<std::optional<Time>>(units_)),
+            std::get<std::optional<Mass>>(units_)),
+        std::get<std::optional<Length>>(units_));
+  }
+
+ private:
+  template<std::int64_t exponent, typename QLeft, typename QRight>
+  static Quotient<QLeft, Exponentiation<QRight, exponent>> Divide(
+    QLeft const& q_left,
+    std::optional<QRight> const& q_right) {
+    if constexpr (exponent == 0) {
+      return q_left;
+    }
+    else {
+      CHECK(q_right.has_value()) << "Missing unit to decompose " << q_left;
+      return q_left / Pow<exponent>(q_right.value());
+    }
+  }
+
+
+  template<typename QHead, typename... QTail>
+  void FillUnits(QHead const& qhead, QTail const&... qtail) {
+    // The following will fail to compile if QHead is not one of the units in
+    // units_.
+    auto& unit = std::get<std::optional<QHead>>(units_);
+    CHECK(!unit.has_value()) << qhead << " is a redundant specification";
+    unit = qhead;
+    if constexpr (sizeof...(QTail) > 0) {
+      FillUnits(qtail...);
+    }
+  }
+
+  std::tuple<std::optional<Length>,
+    std::optional<Mass>,
+    std::optional<Time>,
+    std::optional<Current>,
+    std::optional<Temperature>,
+    std::optional<Amount>,
+    std::optional<LuminousIntensity>,
+    std::optional<Angle>>
+    units_;
+};
 
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
@@ -70,14 +135,8 @@ std::string ToMathematica(R3Element<T> const& r3_element);
 std::string ToMathematica(Quaternion const& quaternion);
 
 template<typename D>
-std::string ToMathematica(Quantity<D> const& quantity);
-
-template<typename D>
-std::string ToMathematica(Quantity<D> const& quantity);
-
-template<typename D>
 std::string ToMathematica(Quantity<D> const& quantity,
-                          const ExpressIn2& express_in);
+                          std::optional<ExpressIn2> express_in = std::nullopt);
 
 template<typename S, typename F>
 std::string ToMathematica(Vector<S, F> const& vector);
@@ -108,73 +167,6 @@ std::string ToMathematica(std::string const& str);
 // Wraps the string in quotes.
 // TODO(egg): escape things properly.
 std::string Escape(std::string const& str);
-
-class ExpressIn2 {
- public:
-  template<typename... Q>
-  ExpressIn2(Q const&... q) {
-    if (sizeof...(Q) > 0) {
-      FillUnits(q...);
-    }
-  }
-
-  template<typename Q>
-  double operator()(Q const& q) const {
-    return Divide<Q::Dimensions::Length>(
-        Divide<Q::Dimensions::Mass>(
-            Divide<Q::Dimensions::Time>(
-                Divide<Q::Dimensions::Current>(
-                    Divide<Q::Dimensions::Temperature>(
-                        Divide<Q::Dimensions::Amount>(
-                            Divide<Q::Dimensions::LuminousIntensity>(
-                                Divide<Q::Dimensions::Angle>(
-                                    q, std::get<std::optional<Angle>>(units_)),
-                                std::get<std::optional<LuminousIntensity>>(
-                                    units_)),
-                            std::get<std::optional<Amount>>(units_)),
-                        std::get<std::optional<Temperature>>(units_)),
-                    std::get<std::optional<Current>>(units_)),
-                std::get<std::optional<Time>>(units_)),
-            std::get<std::optional<Mass>>(units_)),
-        std::get<std::optional<Length>>(units_));
-  }
-
- private:
-  template<std::int64_t exponent, typename QLeft, typename QRight>
-  static Quotient<QLeft, Exponentiation<QRight, exponent>> Divide(
-      QLeft const& q_left,
-      std::optional<QRight> const& q_right) {
-    if constexpr (exponent == 0) {
-      return q_left;
-    } else {
-      CHECK(q_right.has_value()) << "Missing unit to decompose " << q_left;
-      return q_left / Pow<exponent>(q_right.value());
-    }
-  }
-
-
-  template<typename QHead, typename... QTail>
-  void FillUnits(QHead const& qhead, QTail const&... qtail) {
-    // The following will fail to compile if QHead is not one of the units in
-    // units_.
-    auto& unit = std::get<std::optional<QHead>>(units_);
-    CHECK(!unit.has_value()) << qhead << " is a redundant specification";
-    unit = qhead;
-    if constexpr (sizeof...(QTail) > 0) {
-      FillUnits(qtail...);
-    }
-  }
-
-  std::tuple<std::optional<Length>,
-             std::optional<Mass>,
-             std::optional<Time>,
-             std::optional<Current>,
-             std::optional<Temperature>,
-             std::optional<Amount>,
-             std::optional<LuminousIntensity>,
-             std::optional<Angle>>
-      units_;
-};
 
 // TODO(phl): This doesn't work well for complex structures like orbital
 // elements or trajectory iterators.  Surely we can do better.

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -50,7 +50,8 @@ using quantities::Time;
 //
 // The construction parameters must be for the base SI units.  They may be in
 // any order.  If not enough parameters are specified for complete type erasure
-// of the argument, compilation fails.
+// of the argument, compilation fails.  An object with no template parameters
+// may be used to indicate that type erasure should not happen.
 template<typename... Qs>
 class ExpressIn {
  public:

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -53,16 +53,12 @@ using quantities::Time;
 // The construction parameters must be values of distinct SI base quantities
 // (or Angle). They define a system of units..  They may be in any order.  If
 // the other arguments of the functions contain quantities that are not spanned
-// by that system of units, the call is ill-formed.  An object with no template
-// parameters may be used to indicate that type erasure should not happen.
+// by that system of units, the call is ill-formed.
 template<typename... Qs>
 class ExpressIn {
  public:
-  static constexpr bool is_default = sizeof...(Qs) == 0;
-
   // Check that only SI base quantities or Angle are specified.
   static_assert(
-      is_default ||
       ((std::is_same_v<Qs, Length> || std::is_same_v<Qs, Mass> ||
         std::is_same_v<Qs, Time> || std::is_same_v<Qs, Current> ||
         std::is_same_v<Qs, Temperature> || std::is_same_v<Qs, Amount> ||
@@ -70,8 +66,7 @@ class ExpressIn {
        ...), "Must instantiate with SI base quantities or Angle");
 
   // Check that all quantities are different.
-  static_assert(is_default || all_different_v<Qs...>,
-                "Must use different quantities");
+  static_assert(all_different_v<Qs...>, "Must use different quantities");
 
   ExpressIn(Qs const&... qs);  // NOLINT(runtime/explicit)
 
@@ -88,87 +83,91 @@ class ExpressIn {
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
 
-template<typename T, typename... Qs>
+template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string Option(std::string const& name,
                    T const& right,
-                   ExpressIn<Qs...> express_in = {});
+                   OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, typename... Qs>
+template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string Assign(std::string const& name,
                    T const& right,
-                   ExpressIn<Qs...> express_in = {});
+                   OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, typename U, typename... Qs>
+template<typename T, typename U, typename OptionalExpressIn = std::nullopt_t>
 std::string PlottableDataset(std::vector<T> const& x,
                              std::vector<U> const& y,
-                             ExpressIn<Qs...> express_in = {});
+                             OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, typename... Qs>
+template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::vector<T> const& list,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename It, typename... Qs>
+template<typename It, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(It begin, It end,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename... Qs>
+template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(double real,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, int size, typename... Qs>
+template<typename T, int size, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(FixedVector<T, size> const& fixed_vector,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, typename... Qs>
+template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(R3Element<T> const& r3_element,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename... Qs>
+template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(Quaternion const& quaternion,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
 template<typename D, typename... Qs>
 std::string ToMathematica(Quantity<D> const& quantity,
-                          ExpressIn<Qs...> express_in = {});
+                          ExpressIn<Qs...> express_in);
 
-template<typename S, typename F, typename... Qs>
+template<typename D, typename OptionalExpressIn = std::nullopt_t>
+std::string ToMathematica(Quantity<D> const& quantity,
+                          std::nullopt_t express_in = std::nullopt);
+
+template<typename S, typename F, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(Vector<S, F> const& vector,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename S, typename F, typename... Qs>
+template<typename S, typename F, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(Bivector<S, F> const& bivector,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename V, typename... Qs>
+template<typename V, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(Point<V> const& point,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename F, typename... Qs>
+template<typename F, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(DegreesOfFreedom<F> const& degrees_of_freedom,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
 template<typename Tuple,
          typename = std::enable_if_t<is_tuple_v<Tuple>>,
-         typename... Qs>
+         typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(Tuple const& tuple,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
 template<typename R,
          typename = std::void_t<decltype(std::declval<R>().time)>,
          typename = std::void_t<decltype(std::declval<R>().degrees_of_freedom)>,
-         typename... Qs>
+         typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(R ref,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
-template<typename... Qs>
+template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(
     astronomy::OrbitalElements::EquinoctialElements const& elements,
-    ExpressIn<Qs...> express_in = {});
+    OptionalExpressIn express_in = std::nullopt);
 
 // Returns its argument.
-template<typename... Qs>
+template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::string const& str,
-                          ExpressIn<Qs...> express_in = {});
+                          OptionalExpressIn express_in = std::nullopt);
 
 // Wraps the string in quotes.
 // TODO(egg): escape things properly.

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -15,6 +15,7 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/quantities.hpp"
+#include "quantities/tuples.hpp"
 
 namespace principia {
 namespace mathematica {
@@ -31,6 +32,7 @@ using quantities::Amount;
 using quantities::Angle;
 using quantities::Current;
 using quantities::Exponentiation;
+using quantities::is_tuple_v;
 using quantities::Length;
 using quantities::LuminousIntensity;
 using quantities::Mass;
@@ -41,7 +43,7 @@ using quantities::Temperature;
 using quantities::Time;
 
 // A helper class for type erasure of quantities.  It may be used with the
-// functions on this class to remove the dimensions of quantities (we know that
+// functions on this file to remove the dimensions of quantities (we know that
 // Mathematica is sluggish when processing quantities).  Usage:
 //
 //   ToMathematica(... , ExpressIn(Metre, Second, Degree));
@@ -130,8 +132,11 @@ template<typename F, typename... Qs>
 std::string ToMathematica(DegreesOfFreedom<F> const& degrees_of_freedom,
                           ExpressIn<Qs...> express_in = {});
 
-template<typename... Types>
-std::string ToMathematica(std::tuple<Types...> const& tuple);
+template<typename Tuple,
+         typename = std::enable_if_t<is_tuple_v<Tuple>>,
+         typename... Qs>
+std::string ToMathematica(Tuple const& tuple,
+                          ExpressIn<Qs...> express_in = {});
 
 template<typename R,
          typename = std::void_t<decltype(std::declval<R>().time)>,

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -130,17 +130,18 @@ std::string ToMathematica(R3Element<T> const& r3_element) {
 }
 
 template<typename D>
-std::string ToMathematica(Quantity<D> const& quantity) {
-  std::string s = DebugString(quantity);
-  if (IsFinite(quantity)) {
-    s.replace(s.find("e"), 1, "*^");
+std::string ToMathematica(Quantity<D> const& quantity,
+                          std::optional<ExpressIn2> express_in) {
+  if (express_in == std::nullopt) {
+    std::string s = DebugString(quantity);
+    std::string const number = ToMathematica(quantity / si::Unit<Quantity<D>>);
+    std::size_t const split = s.find(" ");
+    std::string const units = Escape(s.substr(split, s.size()));
+    return Apply("SetPrecision",
+                 {Apply("Quantity", {number, units}), "$MachinePrecision"});
+  } else {
+    return ToMathematica(express_in.value()(quantity));
   }
-  std::string const number = ToMathematica(quantity / si::Unit<Quantity<D>>);
-  std::size_t const split = s.find(" ");
-  std::string const units = Escape(s.substr(split, s.size()));
-  return Apply(
-      "SetPrecision",
-      {Apply("Quantity", {number, units}), "$MachinePrecision"});
 }
 
 template<typename D>

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -143,6 +143,12 @@ std::string ToMathematica(Quantity<D> const& quantity) {
       {Apply("Quantity", {number, units}), "$MachinePrecision"});
 }
 
+template<typename D>
+std::string ToMathematica(Quantity<D> const& quantity,
+                          const ExpressIn2& express_in) {
+  return ToMathematica(express_in(quantity));
+}
+
 template<typename S, typename F>
 std::string ToMathematica(Vector<S, F> const& vector) {
   return ToMathematica(vector.coordinates());

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -129,10 +129,10 @@ std::string ToMathematica(R3Element<T> const& r3_element) {
   return Apply("List", expressions);
 }
 
-template<typename D>
+template<typename D, typename... Qs>
 std::string ToMathematica(Quantity<D> const& quantity,
-                          std::optional<ExpressIn2> express_in) {
-  if (express_in == std::nullopt) {
+                          ExpressIn2<Qs...> express_in) {
+  if (express_in.is_default()) {
     std::string s = DebugString(quantity);
     std::string const number = ToMathematica(quantity / si::Unit<Quantity<D>>);
     std::size_t const split = s.find(" ");
@@ -140,14 +140,8 @@ std::string ToMathematica(Quantity<D> const& quantity,
     return Apply("SetPrecision",
                  {Apply("Quantity", {number, units}), "$MachinePrecision"});
   } else {
-    return ToMathematica(express_in.value()(quantity));
+    return ToMathematica(express_in(quantity));
   }
-}
-
-template<typename D>
-std::string ToMathematica(Quantity<D> const& quantity,
-                          const ExpressIn2& express_in) {
-  return ToMathematica(express_in(quantity));
 }
 
 template<typename S, typename F>

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -227,8 +227,8 @@ template<typename Tuple, typename, typename OptionalExpressIn>
 std::string ToMathematica(Tuple const& tuple, OptionalExpressIn express_in) {
   std::vector<std::string> expressions;
   expressions.reserve(std::tuple_size_v<Tuple>);
-  TupleHelper<std::tuple_size_v<Tuple>, Tuple, OptionalExpressIn>::ToMathematicaStrings(
-      tuple, expressions, express_in);
+  TupleHelper<std::tuple_size_v<Tuple>, Tuple, OptionalExpressIn>::
+      ToMathematicaStrings(tuple, expressions, express_in);
   return Apply("List", expressions);
 }
 

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -225,12 +225,13 @@ std::string ToMathematica(std::tuple<Types...> const& tuple) {
   return Apply("List", expressions);
 }
 
-template<typename R, typename, typename>
-std::string ToMathematica(R const ref) {
-  return Apply(
-      "List",
-      std::vector<std::string>{ToMathematica(ref.time),
-                               ToMathematica(ref.degrees_of_freedom)});
+template<typename R, typename, typename, typename... Qs>
+std::string ToMathematica(R const ref,
+                          ExpressIn<Qs...> express_in) {
+  return Apply("List",
+               std::vector<std::string>{
+                   ToMathematica(ref.time, express_in),
+                   ToMathematica(ref.degrees_of_freedom, express_in)});
 }
 
 template<typename... Qs>

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -71,8 +71,8 @@ TEST_F(MathematicaTest, ToMathematica) {
   {
     EXPECT_EQ("SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
               ToMathematica(3.0));
-    EXPECT_EQ("SetPrecision[-2.00000000000000000*^+00,$MachinePrecision]",
-              ToMathematica(-2.0));
+    EXPECT_EQ("SetPrecision[-2.00000000000000000*^+09,$MachinePrecision]",
+              ToMathematica(-2.0e9));
     EXPECT_EQ("SetPrecision[-0.00000000000000000*^+00,$MachinePrecision]",
               ToMathematica(-0.0));
   }
@@ -254,10 +254,13 @@ TEST_F(MathematicaTest, Escape) {
 
 TEST_F(MathematicaTest, ExpressIn2) {
   EXPECT_EQ(
-      "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
-      ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
+    "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
+    ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
   EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
-            ToMathematica(1 * Radian, ExpressIn2(Degree)));
+    ToMathematica(1 * Radian, ExpressIn2(Degree)));
+  EXPECT_DEATH({
+      ToMathematica(1 * Radian, ExpressIn2(Metre));
+    }, "Missing unit to decompose");
 }
 
 }  // namespace mathematica

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -380,6 +380,7 @@ TEST_F(MathematicaTest, ExpressIn) {
 // Does not compile, by design.
 #if 0
   ToMathematica(1 * Radian, ExpressIn(Metre));
+  ToMathematica(1 * Radian, ExpressIn(Degree, Metre, Metre));
 #endif
 }
 

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -158,18 +158,18 @@ TEST_F(MathematicaTest, ToMathematica) {
                          8.0 * Metre / Second}))));
   }
   {
-    EXPECT_EQ(
-        "List["
-        "SetPrecision["
-        "Quantity[SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
-        "\" m\"],$MachinePrecision],"
-        "SetPrecision["
-        "Quantity[SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
-        "\" s\"],$MachinePrecision],"
-        "SetPrecision["
-        "Quantity[SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
-        "\" m s^-1\"],$MachinePrecision]]",
-        ToMathematica(std::tuple{1 * Metre, 2 * Second, 3 * Metre / Second}));
+    //EXPECT_EQ(
+    //    "List["
+    //    "SetPrecision["
+    //    "Quantity[SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
+    //    "\" m\"],$MachinePrecision],"
+    //    "SetPrecision["
+    //    "Quantity[SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+    //    "\" s\"],$MachinePrecision],"
+    //    "SetPrecision["
+    //    "Quantity[SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
+    //    "\" m s^-1\"],$MachinePrecision]]",
+    //    ToMathematica(std::tuple{1 * Metre, 2 * Second, 3 * Metre / Second}));
   }
   {
     DiscreteTrajectory<F> trajectory;
@@ -253,14 +253,19 @@ TEST_F(MathematicaTest, Escape) {
 }
 
 TEST_F(MathematicaTest, ExpressIn2) {
-  EXPECT_EQ(
-    "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
-    ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
-  EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
-    ToMathematica(1 * Radian, ExpressIn2(Degree)));
-  EXPECT_DEATH({
-      ToMathematica(1 * Radian, ExpressIn2(Metre));
-    }, "Missing unit to decompose");
+  auto c = ExpressIn2<quantities::Angle>().Divide<1, quantities::Angle>(
+      1 * quantities::si::Radian);
+
+  //auto a = ExpressIn2(Metre, Second);
+  //ExpressIn2<quantities::Length> b;
+  //EXPECT_EQ(
+  //  "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
+  //  ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
+  //EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
+  //  ToMathematica(1 * Radian, ExpressIn2(Degree)));
+  //EXPECT_DEATH({
+  //    ToMathematica(1 * Radian, ExpressIn2(Metre));
+  //  }, "Missing unit to decompose");
 }
 
 }  // namespace mathematica

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -379,7 +379,12 @@ TEST_F(MathematicaTest, ExpressIn) {
 
 // Does not compile, by design.
 #if 0
+  ToMathematica(1 * Radian, "foobar");
+#endif
+#if 0
   ToMathematica(1 * Radian, ExpressIn(Metre));
+#endif
+#if 0
   ToMathematica(1 * Radian, ExpressIn(Degree, Metre, Metre));
 #endif
 }

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -34,6 +34,7 @@ using geometry::Velocity;
 using numerics::FixedVector;
 using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
+using quantities::Speed;
 using quantities::si::Degree;
 using quantities::si::Metre;
 using quantities::si::Radian;
@@ -41,10 +42,10 @@ using quantities::si::Second;
 
 class MathematicaTest : public ::testing::Test {
  protected:
+  using F = Frame<enum class FTag>;
 };
 
 TEST_F(MathematicaTest, ToMathematica) {
-  using F = Frame<enum class FTag>;
   {
     EXPECT_EQ(
         "List["
@@ -143,13 +144,37 @@ TEST_F(MathematicaTest, ToMathematica) {
     EXPECT_EQ(
         "List["
         "List["
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision]],"
+        "\" m\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
+        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],"
+        "$MachinePrecision]],"
         "List["
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[-1.00000000000000000*^+00,$MachinePrecision],"
+        "\" m s^-1\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[-5.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]]",
+        "\" m s^-1\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
+        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision],"
+        "\" m s^-1\"],"
+        "$MachinePrecision]]]",
         ToMathematica(DegreesOfFreedom<F>(
             F::origin +
                 Displacement<F>({2.0 * Metre, 3.0 * Metre, -4.0 * Metre}),
@@ -158,18 +183,18 @@ TEST_F(MathematicaTest, ToMathematica) {
                          8.0 * Metre / Second}))));
   }
   {
-    //EXPECT_EQ(
-    //    "List["
-    //    "SetPrecision["
-    //    "Quantity[SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
-    //    "\" m\"],$MachinePrecision],"
-    //    "SetPrecision["
-    //    "Quantity[SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
-    //    "\" s\"],$MachinePrecision],"
-    //    "SetPrecision["
-    //    "Quantity[SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
-    //    "\" m s^-1\"],$MachinePrecision]]",
-    //    ToMathematica(std::tuple{1 * Metre, 2 * Second, 3 * Metre / Second}));
+    EXPECT_EQ(
+        "List["
+        "SetPrecision["
+        "Quantity[SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],$MachinePrecision],"
+        "SetPrecision["
+        "Quantity[SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "\" s\"],$MachinePrecision],"
+        "SetPrecision["
+        "Quantity[SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
+        "\" m s^-1\"],$MachinePrecision]]",
+        ToMathematica(std::tuple{1 * Metre, 2 * Second, 3 * Metre / Second}));
   }
   {
     DiscreteTrajectory<F> trajectory;
@@ -185,13 +210,37 @@ TEST_F(MathematicaTest, ToMathematica) {
         "List[SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
         "List["
         "List["
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision]],"
+        "\" m\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
+        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],"
+        "$MachinePrecision]],"
         "List["
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[-1.00000000000000000*^+00,$MachinePrecision],"
+        "\" m s^-1\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[-5.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]]]",
+        "\" m s^-1\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity["
+        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision],"
+        "\" m s^-1\"],"
+        "$MachinePrecision]]]]",
         ToMathematica(*trajectory.begin()));
   }
   {
@@ -253,19 +302,28 @@ TEST_F(MathematicaTest, Escape) {
 }
 
 TEST_F(MathematicaTest, ExpressIn2) {
-  auto c = ExpressIn2<quantities::Angle>().Divide<1, quantities::Angle>(
-      1 * quantities::si::Radian);
-
-  //auto a = ExpressIn2(Metre, Second);
-  //ExpressIn2<quantities::Length> b;
-  //EXPECT_EQ(
-  //  "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
-  //  ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
-  //EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
-  //  ToMathematica(1 * Radian, ExpressIn2(Degree)));
-  //EXPECT_DEATH({
-  //    ToMathematica(1 * Radian, ExpressIn2(Metre));
-  //  }, "Missing unit to decompose");
+  ExpressIn2<> default;  // Check that this compiles.
+  {
+    EXPECT_EQ("SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
+              ToMathematica(3.0 * Metre / Second / Second,
+                            ExpressIn2(Metre, Second)));
+    EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
+              ToMathematica(1 * Radian, ExpressIn2(Degree)));
+  }
+  {
+    EXPECT_EQ(
+        "List["
+        "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision]]",
+        ToMathematica(Vector<Speed, F>({2.0 * Metre / Second,
+                                        3.0 * Metre / Second,
+                                        -4.0 * Metre / Second}),
+                      ExpressIn2(Metre, Second)));
+  }
+#if 0
+  ToMathematica(1 * Radian, ExpressIn2(Metre));
+#endif
 }
 
 }  // namespace mathematica

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -326,6 +326,32 @@ TEST_F(MathematicaTest, ExpressIn) {
                                         -4.0 * Metre / Second}),
                       ExpressIn(Metre, Second)));
   }
+  {
+    DiscreteTrajectory<F> trajectory;
+    trajectory.Append(
+        Instant(),
+        DegreesOfFreedom<F>(
+            F::origin +
+                Displacement<F>({2.0 * Metre, 3.0 * Metre, -4.0 * Metre}),
+            Velocity<F>({-1.0 * Metre / Second,
+                         -5.0 * Metre / Second,
+                         8.0 * Metre / Second})));
+    EXPECT_EQ(
+        "List["
+        "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
+        "List["
+        "List["
+        "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[-4.00000000000000000*^+00,$MachinePrecision]],"
+        "List["
+        "SetPrecision[-1.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[-5.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]]]",
+        ToMathematica(*trajectory.begin(), ExpressIn(Metre, Second)));
+  }
+
+// Does not compile, by design.
 #if 0
   ToMathematica(1 * Radian, ExpressIn(Metre));
 #endif

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -207,7 +207,12 @@ TEST_F(MathematicaTest, ToMathematica) {
                          -5.0 * Metre / Second,
                          8.0 * Metre / Second})));
     EXPECT_EQ(
-        "List[SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
+        "List["
+        "SetPrecision["
+        "Quantity["
+        "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
+        "\" s\"],"
+        "$MachinePrecision],"
         "List["
         "List["
         "SetPrecision["
@@ -301,14 +306,14 @@ TEST_F(MathematicaTest, Escape) {
   EXPECT_EQ("\"foo\"", Escape("foo"));
 }
 
-TEST_F(MathematicaTest, ExpressIn2) {
-  ExpressIn2<> default;  // Check that this compiles.
+TEST_F(MathematicaTest, ExpressIn) {
+  ExpressIn<> default;  // Check that this compiles.
   {
     EXPECT_EQ("SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
               ToMathematica(3.0 * Metre / Second / Second,
-                            ExpressIn2(Metre, Second)));
+                            ExpressIn(Metre, Second)));
     EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
-              ToMathematica(1 * Radian, ExpressIn2(Degree)));
+              ToMathematica(1 * Radian, ExpressIn(Degree)));
   }
   {
     EXPECT_EQ(
@@ -319,10 +324,10 @@ TEST_F(MathematicaTest, ExpressIn2) {
         ToMathematica(Vector<Speed, F>({2.0 * Metre / Second,
                                         3.0 * Metre / Second,
                                         -4.0 * Metre / Second}),
-                      ExpressIn2(Metre, Second)));
+                      ExpressIn(Metre, Second)));
   }
 #if 0
-  ToMathematica(1 * Radian, ExpressIn2(Metre));
+  ToMathematica(1 * Radian, ExpressIn(Metre));
 #endif
 }
 

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -34,6 +34,7 @@ using geometry::Velocity;
 using numerics::FixedVector;
 using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
+using quantities::si::Degree;
 using quantities::si::Metre;
 using quantities::si::Radian;
 using quantities::si::Second;
@@ -249,6 +250,14 @@ TEST_F(MathematicaTest, PlottableDataset) {
 
 TEST_F(MathematicaTest, Escape) {
   EXPECT_EQ("\"foo\"", Escape("foo"));
+}
+
+TEST_F(MathematicaTest, ExpressIn2) {
+  EXPECT_EQ(
+      "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]",
+      ToMathematica(3.0 * Metre / Second / Second, ExpressIn2(Metre, Second)));
+  EXPECT_EQ("SetPrecision[+5.72957795130823229*^+01,$MachinePrecision]",
+            ToMathematica(1 * Radian, ExpressIn2(Degree)));
 }
 
 }  // namespace mathematica

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -253,16 +253,26 @@ TEST_F(MathematicaTest, ToMathematica) {
         Instant(), 1 * Metre, 2, 3, 4 * Radian, 5, 6, 7, 8};
     EXPECT_EQ(
         "List["
+        "SetPrecision["
+        "Quantity["
         "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
+        "\" s\"],"
+        "$MachinePrecision],"
+        "SetPrecision["
+        "Quantity[SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
+        "\" m\"],"
+        "$MachinePrecision],"
         "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
         "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[+4.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision["
+        "Quantity[SetPrecision[+4.00000000000000000*^+00,$MachinePrecision],"
+        "\" rad\"],"
+        "$MachinePrecision],"
         "SetPrecision[+5.00000000000000000*^+00,$MachinePrecision],"
         "SetPrecision[+6.00000000000000000*^+00,$MachinePrecision],"
         "SetPrecision[+7.00000000000000000*^+00,$MachinePrecision],"
-        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]"
-    , ToMathematica(elements));
+        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]",
+        ToMathematica(elements));
   }
   {
     EXPECT_EQ("foo\"bar", ToMathematica("foo\"bar"));
@@ -349,6 +359,22 @@ TEST_F(MathematicaTest, ExpressIn) {
         "SetPrecision[-5.00000000000000000*^+00,$MachinePrecision],"
         "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]]]",
         ToMathematica(*trajectory.begin(), ExpressIn(Metre, Second)));
+  }
+  {
+    OrbitalElements::EquinoctialElements elements{
+        Instant(), 1 * Metre, 2, 3, 4 * Radian, 5, 6, 7, 8};
+    EXPECT_EQ(
+        "List["
+        "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+1.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+4.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+5.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+6.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+7.00000000000000000*^+00,$MachinePrecision],"
+        "SetPrecision[+8.00000000000000000*^+00,$MachinePrecision]]",
+        ToMathematica(elements, ExpressIn(Metre, Second, Radian)));
   }
 
 // Does not compile, by design.

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -351,33 +351,46 @@ void ProduceCenturyPlots(Ephemeris<Barycentric>& ephemeris) {
   }
 
   OFStream file(TEMP_DIR / "retrobop_century.generated.wl");
-  file << Assign("laytheTimes", ExpressIn(Second, times_from_epoch[Laythe]));
-  file << Assign("vallTimes", ExpressIn(Second, times_from_epoch[Vall]));
-  file << Assign("tyloTimes", ExpressIn(Second, times_from_epoch[Tylo]));
-  file << Assign("polTimes", ExpressIn(Second, times_from_epoch[Pol]));
-  file << Assign("bopTimes", ExpressIn(Second, times_from_epoch[Bop]));
+  file << Assign("laytheTimes",
+                 ToMathematica(times_from_epoch[Laythe], ExpressIn(Second)));
+  file << Assign("vallTimes",
+                 ToMathematica(times_from_epoch[Vall], ExpressIn(Second)));
+  file << Assign("tyloTimes",
+                 ToMathematica(times_from_epoch[Tylo], ExpressIn(Second)));
+  file << Assign("polTimes",
+                 ToMathematica(times_from_epoch[Pol], ExpressIn(Second)));
+  file << Assign("bopTimes",
+                 ToMathematica(times_from_epoch[Bop], ExpressIn(Second)));
   file << Assign("laytheSeparations",
-                 ExpressIn(Metre, extremal_separations[Laythe]));
+                 ToMathematica(extremal_separations[Laythe], ExpressIn(Metre)));
   file << Assign("vallSeparations",
-                 ExpressIn(Metre, extremal_separations[Vall]));
+                 ToMathematica(extremal_separations[Vall], ExpressIn(Metre)));
   file << Assign("tyloSeparations",
-                 ExpressIn(Metre, extremal_separations[Tylo]));
-  file << Assign("polSeparations", ExpressIn(Metre, extremal_separations[Pol]));
-  file << Assign("bopSeparations", ExpressIn(Metre, extremal_separations[Bop]));
+                 ToMathematica(extremal_separations[Tylo], ExpressIn(Metre)));
+  file << Assign("polSeparations",
+                 ToMathematica(extremal_separations[Pol], ExpressIn(Metre)));
+  file << Assign("bopSeparations",
+                 ToMathematica(extremal_separations[Bop], ExpressIn(Metre)));
 
   file << Assign("bopEccentricities", bop_eccentricities);
-  file << Assign("bopInclinations", ExpressIn(Degree, bop_inclinations));
-  file << Assign("bopNodes", ExpressIn(Degree, bop_nodes));
-  file << Assign("bopArguments", ExpressIn(Degree, bop_arguments_of_periapsis));
+  file << Assign("bopInclinations",
+                 ToMathematica(bop_inclinations, ExpressIn(Degree)));
+  file << Assign("bopNodes", ToMathematica(bop_nodes, ExpressIn(Degree)));
+  file << Assign("bopArguments",
+                 ToMathematica(bop_arguments_of_periapsis, ExpressIn(Degree)));
   file << Assign("bopJacobiEccentricities", bop_jacobi_eccentricities);
   file << Assign("bopJacobiInclinations",
-                 ExpressIn(Degree, bop_jacobi_inclinations));
-  file << Assign("bopJacobiNodes", ExpressIn(Degree, bop_jacobi_nodes));
-  file << Assign("bopJacobiArguments",
-                 ExpressIn(Degree, bop_jacobi_arguments_of_periapsis));
+                 ToMathematica(bop_jacobi_inclinations, ExpressIn(Degree)));
+  file << Assign("bopJacobiNodes",
+                 ToMathematica(bop_jacobi_nodes, ExpressIn(Degree)));
+  file << Assign(
+      "bopJacobiArguments",
+      ToMathematica(bop_jacobi_arguments_of_periapsis, ExpressIn(Degree)));
 
-  file << Assign("tyloBop", ExpressIn(Metre, tylo_bop_separations));
-  file << Assign("polBop", ExpressIn(Metre, pol_bop_separations));
+  file << Assign("tyloBop",
+                 ToMathematica(tylo_bop_separations, ExpressIn(Metre)));
+  file << Assign("polBop",
+                 ToMathematica(pol_bop_separations, ExpressIn(Metre)));
 }
 
 void ComputeHighestMoonError(Ephemeris<Barycentric> const& left,
@@ -428,11 +441,11 @@ void PlotPredictableYears() {
 
   OFStream file(TEMP_DIR / "retrobop_predictable_years.generated.wl");
   file << Assign("barycentricPositions1",
-                 ExpressIn(Metre, barycentric_positions_1_year));
+                 ToMathematica(barycentric_positions_1_year, ExpressIn(Metre)));
   file << Assign("barycentricPositions2",
-                 ExpressIn(Metre, barycentric_positions_2_year));
+                 ToMathematica(barycentric_positions_2_year, ExpressIn(Metre)));
   file << Assign("barycentricPositions5",
-                 ExpressIn(Metre, barycentric_positions_5_year));
+                 ToMathematica(barycentric_positions_5_year, ExpressIn(Metre)));
 }
 
 void PlotCentury() {

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -352,45 +352,45 @@ void ProduceCenturyPlots(Ephemeris<Barycentric>& ephemeris) {
 
   OFStream file(TEMP_DIR / "retrobop_century.generated.wl");
   file << Assign("laytheTimes",
-                 ToMathematica(times_from_epoch[Laythe], ExpressIn(Second)));
+                 times_from_epoch[Laythe], ExpressIn(Second));
   file << Assign("vallTimes",
-                 ToMathematica(times_from_epoch[Vall], ExpressIn(Second)));
+                 times_from_epoch[Vall], ExpressIn(Second));
   file << Assign("tyloTimes",
-                 ToMathematica(times_from_epoch[Tylo], ExpressIn(Second)));
+                 times_from_epoch[Tylo], ExpressIn(Second));
   file << Assign("polTimes",
-                 ToMathematica(times_from_epoch[Pol], ExpressIn(Second)));
+                 times_from_epoch[Pol], ExpressIn(Second));
   file << Assign("bopTimes",
-                 ToMathematica(times_from_epoch[Bop], ExpressIn(Second)));
+                 times_from_epoch[Bop], ExpressIn(Second));
   file << Assign("laytheSeparations",
-                 ToMathematica(extremal_separations[Laythe], ExpressIn(Metre)));
+                 extremal_separations[Laythe], ExpressIn(Metre));
   file << Assign("vallSeparations",
-                 ToMathematica(extremal_separations[Vall], ExpressIn(Metre)));
+                 extremal_separations[Vall], ExpressIn(Metre));
   file << Assign("tyloSeparations",
-                 ToMathematica(extremal_separations[Tylo], ExpressIn(Metre)));
+                 extremal_separations[Tylo], ExpressIn(Metre));
   file << Assign("polSeparations",
-                 ToMathematica(extremal_separations[Pol], ExpressIn(Metre)));
+                 extremal_separations[Pol], ExpressIn(Metre));
   file << Assign("bopSeparations",
-                 ToMathematica(extremal_separations[Bop], ExpressIn(Metre)));
+                 extremal_separations[Bop], ExpressIn(Metre));
 
   file << Assign("bopEccentricities", bop_eccentricities);
   file << Assign("bopInclinations",
-                 ToMathematica(bop_inclinations, ExpressIn(Degree)));
-  file << Assign("bopNodes", ToMathematica(bop_nodes, ExpressIn(Degree)));
+                 bop_inclinations, ExpressIn(Degree));
+  file << Assign("bopNodes",
+                 bop_nodes, ExpressIn(Degree));
   file << Assign("bopArguments",
-                 ToMathematica(bop_arguments_of_periapsis, ExpressIn(Degree)));
+                 bop_arguments_of_periapsis, ExpressIn(Degree));
   file << Assign("bopJacobiEccentricities", bop_jacobi_eccentricities);
   file << Assign("bopJacobiInclinations",
-                 ToMathematica(bop_jacobi_inclinations, ExpressIn(Degree)));
+                 bop_jacobi_inclinations, ExpressIn(Degree));
   file << Assign("bopJacobiNodes",
-                 ToMathematica(bop_jacobi_nodes, ExpressIn(Degree)));
-  file << Assign(
-      "bopJacobiArguments",
-      ToMathematica(bop_jacobi_arguments_of_periapsis, ExpressIn(Degree)));
+                 bop_jacobi_nodes, ExpressIn(Degree));
+  file << Assign("bopJacobiArguments",
+                 bop_jacobi_arguments_of_periapsis, ExpressIn(Degree));
 
   file << Assign("tyloBop",
-                 ToMathematica(tylo_bop_separations, ExpressIn(Metre)));
+                 tylo_bop_separations, ExpressIn(Metre));
   file << Assign("polBop",
-                 ToMathematica(pol_bop_separations, ExpressIn(Metre)));
+                 pol_bop_separations, ExpressIn(Metre));
 }
 
 void ComputeHighestMoonError(Ephemeris<Barycentric> const& left,
@@ -441,11 +441,11 @@ void PlotPredictableYears() {
 
   OFStream file(TEMP_DIR / "retrobop_predictable_years.generated.wl");
   file << Assign("barycentricPositions1",
-                 ToMathematica(barycentric_positions_1_year, ExpressIn(Metre)));
+                 barycentric_positions_1_year, ExpressIn(Metre));
   file << Assign("barycentricPositions2",
-                 ToMathematica(barycentric_positions_2_year, ExpressIn(Metre)));
+                 barycentric_positions_2_year, ExpressIn(Metre));
   file << Assign("barycentricPositions5",
-                 ToMathematica(barycentric_positions_5_year, ExpressIn(Metre)));
+                 barycentric_positions_5_year, ExpressIn(Metre));
 }
 
 void PlotCentury() {


### PR DESCRIPTION
1. All *Mathematica* conversion function now take an `ExpressIn`, for composability, even if they don't use it.
1. `ExpressIn` automatically applies to all types for which `ToMathematica` and related functions apply.
1. All checks are compile-time, so if it compiles it's going to do the right thing.
