### PR TITLE
A smoother correction

### DIFF
--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -501,14 +501,11 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // This amounts to trusting the direction of the angular momentum with respect
   // to the vessel as given to us by the game.
   // However, mapping L̂_apparent to L̂_actual is essentially singular when either
-  // is 0.  We remedy to that by only performing an attitude correction if its
-  // angle would be less than ω Δt, where ω is the smaller of the two equivalent
-  // angular frequencies |L_actual / I| and |L_apparent / I|.
+  // is 0.  We remedy to that by only performing the full attitude correction if
+  // its angle would be much less than ω Δt, where ω is the geometric mean of
+  // the two equivalent angular frequencies |L_actual / I| and |L_apparent / I|.
   // As a result, as either L tends towards 0, so does the largest attitude
   // correction that we allow.
-  // If the attitude correction would exceed this threshold, we leave the
-  // attitude unchanged, and the correction in angular momentum is effected
-  // solely by a change in angular velocity.
 
   // The correction is computed via an intermediate frame.
   // In the |EquivalentRigidPileUp| reference frame, a rigid body with the same
@@ -516,9 +513,8 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // If no attitude correction is performed, the axes of
   // |EquivalentRigidPileUp|, |ApparentPileUp|, and |NonRotatingPileUp| are
   // identical.
-  // If an attitude correction is performed, the y axis of
-  // |EquivalentRigidPileUp| is the direction of the angular momentum, and the x
-  // axis is the correction axis.
+  // If an attitude correction is performed, the correction occurs between
+  // |ApparentPileUp| and |EquivalentRigidPileUp|.
   // NOTE(egg): while the correction axis is essentially singular at
   // L_apparent = L_actual, the correction itself is only removably singular (as
   // the angle goes to 0).  Since the computation ensured that
@@ -583,17 +579,36 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // The geometric mean of the norms of the equivalent angular velocities; this
   // is zero when either one is zero, and thus it is zero when either angular
   // momentum is zero.
-  AngularFrequency const ω = Sqrt(apparent_equivalent_angular_velocity.Norm() *
-                                  actual_equivalent_angular_velocity.Norm());
+  AngularFrequency const ω =
+      thresholding ? std::min(apparent_equivalent_angular_velocity.Norm(),
+                              actual_equivalent_angular_velocity.Norm())
+                   : Sqrt(apparent_equivalent_angular_velocity.Norm() *
+                          actual_equivalent_angular_velocity.Norm());
   Time const Δt = t - psychohistory_->back().time;
-  Angle const β = thresholding ? Tanh(ω * Δt / α * Radian) * α : α;
+  // This correction angle is bounded by ωΔt (correct at most as fast as the
+  // ship is turning) and by α (correct at most what is needed).
+  // This in particular eliminates the neighbourhood of the singularity where L
+  // is small (and thus ω is small), by using α itself as a scale-free
+  // definition of “small”.
+  Angle const β = thresholding ? (α > ω * Δt ? Angle{} : α)
+                               : Tanh(ω * Δt / α * Radian) * α;
   auto attitude_correction =
       Rotation<ApparentPileUp, EquivalentRigidPileUp>::Identity();
   if (!trivial_rotations) {
-    attitude_correction = Rotation<ApparentPileUp, EquivalentRigidPileUp>(
-        -β,
-        apparent_correction_axis,
-        geometry::DefinesFrame<EquivalentRigidPileUp>{});
+    // An active rotation of angle β around apparent_correction_axis maps 
+    // L̂_apparent to its corrected direction.
+    // TODO(egg): The definitions might be more readable if
+    // |EquivalentRigidPileUp| were defined as in Fubini, with its y axis being
+    // L̂_apparent in |ApparentPileUp| and
+    //   Identity<ApparentPileUp, NonRotatingPileUp>()(
+    //       Rotation<ApparentPileUp, ApparentPileUp>(β)(L̂_apparent));
+    // in |NonRotatingPileUp|.  On the other hand, this would make the
+    // computations even more convoluted.
+    attitude_correction =
+        Rotation<ApparentPileUp, EquivalentRigidPileUp>::Identity() *
+        Rotation<ApparentPileUp, ApparentPileUp>(
+        β,
+        apparent_correction_axis);
   }
   actual_equivalent_angular_velocity =
       angular_momentum_ / Identity<EquivalentRigidPileUp, NonRotatingPileUp>()(
@@ -798,7 +813,7 @@ PileUpFuture::PileUpFuture(not_null<PileUp const*> const pile_up,
 
 bool PileUp::correct_orientation = true;
 bool PileUp::correct_angular_velocity = true;
-bool PileUp::thresholding = true;
+bool PileUp::thresholding = false;
 
 }  // namespace internal_pile_up
 }  // namespace ksp_plugin

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -595,7 +595,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   auto attitude_correction =
       Rotation<ApparentPileUp, EquivalentRigidPileUp>::Identity();
   if (!trivial_rotations) {
-    // An active rotation of angle β around apparent_correction_axis maps 
+    // An active rotation of angle β around apparent_correction_axis maps
     // L̂_apparent to its corrected direction.
     // TODO(egg): The definitions might be more readable if
     // |EquivalentRigidPileUp| were defined as in Fubini, with its y axis being
@@ -630,7 +630,8 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
           RigidTransformation<NonRotatingPileUp, EquivalentRigidPileUp>(
               NonRotatingPileUp::origin,
               EquivalentRigidPileUp::origin,
-              OrthogonalMap<NonRotatingPileUp, EquivalentRigidPileUp>::Identity()),
+              OrthogonalMap<NonRotatingPileUp,
+                            EquivalentRigidPileUp>::Identity()),
           correct_angular_velocity ? actual_equivalent_angular_velocity
                                    : NonRotatingPileUp::nonrotating,
           NonRotatingPileUp::unmoving);

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -585,7 +585,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
                    : Sqrt(apparent_equivalent_angular_velocity.Norm() *
                           actual_equivalent_angular_velocity.Norm());
   Time const Δt = t - psychohistory_->back().time;
-  // This correction angle is bounded by ωΔt (correct at most as fast as the
+  // This correction angle is bounded by ω Δt (correct at most as fast as the
   // ship is turning) and by α (correct at most what is needed).
   // This in particular eliminates the neighbourhood of the singularity where L
   // is small (and thus ω is small), by using α itself as a scale-free
@@ -606,9 +606,7 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
     // computations even more convoluted.
     attitude_correction =
         Rotation<ApparentPileUp, EquivalentRigidPileUp>::Identity() *
-        Rotation<ApparentPileUp, ApparentPileUp>(
-        β,
-        apparent_correction_axis);
+        Rotation<ApparentPileUp, ApparentPileUp>(β, apparent_correction_axis);
   }
   actual_equivalent_angular_velocity =
       angular_momentum_ / Identity<EquivalentRigidPileUp, NonRotatingPileUp>()(

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -247,7 +247,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
           "Correct angular velocity");
       thresholding = UnityEngine.GUILayout.Toggle(
           thresholding,
-          "Only correct orientation slower than ω");
+          "Fubini orientation correction");
       Interface.SetAngularMomentumConservation(
           correct_orientation, correct_angular_velocity, thresholding);
       string trace = null;
@@ -517,7 +517,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   // behaviour.
   private static bool correct_orientation = true;
   private static bool correct_angular_velocity = true;
-  private static bool thresholding = true;
+  private static bool thresholding = false;
   private static readonly bool show_2519_debugging_ui = true;
 
   private static readonly double[] prediction_length_tolerances_ =

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -518,7 +518,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   private static bool correct_orientation = true;
   private static bool correct_angular_velocity = true;
   private static bool thresholding = true;
-  private static readonly bool show_2519_debugging_ui = false;
+  private static readonly bool show_2519_debugging_ui = true;
 
   private static readonly double[] prediction_length_tolerances_ =
       {1e-3, 1e-2, 1e0, 1e1, 1e2, 1e3, 1e4};

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -213,30 +213,32 @@ class PileUpTest : public testing::Test {
   }
 
   void CheckPreAdvanceTimeInvariants(TestablePileUp& pile_up) {
-    EXPECT_THAT(
-        pile_up.actual_part_rigid_motion().at(&p1_)({RigidPart::origin,
-                                                     RigidPart::unmoving}),
-        Componentwise(AlmostEquals(NonRotatingPileUp::origin +
-                                       Displacement<NonRotatingPileUp>(
-                                           {-34.0 / 9.0 * Metre,
-                                            -2.0 / 3.0 * Metre,
-                                            8.0 / 9.0 * Metre}), 1),
-                      AlmostEquals(Velocity<NonRotatingPileUp>(
-                                       {-340.0 / 9.0 * Metre / Second,
-                                        -20.0 / 3.0 * Metre / Second,
-                                        80.0 / 9.0 * Metre / Second}), 8)));
-    EXPECT_THAT(
-        pile_up.actual_part_rigid_motion().at(&p2_)({RigidPart::origin,
-                                                     RigidPart::unmoving}),
-        Componentwise(AlmostEquals(NonRotatingPileUp::origin +
-                                       Displacement<NonRotatingPileUp>(
-                                           {17.0 / 9.0 * Metre,
-                                            1.0 / 3.0 * Metre,
-                                            -4.0 / 9.0 * Metre}), 0),
-                      AlmostEquals(Velocity<NonRotatingPileUp>(
-                                       {170.0 / 9.0 * Metre / Second,
-                                        10.0 / 3.0 * Metre / Second,
-                                        -40.0 / 9.0 * Metre / Second}), 8)));
+    EXPECT_THAT(pile_up.actual_part_rigid_motion().at(&p1_)(
+                    {RigidPart::origin, RigidPart::unmoving}),
+                Componentwise(AlmostEquals(NonRotatingPileUp::origin +
+                                               Displacement<NonRotatingPileUp>(
+                                                   {-34.0 / 9.0 * Metre,
+                                                    -2.0 / 3.0 * Metre,
+                                                    8.0 / 9.0 * Metre}),
+                                           1122),
+                              AlmostEquals(Velocity<NonRotatingPileUp>(
+                                               {-340.0 / 9.0 * Metre / Second,
+                                                -20.0 / 3.0 * Metre / Second,
+                                                80.0 / 9.0 * Metre / Second}),
+                                           1372)));
+    EXPECT_THAT(pile_up.actual_part_rigid_motion().at(&p2_)(
+                    {RigidPart::origin, RigidPart::unmoving}),
+                Componentwise(AlmostEquals(NonRotatingPileUp::origin +
+                                               Displacement<NonRotatingPileUp>(
+                                                   {17.0 / 9.0 * Metre,
+                                                    1.0 / 3.0 * Metre,
+                                                    -4.0 / 9.0 * Metre}),
+                                           1122),
+                              AlmostEquals(Velocity<NonRotatingPileUp>(
+                                               {170.0 / 9.0 * Metre / Second,
+                                                10.0 / 3.0 * Metre / Second,
+                                                -40.0 / 9.0 * Metre / Second}),
+                                           1373)));
     EXPECT_THAT(pile_up.apparent_part_rigid_motion(), IsEmpty());
   }
 
@@ -308,28 +310,30 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
   EXPECT_EQ(p1_.psychohistory_begin(), p1_.psychohistory_end());
   EXPECT_THAT(
       p1_.history_begin()->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {-25.0 / 9.0 * Metre,
-                                          40.0 / 3.0 * Metre,
-                                          101.0 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {-250.0 / 9.0 * Metre / Second,
-                                      400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 16)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({-25.0 / 9.0 * Metre,
+                                                      40.0 / 3.0 * Metre,
+                                                      101.0 / 9.0 * Metre}),
+                       69),
+          AlmostEquals(Velocity<Barycentric>({-250.0 / 9.0 * Metre / Second,
+                                              400.0 / 3.0 * Metre / Second,
+                                              1010.0 / 9.0 * Metre / Second}),
+                       88)));
   EXPECT_EQ(++p2_.history_begin(), p2_.history_end());
   EXPECT_EQ(p2_.psychohistory_begin(), p2_.psychohistory_end());
   EXPECT_THAT(
       p2_.history_begin()->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {26.0 / 9.0 * Metre,
-                                          43.0 / 3.0 * Metre,
-                                          89.0 / 9.0 * Metre}), 0),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {260.0 / 9.0 * Metre / Second,
-                                      430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 8)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({26.0 / 9.0 * Metre,
+                                                      43.0 / 3.0 * Metre,
+                                                      89.0 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({260.0 / 9.0 * Metre / Second,
+                                              430.0 / 3.0 * Metre / Second,
+                                              890.0 / 9.0 * Metre / Second}),
+                       43)));
   EXPECT_EQ(1, pile_up.psychohistory()->Size());
   EXPECT_THAT(
       pile_up.psychohistory()->back().degrees_of_freedom,
@@ -347,26 +351,28 @@ TEST_F(PileUpTest, LifecycleWithIntrinsicForce) {
 
   EXPECT_THAT(
       p1_.degrees_of_freedom(),
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {-25.0 / 9.0 * Metre,
-                                          40.0 / 3.0 * Metre,
-                                          101.0 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {-250.0 / 9.0 * Metre / Second,
-                                      400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 20)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({-25.0 / 9.0 * Metre,
+                                                      40.0 / 3.0 * Metre,
+                                                      101.0 / 9.0 * Metre}),
+                       69),
+          AlmostEquals(Velocity<Barycentric>({-250.0 / 9.0 * Metre / Second,
+                                              400.0 / 3.0 * Metre / Second,
+                                              1010.0 / 9.0 * Metre / Second}),
+                       82)));
   EXPECT_THAT(
       p2_.degrees_of_freedom(),
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {26.0 / 9.0 * Metre,
-                                          43.0 / 3.0 * Metre,
-                                          89.0 / 9.0 * Metre}), 0),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {260.0 / 9.0 * Metre / Second,
-                                      430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 12)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({26.0 / 9.0 * Metre,
+                                                      43.0 / 3.0 * Metre,
+                                                      89.0 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({260.0 / 9.0 * Metre / Second,
+                                              430.0 / 3.0 * Metre / Second,
+                                              890.0 / 9.0 * Metre / Second}),
+                       46)));
 }
 
 // Same as above, but without an intrinsic force.
@@ -439,11 +445,11 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                            Displacement<Barycentric>({-24.1 / 9.0 * Metre,
                                                       40.3 / 3.0 * Metre,
                                                       101.3 / 9.0 * Metre}),
-                       1),
+                       69),
           AlmostEquals(Velocity<Barycentric>({-249.1 / 9.0 * Metre / Second,
                                               400.3 / 3.0 * Metre / Second,
                                               1010.3 / 9.0 * Metre / Second}),
-                       16)));
+                       86)));
   EXPECT_THAT(
       (++p1_.history_begin())->degrees_of_freedom,
       Componentwise(
@@ -451,57 +457,61 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                            Displacement<Barycentric>({-23.2 / 9.0 * Metre,
                                                       40.6 / 3.0 * Metre,
                                                       101.6 / 9.0 * Metre}),
-                       1),
+                       69),
           AlmostEquals(Velocity<Barycentric>({-248.2 / 9.0 * Metre / Second,
                                               400.6 / 3.0 * Metre / Second,
                                               1010.6 / 9.0 * Metre / Second}),
-                       17)));
+                       88)));
   EXPECT_THAT(
       p1_.psychohistory_begin()->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {-25.0 / 9.0 * Metre,
-                                          40.0 / 3.0 * Metre,
-                                          101.0 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {-250.0 / 9.0 * Metre / Second,
-                                      400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 16)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({-25.0 / 9.0 * Metre,
+                                                      40.0 / 3.0 * Metre,
+                                                      101.0 / 9.0 * Metre}),
+                       69),
+          AlmostEquals(Velocity<Barycentric>({-250.0 / 9.0 * Metre / Second,
+                                              400.0 / 3.0 * Metre / Second,
+                                              1010.0 / 9.0 * Metre / Second}),
+                       88)));
   EXPECT_EQ(++(++p2_.history_begin()), p2_.history_end());
   EXPECT_EQ(++p2_.psychohistory_begin(), p2_.psychohistory_end());
   EXPECT_THAT(
       p2_.history_begin()->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {26.9 / 9.0 * Metre,
-                                          43.3 / 3.0 * Metre,
-                                          89.3 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {260.9 / 9.0 * Metre / Second,
-                                      430.3 / 3.0 * Metre / Second,
-                                      890.3 / 9.0 * Metre / Second}), 8)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({26.9 / 9.0 * Metre,
+                                                      43.3 / 3.0 * Metre,
+                                                      89.3 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({260.9 / 9.0 * Metre / Second,
+                                              430.3 / 3.0 * Metre / Second,
+                                              890.3 / 9.0 * Metre / Second}),
+                       44)));
   EXPECT_THAT(
       (++p2_.history_begin())->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {27.8 / 9.0 * Metre,
-                                          43.6 / 3.0 * Metre,
-                                          89.6 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {261.8 / 9.0 * Metre / Second,
-                                      430.6 / 3.0 * Metre / Second,
-                                      890.6 / 9.0 * Metre / Second}), 8)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({27.8 / 9.0 * Metre,
+                                                      43.6 / 3.0 * Metre,
+                                                      89.6 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({261.8 / 9.0 * Metre / Second,
+                                              430.6 / 3.0 * Metre / Second,
+                                              890.6 / 9.0 * Metre / Second}),
+                       42)));
   EXPECT_THAT(
       p2_.psychohistory_begin()->degrees_of_freedom,
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {26.0 / 9.0 * Metre,
-                                          43.0 / 3.0 * Metre,
-                                          89.0 / 9.0 * Metre}), 0),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {260.0 / 9.0 * Metre / Second,
-                                      430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 8)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({26.0 / 9.0 * Metre,
+                                                      43.0 / 3.0 * Metre,
+                                                      89.0 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({260.0 / 9.0 * Metre / Second,
+                                              430.0 / 3.0 * Metre / Second,
+                                              890.0 / 9.0 * Metre / Second}),
+                       43)));
   EXPECT_EQ(2, pile_up.psychohistory()->Size());
   EXPECT_THAT(
       pile_up.psychohistory()->front().degrees_of_freedom,
@@ -530,15 +540,16 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
 
   EXPECT_THAT(
       p1_.degrees_of_freedom(),
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {-25.0 / 9.0 * Metre,
-                                          40.0 / 3.0 * Metre,
-                                          101.0 / 9.0 * Metre}), 1),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {-250.0 / 9.0 * Metre / Second,
-                                      400.0 / 3.0 * Metre / Second,
-                                      1010.0 / 9.0 * Metre / Second}), 20)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({-25.0 / 9.0 * Metre,
+                                                      40.0 / 3.0 * Metre,
+                                                      101.0 / 9.0 * Metre}),
+                       69),
+          AlmostEquals(Velocity<Barycentric>({-250.0 / 9.0 * Metre / Second,
+                                              400.0 / 3.0 * Metre / Second,
+                                              1010.0 / 9.0 * Metre / Second}),
+                       82)));
   EXPECT_THAT(
       p2_.degrees_of_freedom(),
       Componentwise(AlmostEquals(Barycentric::origin +

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -561,7 +561,7 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
           AlmostEquals(Velocity<Barycentric>({260.0 / 9.0 * Metre / Second,
                                               430.0 / 3.0 * Metre / Second,
                                               890.0 / 9.0 * Metre / Second}),
-                       36)));
+                       46)));
 }
 
 TEST_F(PileUpTest, MidStepIntrinsicForce) {

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -552,15 +552,16 @@ TEST_F(PileUpTest, LifecycleWithoutIntrinsicForce) {
                        82)));
   EXPECT_THAT(
       p2_.degrees_of_freedom(),
-      Componentwise(AlmostEquals(Barycentric::origin +
-                                     Displacement<Barycentric>(
-                                         {26.0 / 9.0 * Metre,
-                                          43.0 / 3.0 * Metre,
-                                          89.0 / 9.0 * Metre}), 0),
-                    AlmostEquals(Velocity<Barycentric>(
-                                     {260.0 / 9.0 * Metre / Second,
-                                      430.0 / 3.0 * Metre / Second,
-                                      890.0 / 9.0 * Metre / Second}), 12)));
+      Componentwise(
+          AlmostEquals(Barycentric::origin +
+                           Displacement<Barycentric>({26.0 / 9.0 * Metre,
+                                                      43.0 / 3.0 * Metre,
+                                                      89.0 / 9.0 * Metre}),
+                       35),
+          AlmostEquals(Velocity<Barycentric>({260.0 / 9.0 * Metre / Second,
+                                              430.0 / 3.0 * Metre / Second,
+                                              890.0 / 9.0 * Metre / Second}),
+                       36)));
 }
 
 TEST_F(PileUpTest, MidStepIntrinsicForce) {


### PR DESCRIPTION
The thresholding toggle now switches between this behaviour when off and the Fubini behaviour + PID  (as in test2550) when on.

There seems to be an improvement: in the save given in https://github.com/mockingbirdnest/Principia/issues/2519#issuecomment-612605437, the vessel now explodes on reentry as it does in stock (the oscillations no longer slow it down enough for it to make it to the water unharmed).
However:
1. the oscillations on descent are still larger than in stock;
2. the westward drift on ascent is larger than in Fubini (where it was larger than in Frobenius).

Perhaps some PID tuning might help with those issues (especially 1).