### PR TITLE
Fix linker error when compiling with clang 9+

### DIFF
--- a/base/traits.hpp
+++ b/base/traits.hpp
@@ -10,7 +10,7 @@ template<typename... Ts>
 constexpr bool all_different_v = false;
 
 template<>
-constexpr bool all_different_v<> = true;
+inline constexpr bool all_different_v<> = true;
 
 template<typename T0, typename... Ts>
 constexpr bool all_different_v<T0, Ts...> =

--- a/quantities/si.hpp
+++ b/quantities/si.hpp
@@ -20,7 +20,7 @@ namespace si {
 template<typename Q>
 constexpr Q Unit = internal_quantities::SIUnit<Q>();
 template<>
-constexpr double Unit<double> = 1;
+inline constexpr double Unit<double> = 1;
 
 // Prefixes
 template<typename D> constexpr Quantity<D> Yotta(Quantity<D>);


### PR DESCRIPTION
Clang 9 changed the linkage definition for variable templates with const-qualified type
(see https://github.com/llvm/llvm-project/commit/bb750689d51d2109b9898b53a4b69d8183ab1f26).

This leads to the following linker error in "make test" when compiling with clang versions >= 9:

```
clang++ -c -std=c++1z -stdlib=libc++ -O3 -g -fPIC -fexceptions -ferror-limit=1000 -fno-omit-frame-pointer -Wall -Wpedantic -Wno-char-subscripts -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-nested-anon-types -Wno-unknown-pragmas -DPROJECT_DIR='std::filesystem::path("ksp_plugin_adapter/")' -DSOLUTION_DIR='std::filesystem::path("./")' -DTEMP_DIR='std::filesystem::path("/tmp")' -DNDEBUG -m64 -I. -Ideps/glog/src -Ideps/protobuf/src -Ideps/gipfeli/include -Ideps/abseil-cpp -Ideps/zfp/include base/version.generated.cc -o obj/base/version.generated.o
clang++ -std=c++1z -stdlib=libc++ -O3 -g -fPIC -fexceptions -ferror-limit=1000 -fno-omit-frame-pointer -Wall -Wpedantic -Wno-char-subscripts -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-nested-anon-types -Wno-unknown-pragmas -DPROJECT_DIR='std::filesystem::path("ksp_plugin_adapter/")' -DSOLUTION_DIR='std::filesystem::path("./")' -DTEMP_DIR='std::filesystem::path("/tmp")' -DNDEBUG -m64 obj/tools/generate_configuration.o obj/tools/generate_kopernicus.o obj/tools/generate_profiles.o obj/tools/journal_proto_processor.o obj/tools/main.o obj/serialization/astronomy.pb.o obj/serialization/geometry.pb.o obj/serialization/integrators.pb.o obj/serialization/journal.pb.o obj/serialization/ksp_plugin.pb.o obj/serialization/numerics.pb.o obj/serialization/physics.pb.o obj/serialization/quantities.pb.o obj/serialization/testing_utilities.pb.o obj/numerics/cbrt.o obj/numerics/elliptic_functions.o obj/numerics/elliptic_integrals.o obj/numerics/fast_sin_cos_2π.o obj/base/version.generated.o deps/protobuf/src/.libs/libprotobuf.a deps/gipfeli/libgipfeli.a deps/abseil-cpp/absl/strings/libabsl_strings.a deps/abseil-cpp/absl/synchronization/libabsl_synchronization.a deps/abseil-cpp/absl/time/libabsl_*.a deps/abseil-cpp/absl/debugging/libabsl_*.a deps/abseil-cpp/absl/numeric/libabsl_*.a deps/abseil-cpp/absl/base/libabsl_*.a deps/zfp/build/lib/libzfp.a deps/glog/.libs/libglog.a -lpthread -lc++ -lc++abi -lsupc++ -lc++fs -o bin/tools
/usr/bin/ld: obj/tools/generate_kopernicus.o:(.rodata+0x8): multiple definition of `principia::quantities::si::Unit<double>'; obj/tools/generate_configuration.o:(.rodata+0x8): first defined here
/usr/bin/ld: obj/tools/generate_kopernicus.o:(.rodata+0x0): multiple definition of `principia::base::internal_traits::all_different_v<>'; obj/tools/generate_configuration.o:(.rodata+0x0): first defined here
/usr/bin/ld: obj/tools/main.o:(.rodata+0x8): multiple definition of `principia::quantities::si::Unit<double>'; obj/tools/generate_configuration.o:(.rodata+0x8): first defined here
/usr/bin/ld: obj/tools/main.o:(.rodata+0x0): multiple definition of `principia::base::internal_traits::all_different_v<>'; obj/tools/generate_configuration.o:(.rodata+0x0): first defined here
/usr/bin/ld: obj/numerics/elliptic_functions.o:(.rodata+0x8): multiple definition of `principia::quantities::si::Unit<double>'; obj/tools/generate_configuration.o:(.rodata+0x8): first defined here
/usr/bin/ld: obj/numerics/elliptic_functions.o:(.rodata+0x0): multiple definition of `principia::base::internal_traits::all_different_v<>'; obj/tools/generate_configuration.o:(.rodata+0x0): first defined here
/usr/bin/ld: obj/numerics/elliptic_integrals.o:(.rodata+0x8): multiple definition of `principia::quantities::si::Unit<double>'; obj/tools/generate_configuration.o:(.rodata+0x8): first defined here
/usr/bin/ld: obj/numerics/elliptic_integrals.o:(.rodata+0x0): multiple definition of `principia::base::internal_traits::all_different_v<>'; obj/tools/generate_configuration.o:(.rodata+0x0): first defined here
/usr/bin/ld: obj/numerics/fast_sin_cos_2π.o:(.rodata+0x18): multiple definition of `principia::quantities::si::Unit<double>'; obj/tools/generate_configuration.o:(.rodata+0x8): first defined here
/usr/bin/ld: obj/numerics/fast_sin_cos_2π.o:(.rodata+0x10): multiple definition of `principia::base::internal_traits::all_different_v<>'; obj/tools/generate_configuration.o:(.rodata+0x0): first defined here
```

Adding "inline" to the definitions for `principia::quantities::si::Unit<double>` and `principia::base::internal_traits::all_different_v<>` fixes this error.

With these changes, compilation worked on my system (Arch Linux, clang 10, libc++ 10) with one additional change: Since LLVM version 9, `libc++fs` is integrated into the main library (see https://libcxx.llvm.org/docs/UsingLibcxx.html#using-filesystem), so it needs to be removed from the linker flags.

Running `make test` on this version failed one test for me, though:

```
astronomy/orbital_elements_test.cpp:205: Failure
Value of: elements.mean_semimajor_axis_interval().measure()
Expected: is < +1.00000000000000002e-03 m
  Actual: +1.09284557402133942e-03 m
[  FAILED  ] OrbitalElementsTest.KeplerOrbit (2829 ms)
```