### PR TITLE
Change Forkable to distinguish two kinds of iterators

### DIFF
--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -200,6 +200,8 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   bool timeline_empty() const override;
   std::int64_t timeline_size() const override;
 
+  TimelineDurableConstIterator MakeDurable(
+      TimelineEphemeralConstIterator it) const override;
   TimelineEphemeralConstIterator MakeEphemeral(
       TimelineDurableConstIterator it) const override;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -189,11 +189,11 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
 
   TimelineDurableConstIterator timeline_begin() const override;
   TimelineDurableConstIterator timeline_end() const override;
-  TimelineDurableConstIterator timeline_find(
-      Instant const& time) const override;
 
   TimelineEphemeralConstIterator timeline_ephemeral_begin() const override;
   TimelineEphemeralConstIterator timeline_ephemeral_end() const override;
+  TimelineEphemeralConstIterator timeline_ephemeral_find(
+      Instant const& time) const override;
   TimelineEphemeralConstIterator timeline_ephemeral_lower_bound(
       Instant const& time) const override;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -191,11 +191,11 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   TimelineDurableConstIterator timeline_end() const override;
   TimelineDurableConstIterator timeline_find(
       Instant const& time) const override;
-  TimelineDurableConstIterator timeline_lower_bound(
-      Instant const& time) const override;
 
   TimelineEphemeralConstIterator timeline_ephemeral_begin() const override;
   TimelineEphemeralConstIterator timeline_ephemeral_end() const override;
+  TimelineEphemeralConstIterator timeline_ephemeral_lower_bound(
+      Instant const& time) const override;
 
   bool timeline_empty() const override;
   std::int64_t timeline_size() const override;

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -384,12 +384,6 @@ DiscreteTrajectory<Frame>::timeline_end() const {
 }
 
 template<typename Frame>
-typename DiscreteTrajectory<Frame>::TimelineDurableConstIterator
-DiscreteTrajectory<Frame>::timeline_find(Instant const& time) const {
-  return timeline_.find(time);
-}
-
-template<typename Frame>
 typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
 DiscreteTrajectory<Frame>::timeline_ephemeral_begin() const {
   return timeline_.begin();
@@ -399,6 +393,12 @@ template<typename Frame>
 typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
 DiscreteTrajectory<Frame>::timeline_ephemeral_end() const {
   return timeline_.end();
+}
+
+template<typename Frame>
+typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
+DiscreteTrajectory<Frame>::timeline_ephemeral_find(Instant const& time) const {
+  return timeline_.find(time);
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -418,6 +418,13 @@ std::int64_t DiscreteTrajectory<Frame>::timeline_size() const {
 }
 
 template<typename Frame>
+typename DiscreteTrajectory<Frame>::TimelineDurableConstIterator
+DiscreteTrajectory<Frame>::MakeDurable(
+    TimelineEphemeralConstIterator const it) const {
+  return it;
+}
+
+template<typename Frame>
 typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
 DiscreteTrajectory<Frame>::MakeEphemeral(
     TimelineDurableConstIterator const it) const {

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -390,12 +390,6 @@ DiscreteTrajectory<Frame>::timeline_find(Instant const& time) const {
 }
 
 template<typename Frame>
-typename DiscreteTrajectory<Frame>::TimelineDurableConstIterator
-DiscreteTrajectory<Frame>::timeline_lower_bound(Instant const& time) const {
-  return timeline_.lower_bound(time);
-}
-
-template<typename Frame>
 typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
 DiscreteTrajectory<Frame>::timeline_ephemeral_begin() const {
   return timeline_.begin();
@@ -405,6 +399,13 @@ template<typename Frame>
 typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
 DiscreteTrajectory<Frame>::timeline_ephemeral_end() const {
   return timeline_.end();
+}
+
+template<typename Frame>
+typename DiscreteTrajectory<Frame>::TimelineEphemeralConstIterator
+DiscreteTrajectory<Frame>::timeline_ephemeral_lower_bound(
+    Instant const& time) const {
+  return timeline_.lower_bound(time);
 }
 
 template<typename Frame>

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -29,17 +29,25 @@ using geometry::Instant;
 // and Forkable may then be instantiated using ForkableIterator.
 // The template parameters with 1337 names are those that participate in this
 // mutual CRTP.
-//TODO(phl):fix
+//
 // Both classes have a Traits template parameter that gathers common
 // implementation properties.  The Traits class must export declarations similar
 // to the following:
 //   using Timeline = ...;
-//   using TimelineConstIterator = ...;
-//   static Instant const& time(TimelineConstIterator it);
+//   using TimelineDurableConstIterator = ...;
+//   using TimelineEphemeralConstIterator = ...;
+//   static Instant const& time(TimelineDurableConstIterator it);
+//   static Instant const& time(TimelineEphemeralConstIterator it);
+//   friend bool operator==(TimelineDurableConstIterator left,
+//                          TimelineDurableConstIterator right);
+//   friend bool operator!=(TimelineDurableConstIterator left,
+//                          TimelineDurableConstIterator right);
 //
-// TimelineConstIterator must be an STL-like iterator in the timeline of
-// Tr4jectory.  |time()| must return the corresponding time.  Iterators must be
-// STL-like and *must*not* be invalidated when the trajectory changes.
+// TimelineDurableConstIterator must designate a point in the trajectory and
+// *must*not* be invalidated by changes to the trajectory.
+// TimelineEphemeralConstIterator must be an STL-like iterator in the timeline
+// of Tr4jectory; it may be invalidated by changes to the trajectory.
+// |time()| must return the corresponding time.
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 class Forkable;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -160,12 +160,12 @@ class Forkable {
   // Durable STL-like operations.
   virtual TimelineDurableConstIterator timeline_begin() const = 0;
   virtual TimelineDurableConstIterator timeline_end() const = 0;
-  virtual TimelineDurableConstIterator timeline_find(
-      Instant const& time) const = 0;
 
   // Ephemeral STL-like operations.
   virtual TimelineEphemeralConstIterator timeline_ephemeral_begin() const = 0;
   virtual TimelineEphemeralConstIterator timeline_ephemeral_end() const = 0;
+  virtual TimelineEphemeralConstIterator timeline_ephemeral_find(
+      Instant const& time) const = 0;
   virtual TimelineEphemeralConstIterator timeline_ephemeral_lower_bound(
       Instant const& time) const = 0;
 
@@ -189,7 +189,7 @@ class Forkable {
   // trajectory.  Deleting the parent trajectory deletes all child trajectories.
   // |timeline_it| may be at end if it denotes the fork time of this object.
   not_null<Tr4jectory*> NewFork(
-      TimelineDurableConstIterator const& timeline_it);
+      TimelineEphemeralConstIterator const& timeline_it);
 
   // |fork| must be a non-empty root and its first point must be at the same
   // time as the last point of this object.  |fork| is attached to this object

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -146,6 +146,8 @@ class Forkable {
   bool Empty() const;
 
  protected:
+  using TimelineDurableConstIterator =
+      typename Traits::TimelineDurableConstIterator;
   using TimelineEphemeralConstIterator =
       typename Traits::TimelineEphemeralConstIterator;
 
@@ -164,6 +166,12 @@ class Forkable {
       Instant const& time) const = 0;
   virtual bool timeline_empty() const = 0;
   virtual std::int64_t timeline_size() const = 0;
+
+  // Iterator conversion.
+  virtual TimelineDurableConstIterator MakeDurable(
+      TimelineEphemeralConstIterator it) const = 0;
+  virtual TimelineEphemeralConstIterator MakeEphemeral(
+      TimelineDurableConstIterator it) const = 0;
 
  protected:
   // The API that subclasses may use to implement their public operations.
@@ -210,9 +218,6 @@ class Forkable {
                               std::vector<Tr4jectory**> const& forks);
 
  private:
-  using TimelineDurableConstIterator =
-      typename Traits::TimelineDurableConstIterator;
-
   // Constructs an Iterator by wrapping the timeline iterator
   // |position_in_ancestor_timeline| which must be an iterator in the timeline
   // of |ancestor|.  |ancestor| must be an ancestor of this trajectory
@@ -220,7 +225,7 @@ class Forkable {
   // end if it is an iterator in this object (and |ancestor| is this object).
   It3rator Wrap(
       not_null<Tr4jectory const*> ancestor,
-      TimelineEphemeralConstIterator position_in_ancestor_timeline) const;
+      TimelineDurableConstIterator position_in_ancestor_timeline) const;
 
   // There may be several forks starting from the same time, hence the multimap.
   // A level of indirection is needed to avoid referencing an incomplete type in

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -158,16 +158,17 @@ class Forkable {
   virtual not_null<Tr4jectory const*> that() const = 0;
 
   // Durable STL-like operations.
-  virtual TimelineDurableConstIterator timeline_durable_begin() const = 0;
-  virtual TimelineDurableConstIterator timeline_durable_end() const = 0;
-  virtual TimelineDurableConstIterator timeline_durable_find(
+  virtual TimelineDurableConstIterator timeline_begin() const = 0;
+  virtual TimelineDurableConstIterator timeline_end() const = 0;
+  virtual TimelineDurableConstIterator timeline_find(
       Instant const& time) const = 0;
-  virtual TimelineDurableConstIterator timeline_durable_lower_bound(
+  virtual TimelineDurableConstIterator timeline_lower_bound(
       Instant const& time) const = 0;
 
   // Ephemeral STL-like operations.
-  virtual TimelineEphemeralConstIterator timeline_begin() const = 0;
-  virtual TimelineEphemeralConstIterator timeline_end() const = 0;
+  virtual TimelineEphemeralConstIterator timeline_ephemeral_begin() const = 0;
+  virtual TimelineEphemeralConstIterator timeline_ephemeral_end() const = 0;
+
   virtual bool timeline_empty() const = 0;
   virtual std::int64_t timeline_size() const = 0;
 

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -173,6 +173,8 @@ class Forkable {
   virtual std::int64_t timeline_size() const = 0;
 
   // Iterator conversion.
+  virtual TimelineDurableConstIterator MakeDurable(
+      TimelineEphemeralConstIterator it) const = 0;
   virtual TimelineEphemeralConstIterator MakeEphemeral(
       TimelineDurableConstIterator it) const = 0;
 

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -162,12 +162,12 @@ class Forkable {
   virtual TimelineDurableConstIterator timeline_end() const = 0;
   virtual TimelineDurableConstIterator timeline_find(
       Instant const& time) const = 0;
-  virtual TimelineDurableConstIterator timeline_lower_bound(
-      Instant const& time) const = 0;
 
   // Ephemeral STL-like operations.
   virtual TimelineEphemeralConstIterator timeline_ephemeral_begin() const = 0;
   virtual TimelineEphemeralConstIterator timeline_ephemeral_end() const = 0;
+  virtual TimelineEphemeralConstIterator timeline_ephemeral_lower_bound(
+      Instant const& time) const = 0;
 
   virtual bool timeline_empty() const = 0;
   virtual std::int64_t timeline_size() const = 0;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -157,19 +157,21 @@ class Forkable {
   virtual not_null<Tr4jectory*> that() = 0;
   virtual not_null<Tr4jectory const*> that() const = 0;
 
-  // STL-like operations.
+  // Durable STL-like operations.
+  virtual TimelineDurableConstIterator timeline_durable_begin() const = 0;
+  virtual TimelineDurableConstIterator timeline_durable_end() const = 0;
+  virtual TimelineDurableConstIterator timeline_durable_find(
+      Instant const& time) const = 0;
+  virtual TimelineDurableConstIterator timeline_durable_lower_bound(
+      Instant const& time) const = 0;
+
+  // Ephemeral STL-like operations.
   virtual TimelineEphemeralConstIterator timeline_begin() const = 0;
   virtual TimelineEphemeralConstIterator timeline_end() const = 0;
-  virtual TimelineEphemeralConstIterator timeline_find(
-      Instant const& time) const = 0;
-  virtual TimelineEphemeralConstIterator timeline_lower_bound(
-      Instant const& time) const = 0;
   virtual bool timeline_empty() const = 0;
   virtual std::int64_t timeline_size() const = 0;
 
   // Iterator conversion.
-  virtual TimelineDurableConstIterator MakeDurable(
-      TimelineEphemeralConstIterator it) const = 0;
   virtual TimelineEphemeralConstIterator MakeEphemeral(
       TimelineDurableConstIterator it) const = 0;
 
@@ -184,7 +186,7 @@ class Forkable {
   // trajectory.  Deleting the parent trajectory deletes all child trajectories.
   // |timeline_it| may be at end if it denotes the fork time of this object.
   not_null<Tr4jectory*> NewFork(
-      TimelineEphemeralConstIterator const& timeline_it);
+      TimelineDurableConstIterator const& timeline_it);
 
   // |fork| must be a non-empty root and its first point must be at the same
   // time as the last point of this object.  |fork| is attached to this object

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -72,8 +72,6 @@ class ForkableIterator {
  protected:
   using TimelineDurableConstIterator =
       typename Traits::TimelineDurableConstIterator;
-  using TimelineEphemeralConstIterator =
-      typename Traits::TimelineEphemeralConstIterator;
 
   // The API that must be implemented by subclasses.
   // Must return |this| of the proper type.
@@ -180,7 +178,7 @@ class Forkable {
   virtual bool timeline_empty() const = 0;
   virtual std::int64_t timeline_size() const = 0;
 
-  // Iterator conversion.
+  // Iterator conversions.
   virtual TimelineDurableConstIterator MakeDurable(
       TimelineEphemeralConstIterator it) const = 0;
   virtual TimelineEphemeralConstIterator MakeEphemeral(

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -57,7 +57,8 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator++() {
       // forks at that time so we must skip them until we find a fork that is at
       // a different time or the end of the children.
       do {
-        current_ = child->timeline_begin();  // May be at end.
+        current_ =
+            Traits::MakeDurable(child->timeline_begin());  // May be at end.
         ancestry_.pop_front();
         if (++ancestry_it == ancestry_.end()) {
           break;
@@ -102,7 +103,7 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator--() {
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 typename ForkableIterator<Tr4jectory, It3rator, Traits>::
-TimelineConstIterator const&
+TimelineDurableConstIterator const&
 ForkableIterator<Tr4jectory, It3rator, Traits>::current() const {
   return current_;
 }
@@ -188,7 +189,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
   not_null<Tr4jectory const*> const ancestor = that();
   It3rator iterator;
   iterator.ancestry_.push_front(ancestor);
-  iterator.current_ = ancestor->timeline_end();
+  iterator.current_ = MakeDurable(ancestor->timeline_end());
   iterator.CheckNormalizedIfEnd();
   return iterator;
 }
@@ -221,10 +222,11 @@ Find(Instant const& time) const {
     iterator.ancestry_.push_front(ancestor);
     if (!ancestor->timeline_empty() &&
         Traits::time(ancestor->timeline_begin()) <= time) {
-      iterator.current_ = ancestor->timeline_find(time);  // May be at end.
+      iterator.current_ =
+          Traits::MakeDurable(ancestor->timeline_find(time));  // May be at end.
       break;
     }
-    iterator.current_ = ancestor->timeline_end();
+    iterator.current_ = MakeDurable(ancestor->timeline_end());
     ancestor = ancestor->parent_;
   } while (ancestor != nullptr);
 
@@ -346,7 +348,7 @@ bool Forkable<Tr4jectory, It3rator, Traits>::Empty() const {
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::NewFork(
-    TimelineConstIterator const& timeline_it) {
+    TimelineEphemeralConstIterator const& timeline_it) {
   // First create a child in the multimap.
   Instant time;
   if (timeline_it == timeline_end()) {
@@ -503,7 +505,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
 template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator Forkable<Tr4jectory, It3rator, Traits>::Wrap(
     not_null<const Tr4jectory*> const ancestor,
-    TimelineConstIterator const position_in_ancestor_timeline) const {
+    TimelineEphemeralConstIterator const position_in_ancestor_timeline) const {
   It3rator iterator;
 
   // Go up the ancestry chain until we find |ancestor| and set |current_| to

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -527,8 +527,8 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::Wrap(
   It3rator iterator;
 
   // Go up the ancestry chain until we find |ancestor| and set |current_| to
-  // |position_in_ancestor_timeline|.  The ancestry has |forkable|
-  // at the back, and the object containing |current_| at the front.
+  // |position_in_ancestor_timeline|.  The ancestry has |that()| at the back,
+  // and the object containing |current_| at the front.
   not_null<Tr4jectory const*> ancest0r = that();
   do {
     iterator.ancestry_.push_front(ancest0r);
@@ -537,7 +537,6 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::Wrap(
       iterator.CheckNormalizedIfEnd();
       return iterator;
     }
-    iterator.current_ = ancest0r->timeline_end();
     ancest0r = ancest0r->parent_;
   } while (ancest0r != nullptr);
 

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -57,8 +57,7 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator++() {
       // forks at that time so we must skip them until we find a fork that is at
       // a different time or the end of the children.
       do {
-        current_ =
-            child->MakeDurable(child->timeline_begin());  // May be at end.
+        current_ = child->timeline_durable_begin();  // May be at end.
         ancestry_.pop_front();
         if (++ancestry_it == ancestry_.end()) {
           break;
@@ -114,8 +113,7 @@ void ForkableIterator<Tr4jectory, It3rator, Traits>::NormalizeIfEnd() {
   if (current_ == ancestry_.front()->timeline_end() &&
       ancestry_.size() > 1) {
     ancestry_.erase(ancestry_.begin(), --ancestry_.end());
-    auto const ancestor = ancestry_.front();
-    current_ = ancestor->MakeDurable(ancestor->timeline_end());
+    current_ = ancestry_.front()->timeline_durable_end();
   }
 }
 
@@ -182,7 +180,7 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::parent() {
 template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator Forkable<Tr4jectory, It3rator, Traits>::begin() const {
   not_null<Tr4jectory const*> ancestor = root();
-  return Wrap(ancestor, ancestor->MakeDurable(ancestor->timeline_begin()));
+  return Wrap(ancestor, ancestor->timeline_durable_begin());
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -190,7 +188,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
   not_null<Tr4jectory const*> const ancestor = that();
   It3rator iterator;
   iterator.ancestry_.push_front(ancestor);
-  iterator.current_ = ancestor->MakeDurable(ancestor->timeline_end());
+  iterator.current_ = ancestor->timeline_durable_end();
   iterator.CheckNormalizedIfEnd();
   return iterator;
 }
@@ -223,11 +221,11 @@ Find(Instant const& time) const {
     iterator.ancestry_.push_front(ancestor);
     if (!ancestor->timeline_empty() &&
         Traits::time(ancestor->timeline_begin()) <= time) {
-      iterator.current_ = ancestor->MakeDurable(
-          ancestor->timeline_find(time));  // May be at end.
+      iterator.current_ =
+          ancestor->timeline_durable_find(time);  // May be at end.
       break;
     }
-    iterator.current_ = ancestor->MakeDurable(ancestor->timeline_end());
+    iterator.current_ = ancestor->timeline_durable_end();
     ancestor = ancestor->parent_;
   } while (ancestor != nullptr);
 
@@ -255,8 +253,7 @@ LowerBound(Instant const& time) const {
         Traits::time(ancestor->timeline_begin()) <= time) {
       // We have found a timeline that covers |time|.  Find where |time| falls
       // in that timeline (that may be after the end).
-      iterator.current_ =
-          ancestor->MakeDurable(ancestor->timeline_lower_bound(time));
+      iterator.current_ = ancestor->timeline_durable_lower_bound(time);
 
       // Check if the returned iterator is directly usable.
       auto const& fork_point = fork_points.front();
@@ -267,7 +264,7 @@ LowerBound(Instant const& time) const {
         // |time| is after the end of this timeline or after the |fork_point|
         // (if any).  We may have to return an |End| iterator, so let's prepare
         // |iterator.current_| for that case.
-        iterator.current_ = ancestor->MakeDurable(ancestor->timeline_end());
+        iterator.current_ = ancestor->timeline_durable_end();
 
         // Check if we have a more nested fork with a point before |time|.  Go
         // down the ancestry looking for a timeline that is nonempty and not
@@ -290,9 +287,7 @@ LowerBound(Instant const& time) const {
             // not forked at the fork point of its parent.  Cut the ancestry and
             // return the beginning of that timeline.
             iterator.ancestry_.erase(iterator.ancestry_.begin(), ancestry_it);
-            auto const ancestor = *ancestry_it;
-            iterator.current_ =
-                ancestor->MakeDurable(ancestor->timeline_begin());
+            iterator.current_ = (*ancestry_it)->timeline_durable_begin();
             break;
           }
         }
@@ -300,7 +295,7 @@ LowerBound(Instant const& time) const {
       break;
     }
     fork_points.push_front(ancestor->position_in_parent_timeline_);
-    iterator.current_ = ancestor->MakeDurable(ancestor->timeline_begin());
+    iterator.current_ = ancestor->timeline_durable_begin();
     ancestor = ancestor->parent_;
   } while (ancestor != nullptr);
 
@@ -353,7 +348,7 @@ bool Forkable<Tr4jectory, It3rator, Traits>::Empty() const {
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::NewFork(
-    TimelineEphemeralConstIterator const& timeline_it) {
+    TimelineDurableConstIterator const& timeline_it) {
   // First create a child in the multimap.
   Instant time;
   if (timeline_it == timeline_end()) {
@@ -368,8 +363,7 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::NewFork(
   std::unique_ptr<Tr4jectory> const& child_forkable = child_it->second;
   child_forkable->parent_ = that();
   child_forkable->position_in_parent_children_ = child_it;
-  child_forkable->position_in_parent_timeline_ =
-      that()->MakeDurable(timeline_it);
+  child_forkable->position_in_parent_timeline_ = timeline_it;
 
   return child_forkable.get();
 }
@@ -379,8 +373,8 @@ void Forkable<Tr4jectory, It3rator, Traits>::AttachForkToCopiedBegin(
     not_null<std::unique_ptr<Tr4jectory>> fork) {
   CHECK(fork->is_root());
   CHECK(!fork->timeline_empty());
-  auto const fork_timeline_begin = fork->timeline_begin();
-  auto const fork_timeline_end = fork->timeline_end();
+  auto const fork_timeline_begin = fork->timeline_durable_begin();
+  auto const fork_timeline_end = fork->timeline_durable_end();
 
   // The children of |fork| whose |position_in_parent_timeline_| was at
   // |begin()| are referencing a point that will soon be removed from the
@@ -388,8 +382,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::AttachForkToCopiedBegin(
   // is not in |fork|'s timeline.
   for (auto const& [_, child] : fork->children_) {
     if (child->position_in_parent_timeline_ == fork_timeline_begin) {
-      child->position_in_parent_timeline_ =
-          fork->MakeDurable(fork_timeline_end);
+      child->position_in_parent_timeline_ = fork_timeline_end;
     }
   }
 
@@ -402,7 +395,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::AttachForkToCopiedBegin(
   // Set the pointer into this object.  Note that |fork| is no longer usable.
   child_it->second->parent_ = that();
   child_it->second->position_in_parent_children_ = child_it;
-  child_it->second->position_in_parent_timeline_ = MakeDurable(timeline_end());
+  child_it->second->position_in_parent_timeline_ = timeline_durable_end();
   if (!timeline_empty()) {
     --*child_it->second->position_in_parent_timeline_;
   }
@@ -418,7 +411,7 @@ Forkable<Tr4jectory, It3rator, Traits>::DetachForkWithCopiedBegin() {
   // ensured that now it is, so point them to the beginning of this timeline.
   for (auto const& [_, child] : children_) {
     if (child->position_in_parent_timeline_ == timeline_end()) {
-      child->position_in_parent_timeline_ = MakeDurable(timeline_begin());
+      child->position_in_parent_timeline_ = timeline_durable_begin();
     }
   }
 
@@ -526,7 +519,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::Wrap(
       iterator.CheckNormalizedIfEnd();
       return iterator;
     }
-    iterator.current_ = ancest0r->MakeDurable(ancest0r->timeline_end());
+    iterator.current_ = ancest0r->timeline_durable_end();
     ancest0r = ancest0r->parent_;
   } while (ancest0r != nullptr);
 

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -83,17 +83,18 @@ class FakeTrajectory : public Forkable<FakeTrajectory,
   using Forkable<FakeTrajectory, Iterator, FakeTrajectoryTraits>::
       CheckNoForksBefore;
 
+  TimelineDurableConstIterator timeline_durable_begin() const override;
+  TimelineDurableConstIterator timeline_durable_end() const override;
+  TimelineDurableConstIterator timeline_durable_find(
+      Instant const& time) const override;
+  TimelineDurableConstIterator timeline_durable_lower_bound(
+      Instant const& time) const override;
+
   TimelineEphemeralConstIterator timeline_begin() const override;
   TimelineEphemeralConstIterator timeline_end() const override;
-  TimelineEphemeralConstIterator timeline_find(
-      Instant const& time) const override;
-  TimelineEphemeralConstIterator timeline_lower_bound(
-      Instant const& time) const override;
   bool timeline_empty() const override;
   std::int64_t timeline_size() const override;
 
-  TimelineDurableConstIterator MakeDurable(
-      TimelineEphemeralConstIterator it) const override;
   TimelineEphemeralConstIterator MakeEphemeral(
       TimelineDurableConstIterator it) const override;
 
@@ -149,6 +150,41 @@ void FakeTrajectory::push_back(Instant const& time) {
   timeline_.push_back(time);
 }
 
+FakeTrajectory::TimelineDurableConstIterator
+FakeTrajectory::timeline_durable_begin() const {
+  return {&timeline_, timeline_.empty() ? -1 : 0};
+}
+
+FakeTrajectory::TimelineDurableConstIterator
+FakeTrajectory::timeline_durable_end() const {
+  return {&timeline_, -1};
+}
+
+FakeTrajectory::TimelineDurableConstIterator
+FakeTrajectory::timeline_durable_find(
+    Instant const& time) const {
+  // Stupid O(N) search.
+  std::int64_t pos = 0;
+  for (auto it = timeline_.begin(); it != timeline_.end(); ++it, ++pos) {
+    if (*it == time) {
+      return {&timeline_, pos};
+    }
+  }
+  return {&timeline_, -1};
+}
+
+FakeTrajectory::TimelineDurableConstIterator
+FakeTrajectory::timeline_durable_lower_bound(Instant const& time) const {
+  // Stupid O(N) search.
+  std::int64_t pos = 0;
+  for (auto it = timeline_.begin(); it != timeline_.end(); ++it, ++pos) {
+    if (*it >= time) {
+      return {&timeline_, pos};
+    }
+  }
+  return {&timeline_, -1};
+}
+
 FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_begin()
     const {
   return timeline_.begin();
@@ -156,28 +192,6 @@ FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_begin()
 
 FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_end()
     const {
-  return timeline_.end();
-}
-
-FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_find(
-    Instant const& time) const {
-  // Stupid O(N) search.
-  for (auto it = timeline_.begin(); it != timeline_.end(); ++it) {
-    if (*it == time) {
-      return it;
-    }
-  }
-  return timeline_.end();
-}
-
-FakeTrajectory::TimelineEphemeralConstIterator
-FakeTrajectory::timeline_lower_bound(Instant const& time) const {
-  // Stupid O(N) search.
-  for (auto it = timeline_.begin(); it != timeline_.end(); ++it) {
-    if (*it >= time) {
-      return it;
-    }
-  }
   return timeline_.end();
 }
 
@@ -247,7 +261,7 @@ TEST_F(ForkableDeathTest, ForkError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     trajectory_.push_back(t3_);
-    trajectory_.NewFork(trajectory_.timeline_find(t2_));
+    trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   }, "!is_root");
   EXPECT_DEATH({
     trajectory_.Fork();
@@ -266,7 +280,7 @@ TEST_F(ForkableTest, ForkSuccess) {
   EXPECT_EQ(3, trajectory_.Size());
   EXPECT_FALSE(trajectory_.Empty());
   not_null<FakeTrajectory*> const fork =
-       trajectory_.NewFork(trajectory_.timeline_find(t2_));
+       trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   EXPECT_EQ(2, fork->Size());
   EXPECT_FALSE(fork->Empty());
   fork->push_back(t4_);
@@ -283,9 +297,10 @@ TEST_F(ForkableTest, Size) {
   trajectory_.push_back(t1_);
   EXPECT_EQ(1, trajectory_.Size());
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t1_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
   EXPECT_EQ(1, fork1->Size());
-  not_null<FakeTrajectory*> const fork2 = fork1->NewFork(fork1->timeline_end());
+  not_null<FakeTrajectory*> const fork2 =
+      fork1->NewFork(fork1->timeline_durable_end());
   fork2->push_back(t2_);
   EXPECT_EQ(2, fork2->Size());
 }
@@ -295,11 +310,11 @@ TEST_F(ForkableTest, ForkAtLast) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t3_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t3_));
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(LastTime(fork1)));
+      fork1->NewFork(fork1->timeline_durable_find(LastTime(fork1)));
   not_null<FakeTrajectory*> const fork3 =
-      fork2->NewFork(fork2->timeline_find(LastTime(fork1)));
+      fork2->NewFork(fork2->timeline_durable_find(LastTime(fork1)));
   EXPECT_EQ(t3_, LastTime(&trajectory_));
   EXPECT_EQ(t3_, LastTime(fork1));
 
@@ -344,9 +359,9 @@ TEST_F(ForkableDeathTest, DeleteForkError) {
   }, "!is_root");
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
-    FakeTrajectory* fork1 = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+    FakeTrajectory* fork1 = trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
     fork1->push_back(t2_);
-    FakeTrajectory* fork2 = fork1->NewFork(fork1->timeline_find(t2_));
+    FakeTrajectory* fork2 = fork1->NewFork(fork1->timeline_durable_find(t2_));
     trajectory_.DeleteFork(fork2);
   }, "not a child");
 }
@@ -356,8 +371,8 @@ TEST_F(ForkableTest, DeleteForkSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
+  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork1->push_back(t4_);
   trajectory_.DeleteFork(fork2);
   EXPECT_EQ(nullptr, fork2);
@@ -371,7 +386,7 @@ TEST_F(ForkableDeathTest, AttachForkWithCopiedBeginError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t1_));
+        trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
     trajectory_.AttachForkToCopiedBegin(std::unique_ptr<FakeTrajectory>(fork));
   }, "is_root");
   EXPECT_DEATH({
@@ -391,7 +406,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginSuccess) {
       make_not_null_unique<FakeTrajectory>();
   fork1->push_back(t3_);
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t3_));
+      fork1->NewFork(fork1->timeline_durable_find(t3_));
   fork2->push_back(t4_);
   auto times = Times(fork1.get());
   EXPECT_THAT(times, ElementsAre(t3_));
@@ -411,7 +426,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginSuccess) {
 TEST_F(ForkableTest, AttachForkWithCopiedBeginEmpty) {
   trajectory_.push_back(t1_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t1_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
   not_null<std::unique_ptr<FakeTrajectory>> fork2 =
       make_not_null_unique<FakeTrajectory>();
   fork2->push_back(t3_);
@@ -430,9 +445,9 @@ TEST_F(ForkableTest, DetachForkWithCopiedBeginSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork3 = fork1->NewFork(fork1->timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
+  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
+  FakeTrajectory* fork3 = fork1->NewFork(fork1->timeline_durable_find(t2_));
   fork1->push_back(t4_);
 
   fork1->push_front(t2_);
@@ -463,7 +478,7 @@ TEST_F(ForkableDeathTest, DeleteAllForksAfterError) {
     trajectory_.push_back(t1_);
     trajectory_.push_back(t2_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t2_));
+        trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
     fork->DeleteAllForksAfter(t1_);
   }, "before the fork time");
 }
@@ -473,7 +488,7 @@ TEST_F(ForkableTest, DeleteAllForksAfterSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork->push_back(t4_);
 
   fork->DeleteAllForksAfter(t3_ + (t4_ - t3_) / 2);
@@ -497,7 +512,7 @@ TEST_F(ForkableDeathTest, CheckNoForksBeforeError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t1_));
+        trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
     fork->CheckNoForksBefore(t1_);
   }, "nonroot");
   EXPECT_DEATH({
@@ -505,7 +520,7 @@ TEST_F(ForkableDeathTest, CheckNoForksBeforeError) {
     trajectory_.push_back(t2_);
     trajectory_.push_back(t3_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t2_));
+        trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
     fork->push_back(t4_);
     trajectory_.CheckNoForksBefore(t3_);
   }, "found 1 fork");
@@ -516,7 +531,7 @@ TEST_F(ForkableTest, CheckNoForksBeforeSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork->push_back(t4_);
 
   trajectory_.CheckNoForksBefore(t1_ + (t2_ - t1_) / 2);
@@ -553,7 +568,7 @@ TEST_F(ForkableTest, IteratorDecrementNoForkSuccess) {
 TEST_F(ForkableTest, IteratorDecrementForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+  auto fork = trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
   auto it = fork->end();
@@ -566,9 +581,9 @@ TEST_F(ForkableTest, IteratorDecrementForkSuccess) {
 TEST_F(ForkableTest, IteratorDecrementMultipleForksSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
-  auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
+  auto fork2 = fork1->NewFork(fork1->timeline_durable_find(t2_));
+  auto fork3 = fork2->NewFork(fork2->timeline_durable_find(t2_));
   fork2->push_back(t3_);
   auto it = fork3->end();
   --it;
@@ -600,7 +615,7 @@ TEST_F(ForkableTest, IteratorIncrementNoForkSuccess) {
 TEST_F(ForkableTest, IteratorIncrementForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+  auto fork = trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
   auto it = fork->begin();
@@ -614,9 +629,9 @@ TEST_F(ForkableTest, IteratorIncrementForkSuccess) {
 TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
-  auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
+  auto fork2 = fork1->NewFork(fork1->timeline_durable_find(t2_));
+  auto fork3 = fork2->NewFork(fork2->timeline_durable_find(t2_));
   auto it = fork3->begin();
   EXPECT_EQ(t1_, *it);
   ++it;
@@ -640,8 +655,8 @@ TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
 TEST_F(ForkableTest, IteratorEndEquality) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t1_));
-  auto fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_durable_find(t1_));
+  auto fork2 = trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   auto it1 = fork1->end();
   auto it2 = fork2->end();
   EXPECT_NE(it1, it2);
@@ -653,7 +668,7 @@ TEST_F(ForkableTest, Root) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   EXPECT_TRUE(trajectory_.is_root());
   EXPECT_FALSE(fork->is_root());
   EXPECT_EQ(&trajectory_, trajectory_.root());
@@ -680,7 +695,7 @@ TEST_F(ForkableTest, IteratorBeginSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork->push_back(t4_);
 
   it = fork->begin();
@@ -713,7 +728,7 @@ TEST_F(ForkableTest, IteratorFindSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork->push_back(t4_);
 
   it = fork->Find(t0_);
@@ -747,7 +762,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork1->push_back(t4_);
 
   it = fork1->LowerBound(t0_);
@@ -768,7 +783,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   EXPECT_EQ(it, fork1->end());
 
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t2_));
+      fork1->NewFork(fork1->timeline_durable_find(t2_));
   fork2->push_back(t5_);
   it = fork2->LowerBound(t4_ - 1 * Second);
   EXPECT_EQ(t5_, *it);
@@ -783,14 +798,14 @@ TEST_F(ForkableTest, FrontBack) {
   EXPECT_EQ(t3_, trajectory_.back());
 
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_durable_find(t2_));
   fork1->push_back(t4_);
 
   EXPECT_EQ(t1_, fork1->front());
   EXPECT_EQ(t4_, fork1->back());
 
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t2_));
+      fork1->NewFork(fork1->timeline_durable_find(t2_));
   fork2->push_back(t5_);
 
   EXPECT_EQ(t1_, fork2->front());

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -31,14 +31,12 @@ struct FakeTrajectoryTraits : not_constructible {
   static Instant const& time(TimelineDurableConstIterator const& it);
   static Instant const& time(TimelineEphemeralConstIterator const& it);
 
-  static TimelineDurableConstIterator MakeDurable(
-      Timeline const& container,
-      TimelineEphemeralConstIterator const& it);
-  //static TimelineEphemeralConstIterator MakeEphemeral(
-  //    TimelineDurableConstIterator const& it);
-
+  friend bool operator==(TimelineDurableConstIterator const& left,
+                         TimelineDurableConstIterator const& right);
   friend bool operator==(TimelineDurableConstIterator const& left,
                          TimelineEphemeralConstIterator const& right);
+  friend bool operator!=(TimelineDurableConstIterator const& left,
+                         TimelineDurableConstIterator const& right);
   friend bool operator!=(TimelineDurableConstIterator const& left,
                          TimelineEphemeralConstIterator const& right);
   friend TimelineDurableConstIterator& operator++(
@@ -93,6 +91,11 @@ class FakeTrajectory : public Forkable<FakeTrajectory,
       Instant const& time) const override;
   bool timeline_empty() const override;
   std::int64_t timeline_size() const override;
+
+  TimelineDurableConstIterator MakeDurable(
+      TimelineEphemeralConstIterator it) const override;
+  TimelineEphemeralConstIterator MakeEphemeral(
+      TimelineDurableConstIterator it) const override;
 
  protected:
   not_null<FakeTrajectory*> that() override;

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -229,8 +229,7 @@ FakeTrajectory::TimelineDurableConstIterator FakeTrajectory::MakeDurable(
     TimelineEphemeralConstIterator it) const {
   if (it == timeline_.cend()) {
     return {&timeline_, FakeTrajectory::TimelineDurableConstIterator::end};
-  }
-  else {
+  } else {
     return {&timeline_, std::distance(timeline_.cbegin(), it)};
   }
 }
@@ -402,7 +401,8 @@ TEST_F(ForkableDeathTest, DeleteForkError) {
   }, "!is_root");
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
-    FakeTrajectory* fork1 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
+        FakeTrajectory* fork1 =
+            trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
     fork1->push_back(t2_);
     FakeTrajectory* fork2 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
     trajectory_.DeleteFork(fork2);
@@ -415,7 +415,8 @@ TEST_F(ForkableTest, DeleteForkSuccess) {
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
       trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  FakeTrajectory* fork2 =
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
   trajectory_.DeleteFork(fork2);
   EXPECT_EQ(nullptr, fork2);
@@ -489,7 +490,8 @@ TEST_F(ForkableTest, DetachForkWithCopiedBeginSuccess) {
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
       trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  FakeTrajectory* fork2 =
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   FakeTrajectory* fork3 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
 

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -81,11 +81,11 @@ class FakeTrajectory : public Forkable<FakeTrajectory,
 
   TimelineDurableConstIterator timeline_begin() const override;
   TimelineDurableConstIterator timeline_end() const override;
-  TimelineDurableConstIterator timeline_find(
-      Instant const& time) const override;
 
   TimelineEphemeralConstIterator timeline_ephemeral_begin() const override;
   TimelineEphemeralConstIterator timeline_ephemeral_end() const override;
+  TimelineEphemeralConstIterator timeline_ephemeral_find(
+      Instant const& time) const override;
   TimelineEphemeralConstIterator timeline_ephemeral_lower_bound(
       Instant const& time) const override;
 
@@ -180,31 +180,6 @@ FakeTrajectory::timeline_end() const {
   return {&timeline_, FakeTrajectory::TimelineDurableConstIterator::end};
 }
 
-FakeTrajectory::TimelineDurableConstIterator
-FakeTrajectory::timeline_find(
-    Instant const& time) const {
-  // Stupid O(N) search.
-  std::int64_t pos = 0;
-  for (auto it = timeline_.cbegin(); it != timeline_.cend(); ++it, ++pos) {
-    if (*it == time) {
-      return {&timeline_, pos};
-    }
-  }
-  return {&timeline_, FakeTrajectory::TimelineDurableConstIterator::end};
-}
-
-FakeTrajectory::TimelineEphemeralConstIterator
-FakeTrajectory::timeline_ephemeral_lower_bound(Instant const& time) const {
-  // Stupid O(N) search.
-  std::int64_t pos = 0;
-  for (auto it = timeline_.cbegin(); it != timeline_.cend(); ++it, ++pos) {
-    if (*it >= time) {
-      return it;
-    }
-  }
-  return timeline_.cend();
-}
-
 FakeTrajectory::TimelineEphemeralConstIterator
 FakeTrajectory::timeline_ephemeral_begin() const {
   return timeline_.cbegin();
@@ -212,6 +187,29 @@ FakeTrajectory::timeline_ephemeral_begin() const {
 
 FakeTrajectory::TimelineEphemeralConstIterator
 FakeTrajectory::timeline_ephemeral_end() const {
+  return timeline_.cend();
+}
+
+FakeTrajectory::TimelineEphemeralConstIterator
+FakeTrajectory::timeline_ephemeral_find(
+    Instant const& time) const {
+  // Stupid O(N) search.
+  for (auto it = timeline_.cbegin(); it != timeline_.cend(); ++it) {
+    if (*it == time) {
+      return it;
+    }
+  }
+  return timeline_.cend();
+}
+
+FakeTrajectory::TimelineEphemeralConstIterator
+FakeTrajectory::timeline_ephemeral_lower_bound(Instant const& time) const {
+  // Stupid O(N) search.
+  for (auto it = timeline_.cbegin(); it != timeline_.cend(); ++it) {
+    if (*it >= time) {
+      return it;
+    }
+  }
   return timeline_.cend();
 }
 
@@ -302,7 +300,7 @@ TEST_F(ForkableDeathTest, ForkError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     trajectory_.push_back(t3_);
-    trajectory_.NewFork(trajectory_.timeline_find(t2_));
+    trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   }, "!is_root");
   EXPECT_DEATH({
     trajectory_.Fork();
@@ -321,7 +319,7 @@ TEST_F(ForkableTest, ForkSuccess) {
   EXPECT_EQ(3, trajectory_.Size());
   EXPECT_FALSE(trajectory_.Empty());
   not_null<FakeTrajectory*> const fork =
-       trajectory_.NewFork(trajectory_.timeline_find(t2_));
+       trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   EXPECT_EQ(2, fork->Size());
   EXPECT_FALSE(fork->Empty());
   fork->push_back(t4_);
@@ -338,10 +336,10 @@ TEST_F(ForkableTest, Size) {
   trajectory_.push_back(t1_);
   EXPECT_EQ(1, trajectory_.Size());
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t1_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
   EXPECT_EQ(1, fork1->Size());
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_end());
+      fork1->NewFork(fork1->timeline_ephemeral_end());
   fork2->push_back(t2_);
   EXPECT_EQ(2, fork2->Size());
 }
@@ -351,11 +349,11 @@ TEST_F(ForkableTest, ForkAtLast) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t3_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t3_));
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(LastTime(fork1)));
+      fork1->NewFork(fork1->timeline_ephemeral_find(LastTime(fork1)));
   not_null<FakeTrajectory*> const fork3 =
-      fork2->NewFork(fork2->timeline_find(LastTime(fork1)));
+      fork2->NewFork(fork2->timeline_ephemeral_find(LastTime(fork1)));
   EXPECT_EQ(t3_, LastTime(&trajectory_));
   EXPECT_EQ(t3_, LastTime(fork1));
 
@@ -400,9 +398,9 @@ TEST_F(ForkableDeathTest, DeleteForkError) {
   }, "!is_root");
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
-    FakeTrajectory* fork1 = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+    FakeTrajectory* fork1 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
     fork1->push_back(t2_);
-    FakeTrajectory* fork2 = fork1->NewFork(fork1->timeline_find(t2_));
+    FakeTrajectory* fork2 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
     trajectory_.DeleteFork(fork2);
   }, "not a child");
 }
@@ -412,8 +410,8 @@ TEST_F(ForkableTest, DeleteForkSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
   trajectory_.DeleteFork(fork2);
   EXPECT_EQ(nullptr, fork2);
@@ -427,7 +425,7 @@ TEST_F(ForkableDeathTest, AttachForkWithCopiedBeginError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t1_));
+        trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
     trajectory_.AttachForkToCopiedBegin(std::unique_ptr<FakeTrajectory>(fork));
   }, "is_root");
   EXPECT_DEATH({
@@ -447,7 +445,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginSuccess) {
       make_not_null_unique<FakeTrajectory>();
   fork1->push_back(t3_);
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t3_));
+      fork1->NewFork(fork1->timeline_ephemeral_find(t3_));
   fork2->push_back(t4_);
   auto times = Times(fork1.get());
   EXPECT_THAT(times, ElementsAre(t3_));
@@ -467,7 +465,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginSuccess) {
 TEST_F(ForkableTest, AttachForkWithCopiedBeginEmpty) {
   trajectory_.push_back(t1_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t1_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
   not_null<std::unique_ptr<FakeTrajectory>> fork2 =
       make_not_null_unique<FakeTrajectory>();
   fork2->push_back(t3_);
@@ -486,9 +484,9 @@ TEST_F(ForkableTest, DetachForkWithCopiedBeginSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  FakeTrajectory* fork3 = fork1->NewFork(fork1->timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  FakeTrajectory* fork2 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  FakeTrajectory* fork3 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
 
   fork1->push_front(t2_);
@@ -519,7 +517,7 @@ TEST_F(ForkableDeathTest, DeleteAllForksAfterError) {
     trajectory_.push_back(t1_);
     trajectory_.push_back(t2_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t2_));
+        trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
     fork->DeleteAllForksAfter(t1_);
   }, "before the fork time");
 }
@@ -529,7 +527,7 @@ TEST_F(ForkableTest, DeleteAllForksAfterSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork->push_back(t4_);
 
   fork->DeleteAllForksAfter(t3_ + (t4_ - t3_) / 2);
@@ -553,7 +551,7 @@ TEST_F(ForkableDeathTest, CheckNoForksBeforeError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t1_));
+        trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
     fork->CheckNoForksBefore(t1_);
   }, "nonroot");
   EXPECT_DEATH({
@@ -561,7 +559,7 @@ TEST_F(ForkableDeathTest, CheckNoForksBeforeError) {
     trajectory_.push_back(t2_);
     trajectory_.push_back(t3_);
     not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t2_));
+        trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
     fork->push_back(t4_);
     trajectory_.CheckNoForksBefore(t3_);
   }, "found 1 fork");
@@ -572,7 +570,7 @@ TEST_F(ForkableTest, CheckNoForksBeforeSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork->push_back(t4_);
 
   trajectory_.CheckNoForksBefore(t1_ + (t2_ - t1_) / 2);
@@ -609,7 +607,7 @@ TEST_F(ForkableTest, IteratorDecrementNoForkSuccess) {
 TEST_F(ForkableTest, IteratorDecrementForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+  auto fork = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
   auto it = fork->end();
@@ -622,9 +620,9 @@ TEST_F(ForkableTest, IteratorDecrementForkSuccess) {
 TEST_F(ForkableTest, IteratorDecrementMultipleForksSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
-  auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  auto fork2 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
+  auto fork3 = fork2->NewFork(fork2->timeline_ephemeral_find(t2_));
   fork2->push_back(t3_);
   auto it = fork3->end();
   --it;
@@ -656,7 +654,7 @@ TEST_F(ForkableTest, IteratorIncrementNoForkSuccess) {
 TEST_F(ForkableTest, IteratorIncrementForkSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork = trajectory_.NewFork(trajectory_.timeline_find(t1_));
+  auto fork = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
   trajectory_.push_back(t4_);
   fork->push_back(t3_);
   auto it = fork->begin();
@@ -670,9 +668,9 @@ TEST_F(ForkableTest, IteratorIncrementForkSuccess) {
 TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
-  auto fork2 = fork1->NewFork(fork1->timeline_find(t2_));
-  auto fork3 = fork2->NewFork(fork2->timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
+  auto fork2 = fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
+  auto fork3 = fork2->NewFork(fork2->timeline_ephemeral_find(t2_));
   auto it = fork3->begin();
   EXPECT_EQ(t1_, *it);
   ++it;
@@ -696,8 +694,8 @@ TEST_F(ForkableTest, IteratorIncrementMultipleForksSuccess) {
 TEST_F(ForkableTest, IteratorEndEquality) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);
-  auto fork1 = trajectory_.NewFork(trajectory_.timeline_find(t1_));
-  auto fork2 = trajectory_.NewFork(trajectory_.timeline_find(t2_));
+  auto fork1 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t1_));
+  auto fork2 = trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   auto it1 = fork1->end();
   auto it2 = fork2->end();
   EXPECT_NE(it1, it2);
@@ -709,7 +707,7 @@ TEST_F(ForkableTest, Root) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   EXPECT_TRUE(trajectory_.is_root());
   EXPECT_FALSE(fork->is_root());
   EXPECT_EQ(&trajectory_, trajectory_.root());
@@ -736,7 +734,7 @@ TEST_F(ForkableTest, IteratorBeginSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork->push_back(t4_);
 
   it = fork->begin();
@@ -769,7 +767,7 @@ TEST_F(ForkableTest, IteratorFindSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork->push_back(t4_);
 
   it = fork->Find(t0_);
@@ -803,7 +801,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   EXPECT_EQ(it, trajectory_.end());
 
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
 
   it = fork1->LowerBound(t0_);
@@ -824,7 +822,7 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   EXPECT_EQ(it, fork1->end());
 
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t2_));
+      fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
   fork2->push_back(t5_);
   it = fork2->LowerBound(t4_ - 1 * Second);
   EXPECT_EQ(t5_, *it);
@@ -839,14 +837,14 @@ TEST_F(ForkableTest, FrontBack) {
   EXPECT_EQ(t3_, trajectory_.back());
 
   not_null<FakeTrajectory*> const fork1 =
-      trajectory_.NewFork(trajectory_.timeline_find(t2_));
+      trajectory_.NewFork(trajectory_.timeline_ephemeral_find(t2_));
   fork1->push_back(t4_);
 
   EXPECT_EQ(t1_, fork1->front());
   EXPECT_EQ(t4_, fork1->back());
 
   not_null<FakeTrajectory*> const fork2 =
-      fork1->NewFork(fork1->timeline_find(t2_));
+      fork1->NewFork(fork1->timeline_ephemeral_find(t2_));
   fork2->push_back(t5_);
 
   EXPECT_EQ(t1_, fork2->front());

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -133,7 +133,7 @@ bool operator==(
 bool operator==(
     FakeTrajectoryTraits::TimelineDurableConstIterator const left,
     FakeTrajectoryTraits::TimelineEphemeralConstIterator const right) {
-  if (left.pos < 0) {
+  if (left.pos == -1) {
     return right == left.container->end();
   } else if (right == left.container->end()) {
     return false;
@@ -151,7 +151,7 @@ bool operator!=(
 bool operator!=(
     FakeTrajectoryTraits::TimelineDurableConstIterator const left,
     FakeTrajectoryTraits::TimelineEphemeralConstIterator const right) {
-  if (left.pos < 0) {
+  if (left.pos == -1) {
     return right != left.container->end();
   } else if (right == left.container->end()) {
     return true;
@@ -162,7 +162,8 @@ bool operator!=(
 
 FakeTrajectoryTraits::TimelineDurableConstIterator& operator++(
     FakeTrajectoryTraits::TimelineDurableConstIterator& right) {
-  if (right.pos < 0 || right.pos + 1 == right.container->size()) {
+  DCHECK_NE(right.pos, -1);
+  if (right.pos + 1 == right.container->size()) {
     right.pos = -1;
   } else {
     ++right.pos;
@@ -172,8 +173,9 @@ FakeTrajectoryTraits::TimelineDurableConstIterator& operator++(
 
 FakeTrajectoryTraits::TimelineDurableConstIterator& operator--(
     FakeTrajectoryTraits::TimelineDurableConstIterator& right) {
-  if (right.pos < 0 || right.pos == 0) {
-    right.pos = -1;
+  DCHECK_NE(right.pos, 0);
+  if (right.pos == -1) {
+    right.pos = right.container->size() - 1;
   } else {
     --right.pos;
   }
@@ -241,13 +243,13 @@ FakeTrajectory::timeline_lower_bound(Instant const& time) const {
   return {&timeline_, -1};
 }
 
-FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_ephemeral_begin()
-    const {
+FakeTrajectory::TimelineEphemeralConstIterator
+FakeTrajectory::timeline_ephemeral_begin() const {
   return timeline_.begin();
 }
 
-FakeTrajectory::TimelineEphemeralConstIterator FakeTrajectory::timeline_ephemeral_end()
-    const {
+FakeTrajectory::TimelineEphemeralConstIterator
+FakeTrajectory::timeline_ephemeral_end() const {
   return timeline_.end();
 }
 

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -24,6 +24,8 @@ struct FakeTrajectoryTraits : not_constructible {
   // Use vector<> because we want the iterators to become invalid across
   // operations.
   using Timeline = std::vector<Instant>;
+  // Note that the TimelineDurableConstIterator doesn't remain valid in the
+  // face of insert or erase operations.
   struct TimelineDurableConstIterator {
     Timeline const* container;
     std::int64_t pos;
@@ -125,21 +127,23 @@ Instant const& FakeTrajectoryTraits::time(
 bool operator==(
     FakeTrajectoryTraits::TimelineDurableConstIterator const left,
     FakeTrajectoryTraits::TimelineDurableConstIterator const right) {
-  bool const left_at_end = left.pos >= left.container->size();
-  bool const right_at_end = right.pos >= right.container->size();
-  return left.container == right.container &&
-         (left_at_end == right_at_end &&
-          (left_at_end || left.pos == right.pos));
+  DCHECK(left.container == right.container);
+  DCHECK(left.pos == FakeTrajectoryTraits::TimelineDurableConstIterator::end ||
+         left.pos < left.container->size());
+  DCHECK(right.pos == FakeTrajectoryTraits::TimelineDurableConstIterator::end ||
+         right.pos < right.container->size());
+  return left.pos == right.pos;
 }
 
 bool operator!=(
     FakeTrajectoryTraits::TimelineDurableConstIterator const left,
     FakeTrajectoryTraits::TimelineDurableConstIterator const right) {
-  bool const left_at_end = left.pos >= left.container->size();
-  bool const right_at_end = right.pos >= right.container->size();
-  return left.container != right.container ||
-         (left_at_end != right_at_end ||
-          (!left_at_end && left.pos != right.pos));
+  DCHECK(left.container == right.container);
+  DCHECK(left.pos == FakeTrajectoryTraits::TimelineDurableConstIterator::end ||
+         left.pos < left.container->size());
+  DCHECK(right.pos == FakeTrajectoryTraits::TimelineDurableConstIterator::end ||
+         right.pos < right.container->size());
+  return left.pos != right.pos;
 }
 
 FakeTrajectoryIterator::reference FakeTrajectoryIterator::operator*() const {


### PR DESCRIPTION
* The "ephemeral" iterators are vanilla STL iterators and not guaranteed to remain valid across changes to the container.
* The "durable" iterators designate an entry in the container and must remain valid across changes to the container.

`forkable_test.cpp` shows how this could work.  For the time being, in real code both ephemeral and durable iterators are map iterators, so this PR is mostly harmless.

Another contribution to #2570.