### PR TITLE
Fix the collision warning for bodies with oceans

### DIFF
--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -251,9 +251,10 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
       LabeledField(
           "Lowest altitude",
           (lowest_distance - primary?.Radius)?.FormatAltitude());
-      double? lowest_primary_altitude =
-          primary?.ocean == true ? 0 : primary?.pqsController?.radiusMin;
-      string altitude_warning = lowest_distance < lowest_primary_altitude
+      double? lowest_primary_distance = primary?.ocean == true
+          ? primary.Radius
+          : primary?.pqsController?.radiusMin;
+      string altitude_warning = lowest_distance < lowest_primary_distance
           ? "collision"
           : lowest_distance < primary?.pqsController?.radiusMax
           ? "collision risk"


### PR DESCRIPTION
Due to confusion between radii and altitudes, submarine periapsides were seen as a mere collision *risk*.