### PR TITLE
Poisson series optimization

### DIFF
--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -106,6 +106,14 @@ class PoissonSeries {
   PoissonSeries& operator-=(PoissonSeries<V, d, E> const& right);
 
  private:
+  using AngularFrequencyAndPolynomials =
+      std::pair<AngularFrequency, Polynomials>;
+
+  struct PrivateConstructor {};
+  PoissonSeries(PrivateConstructor,
+                Polynomial aperiodic,
+                std::vector<AngularFrequencyAndPolynomials> periodic);
+
   Instant origin_;  // Common to all polynomials.
   Polynomial aperiodic_;
   // All the keys in this map are positive.

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "geometry/hilbert.hpp"

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -109,10 +109,9 @@ class PoissonSeries {
   using AngularFrequencyAndPolynomials =
       std::pair<AngularFrequency, Polynomials>;
 
-  struct PrivateConstructor {};
-  PoissonSeries(PrivateConstructor,
-                Polynomial aperiodic,
-                std::vector<AngularFrequencyAndPolynomials> periodic);
+  // The vector elements are invalid after this call.
+  PoissonSeries(Polynomial aperiodic,
+                std::vector<AngularFrequencyAndPolynomials>& periodic);
 
   Instant origin_;  // Common to all polynomials.
   Polynomial aperiodic_;

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -115,9 +115,7 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     }
   }
 
-  return Result(typename Result::PrivateConstructor{},
-                std::move(aperiodic),
-                std::move(periodic));
+  return Result(std::move(aperiodic), periodic);
 }
 
 template<typename Value, int degree_,
@@ -249,9 +247,8 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
 template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
-    PrivateConstructor,
     Polynomial aperiodic,
-    std::vector<AngularFrequencyAndPolynomials> periodic)
+    std::vector<AngularFrequencyAndPolynomials>& periodic)
     : origin_(aperiodic.origin()),
       aperiodic_(std::move(aperiodic)) {
   // The |periodic| vector may have elements with positive or negative angular

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -99,24 +99,18 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   }
   for (auto const& [ωl, polynomials_left] : left.periodic_) {
     for (auto const& [ωr, polynomials_right] : right.periodic_) {
+      auto const cos_cos = product(polynomials_left.cos, polynomials_right.cos);
+      auto const cos_sin = product(polynomials_left.cos, polynomials_right.sin);
+      auto const sin_cos = product(polynomials_left.sin, polynomials_right.cos);
+      auto const sin_sin = product(polynomials_left.sin, polynomials_right.sin);
       terms.emplace_back(
           ωl - ωr,
-          typename Result::Polynomials{
-              /*sin=*/(product(-polynomials_left.cos, polynomials_right.sin) +
-                       product(polynomials_left.sin, polynomials_right.cos)) /
-                  2,
-              /*cos=*/(product(polynomials_left.sin, polynomials_right.sin) +
-                       product(polynomials_left.cos, polynomials_right.cos)) /
-                  2});
+          typename Result::Polynomials{/*sin=*/(-cos_sin + sin_cos) / 2,
+                                       /*cos=*/(sin_sin + cos_cos) / 2});
       terms.emplace_back(
           ωl + ωr,
-          typename Result::Polynomials{
-              /*sin=*/(product(polynomials_left.cos, polynomials_right.sin) +
-                       product(polynomials_left.sin, polynomials_right.cos)) /
-                  2,
-              /*cos=*/(product(-polynomials_left.sin, polynomials_right.sin) +
-                       product(polynomials_left.cos, polynomials_right.cos)) /
-                  2});
+          typename Result::Polynomials{/*sin=*/(cos_sin + sin_cos) / 2,
+                                       /*cos=*/(-sin_sin + cos_cos) / 2});
     }
   }
 

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -180,7 +180,7 @@ PoissonSeries<Value, degree_, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
     Instant const& origin) const {
   Time const shift = origin - origin_;
-  auto aperiodic = aperiodic_.AtOrigin(origin);
+  auto const aperiodic = aperiodic_.AtOrigin(origin);
 
   PolynomialsByAngularFrequency periodic;
   for (auto const& [ω, polynomials] : periodic_) {
@@ -192,7 +192,7 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
         Polynomials{/*sin=*/sin * Cos(ω * shift) - cos * Sin(ω * shift),
                     /*cos=*/sin * Sin(ω * shift) + cos * Cos(ω * shift)});
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Value, int degree_,
@@ -209,7 +209,7 @@ PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
         ω,
         AngularFrequencyPrimitive<Value, degree_, Evaluator>(ω, polynomials));
   }
-  return Result{std::move(aperiodic), std::move(periodic)};
+  return Result{aperiodic, periodic};
 }
 
 template<typename Value, int degree_,
@@ -334,7 +334,7 @@ PoissonSeries<Value, rdegree_, Evaluator>
 operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, rdegree_, Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = -right.aperiodic_;
+  auto const aperiodic = -right.aperiodic_;
   for (auto const& [ω, polynomials] : right.periodic_) {
     periodic.emplace_hint(
         periodic.cend(),
@@ -342,7 +342,7 @@ operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
         typename Result::Polynomials{/*sin=*/-polynomials.sin,
                                      /*cos=*/-polynomials.cos});
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Value, int ldegree_, int rdegree_,
@@ -352,7 +352,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = left.aperiodic_ + right.aperiodic_;
+  auto const aperiodic = left.aperiodic_ + right.aperiodic_;
   auto it_left = left.periodic_.cbegin();
   auto it_right = right.periodic_.cbegin();
   while (it_left != left.periodic_.cend() ||
@@ -395,7 +395,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_right;
     }
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Value, int ldegree_, int rdegree_,
@@ -405,7 +405,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = left.aperiodic_ - right.aperiodic_;
+  auto const aperiodic = left.aperiodic_ - right.aperiodic_;
   auto it_left = left.periodic_.cbegin();
   auto it_right = right.periodic_.cbegin();
   while (it_left != left.periodic_.cend() ||
@@ -448,7 +448,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_right;
     }
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -458,7 +458,7 @@ operator*(Scalar const& left,
           PoissonSeries<Value, degree_, Evaluator> const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = left * right.aperiodic_;
+  auto const aperiodic = left * right.aperiodic_;
   for (auto const& [ω, polynomials] : right.periodic_) {
     periodic.emplace_hint(
         periodic.cend(),
@@ -466,7 +466,7 @@ operator*(Scalar const& left,
         typename Result::Polynomials{/*sin=*/left * polynomials.sin,
                                      /*cos=*/left * polynomials.cos});
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -476,7 +476,7 @@ operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
           Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = left.aperiodic_ * right;
+  auto const aperiodic = left.aperiodic_ * right;
   for (auto const& [ω, polynomials] : left.periodic_) {
     periodic.emplace_hint(
         periodic.cend(),
@@ -484,7 +484,7 @@ operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
         typename Result::Polynomials{/*sin=*/polynomials.sin * right,
                                      /*cos=*/polynomials.cos * right});
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -494,7 +494,7 @@ operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
           Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   typename Result::PolynomialsByAngularFrequency periodic;
-  auto aperiodic = left.aperiodic_ / right;
+  auto const aperiodic = left.aperiodic_ / right;
   for (auto const& [ω, polynomials] : left.periodic_) {
     periodic.emplace_hint(
         periodic.cend(),
@@ -502,7 +502,7 @@ operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
         typename Result::Polynomials{/*sin=*/polynomials.sin / right,
                                      /*cos=*/polynomials.cos / right});
   }
-  return {std::move(aperiodic), std::move(periodic)};
+  return {aperiodic, periodic};
 }
 
 template<typename LValue, typename RValue,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -81,21 +81,22 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   // Compute all the individual terms using elementary trigonometric identities
   // and put them in a vector, because the same frequency may appear multiple
   // times.
-  using Term = std::pair<AngularFrequency, typename Result::Polynomials>;
-  std::vector<Term> terms;
-  terms.reserve(left.periodic_.size() + right.periodic_.size() +
-                left.periodic_.size() * right.periodic_.size());
+  std::vector<typename Result::AngularFrequencyAndPolynomials> periodic;
+  periodic.reserve(left.periodic_.size() + right.periodic_.size() +
+                   left.periodic_.size() * right.periodic_.size());
   for (auto const& [ω, polynomials] : left.periodic_) {
-    terms.emplace_back(ω,
-                       typename Result::Polynomials{
-                           /*sin=*/product(polynomials.sin, right.aperiodic_),
-                           /*cos=*/product(polynomials.cos, right.aperiodic_)});
+    periodic.emplace_back(
+        ω,
+        typename Result::Polynomials{
+            /*sin=*/product(polynomials.sin, right.aperiodic_),
+            /*cos=*/product(polynomials.cos, right.aperiodic_)});
   }
   for (auto const& [ω, polynomials] : right.periodic_) {
-    terms.emplace_back(ω,
-                       typename Result::Polynomials{
-                           /*sin=*/product(left.aperiodic_, polynomials.sin),
-                           /*cos=*/product(left.aperiodic_, polynomials.cos)});
+    periodic.emplace_back(
+        ω,
+        typename Result::Polynomials{
+            /*sin=*/product(left.aperiodic_, polynomials.sin),
+            /*cos=*/product(left.aperiodic_, polynomials.cos)});
   }
   for (auto const& [ωl, polynomials_left] : left.periodic_) {
     for (auto const& [ωr, polynomials_right] : right.periodic_) {
@@ -103,40 +104,20 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       auto const cos_sin = product(polynomials_left.cos, polynomials_right.sin);
       auto const sin_cos = product(polynomials_left.sin, polynomials_right.cos);
       auto const sin_sin = product(polynomials_left.sin, polynomials_right.sin);
-      terms.emplace_back(
+      periodic.emplace_back(
           ωl - ωr,
           typename Result::Polynomials{/*sin=*/(-cos_sin + sin_cos) / 2,
                                        /*cos=*/(sin_sin + cos_cos) / 2});
-      terms.emplace_back(
+      periodic.emplace_back(
           ωl + ωr,
           typename Result::Polynomials{/*sin=*/(cos_sin + sin_cos) / 2,
                                        /*cos=*/(-sin_sin + cos_cos) / 2});
     }
   }
 
-  // Sort the vector by ascending frequency.
-  std::sort(terms.begin(), terms.end(),
-            [](Term const& left, Term const& right) {
-              return left.first < right.first;
-            });
-
-  // Now group the terms together by frequency.
-  typename Result::PolynomialsByAngularFrequency periodic;
-  std::optional<AngularFrequency> previous_ω;
-  for (auto it = terms.cbegin(); it != terms.cend(); ++it) {
-    auto const& ω = it->first;
-    auto const& polynomials = it->second;
-    if (previous_ω.has_value() && previous_ω.value() == ω) {
-      auto& previous_polynomials = periodic.rbegin()->second;
-      previous_polynomials.sin += polynomials.sin;
-      previous_polynomials.cos += polynomials.cos;
-    } else {
-      periodic.insert(periodic.cend(), *it);
-    }
-    previous_ω = ω;
-  }
-
-  return Result(std::move(aperiodic), std::move(periodic));
+  return Result(typename Result::PrivateConstructor{},
+                std::move(aperiodic),
+                std::move(periodic));
 }
 
 template<typename Value, int degree_,
@@ -263,6 +244,61 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
     }
   }
   return result;
+}
+
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
+    PrivateConstructor,
+    Polynomial aperiodic,
+    std::vector<AngularFrequencyAndPolynomials> periodic)
+    : origin_(aperiodic.origin()),
+      aperiodic_(std::move(aperiodic)) {
+  // The |periodic| vector may have elements with positive or negative angular
+  // frequencies.  Normalize our member variable to only have positive angular
+  // frequencies.
+
+  // Sort the vector by ascending frequency, irrespective of sign.
+  std::sort(periodic.begin(), periodic.end(),
+            [](AngularFrequencyAndPolynomials const& left,
+               AngularFrequencyAndPolynomials const& right) {
+              return Abs(left.first) < Abs(right.first);
+            });
+
+  // Group the terms together by frequency.
+  std::optional<AngularFrequency> previous_abs_ω;
+  for (auto it = periodic.cbegin(); it != periodic.cend(); ++it) {
+    auto const& ω = it->first;
+    auto const& polynomials = it->second;
+
+    // All polynomials must have the same origin.
+    CHECK_EQ(origin_, polynomials.sin.origin());
+    CHECK_EQ(origin_, polynomials.cos.origin());
+
+    if (ω < AngularFrequency{}) {
+      if (previous_abs_ω.has_value() && previous_abs_ω.value() == -ω) {
+        auto& previous_polynomials = periodic_.rbegin()->second;
+        previous_polynomials.sin -= polynomials.sin;
+        previous_polynomials.cos += polynomials.cos;
+      } else {
+        periodic_.emplace_hint(periodic_.cend(),
+                               -ω,
+                               Polynomials{/*sin=*/-polynomials.sin,
+                                           /*cos=*/polynomials.cos});
+      }
+    } else if (ω > AngularFrequency{}) {
+      if (previous_abs_ω.has_value() && previous_abs_ω.value() == ω) {
+        auto& previous_polynomials = periodic_.rbegin()->second;
+        previous_polynomials.sin += polynomials.sin;
+        previous_polynomials.cos += polynomials.cos;
+      } else {
+        periodic_.insert(periodic_.cend(), *it);
+      }
+    } else {
+      aperiodic_ += polynomials.cos;
+    }
+    previous_abs_ω = Abs(ω);
+  }
 }
 
 template<typename Value, int degree_,


### PR DESCRIPTION
Speed up #2400: no real benchmark, but representation of 3 months of the trajectory of Io using 5th degree and 10 frequencies goes down from 284 s to 168 s.