### PR TITLE
An attempt at addressing ill-conditioned basis elements.

### DIFF
--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -258,7 +258,7 @@ IncrementalProjection(Function const& function,
           // here because our function is real and bounded.  But even if the
           // norm could be computed but was very small, we would end up with an
           // ill-conditioned solution.  Geometrically, we are in a situation
-          // where eₘ/ is very close to the space spanned by the (bₛ), that is,
+          // where eₘ is very close to the space spanned by the (bₛ), that is,
           // by the (eₛ) for i < m.  The fact that the basis elements and no
           // longer independent when the degree increases is duely noted by
           // [CV84].  Given that eₘ effectively doesn't have benefit for the

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -249,17 +249,20 @@ IncrementalProjection(Function const& function,
         for (int s = 0; s < m; ++s) {
           Σ_Bₛ⁽ᵐ⁾² += B[s] * B[s];
         }
-        if (Q[m] <= Σ_Bₛ⁽ᵐ⁾²) {
+        if (Q[m] <= Σ_Bₛ⁽ᵐ⁾² ||
+            (Q[m] - Σ_Bₛ⁽ᵐ⁾²) / std::max(Q[m], Σ_Bₛ⁽ᵐ⁾²) < 0x1.0p-24) {
           // We arrive here when the norm of Σₛ Bₛ⁽ᵐ⁾bₛ + eₘ is small (see
           // [SN97] for the notation) and, due to rounding errors, the computed
-          // value of that norm ends up negative or zero.  It makes no sense to
-          // have complex numbers (or infinities) here because our function is
-          // real and bounded.  Geometrically, we are in a situation where eₘ
-          // is very close to the space spanned by the (bₛ), that is, by the
-          // (eₛ) for i < m.  The fact that the basis elements and no longer
-          // independent when the degree increases is duely noted by [CV84].
-          // Given that eₘ effectively doesn't have benefit for the projection,
-          // we just drop it and continue with the algorithm.
+          // value of the square of that norm ends up negative, zero, or very
+          // small.  It makes no sense to have complex numbers (or infinities)
+          // here because our function is real and bounded.  But even if the
+          // norm could be computed but was very small, we would end up with an
+          // ill-conditioned solution.  Geometrically, we are in a situation
+          // where eₘ/ is very close to the space spanned by the (bₛ), that is,
+          // by the (eₛ) for i < m.  The fact that the basis elements and no
+          // longer independent when the degree increases is duely noted by
+          // [CV84].  Given that eₘ effectively doesn't have benefit for the
+          // projection, we just drop it and continue with the algorithm.
           LOG(ERROR) << "Q[m]: " << Q[m] << " Σ_Bₛ⁽ᵐ⁾² " << Σ_Bₛ⁽ᵐ⁾²
                      << " difference: " << Q[m] - Σ_Bₛ⁽ᵐ⁾²;
           LOG(ERROR) << "Dropping " << basis[m];
@@ -273,8 +276,6 @@ IncrementalProjection(Function const& function,
           --m;
           continue;
         } else {
-          // TODO(phl): If we have a huge cancellation here, we should probably
-          // drop basis[m] too.
           α[m][m] = 1 / Sqrt(Q[m] - Σ_Bₛ⁽ᵐ⁾²);
         }
       }

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -285,7 +285,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjection) {
                     ? AllOf(Gt(6.7e-2 * Metre), Lt(7.9 * Metre))
                     : ω_index == 2
                           ? AllOf(Gt(1.1e-4 * Metre), Lt(9.7e-1 * Metre))
-                          : AllOf(Gt(1.7e-9 * Metre), Lt(1.9e-4 * Metre)))
+                          : AllOf(Gt(7.4e-10 * Metre), Lt(1.2e-5 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {
@@ -306,7 +306,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjection) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
         RelativeErrorFrom(series.value()(t_min + i * (t_max - t_min) / 100),
-                          AllOf(Gt(2.4e-9), Lt(3.7e-3))));
+                          AllOf(Gt(8.0e-10), Lt(3.8e-4))));
   }
 }
 

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -285,7 +285,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjection) {
                     ? AllOf(Gt(6.7e-2 * Metre), Lt(7.9 * Metre))
                     : ω_index == 2
                           ? AllOf(Gt(1.1e-4 * Metre), Lt(9.7e-1 * Metre))
-                          : AllOf(Gt(7.4e-10 * Metre), Lt(1.2e-5 * Metre)))
+                          : AllOf(Gt(4.2e-10 * Metre), Lt(1.7e-5 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {
@@ -306,7 +306,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjection) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
         RelativeErrorFrom(series.value()(t_min + i * (t_max - t_min) / 100),
-                          AllOf(Gt(8.0e-10), Lt(3.8e-4))));
+                          AllOf(Gt(1.3e-10), Lt(5.4e-4))));
   }
 }
 


### PR DESCRIPTION
Ignore a basis element if it is sufficiently close to the span of the preceding basis elements (cancellation of at least 24 bits).  Not only does this yield better accuracy, it doesn't cause such huge tolerance changes between casanova and carpaccio (compare a5d483f445fe5e8eaf9efba1b57e28f1adfb973c and 34e915f61fb010aaa9de1004fae59084d008629c)

Contributes to #2400.