### PR TITLE
More Mathematica improvements

### DIFF
--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -456,7 +456,7 @@ TEST_P(KSPSystemConvergenceTest, DISABLED_Convergence) {
     }
     mathematica_entries.push_back({steps[i + 1],
                                    position_errors[i],
-                                   mathematica::Escape(worst_body[i]),
+                                   worst_body[i],
                                    durations[i + 1].count() * Second});
   }
 

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -697,7 +697,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
     }
     mathematica_entries.push_back({steps[i + 1],
                                    position_errors[i],
-                                   mathematica::Escape(worst_body[i]),
+                                   worst_body[i],
                                    durations[i + 1].count() * Second});
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1494,7 +1494,7 @@ public partial class PrincipiaPluginAdapter
                 part.flightID,
                 (from force in part.forces
                  select PartCentredForceHolder.FromPartForceHolder(
-                    part, force)).ToArray());
+                     part.name, part, force)).ToArray());
           }
         }
       }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1494,7 +1494,7 @@ public partial class PrincipiaPluginAdapter
                 part.flightID,
                 (from force in part.forces
                  select PartCentredForceHolder.FromPartForceHolder(
-                     part.name, part, force)).ToArray());
+                     part, force)).ToArray());
           }
         }
       }

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -253,7 +253,7 @@ class WorkErrorGraphGenerator {
           PlottableDataset(evaluations_[i], v_errors_[i]));
       e_error_data.emplace_back(
           PlottableDataset(evaluations_[i], e_errors_[i]));
-      names.emplace_back(Escape(methods_[i].name));
+      names.emplace_back(ToMathematica(methods_[i].name));
     }
     std::string result;
     result += Assign("qErrorData", q_error_data);

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -88,6 +88,9 @@ class ExpressIn {
   std::tuple<Qs...> units_;
 };
 
+// A tag for logging a string without escaping.
+struct Verbatim final {};
+
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
 
@@ -200,7 +203,6 @@ template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::optional<T> const& opt,
                           OptionalExpressIn express_in = std::nullopt);
 
-// Returns its argument.
 template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(char const* str,
                           OptionalExpressIn express_in = std::nullopt);
@@ -208,17 +210,17 @@ template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::string const& str,
                           OptionalExpressIn express_in = std::nullopt);
 
-// Wraps the string in quotes and escapes things properly.
-std::string Escape(std::string const& str);
+// Returns its argument.
+std::string ToMathematica(char const* str, Verbatim verbatim);
+std::string ToMathematica(std::string const& str, Verbatim verbatim);
 
-// An RAII object to help with Mathematica logging.
 class Logger final {
  public:
   // Creates a logger object that will, at destruction, write to the given file.
   // If make_unique is true, a unique id is inserted before the file extension
   // to identify different loggers.
   Logger(std::filesystem::path const& path,
-         bool make_unique = false);
+         bool make_unique = true);
   ~Logger();
 
   // Appends an element to the list of values for the variable |name|.  The
@@ -239,7 +241,6 @@ class Logger final {
 
 using internal_mathematica::Apply;
 using internal_mathematica::Assign;
-using internal_mathematica::Escape;
 using internal_mathematica::ExpressIn;
 using internal_mathematica::Logger;
 using internal_mathematica::Option;

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -88,9 +88,6 @@ class ExpressIn {
   std::tuple<Qs...> units_;
 };
 
-// A tag for logging a string without escaping.
-struct Verbatim final {};
-
 std::string Apply(std::string const& function,
                   std::vector<std::string> const& arguments);
 
@@ -209,10 +206,6 @@ std::string ToMathematica(char const* str,
 template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::string const& str,
                           OptionalExpressIn express_in = std::nullopt);
-
-// Returns its argument.
-std::string ToMathematica(char const* str, Verbatim verbatim);
-std::string ToMathematica(std::string const& str, Verbatim verbatim);
 
 class Logger final {
  public:

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -88,9 +88,6 @@ class ExpressIn {
   std::tuple<Qs...> units_;
 };
 
-std::string Apply(std::string const& function,
-                  std::vector<std::string> const& arguments);
-
 template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string Option(std::string const& name,
                    T const& right,
@@ -207,6 +204,7 @@ template<typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::string const& str,
                           OptionalExpressIn express_in = std::nullopt);
 
+// An RAII object to help with Mathematica logging.
 class Logger final {
  public:
   // Creates a logger object that will, at destruction, write to the given file.
@@ -232,7 +230,6 @@ class Logger final {
 
 }  // namespace internal_mathematica
 
-using internal_mathematica::Apply;
 using internal_mathematica::Assign;
 using internal_mathematica::ExpressIn;
 using internal_mathematica::Logger;

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -332,16 +332,6 @@ std::string ToMathematica(std::string const& str,
   return Escape(str);
 }
 
-inline std::string ToMathematica(char const* const str,
-                                 Verbatim const verbatim) {
-  return std::string(str);
-}
-
-inline std::string ToMathematica(std::string const& str,
-                                 Verbatim const verbatim) {
-  return str;
-}
-
 inline Logger::Logger(std::filesystem::path const& path, bool const make_unique)
     : file_([make_unique, &path]() {
         if (make_unique) {

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -46,7 +46,20 @@ inline std::string Escape(std::string_view const str) {
   return result;
 }
 
-// An RAII object to help with Mathematica logging.
+// Does not wrap its arguments in ToMathematica.
+inline std::string Apply(
+    std::string const& function,
+    std::vector<std::string> const& arguments) {
+  std::string result;
+  result += function;
+  result += "[";
+  for (int i = 0; i < arguments.size(); ++i) {
+    result += arguments[i];
+    result += (i + 1 < arguments.size() ? "," : "");
+  }
+  result += "]";
+  return result;
+}
 
 // A helper struct to scan the elements of a tuple and stringify them.
 template<int index, typename Tuple, typename OptionalExpressIn>
@@ -67,20 +80,6 @@ struct TupleHelper<0, Tuple, OptionalExpressIn> : not_constructible {
                                    std::vector<std::string>& expressions,
                                    OptionalExpressIn express_in) {}
 };
-
-inline std::string Apply(
-    std::string const& function,
-    std::vector<std::string> const& arguments) {
-  std::string result;
-  result += function;
-  result += "[";
-  for (int i = 0; i < arguments.size(); ++i) {
-    result += arguments[i];
-    result += (i + 1 < arguments.size() ? "," : "");
-  }
-  result += "]";
-  return result;
-}
 
 template<typename... Qs>
 ExpressIn<Qs...>::ExpressIn(Qs const&... qs)

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -295,11 +295,6 @@ TEST_F(MathematicaTest, ToMathematica) {
   }
 }
 
-TEST_F(MathematicaTest, Apply) {
-  EXPECT_EQ("Fun[]", Apply("Fun", {}));
-  EXPECT_EQ("Fun[1,[],\"string\"]", Apply("Fun", {"1", "[]", "\"string\""}));
-}
-
 TEST_F(MathematicaTest, Option) {
   EXPECT_EQ(
       "Rule["

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -440,7 +440,7 @@ TEST_F(MathematicaTest, Logger) {
       "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
       "\" m\"]]]];\n"
       "Set["
-      "β,"
+      u8"β,"
       "List["
       "Quantity["
       "SetPrecision[+4.00000000000000000*^+00,$MachinePrecision],"

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -1,4 +1,4 @@
-#include "mathematica/mathematica.hpp"
+﻿#include "mathematica/mathematica.hpp"
 
 #include <list>
 #include <string>
@@ -288,10 +288,10 @@ TEST_F(MathematicaTest, ToMathematica) {
     std::optional<std::string> opt1;
     std::optional<std::string> opt2("foo");
     EXPECT_EQ("List[]", ToMathematica(opt1));
-    EXPECT_EQ("List[foo]", ToMathematica(opt2));
+    EXPECT_EQ("List[\"foo\"]", ToMathematica(opt2));
   }
   {
-    EXPECT_EQ("foo\"bar", ToMathematica("foo\"bar"));
+    EXPECT_EQ("\"foo\\\"bar\"", ToMathematica("foo\"bar"));
   }
 }
 
@@ -305,7 +305,7 @@ TEST_F(MathematicaTest, Option) {
       "Rule["
       "option,"
       "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]]",
-      Option("option", ToMathematica(3.0)));
+      Option("option", 3.0));
 }
 
 TEST_F(MathematicaTest, Assign) {
@@ -313,7 +313,7 @@ TEST_F(MathematicaTest, Assign) {
       "Set["
       "var,"
       "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]];\n",
-      Assign("var", ToMathematica(3.0)));
+      Assign("var", 3.0));
 }
 
 TEST_F(MathematicaTest, PlottableDataset) {
@@ -323,20 +323,20 @@ TEST_F(MathematicaTest, PlottableDataset) {
       "List["
       "SetPrecision[+2.00000000000000000*^+00,$MachinePrecision],"
       "SetPrecision[+3.00000000000000000*^+00,$MachinePrecision]],"
-      "List[2,3]]]",
+      "List[\"2\",\"3\"]]]",
       PlottableDataset(std::vector<double>{2, 3},
                        std::vector<std::string>{"2", "3"}));
 }
 
 TEST_F(MathematicaTest, Escape) {
-  EXPECT_EQ(R"("foo")", Escape("foo"));
+  EXPECT_EQ(R"("foo")", ToMathematica("foo"));
   {
     // This string messes up the macro.
     std::string expected = R"("fo\"o")";
-    EXPECT_EQ(expected, Escape("fo\"o"));
+    EXPECT_EQ(expected, ToMathematica("fo\"o"));
   }
-  EXPECT_EQ(R"("fo\\o")", Escape("fo\\o"));
-  EXPECT_EQ(R"("")", Escape(""));
+  EXPECT_EQ(R"("fo\\o")", ToMathematica("fo\\o"));
+  EXPECT_EQ(R"("")", ToMathematica(""));
 }
 
 TEST_F(MathematicaTest, ExpressIn) {
@@ -415,9 +415,9 @@ TEST_F(MathematicaTest, ExpressIn) {
 #if !defined(__APPLE__)
 TEST_F(MathematicaTest, Logger) {
   {
-    Logger logger(TEMP_DIR / "mathematica_test.wl", /*make_unique=*/true);
+    Logger logger(TEMP_DIR / "mathematica_test.wl");
     logger.Append("a", std::vector{1.0, 2.0, 3.0});
-    logger.Append("b", 4 * Metre / Second);
+    logger.Append(u8"β", 4 * Metre / Second);
     logger.Append("a", F::origin);
   }
   // Go check the file.
@@ -440,7 +440,7 @@ TEST_F(MathematicaTest, Logger) {
       "SetPrecision[+0.00000000000000000*^+00,$MachinePrecision],"
       "\" m\"]]]];\n"
       "Set["
-      "b,"
+      "β,"
       "List["
       "Quantity["
       "SetPrecision[+4.00000000000000000*^+00,$MachinePrecision],"


### PR DESCRIPTION
1. Change the default of `make_unique`.
1. Change `ToMathematica` for a string to escape its argument.