### PR TITLE
Handle collisions ourselves

### DIFF
--- a/ksp_plugin_adapter/collision_reporter.cs
+++ b/ksp_plugin_adapter/collision_reporter.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace principia {
+namespace ksp_plugin_adapter {
+
+internal class CollisionReporter : UnityEngine.MonoBehaviour {
+  private void FixedUpdate() {
+    collisions.Clear();
+  }
+
+  private void OnCollisionEnter(UnityEngine.Collision collision) {
+    collisions.Add(collision);
+  }
+
+  private void OnCollisionStay(UnityEngine.Collision collision) {
+    collisions.Add(collision);
+  }
+
+  public List<UnityEngine.Collision> collisions =
+      new List<UnityEngine.Collision>();
+}
+
+}  // namespace ksp_plugin_adapter
+}  // namespace principia

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1189,7 +1189,6 @@ public partial class PrincipiaPluginAdapter
             plugin_.ReportGroundCollision(
                 closest_physical_parent(part1).flightID);
           }
-#if KSP_VERSION_1_9_1
           var collision_reporter =
               part1.gameObject.GetComponent<CollisionReporter>();
           if (part1.gameObject.GetComponent<CollisionReporter>() == null) {
@@ -1200,9 +1199,6 @@ public partial class PrincipiaPluginAdapter
           }
           foreach (var collision in collision_reporter.collisions) {
             var collider = collision.collider;
-#elif KSP_VERSION_1_7_3
-          foreach (var collider in part1.currentCollisions) {
-#endif
             if (collider == null) {
               // This happens, albeit quite rarely, see #1447.  When it happens,
               // the null collider remains in |currentCollisions| until the next

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1155,11 +1155,11 @@ public partial class PrincipiaPluginAdapter
 
     plugin_.PrepareToReportCollisions();
 
-    // The collisions are reported and stored into |currentCollisions| in
-    // OnCollisionEnter|Stay|Exit, which occurred while we yielded.
-    // Here, the |currentCollisions| are the collisions that occurred in the
-    // physics simulation, which is why we report them before calling
-    // |AdvanceTime|.
+    // The collisions are reported by the
+    // CollisionReporter.OnCollisionEnter|Stay events, which occurred while we
+    // yielded.
+    // Here, the |CollisionReporter.collisions| are the collisions that occurred
+    // in the physics simulation.
     foreach (Vessel vessel1 in
              FlightGlobals.Vessels.Where(v => !v.packed && is_manageable(v))) {
       if (plugin_.HasVessel(vessel1.id.ToString())) {
@@ -1167,6 +1167,7 @@ public partial class PrincipiaPluginAdapter
                               is_clambering(vessel1.evaController))) {
           var vessel2 = vessel1.evaController.LadderPart?.vessel;
           if (vessel2 != null && !vessel2.packed && is_manageable(vessel2)) {
+            Log.Info("Reporting climbing a ladder");
             plugin_.ReportPartCollision(
                 vessel1.rootPart.flightID,
                 closest_physical_parent(
@@ -1189,7 +1190,16 @@ public partial class PrincipiaPluginAdapter
                 closest_physical_parent(part1).flightID);
           }
 #if KSP_VERSION_1_9_1
-          foreach (var collider in part1.currentCollisions.Keys) {
+          var collision_reporter =
+              part1.gameObject.GetComponent<CollisionReporter>();
+          if (part1.gameObject.GetComponent<CollisionReporter>() == null) {
+            // This would only happen if |part1| had been added after
+            // |BetterLateThanNever|, but we never know what the game will throw
+            // at us.
+            continue;
+          }
+          foreach (var collision in collision_reporter.collisions) {
+            var collider = collision.collider;
 #elif KSP_VERSION_1_7_3
           foreach (var collider in part1.currentCollisions) {
 #endif
@@ -1211,6 +1221,8 @@ public partial class PrincipiaPluginAdapter
               // All parts in a vessel are in the same pile up, so there is no
               // point in reporting this collision; this also causes issues
               // where disappearing kerbals collide with themselves.
+              // NOTE(egg): It is unclear whether this is needed now that we
+              // have the |CollisionReporter|.
               continue;
             }
             if (part1.State == PartStates.DEAD ||
@@ -1229,6 +1241,8 @@ public partial class PrincipiaPluginAdapter
                 // better ignore the collision, the Kerbal will soon become
                 // ready anyway.
               } else if (is_manageable(vessel2)) {
+                Log.Info($@"Reporting collision with collider {collider.name} ({
+                            (UnityLayers)collider.gameObject.layer})");
                 plugin_.ReportPartCollision(
                     closest_physical_parent(part1).flightID,
                     closest_physical_parent(part2).flightID);
@@ -1577,6 +1591,13 @@ public partial class PrincipiaPluginAdapter
               new QP{q = (XYZ)(Vector3d)part.rb.position,
                      p = (XYZ)(Vector3d)part.rb.velocity});
         }
+      }
+    }
+    foreach (Vessel vessel in FlightGlobals.Vessels.Where(v => !v.packed)) {
+      foreach (Part part in vessel.parts.Where(
+                   p => p.gameObject.GetComponent<CollisionReporter>() == null)) {
+        // Ensure that all unpacked parts have a collision reporter.
+        part.gameObject.AddComponent<CollisionReporter>();
       }
     }
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -105,6 +105,7 @@
   <ItemGroup>
     <Compile Include="boxed.cs" />
     <Compile Include="burn_editor.cs" />
+    <Compile Include="collision_reporter.cs" />
     <Compile Include="compatibility_extensions.cs" />
     <Compile Include="config_node_extensions.cs" />
     <Compile Include="config_node_parsers.cs" />

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -521,7 +521,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   // They must not be serialized: their non-default values can lead to absurd
   // behaviour.
   private static bool conserve_angular_momentum = true;
-  private static readonly bool show_2519_debugging_ui = false;
+  private static readonly bool show_2519_debugging_ui = true;
 
   private static readonly double[] prediction_length_tolerances_ =
       {1e-3, 1e-2, 1e0, 1e1, 1e2, 1e3, 1e4};

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -521,7 +521,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   // They must not be serialized: their non-default values can lead to absurd
   // behaviour.
   private static bool conserve_angular_momentum = true;
-  private static readonly bool show_2519_debugging_ui = true;
+  private static readonly bool show_2519_debugging_ui = false;
 
   private static readonly double[] prediction_length_tolerances_ =
       {1e-3, 1e-2, 1e0, 1e1, 1e2, 1e3, 1e4};


### PR DESCRIPTION
It appears that `currentCollisions` is often wrong (reference counting never works).

This improves matters with respect to the ejection part of #2607: the elimination of spurious collisions means that the Kerbal is no longer considered part of its aircraft, and thus we no longer impart erratic velocity and position corrections after ejection.

The issue of the attitude under parachute remains, as we do not understand how the parachute acts upon the Kerbal’s attitude.