### PR TITLE
Mean apsides and minimal distance

### DIFF
--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -106,9 +106,9 @@ class OrbitalElements {
   Interval<Angle> mean_longitude_of_ascending_node_interval() const;
   Interval<Angle> mean_argument_of_periapsis_interval() const;
 
-  Interval<Length> mean_periapsis_interval() const;
-  Interval<Length> mean_apoapsis_interval() const;
-  Interval<Length> distance_interval() const;
+  Interval<Length> mean_periapsis_distance_interval() const;
+  Interval<Length> mean_apoapsis_distance_interval() const;
+  Interval<Length> radial_distance_interval() const;
 
   // The equinoctial elements, and in particular the osculating equinoctial
   // elements, are not directly interesting; anything that could be derived from
@@ -148,7 +148,7 @@ class OrbitalElements {
       Body const& secondary);
 
   template<typename PrimaryCentred>
-  static std::vector<Length> Distances(
+  static std::vector<Length> RadialDistances(
       DiscreteTrajectory<PrimaryCentred> const& trajectory);
 
   // |equinoctial_elements| must contain at least 2 elements.
@@ -171,12 +171,12 @@ class OrbitalElements {
   // element computation is based on it, so it gets computed earlier).
   void ComputePeriodsAndPrecession();
 
-  // |distances_| and |mean_classical_elements_| must have been computed; sets
-  // |distance_interval_| and |mean_*_interval_| accordingly.
+  // |radial_distances_| and |mean_classical_elements_| must have been computed;
+  // sets |radial_distance_interval_| and |mean_*_interval_| accordingly.
   void ComputeIntervals();
 
   std::vector<EquinoctialElements> osculating_equinoctial_elements_;
-  std::vector<Length> distances_;
+  std::vector<Length> radial_distances_;
   Time sidereal_period_;
   std::vector<EquinoctialElements> mean_equinoctial_elements_;
   std::vector<ClassicalElements> mean_classical_elements_;
@@ -184,11 +184,11 @@ class OrbitalElements {
   Time nodal_period_;
   AngularFrequency nodal_precession_;
 
-  Interval<Length> distance_interval_;
+  Interval<Length> radial_distance_interval_;
 
   Interval<Length> mean_semimajor_axis_interval_;
-  Interval<Length> mean_periapsis_interval_;
-  Interval<Length> mean_apoapsis_interval_;
+  Interval<Length> mean_periapsis_distance_interval_;
+  Interval<Length> mean_apoapsis_distance_interval_;
   Interval<double> mean_eccentricity_interval_;
   Interval<Angle> mean_inclination_interval_;
   Interval<Angle> mean_longitude_of_ascending_node_interval_;

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -38,8 +38,8 @@ class OrbitalElements {
 
   // The classical Keplerian elements (a, e, i, Ω, ω, M),
   // together with an epoch.
-  // TODO(egg): consider just using Keplerian elements now that we have the
-  // apsides as well...
+  // TODO(egg): consider just using KeplerianElements now that we have the
+  // apsides as well.
   struct ClassicalElements {
     Instant time;
     Length semimajor_axis;
@@ -132,9 +132,6 @@ class OrbitalElements {
     // tangent; they are better suited to retrograde orbits.
     double pʹ;  // cotg i/2 sin Ω.
     double qʹ;  // cotg i/2 cos Ω.
-
-    // TODO(egg): move this out of here.
-    Length r;
   };
 
   std::vector<EquinoctialElements> const& osculating_equinoctial_elements()
@@ -149,6 +146,10 @@ class OrbitalElements {
       DiscreteTrajectory<PrimaryCentred> const& trajectory,
       MassiveBody const& primary,
       Body const& secondary);
+
+  template<typename PrimaryCentred>
+  static std::vector<Length> Distances(
+      DiscreteTrajectory<PrimaryCentred> const& trajectory);
 
   // |equinoctial_elements| must contain at least 2 elements.
   static Time SiderealPeriod(
@@ -170,11 +171,12 @@ class OrbitalElements {
   // element computation is based on it, so it gets computed earlier).
   void ComputePeriodsAndPrecession();
 
-  // |mean_classical_elements_| must have been computed; sets
-  // |mean_*_interval_| accordingly.
-  void ComputeMeanElementIntervals();
+  // |distances_| and |mean_classical_elements_| must have been computed; sets
+  // |distance_interval_| and |mean_*_interval_| accordingly.
+  void ComputeIntervals();
 
   std::vector<EquinoctialElements> osculating_equinoctial_elements_;
+  std::vector<Length> distances_;
   Time sidereal_period_;
   std::vector<EquinoctialElements> mean_equinoctial_elements_;
   std::vector<ClassicalElements> mean_classical_elements_;

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -38,6 +38,8 @@ class OrbitalElements {
 
   // The classical Keplerian elements (a, e, i, Ω, ω, M),
   // together with an epoch.
+  // TODO(egg): consider just using Keplerian elements now that we have the
+  // apsides as well...
   struct ClassicalElements {
     Instant time;
     Length semimajor_axis;
@@ -46,6 +48,9 @@ class OrbitalElements {
     Angle longitude_of_ascending_node;
     Angle argument_of_periapsis;
     Angle mean_anomaly;
+
+    Length periapsis_distance;
+    Length apoapsis_distance;
   };
 
   // Mean element time series.  These elements are free of short-period
@@ -101,6 +106,10 @@ class OrbitalElements {
   Interval<Angle> mean_longitude_of_ascending_node_interval() const;
   Interval<Angle> mean_argument_of_periapsis_interval() const;
 
+  Interval<Length> mean_periapsis_interval() const;
+  Interval<Length> mean_apoapsis_interval() const;
+  Interval<Length> distance_interval() const;
+
   // The equinoctial elements, and in particular the osculating equinoctial
   // elements, are not directly interesting; anything that could be derived from
   // them should be directly computed by this class instead.  They are however
@@ -123,6 +132,9 @@ class OrbitalElements {
     // tangent; they are better suited to retrograde orbits.
     double pʹ;  // cotg i/2 sin Ω.
     double qʹ;  // cotg i/2 cos Ω.
+
+    // TODO(egg): move this out of here.
+    Length r;
   };
 
   std::vector<EquinoctialElements> const& osculating_equinoctial_elements()
@@ -170,7 +182,11 @@ class OrbitalElements {
   Time nodal_period_;
   AngularFrequency nodal_precession_;
 
+  Interval<Length> distance_interval_;
+
   Interval<Length> mean_semimajor_axis_interval_;
+  Interval<Length> mean_periapsis_interval_;
+  Interval<Length> mean_apoapsis_interval_;
   Interval<double> mean_eccentricity_interval_;
   Interval<Angle> mean_inclination_interval_;
   Interval<Angle> mean_longitude_of_ascending_node_interval_;

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -150,15 +150,15 @@ OrbitalElements::OsculatingEquinoctialElements(
     double const tg_½i = Tan(i / 2);
     double const cotg_½i = 1 / tg_½i;
     result.push_back(
-        {/*.t = */ time,
-         /*.a = */ *osculating_elements.semimajor_axis,
-         /*.h = */ e * Sin(ϖ),
-         /*.k = */ e * Cos(ϖ),
-         /*.λ = */ result.empty() ? ϖ + M : UnwindFrom(result.back().λ, ϖ + M),
-         /*.p = */ tg_½i * Sin(Ω),
-         /*.q = */ tg_½i * Cos(Ω),
-         /*.pʹ = */ cotg_½i * Sin(Ω),
-         /*.qʹ = */ cotg_½i * Cos(Ω)});
+        {.t = time,
+         .a = *osculating_elements.semimajor_axis,
+         .h = e * Sin(ϖ),
+         .k = e * Cos(ϖ),
+         .λ = result.empty() ? ϖ + M : UnwindFrom(result.back().λ, ϖ + M),
+         .p = tg_½i * Sin(Ω),
+         .q = tg_½i * Cos(Ω),
+         .pʹ = cotg_½i * Sin(Ω),
+         .qʹ = cotg_½i * Cos(Ω)});
   }
   return result;
 }
@@ -335,22 +335,22 @@ OrbitalElements::ToClassicalElements(
     Angle const ω = ϖ - Ω;
     Angle const M = equinoctial.λ - ϖ;
     classical_elements.push_back(
-        {/*.time = */ equinoctial.t,
-         /*.semimajor_axis = */ equinoctial.a,
-         /*.eccentricity = */ e,
-         /*.inclination = */ i,
-         /*.longitude_of_ascending_node = */ classical_elements.empty()
+        {.time = equinoctial.t,
+         .semimajor_axis = equinoctial.a,
+         .eccentricity = e,
+         .inclination = i,
+         .longitude_of_ascending_node = classical_elements.empty()
              ? Mod(Ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().longitude_of_ascending_node,
                           Ω),
-         /*.argument_of_periapsis = */ classical_elements.empty()
+         .argument_of_periapsis = classical_elements.empty()
              ? Mod(ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().argument_of_periapsis, ω),
-         /*.mean_anomaly = */ classical_elements.empty()
+         .mean_anomaly = classical_elements.empty()
              ? Mod(M, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().mean_anomaly, M),
-         /*.periapsis_distance = */ (1 - e) * equinoctial.a,
-         /*.apoapsis_distance = */ (1 + e) * equinoctial.a});
+         .periapsis_distance = (1 - e) * equinoctial.a,
+         .apoapsis_distance = (1 + e) * equinoctial.a});
   }
   return classical_elements;
 }

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -172,6 +172,7 @@ std::vector<Length> OrbitalElements::Distances(
     distances.push_back(
         (degrees_of_freedom.position() - primary_dof.position()).Norm());
   }
+  return distances;
 }
 
 inline std::vector<OrbitalElements::EquinoctialElements> const&

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -333,22 +333,22 @@ OrbitalElements::ToClassicalElements(
     Angle const ω = ϖ - Ω;
     Angle const M = equinoctial.λ - ϖ;
     classical_elements.push_back(
-        {equinoctial.t,
-         equinoctial.a,
-         e,
-         i,
-         classical_elements.empty()
+        {/*.time = */ equinoctial.t,
+         /*.semimajor_axis = */ equinoctial.a,
+         /*.eccentricity = */ e,
+         /*.inclination = */ i,
+         /*.longitude_of_ascending_node = */ classical_elements.empty()
              ? Mod(Ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().longitude_of_ascending_node,
                           Ω),
-         classical_elements.empty()
+         /*.argument_of_periapsis = */ classical_elements.empty()
              ? Mod(ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().argument_of_periapsis, ω),
-         classical_elements.empty()
+         /*.mean_anomaly = */ classical_elements.empty()
              ? Mod(M, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().mean_anomaly, M),
-         (1 - e) * equinoctial.a,
-         (1 + e) * equinoctial.a});
+         /*.periapsis_distance = */ (1 - e) * equinoctial.a,
+         /*.apoapsis_distance = */ (1 + e) * equinoctial.a});
   }
   return classical_elements;
 }

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -150,15 +150,15 @@ OrbitalElements::OsculatingEquinoctialElements(
     double const tg_½i = Tan(i / 2);
     double const cotg_½i = 1 / tg_½i;
     result.push_back(
-        {.t = time,
-         .a = *osculating_elements.semimajor_axis,
-         .h = e * Sin(ϖ),
-         .k = e * Cos(ϖ),
-         .λ = result.empty() ? ϖ + M : UnwindFrom(result.back().λ, ϖ + M),
-         .p = tg_½i * Sin(Ω),
-         .q = tg_½i * Cos(Ω),
-         .pʹ = cotg_½i * Sin(Ω),
-         .qʹ = cotg_½i * Cos(Ω)});
+        {/*.t = */ time,
+         /*.a = */ *osculating_elements.semimajor_axis,
+         /*.h = */ e * Sin(ϖ),
+         /*.k = */ e * Cos(ϖ),
+         /*.λ = */ result.empty() ? ϖ + M : UnwindFrom(result.back().λ, ϖ + M),
+         /*.p = */ tg_½i * Sin(Ω),
+         /*.q = */ tg_½i * Cos(Ω),
+         /*.pʹ = */ cotg_½i * Sin(Ω),
+         /*.qʹ = */ cotg_½i * Cos(Ω)});
   }
   return result;
 }
@@ -335,22 +335,22 @@ OrbitalElements::ToClassicalElements(
     Angle const ω = ϖ - Ω;
     Angle const M = equinoctial.λ - ϖ;
     classical_elements.push_back(
-        {.time = equinoctial.t,
-         .semimajor_axis = equinoctial.a,
-         .eccentricity = e,
-         .inclination = i,
-         .longitude_of_ascending_node = classical_elements.empty()
+        {/*.time = */ equinoctial.t,
+         /*.semimajor_axis = */ equinoctial.a,
+         /*.eccentricity = */ e,
+         /*.inclination = */ i,
+         /*.longitude_of_ascending_node = */ classical_elements.empty()
              ? Mod(Ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().longitude_of_ascending_node,
                           Ω),
-         .argument_of_periapsis = classical_elements.empty()
+         /*.argument_of_periapsis = */ classical_elements.empty()
              ? Mod(ω, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().argument_of_periapsis, ω),
-         .mean_anomaly = classical_elements.empty()
+         /*.mean_anomaly = */ classical_elements.empty()
              ? Mod(M, 2 * π * Radian)
              : UnwindFrom(classical_elements.back().mean_anomaly, M),
-         .periapsis_distance = (1 - e) * equinoctial.a,
-         .apoapsis_distance = (1 + e) * equinoctial.a});
+         /*.periapsis_distance = */ (1 - e) * equinoctial.a,
+         /*.apoapsis_distance = */ (1 + e) * equinoctial.a});
   }
   return classical_elements;
 }

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -409,7 +409,7 @@ inline void OrbitalElements::ComputePeriodsAndPrecession() {
 inline void OrbitalElements::ComputeIntervals() {
   for (auto const& r : distances_) {
     distance_interval_.Include(r);
-  } 
+  }
   for (auto const& elements : mean_classical_elements_) {
     mean_semimajor_axis_interval_.Include(elements.semimajor_axis);
     mean_eccentricity_interval_.Include(elements.eccentricity);

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -116,6 +116,9 @@ OrbitAnalysis* __cdecl principia__VesselRefreshAnalysis(
           ToInterval(elements.mean_longitude_of_ascending_node_interval()),
           .mean_argument_of_periapsis =
           ToInterval(elements.mean_argument_of_periapsis_interval()),
+          .mean_periapsis = ToInterval(elements.mean_periapsis_interval()),
+          .mean_apoapsis = ToInterval(elements.mean_apoapsis_interval()),
+          .distance = ToInterval(elements.distance_interval()),
       };
     }
     if (has_nominal_recurrence) {

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -116,9 +116,11 @@ OrbitAnalysis* __cdecl principia__VesselRefreshAnalysis(
           ToInterval(elements.mean_longitude_of_ascending_node_interval()),
           .mean_argument_of_periapsis =
           ToInterval(elements.mean_argument_of_periapsis_interval()),
-          .mean_periapsis = ToInterval(elements.mean_periapsis_interval()),
-          .mean_apoapsis = ToInterval(elements.mean_apoapsis_interval()),
-          .distance = ToInterval(elements.distance_interval()),
+          .mean_periapsis_distance =
+          ToInterval(elements.mean_periapsis_distance_interval()),
+          .mean_apoapsis_distance =
+          ToInterval(elements.mean_apoapsis_distance_interval()),
+          .radial_distance = ToInterval(elements.radial_distance_interval()),
       };
     }
     if (has_nominal_recurrence) {

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -247,7 +247,7 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
 
   private void RenderOrbitalElements(OrbitalElements? elements,
                                      CelestialBody primary) {
-      double? lowest_distance = elements?.distance.min;
+      double? lowest_distance = elements?.radial_distance.min;
       LabeledField(
           "Lowest altitude",
           (lowest_distance - primary?.Radius)?.FormatAltitude());
@@ -285,10 +285,10 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
             "Argument of periapsis",
             elements?.mean_argument_of_periapsis.FormatAngleInterval());
       LabeledField("Altitude of mean periapsis",
-                   elements?.mean_periapsis.FormatLengthInterval(
+                   elements?.mean_periapsis_distance.FormatLengthInterval(
                        primary.Radius));
       LabeledField("Altitude of mean apoapsis",
-                   elements?.mean_apoapsis.FormatLengthInterval(
+                   elements?.mean_apoapsis_distance.FormatLengthInterval(
                        primary.Radius));
   }
 

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 
 namespace principia {
 namespace ksp_plugin_adapter {

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -7,8 +7,7 @@ namespace ksp_plugin_adapter {
 // handling easier, thanks to null-coalescing operators.
 internal static class Formatters {
   // Formats |value| in "N<fractional_digits>" using the Principia culture.
-  public static string FormatN(this double value,
-                               int fractional_digits) {
+  public static string FormatN(this double value, int fractional_digits) {
     return value.ToString($"N{fractional_digits}", Culture.culture);
   }
 
@@ -34,7 +33,9 @@ internal static class Formatters {
   }
 
   // Displays an interval of lengths as midpoint±half-width, in km if the
-  // half-width is 100 m or more.
+  // half-width is 100 m or more.  The midpoint is given with respect to
+  // |offset| (for instance, if |interval| is an interval of distances from the
+  // primary and |offset| is the radius of the primary, altitudes are shown).
   public static string FormatLengthInterval(this Interval interval,
                                             double offset = 0) {
     double half_width = (interval.max - interval.min) / 2;

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -262,7 +262,7 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
           : "";
       UnityEngine.GUILayout.Label(altitude_warning,
                                   Style.Warning(UnityEngine.GUI.skin.label));
-      UnityEngine.GUILayout.Label("Orbital elements");
+      UnityEngine.GUILayout.Label("Mean orbital elements");
       LabeledField("Sidereal period",
                    elements?.sidereal_period.FormatDuration());
       LabeledField("Nodal period",
@@ -273,12 +273,6 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
                    elements?.mean_semimajor_axis.FormatLengthInterval());
       LabeledField("Eccentricity",
                    elements?.mean_eccentricity.FormatInterval());
-      LabeledField("Mean periapsis altitude",
-                   elements?.mean_periapsis.FormatLengthInterval(
-                       primary.Radius));
-      LabeledField("Mean apoapsis altitude",
-                   elements?.mean_apoapsis.FormatLengthInterval(
-                       primary.Radius));
       LabeledField("Inclination",
                    elements?.mean_inclination.FormatAngleInterval());
       LabeledField(
@@ -290,6 +284,12 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
       LabeledField(
             "Argument of periapsis",
             elements?.mean_argument_of_periapsis.FormatAngleInterval());
+      LabeledField("Altitude of mean periapsis",
+                   elements?.mean_periapsis.FormatLengthInterval(
+                       primary.Radius));
+      LabeledField("Altitude of mean apoapsis",
+                   elements?.mean_apoapsis.FormatLengthInterval(
+                       primary.Radius));
   }
 
   private void RenderOrbitRecurrence(OrbitRecurrence? recurrence,

--- a/principia.props
+++ b/principia.props
@@ -76,7 +76,8 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard Condition="$(ProjectName) == astronomy or
                                    $(ProjectName) == ksp_plugin or
-                                   $(ProjectName) == ksp_plugin_test">stdcpplatest</LanguageStandard>
+                                   $(ProjectName) == ksp_plugin_test or
+                                   $(ProjectName) == mathematica">stdcpplatest</LanguageStandard>
       <WarningLevel Condition="!$(PrincipiaCompilerClangLLVM)">Level3</WarningLevel>
       <WarningLevel Condition="$(PrincipiaCompilerClangLLVM) and
                                $(ProjectName) == serialization">TurnOffAllWarnings</WarningLevel>

--- a/principia.props
+++ b/principia.props
@@ -74,10 +74,7 @@
       <AdditionalOptions>/bigobj /w14714 /Zc:char8_t-</AdditionalOptions>
       <AdditionalOptions Condition="$(ProjectName) != serialization">/w14061 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <LanguageStandard Condition="$(ProjectName) == astronomy or
-                                   $(ProjectName) == ksp_plugin or
-                                   $(ProjectName) == ksp_plugin_test or
-                                   $(ProjectName) == mathematica">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="$(ProjectName) != numerics">stdcpplatest</LanguageStandard>
       <WarningLevel Condition="!$(PrincipiaCompilerClangLLVM)">Level3</WarningLevel>
       <WarningLevel Condition="$(PrincipiaCompilerClangLLVM) and
                                $(ProjectName) == serialization">TurnOffAllWarnings</WarningLevel>

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -180,6 +180,7 @@ message OrbitalElements {
   required Interval mean_argument_of_periapsis = 9;
   required Interval mean_periapsis = 10;
   required Interval mean_apoapsis = 11;
+  // Added in Gallai.
   required Interval distance = 12;
 }
 

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -178,6 +178,9 @@ message OrbitalElements {
   required Interval mean_inclination = 7;
   required Interval mean_longitude_of_ascending_nodes = 8;
   required Interval mean_argument_of_periapsis = 9;
+  required Interval mean_periapsis = 10;
+  required Interval mean_apoapsis = 11;
+  required Interval distance = 12;
 }
 
 message OrbitRecurrence {

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -178,10 +178,10 @@ message OrbitalElements {
   required Interval mean_inclination = 7;
   required Interval mean_longitude_of_ascending_nodes = 8;
   required Interval mean_argument_of_periapsis = 9;
-  required Interval mean_periapsis = 10;
-  required Interval mean_apoapsis = 11;
+  required Interval mean_periapsis_distance = 10;
+  required Interval mean_apoapsis_distance = 11;
   // Added in Gallai.
-  required Interval distance = 12;
+  required Interval radial_distance = 12;
 }
 
 message OrbitRecurrence {


### PR DESCRIPTION
Add the following to the orbit analysis window:
- a warning if any of the following occur over the course of the mission:
  - dropping below the nominal atmosphere height: reentry,
  - dropping below the highest terrain altitude: collision risk,
  - dropping below the lowest terrain altitude or, on a planet with oceans, sea level, whichever one is higher: collision);
- lowest altitude: the lowest altitude reached over the course of the mission;
- altitude of mean periapsis: the altitude corresponding to the periapsis distance itself corresponding to the mean semimajor axis and mean eccentricity;
- altitude of mean apoapsis: the altitude corresponding to the apoapsis distance itself corresponding to the mean semimajor axis and mean eccentricity;

While the mean periapsis and apoapsis altitudes are not really directly meaningful, since it is customary to describe orbits by their periapsis and apoapsis altitudes, they are a more readily understood description of the size and shape of the orbit.