### PR TITLE
Change ComputeRCSCharacteristics to use the sum of positive thrusts, …

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -236,7 +236,7 @@ class BurnEditor : ScalingRenderer {
              (from transform in engine.thrusterTransforms
               select Math.Max(0,
                               Vector3d.Dot(reference_direction,
-                                           -transform.up))).Average()).
+                                           -transform.up))).Sum()).
             ToArray();
     thrust_in_kilonewtons_ = thrusts.Sum();
 


### PR DESCRIPTION
…rather than the average since multi-port thrusters appear to be able to deliver full thrust down any single port.

This fixes #2571.