### PR TITLE
Collapsible manœuvres

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -67,8 +67,8 @@ class BurnEditor : ScalingRenderer {
   // Renders the |BurnEditor|.  Returns true if and only if the settings were
   // changed.
   public Event Render(string header,
-                     bool anomalous,
-                     double burn_final_time) {
+                      bool anomalous,
+                      double burn_final_time) {
     bool changed = false;
     previous_coast_duration_.max_value = burn_final_time - time_base;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -87,7 +87,7 @@ class BurnEditor : ScalingRenderer {
       }
       UnityEngine.GUILayout.Label(
           info,
-          Style.RightAligned(Style.Info(UnityEngine.GUI.skin.label)));
+          Style.Info(UnityEngine.GUI.skin.label));
       if (UnityEngine.GUILayout.Button("Delete", GUILayoutWidth(2))) {
         return Event.Deleted;
       }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
+using VehiclePhysics;
 
 namespace principia {
 namespace ksp_plugin_adapter {
@@ -259,22 +261,17 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
         for (int i = 0; i < burn_editors_.Count; ++i) {
           Style.HorizontalLine();
-          // In the future, coast information, e.g., orbit analysis will be
-          // shown between these lines.  For now, we only have a button to
-          // insert a burn.
-          if (RenderAddManœuvreButton(i)) {
+          if (RenderCoast(i)) {
             return;
           }
           Style.HorizontalLine();
           BurnEditor burn = burn_editors_[i];
-          bool delete = false;
-          if (burn.Render(header          : "Manœuvre #" + (i + 1),
-                          anomalous       :
-                              i >= (burn_editors_.Count -
-                                    number_of_anomalous_manœuvres_),
-                          burn_final_time : final_times[i],
-                          delete          : () => {delete = true;})) {
-            if (delete) {
+          switch (burn.Render(header          : "Manœuvre #" + (i + 1),
+                              anomalous       :
+                                  i >= (burn_editors_.Count -
+                                        number_of_anomalous_manœuvres_),
+                              burn_final_time : final_times[i])) {
+            case BurnEditor.Event.Deleted: {
               var status = plugin.FlightPlanRemove(vessel_guid, i);
               UpdateStatus(status, null);
               burn_editors_[i].Close();
@@ -282,15 +279,24 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
               UpdateBurnEditorIndices();
               Shrink();
               return;
-            } else {
+            }
+            case BurnEditor.Event.Minimized:
+            case BurnEditor.Event.Maximized:
+              Shrink();
+              return;
+            case BurnEditor.Event.Changed: {
               var status =
                   plugin.FlightPlanReplace(vessel_guid, burn.Burn(), i);
               UpdateStatus(status, i);
               burn.Reset(plugin.FlightPlanGetManoeuvre(vessel_guid, i));
+              break;
             }
+            case BurnEditor.Event.None:
+              break;
           }
         }
-        if (RenderAddManœuvreButton(burn_editors_.Count)) {
+        Style.HorizontalLine();
+        if (RenderCoast(burn_editors_.Count)) {
           return;
         }
       }
@@ -347,47 +353,61 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
     }
   }
 
-  private bool RenderAddManœuvreButton(int index) {
+  private bool RenderCoast(int index) {
     string vessel_guid = predicted_vessel.id.ToString();
-    if (UnityEngine.GUILayout.Button(
+    using (new UnityEngine.GUILayout.HorizontalScope()) {
+      double start_of_coast = index == 0
+          ? plugin.FlightPlanGetInitialTime(vessel_guid)
+          : burn_editors_[index - 1].final_time;
+      string coast_description = index == burn_editors_.Count
+          ? "Final trajectory"
+          : $@"Coast for {
+                (burn_editors_[index].initial_time -
+                 start_of_coast).FormatDuration(show_seconds : false)}";
+      UnityEngine.GUILayout.Label(
+          coast_description);
+      if (UnityEngine.GUILayout.Button(
             "Add manœuvre",
-            UnityEngine.GUILayout.ExpandWidth(true))) {
-      double initial_time;
-      if (index == 0) {
-        initial_time = plugin.CurrentTime() + 60;
-      } else {
-        initial_time = plugin.FlightPlanGetManoeuvre(
-                            vessel_guid,
-                            index - 1).final_time + 60;
-      }
-      var editor =
-          new BurnEditor(adapter_,
-                         predicted_vessel,
-                         initial_time,
-                         index,
-                         get_burn_at_index : burn_editors_.ElementAtOrDefault);
-      Burn candidate_burn = editor.Burn();
-      var status = plugin.FlightPlanInsert(
-          vessel_guid, candidate_burn, index);
+            GUILayoutWidth(4))) {
+        double initial_time;
+        if (index == 0) {
+          initial_time = plugin.CurrentTime() + 60;
+        } else {
+          initial_time = plugin.FlightPlanGetManoeuvre(
+                              vessel_guid,
+                              index - 1).final_time + 60;
+        }
+        var editor = new BurnEditor(
+            adapter_,
+            predicted_vessel,
+            initial_time,
+            index,
+            get_burn_at_index : burn_editors_.ElementAtOrDefault);
+        editor.minimized = false;
+        Burn candidate_burn = editor.Burn();
+        var status = plugin.FlightPlanInsert(
+            vessel_guid, candidate_burn, index);
 
-      // The previous call did not necessarily create a manœuvre.  Check if
-      // we need to add an editor.
-      int number_of_manœuvres =
-          plugin.FlightPlanNumberOfManoeuvres(vessel_guid);
-      if (number_of_manœuvres > burn_editors_.Count) {
-        editor.Reset(plugin.FlightPlanGetManoeuvre(
-            vessel_guid, index));
-        burn_editors_.Insert(index, editor);
-        UpdateBurnEditorIndices();
+        // The previous call did not necessarily create a manœuvre.  Check if
+        // we need to add an editor.
+        int number_of_manœuvres =
+            plugin.FlightPlanNumberOfManoeuvres(vessel_guid);
+        if (number_of_manœuvres > burn_editors_.Count) {
+          editor.Reset(plugin.FlightPlanGetManoeuvre(
+              vessel_guid, index));
+          burn_editors_.Insert(index, editor);
+          UpdateBurnEditorIndices();
+          UpdateStatus(status, index);
+          Shrink();
+          return true;
+        }
+        // TODO(phl): The error messaging here will be either confusing or
+        // wrong.  The messages should mention the new manœuvre without
+        // numbering it, since the numbering has not changed (“the new manœuvre
+        // would overlap with manœuvre #1 or manœuvre #2” or something along
+        // these lines).
         UpdateStatus(status, index);
-        Shrink();
-        return true;
       }
-      // TODO(phl): The error messaging here will be either confusing or wrong.
-      // The messages should mention the new manœuvre without numbering it,
-      // since the numbering has not changed (“the new manœuvre would overlap
-      // with manœuvre #1 or manœuvre #2” or something along these lines).
-      UpdateStatus(status, index);
     }
     return false;
   }
@@ -520,11 +540,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
     }
     message_was_displayed_ = true;
     return message;
-  }
-
-  private BurnEditor GetPreviousBurnEditor(BurnEditor editor) {
-    int i = burn_editors_.IndexOf(editor);
-    return i == 0 ? null : burn_editors_[i - 1];
   }
 
   private void UpdateBurnEditorIndices() {

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq;
-using VehiclePhysics;
 
 namespace principia {
 namespace ksp_plugin_adapter {
@@ -281,9 +279,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
               return;
             }
             case BurnEditor.Event.Minimized:
-            case BurnEditor.Event.Maximized:
+            case BurnEditor.Event.Maximized: {
               Shrink();
               return;
+            }
             case BurnEditor.Event.Changed: {
               var status =
                   plugin.FlightPlanReplace(vessel_guid, burn.Burn(), i);
@@ -291,8 +290,9 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
               burn.Reset(plugin.FlightPlanGetManoeuvre(vessel_guid, i));
               break;
             }
-            case BurnEditor.Event.None:
+            case BurnEditor.Event.None: {
               break;
+            }
           }
         }
         Style.HorizontalLine();
@@ -364,18 +364,15 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           : $@"Coast for {
                 (burn_editors_[index].initial_time -
                  start_of_coast).FormatDuration(show_seconds : false)}";
-      UnityEngine.GUILayout.Label(
-          coast_description);
-      if (UnityEngine.GUILayout.Button(
-            "Add manœuvre",
-            GUILayoutWidth(4))) {
+      UnityEngine.GUILayout.Label(coast_description);
+      if (UnityEngine.GUILayout.Button("Add manœuvre", GUILayoutWidth(4))) {
         double initial_time;
         if (index == 0) {
           initial_time = plugin.CurrentTime() + 60;
         } else {
-          initial_time = plugin.FlightPlanGetManoeuvre(
-                              vessel_guid,
-                              index - 1).final_time + 60;
+          initial_time =
+              plugin.FlightPlanGetManoeuvre(vessel_guid,
+                                            index - 1).final_time + 60;
         }
         var editor = new BurnEditor(
             adapter_,


### PR DESCRIPTION
Once we add orbit analysis for coasts, the one-line coast descriptions will reflect that analysis (something like `Coast for 2 d 14 h in Earth orbit (5.2 rev.)`) and will be expandable to show:
- the number of sidereal revolutions, with ±1 buttons;
- the number of nodal revolutions, with ±1 buttons;
- the number of anomalistic revolutions, with ±1 buttons;
- in the distant future, the number of parent-body-synodic revolutions, with ±1 buttons;
- a button to open the full orbit analysis (at least for the final trajectory).

All manœuvres minimized:
![screenshot19](https://user-images.githubusercontent.com/2284290/89355770-86ae7f80-d6bc-11ea-8ee3-186f8c7c999d.png)
One expanded:
![screenshot20](https://user-images.githubusercontent.com/2284290/89355774-8910d980-d6bc-11ea-85fc-e5260ae04f38.png)
