### PR TITLE
Point to the planned initial Frenet frame before ignition

### DIFF
--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -255,10 +255,14 @@ XYZ __cdecl principia__FlightPlanGetGuidance(Plugin const* const plugin,
     result = plugin->renderer().BarycentricToWorld(
                  plugin->PlanetariumRotation())(manœuvre.InertialDirection());
   } else {
-    result = plugin->renderer().FrenetToWorld(
-                 *plugin->GetVessel(vessel_guid),
-                 *manœuvre.frame(),
-                 plugin->PlanetariumRotation())(manœuvre.direction());
+    result = plugin->CurrentTime() < manœuvre.initial_time()
+                 ? plugin->renderer().BarycentricToWorld(
+                       plugin->PlanetariumRotation())(
+                       manœuvre.FrenetFrame()(manœuvre.direction()))
+                 : plugin->renderer().FrenetToWorld(
+                       *plugin->GetVessel(vessel_guid),
+                       *manœuvre.frame(),
+                       plugin->PlanetariumRotation())(manœuvre.direction());
   }
   return m.Return(ToXYZ(result));
 }

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -255,14 +255,14 @@ XYZ __cdecl principia__FlightPlanGetGuidance(Plugin const* const plugin,
     result = plugin->renderer().BarycentricToWorld(
                  plugin->PlanetariumRotation())(manœuvre.InertialDirection());
   } else {
-    result = plugin->CurrentTime() < manœuvre.initial_time()
-                 ? plugin->renderer().BarycentricToWorld(
-                       plugin->PlanetariumRotation())(
-                       manœuvre.FrenetFrame()(manœuvre.direction()))
-                 : plugin->renderer().FrenetToWorld(
-                       *plugin->GetVessel(vessel_guid),
-                       *manœuvre.frame(),
-                       plugin->PlanetariumRotation())(manœuvre.direction());
+    result = (plugin->CurrentTime() < manœuvre.initial_time()
+                  ? plugin->renderer().BarycentricToWorld(
+                        plugin->PlanetariumRotation()) *
+                        manœuvre.FrenetFrame()
+                  : plugin->renderer().FrenetToWorld(
+                        *plugin->GetVessel(vessel_guid),
+                        *manœuvre.frame(),
+                        plugin->PlanetariumRotation()))(manœuvre.direction());
   }
   return m.Return(ToXYZ(result));
 }


### PR DESCRIPTION
On ignition, switch to tracking the current actual Frenet frame (current behaviour).

Fix #2577; all Principia burns can now be executed by MechJeb, and MechJeb warps properly.