### PR TITLE
Reference part offset

### DIFF
--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -161,10 +161,6 @@ RigidMotion<RigidPart, Barycentric> const& Part::rigid_motion() const {
   return rigid_motion_;
 }
 
-DegreesOfFreedom<Barycentric> Part::degrees_of_freedom() const {
-  return rigid_motion_({RigidPart::origin, RigidPart::unmoving});
-}
-
 DiscreteTrajectory<Barycentric>::Iterator Part::history_begin() {
   // Make sure that we skip the point of the prehistory.
   auto it = history_->Fork();

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -112,7 +112,7 @@ class Part final {
 
   // A convenience selector.
   // TODO(phl): Should probably be eliminated at some point.
-  DegreesOfFreedom<Barycentric> degrees_of_freedom() const;
+  // DegreesOfFreedom<Barycentric> degrees_of_freedom() const;
 
   // Return iterators to the beginning and end of the history and psychohistory
   // of the part, respectively.  Either trajectory may be empty, but they are

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -110,10 +110,6 @@ class Part final {
       RigidMotion<RigidPart, Barycentric> const& rigid_motion);
   RigidMotion<RigidPart, Barycentric> const& rigid_motion() const;
 
-  // A convenience selector.
-  // TODO(phl): Should probably be eliminated at some point.
-  // DegreesOfFreedom<Barycentric> degrees_of_freedom() const;
-
   // Return iterators to the beginning and end of the history and psychohistory
   // of the part, respectively.  Either trajectory may be empty, but they are
   // not both empty.

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -715,10 +715,12 @@ RigidMotion<Barycentric, World> Plugin::BarycentricToWorld(
       main_body_frame.ToThisFrameAtTime(current_time_);
   auto const barycentric_to_main_body_rotation =
       barycentric_to_main_body_motion.rigid_transformation().linear_map();
+  Part const& reference_part = *FindOrDie(part_id_to_vessel_, reference_part_id)
+                                    ->part(reference_part_id);
   auto const reference_part_degrees_of_freedom =
-      barycentric_to_main_body_motion(
-          FindOrDie(part_id_to_vessel_, reference_part_id)->
-              part(reference_part_id)->degrees_of_freedom());
+      barycentric_to_main_body_motion(reference_part.rigid_motion()(
+          reference_part.MakeRigidToEccentricMotion().Inverse()(
+              {EccentricPart::origin, EccentricPart::unmoving})));
 
   RigidTransformation<MainBodyCentred, World> const
       main_body_to_world_rigid_transformation = [&]() {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -169,7 +169,9 @@ void Vessel::PrepareHistory(Instant const& t) {
               << " at " << t;
     BarycentreCalculator<DegreesOfFreedom<Barycentric>, Mass> calculator;
     ForAllParts([&calculator](Part& part) {
-      calculator.Add(part.degrees_of_freedom(), part.mass());
+      calculator.Add(
+          part.rigid_motion()({RigidPart::origin, RigidPart::unmoving}),
+          part.mass());
     });
     CHECK(psychohistory_ == nullptr);
     history_->SetDownsampling(max_dense_intervals, downsampling_tolerance);

--- a/ksp_plugin_test/part_test.cpp
+++ b/ksp_plugin_test/part_test.cpp
@@ -147,7 +147,10 @@ TEST_F(PartTest, Serialization) {
   auto const p = Part::ReadFromMessage(message, /*deletion_callback=*/nullptr);
   EXPECT_EQ(part_.inertia_tensor(), p->inertia_tensor());
   EXPECT_EQ(part_.intrinsic_force(), p->intrinsic_force());
-  EXPECT_EQ(part_.degrees_of_freedom(), p->degrees_of_freedom());
+  EXPECT_EQ(part_.rigid_motion()({RigidPart::origin, RigidPart::unmoving}),
+            p->rigid_motion()({RigidPart::origin, RigidPart::unmoving}));
+  EXPECT_EQ(part_.rigid_motion().angular_velocity_of<RigidPart>(),
+            p->rigid_motion().angular_velocity_of<RigidPart>());
 
   serialization::Part second_message;
   p->WriteToMessage(&second_message,

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -626,12 +626,13 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
                          &ephemeris,
                          deletion_callback_.AsStdFunction());
   Velocity<Barycentric> const old_velocity =
-      p1_.degrees_of_freedom().velocity();
+      p1_.rigid_motion()({RigidPart::origin, RigidPart::unmoving}).velocity();
 
   pile_up.AdvanceTime(astronomy::J2000 + 1.5 * fixed_step);
   pile_up.NudgeParts();
-  EXPECT_THAT(p1_.degrees_of_freedom().velocity(),
-              AlmostEquals(old_velocity, 2));
+  EXPECT_THAT(
+      p1_.rigid_motion()({RigidPart::origin, RigidPart::unmoving}).velocity(),
+      AlmostEquals(old_velocity, 2));
 
   Vector<Acceleration, Barycentric> const a{{1729 * Metre / Pow<2>(Second),
                                              -168 * Metre / Pow<2>(Second),
@@ -640,8 +641,9 @@ TEST_F(PileUpTest, MidStepIntrinsicForce) {
   pile_up.RecomputeFromParts();
   pile_up.AdvanceTime(astronomy::J2000 + 2 * fixed_step);
   pile_up.NudgeParts();
-  EXPECT_THAT(p1_.degrees_of_freedom().velocity(),
-              AlmostEquals(old_velocity + 0.5 * fixed_step * a, 1));
+  EXPECT_THAT(
+      p1_.rigid_motion()({RigidPart::origin, RigidPart::unmoving}).velocity(),
+      AlmostEquals(old_velocity + 0.5 * fixed_step * a, 1));
 }
 
 TEST_F(PileUpTest, Serialization) {


### PR DESCRIPTION
Missed in #2604, hidden by an old TODO.

This led to transient jumps when coming out of warp in vessels whose root part had a CoM offset, and, in some mysterious RO setups, to persistent deformation of the vessel.