### PR TITLE
Change the dot product passed to frequency analysis to be a templated functor

### DIFF
--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -60,11 +60,10 @@ template<int degree_,
          typename Dot,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
-Projection(
-    AngularFrequency const& ω,
-    Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Dot const& dot);
+Projection(AngularFrequency const& ω,
+           Function const& function,
+           PoissonSeries<double, wdegree_, Evaluator> const& weight,
+           Dot const& dot);
 
 }  // namespace internal_frequency_analysis
 

--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -23,40 +23,41 @@ using quantities::Time;
 // A function that implements the dot product between a |Function| and a Poisson
 // series with an apodization function |weight| function that is itself a
 // Poisson series.  |Function| must be a functor taking an Instant.
-template<typename Function,
-         typename RValue, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
-using DotProduct =
-    std::function<Product<std::invoke_result_t<Function, Instant>, RValue>(
-        Function const& left,
-        PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-        PoissonSeries<double, wdegree_, Evaluator> const& weight)>;
+//TODO(phl):comment
+//template<typename Function,
+//         typename RValue, int rdegree_, int wdegree_,
+//         template<typename, typename, int> class Evaluator>
+//using DotProduct =
+//    std::function<Product<std::invoke_result_t<Function, Instant>, RValue>(
+//        Function const& left,
+//        PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+//        PoissonSeries<double, wdegree_, Evaluator> const& weight)>;
 
 // Computes the precise mode of a quasi-periodic |function|, assuming that the
 // mode is over the interval |fft_mode| (so named because it has presumably been
 // obtained using FFT).  See [Cha95].
-template<typename Function,
+template<template<typename, typename, typename> class Dot,
+         typename Function,
          int wdegree_,
          template<typename, typename, int> class Evaluator>
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    DotProduct<Function, double, 0, wdegree_, Evaluator> const& dot);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 // Computes the Кудрявцев projection of |function| on a basis with angular
 // frequency ω and maximum degree |degree_|.  See [Kud07].
 // TODO(phl): We really need multiple angular frequencies.
-template<typename Function,
-         int degree_, int wdegree_,
+template<template<typename, typename, typename> class Dot,
+         int degree_,
+         typename Function,
+         int wdegree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(
     AngularFrequency const& ω,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    DotProduct<Function, std::invoke_result_t<Function, Instant>,
-               degree_, wdegree_, Evaluator> const& dot);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 }  // namespace internal_frequency_analysis
 

--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -20,44 +20,51 @@ using quantities::Primitive;
 using quantities::Product;
 using quantities::Time;
 
-// A function that implements the dot product between a |Function| and a Poisson
-// series with an apodization function |weight| function that is itself a
-// Poisson series.  |Function| must be a functor taking an Instant.
-//TODO(phl):comment
-//template<typename Function,
-//         typename RValue, int rdegree_, int wdegree_,
-//         template<typename, typename, int> class Evaluator>
-//using DotProduct =
-//    std::function<Product<std::invoke_result_t<Function, Instant>, RValue>(
-//        Function const& left,
-//        PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-//        PoissonSeries<double, wdegree_, Evaluator> const& weight)>;
+// In this file Dot is a templated functor that implements the dot product
+// between two functors and a weight.  Its declaration must look like:
+//
+// class Dot {
+//  public:
+//   ...
+//   template<typename LFunction, typename RFunction, typename Weight>
+//   Product<std::invoke_result_t<LFunction, Instant>,
+//           std::invoke_result_t<RFunction, Instant>>
+//   operator()(LFunction const& left,
+//              RFunction const& right,
+//              Weight const& weight) const;
+//   ...
+//};
+//
+// Where the implementation of Dot may assume that Weight is a Poisson series
+// returning a double.
 
 // Computes the precise mode of a quasi-periodic |function|, assuming that the
 // mode is over the interval |fft_mode| (so named because it has presumably been
 // obtained using FFT).  See [Cha95].
-template<template<typename, typename, typename> class Dot,
-         typename Function,
+template<typename Function,
          int wdegree_,
+         typename Dot,
          template<typename, typename, int> class Evaluator>
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight,
+    Dot const& dot);
 
 // Computes the Кудрявцев projection of |function| on a basis with angular
 // frequency ω and maximum degree |degree_|.  See [Kud07].
 // TODO(phl): We really need multiple angular frequencies.
-template<template<typename, typename, typename> class Dot,
-         int degree_,
+template<int degree_,
          typename Function,
          int wdegree_,
+         typename Dot,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(
     AngularFrequency const& ω,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight,
+    Dot const& dot);
 
 }  // namespace internal_frequency_analysis
 

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -161,11 +161,10 @@ template<int degree_,
          typename Dot,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
-Projection(
-    AngularFrequency const& ω,
-    Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Dot const& dot) {
+Projection(AngularFrequency const& ω,
+           Function const& function,
+           PoissonSeries<double, wdegree_, Evaluator> const& weight,
+           Dot const& dot) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Series = PoissonSeries<Value, degree_, Evaluator>;
 
@@ -176,7 +175,7 @@ Projection(
   // This code follows [Kud07], section 2.  Our indices start at 0, unlike those
   // of Кудрявцев which start at 1.
   FixedLowerTriangularMatrix<Inverse<Value>, basis_size> α;
-  std::vector<decltype(std::declval<Function>() - basis[0])> f;
+  std::vector<decltype(std::declval<Function>() - std::declval<Series>())> f;
 
   // Only indices 0 to m - 1 are used in this array.  At the beginning of
   // iteration m it contains Aⱼ⁽ᵐ⁻¹⁾.

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -122,18 +122,18 @@ BasisGenerator<Series, std::index_sequence<indices...>>::Basis(
 }
 
 
-template<typename Function,
+template<template<typename, typename, typename> class Dot,
+         typename Function,
          int wdegree_,
          template<typename, typename, int> class Evaluator>
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    DotProduct<Function, double, 0, wdegree_, Evaluator> const& dot) {
+    PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Degree0 = PoissonSeries<double, 0, Evaluator>;
 
-  auto amplitude = [&dot, &function, &weight](AngularFrequency const& ω) {
+  auto amplitude = [&function, &weight](AngularFrequency const& ω) {
     Instant const& t0 = weight.origin();
     Degree0 const sin(typename Degree0::Polynomial({0}, t0),
                       {{ω,
@@ -143,8 +143,12 @@ AngularFrequency PreciseMode(
                       {{ω,
                         {/*sin=*/typename Degree0::Polynomial({0}, t0),
                          /*cos=*/typename Degree0::Polynomial({1}, t0)}}});
-    auto const sin_amplitude = dot(function, sin, weight);
-    auto const cos_amplitude = dot(function, cos, weight);
+    auto const sin_amplitude =
+        Dot<Function, Degree0, decltype(weight)>::Evaluate(
+            function, sin, weight);
+    auto const cos_amplitude =
+        Dot<Function, Degree0, decltype(weight)>::Evaluate(
+            function, cos, weight);
     return sin_amplitude * sin_amplitude + cos_amplitude * cos_amplitude;
   };
 
@@ -154,16 +158,16 @@ AngularFrequency PreciseMode(
                              std::greater<Square<Value>>());
 }
 
-template<typename Function,
-         int degree_, int wdegree_,
+template<template<typename, typename, typename> class Dot,
+         int degree_,
+         typename Function,
+         int wdegree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(
     AngularFrequency const& ω,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    DotProduct<Function, std::invoke_result_t<Function, Instant>,
-               degree_, wdegree_, Evaluator> const& dot) {
+    PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Series = PoissonSeries<Value, degree_, Evaluator>;
 
@@ -180,21 +184,28 @@ Projection(
   // iteration m it contains Aⱼ⁽ᵐ⁻¹⁾.
   std::array<double, basis_size> A;
 
-  auto const F₀ = dot(function, basis[0], weight);
+  //TODO(phl):Cleanup
+  auto const F₀ = Dot<Function, decltype(basis[0]), decltype(weight)>::Evaluate(
+      function, basis[0], weight);
   // TODO(phl): This does not work if basis does not have the same type as
   // Function, i.e., if the degrees don't match.
-  auto const Q₀₀ = dot(basis[0], basis[0], weight);
+  auto const Q₀₀ =
+      Dot<decltype(basis[0]), decltype(basis[0]), decltype(weight)>::Evaluate(
+          basis[0], basis[0], weight);
   α[0][0] = 1 / Sqrt(Q₀₀);
   A[0] = F₀ / Q₀₀;
   f.emplace_back(function - A[0] * basis[0]);
   for (int m = 1; m < basis_size; ++m) {
     // Contains Fₘ.
-    auto const F = dot(f[m - 1], basis[m], weight);
+    auto const F =
+        Dot<Function, decltype(basis[0]), decltype(weight)>::Evaluate(
+            f[m - 1], basis[m], weight);
 
     // Only indices 0 to m are used in this array.  It contains Qₘⱼ.
     std::array<Square<Value>, basis_size> Q;
     for (int j = 0; j <= m; ++j) {
-      Q[j] = dot(basis[m], basis[j], weight);
+      Q[j] = Dot<decltype(basis[0]), decltype(basis[0]), decltype(weight)>::
+          Evaluate(basis[m], basis[j], weight);
     }
 
     // Only indices 0 to m - 1 are used in this array.  It contains Bⱼ⁽ᵐ⁾.

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -176,16 +176,13 @@ Projection(
   // This code follows [Kud07], section 2.  Our indices start at 0, unlike those
   // of Кудрявцев which start at 1.
   FixedLowerTriangularMatrix<Inverse<Value>, basis_size> α;
-  std::vector<Function> f;
+  std::vector<decltype(std::declval<Function>() - basis[0])> f;
 
   // Only indices 0 to m - 1 are used in this array.  At the beginning of
   // iteration m it contains Aⱼ⁽ᵐ⁻¹⁾.
   std::array<double, basis_size> A;
 
-  //TODO(phl):Cleanup
   auto const F₀ = dot(function, basis[0], weight);
-  // TODO(phl): This does not work if basis does not have the same type as
-  // Function, i.e., if the degrees don't match.
   auto const Q₀₀ = dot(basis[0], basis[0], weight);
   α[0][0] = 1 / Sqrt(Q₀₀);
   A[0] = F₀ / Q₀₀;

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -56,8 +56,10 @@ class PoissonSeries {
   PoissonSeries<quantities::Primitive<Value, Time>, degree_ + 1, Evaluator>
   Primitive() const;
 
-  PoissonSeries& operator+=(PoissonSeries const& right);
-  PoissonSeries& operator-=(PoissonSeries const& right);
+  template<typename V, int d, template<typename, typename, int> class E>
+  PoissonSeries& operator+=(PoissonSeries<V, d, E> const& right);
+  template<typename V, int d, template<typename, typename, int> class E>
+  PoissonSeries& operator-=(PoissonSeries<V, d, E> const& right);
 
  private:
   Instant origin_;  // Common to all polynomials.

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -233,15 +233,22 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
                         ? Infinity<AngularFrequency>
                         : it_right->first;
     if (ωl < ωr) {
-      periodic.insert(periodic.cend(), *it_left);
+      auto const& polynomials_left = it_left->second;
+      periodic.emplace_hint(
+          periodic.cend(),
+          ωl,
+          typename Result::Polynomials{
+              /*sin=*/typename Result::Polynomial(polynomials_left.sin),
+              /*cos=*/typename Result::Polynomial(polynomials_left.cos)});
       ++it_left;
     } else if (ωr < ωl) {
       auto const& polynomials_right = it_right->second;
       periodic.emplace_hint(
           periodic.cend(),
           ωr,
-          typename Result::Polynomials{/*sin=*/-polynomials_right.sin,
-                                       /*cos=*/-polynomials_right.cos});
+          typename Result::Polynomials{
+              /*sin=*/typename Result::Polynomial(-polynomials_right.sin),
+              /*cos=*/typename Result::Polynomial(-polynomials_right.cos)});
       ++it_right;
     } else {
       DCHECK_EQ(ωl, ωr);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -133,18 +133,20 @@ PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
 
 template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
+template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator+=(
-    PoissonSeries const& right) {
+    PoissonSeries<V, d, E> const& right) {
   *this = *this + right;
   return *this;
 }
 
 template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
+template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator-=(
-    PoissonSeries const& right) {
+    PoissonSeries<V, d, E> const& right) {
   *this = *this - right;
   return *this;
 }

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -192,10 +192,22 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
                         ? Infinity<AngularFrequency>
                         : it_right->first;
     if (ωl < ωr) {
-      periodic.insert(periodic.cend(), *it_left);
+      auto const& polynomials_left = it_left->second;
+      periodic.emplace_hint(
+          periodic.cend(),
+          ωl,
+          typename Result::Polynomials{
+              /*sin=*/typename Result::Polynomial(polynomials_left.sin),
+              /*cos=*/typename Result::Polynomial(polynomials_left.cos)});
       ++it_left;
     } else if (ωr < ωl) {
-      periodic.insert(periodic.cend(), *it_right);
+      auto const& polynomials_right = it_right->second;
+      periodic.emplace_hint(
+          periodic.cend(),
+          ωr,
+          typename Result::Polynomials{
+              /*sin=*/typename Result::Polynomial(polynomials_right.sin),
+              /*cos=*/typename Result::Polynomial(polynomials_right.cos)});
       ++it_right;
     } else {
       DCHECK_EQ(ωl, ωr);


### PR DESCRIPTION
This makes it usable for dot products between any kind of functions in the implementation.  This in turns makes it possible to project a function of any degree on a basis of any degree (the test projects a function of degree 4 to bases of degrees 3, 4, and 5).

Fix a few places where polynomials were not converted to a higher degree.

Yet another contribution to #2400.