### PR TITLE
Flight plan rebasing

### DIFF
--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -343,6 +343,16 @@ int __cdecl principia__FlightPlanNumberOfSegments(
   return m.Return(GetFlightPlan(*plugin, vessel_guid).number_of_segments());
 }
 
+void __cdecl principia__FlightPlanRebase(Plugin const* const plugin,
+                                         char const* const vessel_guid,
+                                         double const mass_in_tonnes) {
+  journal::Method<journal::FlightPlanRebase> m(
+      {plugin, vessel_guid, mass_in_tonnes});
+  CHECK_NOTNULL(plugin);
+  plugin->GetVessel(vessel_guid)->RebaseFlightPlan(mass_in_tonnes * Tonne);
+  return m.Return();
+}
+
 Status* __cdecl principia__FlightPlanRemoveLast(Plugin const* const plugin,
                                                 char const* const vessel_guid) {
   journal::Method<journal::FlightPlanRemoveLast> m({plugin, vessel_guid});

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -343,14 +343,15 @@ int __cdecl principia__FlightPlanNumberOfSegments(
   return m.Return(GetFlightPlan(*plugin, vessel_guid).number_of_segments());
 }
 
-void __cdecl principia__FlightPlanRebase(Plugin const* const plugin,
+Status* __cdecl principia__FlightPlanRebase(Plugin const* const plugin,
                                          char const* const vessel_guid,
                                          double const mass_in_tonnes) {
   journal::Method<journal::FlightPlanRebase> m(
       {plugin, vessel_guid, mass_in_tonnes});
   CHECK_NOTNULL(plugin);
-  plugin->GetVessel(vessel_guid)->RebaseFlightPlan(mass_in_tonnes * Tonne);
-  return m.Return();
+  auto const status =
+      plugin->GetVessel(vessel_guid)->RebaseFlightPlan(mass_in_tonnes * Tonne);
+  return m.Return(ToNewStatus(status));
 }
 
 Status* __cdecl principia__FlightPlanRemoveLast(Plugin const* const plugin,

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -304,21 +304,34 @@ void Vessel::DeleteFlightPlan() {
   flight_plan_.reset();
 }
 
-void Vessel::RebaseFlightPlan(Mass const& initial_mass) {
-  not_null<std::unique_ptr<FlightPlan>> original_flight_plan =
+Status Vessel::RebaseFlightPlan(Mass const& initial_mass) {
+  CHECK(has_flight_plan());
+  Instant const new_initial_time = history_->back().time;
+  int first_manœuvre_kept = 0;
+  for (int i = 0; i < flight_plan_->number_of_manœuvres(); ++i) {
+    auto const& manœuvre = flight_plan_->GetManœuvre(i);
+    if (manœuvre.initial_time() < new_initial_time) {
+      first_manœuvre_kept = i + 1;
+      if (new_initial_time < manœuvre.final_time()) {
+        return Status(Error::UNAVAILABLE,
+                      u8"Cannot rebase during planned manœuvre execution");
+      }
+    }
+  }
+  not_null<std::unique_ptr<FlightPlan>> const original_flight_plan =
       std::move(flight_plan_);
   CreateFlightPlan(
       original_flight_plan->desired_final_time(),
       initial_mass,
       original_flight_plan->adaptive_step_parameters(),
       original_flight_plan->generalized_adaptive_step_parameters());
-  for (int i = 0; i < original_flight_plan->number_of_manœuvres(); ++i) {
+  for (int i = first_manœuvre_kept;
+       i < original_flight_plan->number_of_manœuvres();
+       ++i) {
     auto const& manœuvre = original_flight_plan->GetManœuvre(i);
-    if (manœuvre.initial_time() < flight_plan_->initial_time()) {
-      continue;
-    }
     flight_plan_->Append(manœuvre.burn());
   }
+  return Status::OK;
 }
 
 void Vessel::RefreshPrediction() {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -150,6 +150,12 @@ class Vessel {
   // Deletes the |flight_plan_|.  Performs no action unless |has_flight_plan()|.
   virtual void DeleteFlightPlan();
 
+  // Requires |has_flight_plan()|.
+  // Deletes |flight_plan_| and recreates it from the current |history_| and
+  // the given |initial_mass|, re-adding any future manœuvres.  Past manœuvres
+  // are discarded, under the assumption that they have been performed.
+  virtual void RebaseFlightPlan(Mass const& initial_mass);
+
   // Tries to replace the current prediction with a more recently computed one.
   // No guarantees that this happens.  No guarantees regarding the end time of
   // the prediction when this call returns.

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -151,10 +151,13 @@ class Vessel {
   virtual void DeleteFlightPlan();
 
   // Requires |has_flight_plan()|.
-  // Deletes |flight_plan_| and recreates it from the current |history_| and
-  // the given |initial_mass|, re-adding any future manœuvres.  Past manœuvres
-  // are discarded, under the assumption that they have been performed.
-  virtual void RebaseFlightPlan(Mass const& initial_mass);
+  // if |history_->back().time| lies within a planned manœuvre, UNAVAILABLE is
+  // returned.
+  // Otherwise, deletes |flight_plan_| and recreates it from the current
+  // |history_| and the given |initial_mass|, re-adding any future manœuvres.
+  // Past manœuvres are discarded, under the assumption that they have been
+  // performed.
+  Status RebaseFlightPlan(Mass const& initial_mass);
 
   // Tries to replace the current prediction with a more recently computed one.
   // No guarantees that this happens.  No guarantees regarding the end time of

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -139,14 +139,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      if (UnityEngine.GUILayout.Button("Rebase")) {
-        var status = plugin.FlightPlanRebase(
-            vessel_guid, predicted_vessel.GetTotalMass());
-        UpdateStatus(status, null);
-        if (status.ok()) {
-          UpdateVesselAndBurnEditors();
-        }
-      }
       if (final_time_.Render(enabled : true)) {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                           final_time_.value);
@@ -237,6 +229,15 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
         Shrink();
         // The state change will happen the next time we go through OnGUI.
       } else {
+        if (UnityEngine.GUILayout.Button("Rebase")) {
+          var status = plugin.FlightPlanRebase(
+              vessel_guid, predicted_vessel.GetTotalMass());
+          UpdateStatus(status, null);
+          if (status.ok()) {
+            return;
+          }
+        }
+
         if (burn_editors_.Count > 0) {
           RenderUpcomingEvents();
         }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -139,6 +139,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
+      if (UnityEngine.GUILayout.Button("Rebase")) {
+        plugin.FlightPlanRebase(vessel_guid, predicted_vessel.GetTotalMass());
+        UpdateVesselAndBurnEditors();
+      }
       if (final_time_.Render(enabled : true)) {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
                                                           final_time_.value);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -140,8 +140,12 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
       if (UnityEngine.GUILayout.Button("Rebase")) {
-        plugin.FlightPlanRebase(vessel_guid, predicted_vessel.GetTotalMass());
-        UpdateVesselAndBurnEditors();
+        var status = plugin.FlightPlanRebase(
+            vessel_guid, predicted_vessel.GetTotalMass());
+        UpdateStatus(status, null);
+        if (status.ok()) {
+          UpdateVesselAndBurnEditors();
+        }
       }
       if (final_time_.Render(enabled : true)) {
         var status = plugin.FlightPlanSetDesiredFinalTime(vessel_guid,
@@ -469,6 +473,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           status_message = "flight plan is too short";
           remedy_message = "increasing the flight plan duration";
         }
+      } else if (status_.is_unavailable()) {
+        status_message =
+            "flight plan cannot be rebased during scheduled manœuvre execution";
+        remedy_message = "moving the manœuvre or waiting for it to finish";
       }
 
       if (anomalous_manœuvres > 0) {

--- a/ksp_plugin_adapter/interface.cs
+++ b/ksp_plugin_adapter/interface.cs
@@ -18,6 +18,9 @@ internal partial class Status {
   public bool is_out_of_range() {
     return error == 11;
   }
+  public bool is_unavailable() {
+    return error == 14;
+  }
   public bool ok() {
     return error == 0;
   }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -211,7 +211,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5172.
+  extensions 5000 to 5999;  // Last used: 5173.
 }
 
 message SetAngularMomentumConservation {
@@ -907,6 +907,19 @@ message FlightPlanNumberOfSegments {
   }
   optional In in = 1;
   optional Return return = 3;
+}
+
+message FlightPlanRebase {
+  extend Method {
+    optional FlightPlanRebase extension = 5173;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+    required double mass_in_tonnes = 3;
+  }
+  optional In in = 1;
 }
 
 message FlightPlanRemoveLast {

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -919,7 +919,11 @@ message FlightPlanRebase {
     required string vessel_guid = 2;
     required double mass_in_tonnes = 3;
   }
+  message Return {
+    required Status result = 1;
+  }
   optional In in = 1;
+  optional Return return = 3;
 }
 
 message FlightPlanRemoveLast {


### PR DESCRIPTION
The `Rebase` button discards past (and ongoing) manœuvres, and sets the flight plan initial state to the current state (in terms of mass as well as position and velocity).

---

Drive-by change: drop the guidance node for one frame when it switches manœuvres; this fixes MuMech/MechJeb2#1276 (though @lamont-granquist wants to leave that one open until the UX is cleaned up a little) and the stock equivalent, whereby guiding to the manœuvre through scheduled burnout would lead to a reorientation to the next manœuvre with the engines still firing.

After this change, at the scheduled end of the burn, MechJeb ceases burn execution (shutting down the engines), and the stock SAS switches to holding attitude.