### PR TITLE
Normalize the dot product of Poisson series

### DIFF
--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -32,9 +32,7 @@ AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    std::function<Primitive<Product<std::invoke_result_t<Function, Instant>,
-                                    RValue>,
-                            Time>(
+    std::function<Product<std::invoke_result_t<Function, Instant>, RValue>(
         Function const& left,
         PoissonSeries<RValue, rdegree_, Evaluator> const& right,
         PoissonSeries<double, wdegree_, Evaluator> const& weight)> const& dot);

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -21,14 +21,11 @@ AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    std::function<Primitive<Product<std::invoke_result_t<Function, Instant>,
-                                    RValue>,
-                            Time>(
+    std::function<Product<std::invoke_result_t<Function, Instant>, RValue>(
         Function const& left,
         PoissonSeries<RValue, rdegree_, Evaluator> const& right,
         PoissonSeries<double, wdegree_, Evaluator> const& weight)> const& dot) {
-  using DotResult =
-      Primitive<Product<std::invoke_result_t<Function, Instant>, RValue>, Time>;
+  using DotResult = Product<std::invoke_result_t<Function, Instant>, RValue>;
   using Degree0 = PoissonSeries<double, 0, Evaluator>;
 
   auto amplitude = [&dot, &function, &weight](AngularFrequency const& ω) {

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -81,9 +81,9 @@ TEST_F(FrequencyAnalysisTest, PreciseMode) {
   EXPECT_THAT(mode.midpoint(),
               RelativeErrorFrom(ω, IsNear(8.1e-4_⑴)));
 
-  std::function<Time(Degree0 const& left,
-                     Degree0 const& right,
-                     Degree0 const& weight)> const dot =
+  std::function<double(Degree0 const& left,
+                       Degree0 const& right,
+                       Degree0 const& weight)> const dot =
     [t_min, t_max](Degree0 const& left,
                    Degree0 const& right,
                    Degree0 const& weight) {

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -156,11 +156,11 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 
 // Technically the weight function must be nonnegative for this to be an inner
 // product.  Not sure how this works with the flat-top windows, which can be
-// negative.
+// negative.  Note that the result is normalized by dividing by (t_max - t_min).
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time>
+Product<LValue, RValue>
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
@@ -245,13 +245,13 @@ class PiecewisePoissonSeries {
                    PoissonSeries<R, r, E> const& right);
   template<typename L, typename R, int l, int r, int w,
            template<typename, typename, int> class E>
-  quantities::Primitive<Product<L, R>, Time>
+  Product<L, R>
   friend Dot(PoissonSeries<L, l, E> const& left,
              PiecewisePoissonSeries<R, r, E> const& right,
              PoissonSeries<double, w, E> const& weight);
   template<typename L, typename R, int l, int r, int w,
            template<typename, typename, int> class E>
-  quantities::Primitive<Product<L, R>, Time>
+  Product<L, R>
   friend Dot(PiecewisePoissonSeries<L, l, E> const& left,
              PoissonSeries<R, r, E> const& right,
              PoissonSeries<double, w, E> const& weight);
@@ -334,7 +334,7 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time>
+Product<LValue, RValue>
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight);
@@ -342,7 +342,7 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time>
+Product<LValue, RValue>
 Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -365,7 +365,7 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time>
+Product<LValue, RValue>
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
@@ -373,7 +373,7 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     Instant const& t_max) {
   auto const integrand = left * right * weight;
   auto const primitive = integrand.Primitive();
-  return primitive(t_max) - primitive(t_min);
+  return (primitive(t_max) - primitive(t_min)) / (t_max - t_min);
 }
 
 template<typename Value, int degree_,
@@ -584,39 +584,35 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time> Dot(
+Product<LValue, RValue> Dot(
     PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   using Result = Primitive<Product<LValue, RValue>, Time>;
   Result result;
   for (int i = 0; i < right.series_.size(); ++i) {
-    result += Dot(left,
-                  right.series_[i],
-                  weight,
-                  right.bounds_[i],
-                  right.bounds_[i + 1]);
+    auto const integrand = left * right.series_[i] * weight;
+    auto const primitive = integrand.Primitive();
+    result += primitive(right.bounds_[i + 1]) - primitive(right.bounds_[i]);
   }
-  return result;
+  return result / (right.t_max() - right.t_min());
 }
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator>
-Primitive<Product<LValue, RValue>, Time> Dot(
+Product<LValue, RValue> Dot(
     PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   using Result = Primitive<Product<LValue, RValue>, Time>;
   Result result;
   for (int i = 0; i < left.series_.size(); ++i) {
-    result += Dot(left.series_[i],
-                  right,
-                  weight,
-                  left.bounds_[i],
-                  left.bounds_[i + 1]);
+    auto const integrand = left.series_[i] * right * weight;
+    auto const primitive = integrand.Primitive();
+    result += primitive(left.bounds_[i + 1]) - primitive(left.bounds_[i]);
   }
-  return result;
+  return result / (left.t_max() - left.t_min());
 }
 
 }  // namespace internal_poisson_series

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -183,7 +183,7 @@ TEST_F(PoissonSeriesTest, Dot) {
                   apodization::Hann<HornerEvaluator>(t_min, t_max),
                   t_min,
                   t_max),
-              AlmostEquals(-1143.765683104456272 * Second, 53));
+              AlmostEquals(-381.25522770148542400, 71));
 }
 
 class PiecewisePoissonSeriesTest : public ::testing::Test {
@@ -297,12 +297,12 @@ TEST_F(PiecewisePoissonSeriesTest, Action) {
 }
 
 TEST_F(PiecewisePoissonSeriesTest, Dot) {
-  Time const d1 = Dot(
+  double const d1 = Dot(
       pp_, p_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  Time const d2 = Dot(
+  double const d2 = Dot(
       p_, pp_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (4 * π) * Second, 1));
-  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (4 * π) * Second, 1));
+  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 1));
+  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 1));
 }
 
 }  // namespace numerics


### PR DESCRIPTION
This yields nicer units when computing norm (we are not prepared to handle fractional exponents in quantity).

A contribution to #2400.