### PR TITLE
Detect non-ASCII paths as they confuse Mono

### DIFF
--- a/ksp_plugin_adapter/loader.cs
+++ b/ksp_plugin_adapter/loader.cs
@@ -48,6 +48,13 @@ internal static class Loader {
              string.Join("', '", possible_dll_paths) + "' in directory '" +
              Directory.GetCurrentDirectory() + "'.";
     }
+    foreach (char c in Directory.GetCurrentDirectory()) {
+      if (c >= 128) {
+        return Directory.GetCurrentDirectory() +
+               " contains the non-ASCII character " + c +
+               "; this is known to confuse Mono.";
+      }
+    }
     try {
       loaded_principia_dll_ = true;
       Log.InitGoogleLogging();


### PR DESCRIPTION
Will help users who run into #2548.  Message:
```
The Principia DLL failed to load.
C:\Program Files\Kerbal Space Program\1.9.1- 多体 contains the non-ASCII character 多; this is known to confuse Mono.

Warning: don't load a Principia save before you have fixed this error; it might get damaged.
```