### PR TITLE
Reduce heap usage in Poisson series

### DIFF
--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -131,7 +131,7 @@ TEST_F(FrequencyAnalysisTest, PreciseModeScalar) {
   Series0::PolynomialsByAngularFrequency polynomials;
 
   // Main harmonic.
-  polynomials.emplace(
+  polynomials.emplace_back(
       ω,
       Series0::Polynomials{/*sin=*/Series0::Polynomial({1 * Metre}, t0_),
                            /*cos=*/Series0::Polynomial({0 * Metre}, t0_)});
@@ -140,10 +140,11 @@ TEST_F(FrequencyAnalysisTest, PreciseModeScalar) {
   for (int i = 0; i < 10; ++i) {
     auto const sin_amplitude = amplitude_distribution(random) * Metre;
     auto const cos_amplitude = amplitude_distribution(random) * Metre;
-    polynomials.emplace(ω * frequency_distribution(random),
-                        Series0::Polynomials{
-                            /*sin=*/Series0::Polynomial({sin_amplitude}, t0_),
-                            /*cos=*/Series0::Polynomial({cos_amplitude}, t0_)});
+    polynomials.emplace_back(
+        ω * frequency_distribution(random),
+        Series0::Polynomials{
+            /*sin=*/Series0::Polynomial({sin_amplitude}, t0_),
+            /*cos=*/Series0::Polynomial({cos_amplitude}, t0_)});
   }
   Series0 const sin(
       Series0::Polynomial({amplitude_distribution(random) * Metre}, t0_),
@@ -181,7 +182,7 @@ TEST_F(FrequencyAnalysisTest, PreciseModeVector) {
   Series0::PolynomialsByAngularFrequency polynomials;
 
   // Main harmonic.
-  polynomials.emplace(
+  polynomials.emplace_back(
       ω,
       Series0::Polynomials{
           /*sin=*/Series0::Polynomial(

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -116,8 +116,8 @@ class PoissonSeries {
 
   Instant origin_;  // Common to all polynomials.
   Polynomial aperiodic_;
-  //TODO(phl):Comment
-  // All the keys in this map are positive.
+  // The frequencies in this vector are positive, distinct and in increasing
+  // order.
   PolynomialsByAngularFrequency periodic_;
 
   template<typename V, int r, template<typename, typename, int> class E>

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -82,7 +82,8 @@ class PoissonSeries {
     Polynomial cos;
   };
 
-  using PolynomialsByAngularFrequency = std::map<AngularFrequency, Polynomials>;
+  using PolynomialsByAngularFrequency =
+      std::vector<std::pair<AngularFrequency, Polynomials>>;
 
   PoissonSeries(Polynomial const& aperiodic,
                 PolynomialsByAngularFrequency const& periodic);
@@ -107,15 +108,15 @@ class PoissonSeries {
   PoissonSeries& operator-=(PoissonSeries<V, d, E> const& right);
 
  private:
-  using AngularFrequencyAndPolynomials =
-      std::pair<AngularFrequency, Polynomials>;
+  struct PrivateConstructor {};
 
-  // The vector elements are invalid after this call.
-  PoissonSeries(Polynomial aperiodic,
-                std::vector<AngularFrequencyAndPolynomials>& periodic);
+  PoissonSeries(PrivateConstructor,
+                Polynomial aperiodic,
+                PolynomialsByAngularFrequency periodic);
 
   Instant origin_;  // Common to all polynomials.
   Polynomial aperiodic_;
+  //TODO(phl):Comment
   // All the keys in this map are positive.
   PolynomialsByAngularFrequency periodic_;
 
@@ -164,6 +165,9 @@ class PoissonSeries {
   friend std::string mathematica::internal_mathematica::ToMathematicaExpression(
       PoissonSeries<V, d, E> const& polynomial,
       O express_in);
+  template<typename V, int d,
+           template<typename, typename, int> class E>
+  friend class PoissonSeries;
 };
 
 // Vector space of Poisson series.

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -171,7 +171,7 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
         Polynomials{/*sin=*/sin * Cos(ω * shift) - cos * Sin(ω * shift),
                     /*cos=*/sin * Sin(ω * shift) + cos * Cos(ω * shift)});
   }
-  return {aperiodic, periodic};
+  return {PrivateConstructor{}, std::move(aperiodic), std::move(periodic)};
 }
 
 template<typename Value, int degree_,
@@ -329,7 +329,9 @@ operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
         typename Result::Polynomials{/*sin=*/-polynomials.sin,
                                      /*cos=*/-polynomials.cos});
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Value, int ldegree_, int rdegree_,
@@ -380,7 +382,9 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_right;
     }
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Value, int ldegree_, int rdegree_,
@@ -431,7 +435,9 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_right;
     }
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -449,7 +455,9 @@ operator*(Scalar const& left,
         typename Result::Polynomials{/*sin=*/left * polynomials.sin,
                                      /*cos=*/left * polynomials.cos});
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -467,7 +475,9 @@ operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
         typename Result::Polynomials{/*sin=*/polynomials.sin * right,
                                      /*cos=*/polynomials.cos * right});
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Scalar, typename Value, int degree_,
@@ -485,7 +495,9 @@ operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
         typename Result::Polynomials{/*sin=*/polynomials.sin / right,
                                      /*cos=*/polynomials.cos / right});
   }
-  return {aperiodic, periodic};
+  return {typename Result::PrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename LValue, typename RValue,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -685,6 +685,7 @@ PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator-(
     PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PiecewisePoissonSeries<Value, rdegree_, Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(right.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     series.push_back(-right.series_[i]);
   }
@@ -699,6 +700,7 @@ PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
   using Result =
       PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(right.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     series.push_back(left * right.series_[i]);
   }
@@ -713,6 +715,7 @@ PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
   using Result =
       PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < left.series_.size(); ++i) {
     series.push_back(left.series_[i] * right);
   }
@@ -727,6 +730,7 @@ PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
   using Result =
       PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < left.series_.size(); ++i) {
     series.push_back(left.series_[i] / right);
   }
@@ -747,6 +751,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   using Result =
       PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(right.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     Instant const origin = right.series_[i].origin();
     series.push_back(left.AtOrigin(origin) + right.series_[i]);
@@ -762,6 +767,7 @@ operator+(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   using Result =
       PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < left.series_.size(); ++i) {
     Instant const origin = left.series_[i].origin();
     series.push_back(left.series_[i] + right.AtOrigin(origin));
@@ -777,6 +783,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   using Result =
       PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(right.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     Instant const origin = right.series_[i].origin();
     series.push_back(left.AtOrigin(origin) - right.series_[i]);
@@ -792,6 +799,7 @@ operator-(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   using Result =
       PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < left.series_.size(); ++i) {
     Instant const origin = left.series_[i].origin();
     series.push_back(left.series_[i] - right.AtOrigin(origin));
@@ -808,6 +816,7 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
                                         ldegree_ + rdegree_,
                                         Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     Instant const origin = right.series_[i].origin();
     series.push_back(left.AtOrigin(origin) * right.series_[i]);
@@ -824,6 +833,7 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
                                         ldegree_ + rdegree_,
                                         Evaluator>;
   std::vector<typename Result::Series> series;
+  series.reserve(left.series_.size());
   for (int i = 0; i < left.series_.size(); ++i) {
     Instant const origin = left.series_[i].origin();
     series.push_back(left.series_[i] * right.AtOrigin(origin));

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "numerics/quadrature.hpp"
 #include "numerics/ulp_distance.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
@@ -27,9 +26,7 @@ using quantities::Primitive;
 using quantities::Sin;
 using quantities::Time;
 using quantities::Variation;
-using quantities::si::Metre;
 using quantities::si::Radian;
-using quantities::si::Second;
 namespace si = quantities::si;
 
 template<typename Value, int degree_,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -87,7 +87,7 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   // Compute all the individual terms using elementary trigonometric identities
   // and put them in a vector, because the same frequency may appear multiple
   // times.
-  std::vector<typename Result::AngularFrequencyAndPolynomials> periodic;
+  typename Result::PolynomialsByAngularFrequency periodic;
   periodic.reserve(left.periodic_.size() + right.periodic_.size() +
                    2 * left.periodic_.size() * right.periodic_.size());
   for (auto const& [ω, polynomials] : left.periodic_) {
@@ -121,7 +121,9 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     }
   }
 
-  return Result(std::move(aperiodic), periodic);
+  return Result(typename Result::PrivateConstructor{},
+                std::move(aperiodic),
+                std::move(periodic));
 }
 
 template<typename Value, int degree_,
@@ -129,36 +131,9 @@ template<typename Value, int degree_,
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     Polynomial const& aperiodic,
     PolynomialsByAngularFrequency const& periodic)
-    : origin_(aperiodic.origin()),
-      aperiodic_(aperiodic) {
-  // The |periodic| map may have elements with positive or negative angular
-  // frequencies.  Normalize our member variable to only have positive angular
-  // frequencies.
-  for (auto it = periodic.crbegin(); it != periodic.crend(); ++it) {
-    auto const ω = it->first;
-    auto const polynomials = it->second;
-
-    // All polynomials must have the same origin.
-    CHECK_EQ(origin_, polynomials.sin.origin());
-    CHECK_EQ(origin_, polynomials.cos.origin());
-
-    if (ω < AngularFrequency{}) {
-      auto const positive_it = periodic_.find(-ω);
-      if (positive_it == periodic_.cend()) {
-        periodic_.emplace(-ω,
-                          Polynomials{/*sin=*/-polynomials.sin,
-                                      /*cos=*/polynomials.cos});
-      } else {
-        positive_it->second.sin -= polynomials.sin;
-        positive_it->second.cos += polynomials.cos;
-      }
-    } else if (ω > AngularFrequency{}) {
-      periodic_.insert(periodic_.cbegin(), *it);
-    } else {
-      aperiodic_ += polynomials.cos;
-    }
-  }
-}
+    : PoissonSeries(PrivateConstructor{},
+                    Polynomial(aperiodic),
+                    PolynomialsByAngularFrequency(periodic)) {}
 
 template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
@@ -187,11 +162,11 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
   auto aperiodic = aperiodic_.AtOrigin(origin);
 
   PolynomialsByAngularFrequency periodic;
+  periodic.reserve(periodic_.size());
   for (auto const& [ω, polynomials] : periodic_) {
     Polynomial const sin = polynomials.sin.AtOrigin(origin);
     Polynomial const cos = polynomials.cos.AtOrigin(origin);
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         Polynomials{/*sin=*/sin * Cos(ω * shift) - cos * Sin(ω * shift),
                     /*cos=*/sin * Sin(ω * shift) + cos * Cos(ω * shift)});
@@ -205,11 +180,11 @@ PoissonSeries<quantities::Primitive<Value, Time>, degree_ + 1, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
   using Result =
       PoissonSeries<quantities::Primitive<Value, Time>, degree_ + 1, Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   typename Result::Polynomial aperiodic = aperiodic_.Primitive();
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(periodic_.size());
   for (auto const& [ω, polynomials] : periodic_) {
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         AngularFrequencyPrimitive<Value, degree_, Evaluator>(ω, polynomials));
   }
@@ -253,26 +228,33 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
 template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
+    PrivateConstructor,
     Polynomial aperiodic,
-    std::vector<AngularFrequencyAndPolynomials>& periodic)
+    PolynomialsByAngularFrequency periodic)
     : origin_(aperiodic.origin()),
-      aperiodic_(std::move(aperiodic)) {
+      aperiodic_(std::move(aperiodic)),
+      periodic_(std::move(periodic)) {
   // The |periodic| vector may have elements with positive or negative angular
   // frequencies.  Normalize our member variable to only have positive angular
   // frequencies.
 
-  // Sort the vector by ascending frequency, irrespective of sign.
-  std::sort(periodic.begin(), periodic.end(),
-            [](AngularFrequencyAndPolynomials const& left,
-               AngularFrequencyAndPolynomials const& right) {
-              return Abs(left.first) < Abs(right.first);
-            });
+  // Sort by ascending frequency, irrespective of sign.
+  std::sort(
+      periodic_.begin(),
+      periodic_.end(),
+      [](typename PolynomialsByAngularFrequency::value_type const& left,
+         typename PolynomialsByAngularFrequency::value_type const& right) {
+        return Abs(left.first) < Abs(right.first);
+      });
 
-  // Group the terms together by frequency.
+  // Group the terms together by frequency, removing consecutive terms with the
+  // same frequency, normalizing negative frequencies, and moving zero
+  // frequencies to the aperiodic term.
   std::optional<AngularFrequency> previous_abs_ω;
-  for (auto it = periodic.cbegin(); it != periodic.cend(); ++it) {
-    auto const& ω = it->first;
-    auto const& polynomials = it->second;
+  for (auto it = periodic_.begin(); it != periodic_.end();) {
+    auto& ω = it->first;
+    auto const abs_ω = Abs(ω);
+    auto& polynomials = it->second;
 
     // All polynomials must have the same origin.
     CHECK_EQ(origin_, polynomials.sin.origin());
@@ -280,27 +262,29 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
 
     if (ω < AngularFrequency{}) {
       if (previous_abs_ω.has_value() && previous_abs_ω.value() == -ω) {
-        auto& previous_polynomials = periodic_.rbegin()->second;
+        auto& previous_polynomials = std::prev(it)->second;
         previous_polynomials.sin -= polynomials.sin;
         previous_polynomials.cos += polynomials.cos;
+        it = periodic_.erase(it);
       } else {
-        periodic_.emplace_hint(periodic_.cend(),
-                               -ω,
-                               Polynomials{/*sin=*/-polynomials.sin,
-                                           /*cos=*/polynomials.cos});
+        ω = -ω;
+        polynomials.sin = -polynomials.sin;
+        ++it;
       }
     } else if (ω > AngularFrequency{}) {
       if (previous_abs_ω.has_value() && previous_abs_ω.value() == ω) {
-        auto& previous_polynomials = periodic_.rbegin()->second;
+        auto& previous_polynomials = std::prev(it)->second;
         previous_polynomials.sin += polynomials.sin;
         previous_polynomials.cos += polynomials.cos;
+        it = periodic_.erase(it);
       } else {
-        periodic_.insert(periodic_.cend(), *it);
+        ++it;
       }
     } else {
       aperiodic_ += polynomials.cos;
+      it = periodic_.erase(it);
     }
-    previous_abs_ω = Abs(ω);
+    previous_abs_ω = abs_ω;
   }
 }
 
@@ -336,11 +320,11 @@ template<typename Value, int rdegree_,
 PoissonSeries<Value, rdegree_, Evaluator>
 operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, rdegree_, Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = -right.aperiodic_;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(right.periodic_.size());
   for (auto const& [ω, polynomials] : right.periodic_) {
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         typename Result::Polynomials{/*sin=*/-polynomials.sin,
                                      /*cos=*/-polynomials.cos});
@@ -354,8 +338,9 @@ PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = left.aperiodic_ + right.aperiodic_;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(left.periodic_.size() + right.periodic_.size());
   auto it_left = left.periodic_.cbegin();
   auto it_right = right.periodic_.cbegin();
   while (it_left != left.periodic_.cend() ||
@@ -368,8 +353,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
                         : it_right->first;
     if (ωl < ωr) {
       auto const& polynomials_left = it_left->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωl,
           typename Result::Polynomials{
               /*sin=*/typename Result::Polynomial(polynomials_left.sin),
@@ -377,8 +361,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_left;
     } else if (ωr < ωl) {
       auto const& polynomials_right = it_right->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωr,
           typename Result::Polynomials{
               /*sin=*/typename Result::Polynomial(polynomials_right.sin),
@@ -388,8 +371,7 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       DCHECK_EQ(ωl, ωr);
       auto const& polynomials_left = it_left->second;
       auto const& polynomials_right = it_right->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωl,
           typename Result::Polynomials{
               /*sin=*/polynomials_left.sin + polynomials_right.sin,
@@ -407,8 +389,9 @@ PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = left.aperiodic_ - right.aperiodic_;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(left.periodic_.size() + right.periodic_.size());
   auto it_left = left.periodic_.cbegin();
   auto it_right = right.periodic_.cbegin();
   while (it_left != left.periodic_.cend() ||
@@ -421,8 +404,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
                         : it_right->first;
     if (ωl < ωr) {
       auto const& polynomials_left = it_left->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωl,
           typename Result::Polynomials{
               /*sin=*/typename Result::Polynomial(polynomials_left.sin),
@@ -430,8 +412,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       ++it_left;
     } else if (ωr < ωl) {
       auto const& polynomials_right = it_right->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωr,
           typename Result::Polynomials{
               /*sin=*/typename Result::Polynomial(-polynomials_right.sin),
@@ -441,8 +422,7 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
       DCHECK_EQ(ωl, ωr);
       auto const& polynomials_left = it_left->second;
       auto const& polynomials_right = it_right->second;
-      periodic.emplace_hint(
-          periodic.cend(),
+      periodic.emplace_back(
           ωl,
           typename Result::Polynomials{
               /*sin=*/polynomials_left.sin - polynomials_right.sin,
@@ -460,11 +440,11 @@ PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>
 operator*(Scalar const& left,
           PoissonSeries<Value, degree_, Evaluator> const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = left * right.aperiodic_;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(right.periodic_.size());
   for (auto const& [ω, polynomials] : right.periodic_) {
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         typename Result::Polynomials{/*sin=*/left * polynomials.sin,
                                      /*cos=*/left * polynomials.cos});
@@ -478,11 +458,11 @@ PoissonSeries<Product<Value, Scalar>, degree_, Evaluator>
 operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
           Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = left.aperiodic_ * right;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(left.periodic_.size());
   for (auto const& [ω, polynomials] : left.periodic_) {
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         typename Result::Polynomials{/*sin=*/polynomials.sin * right,
                                      /*cos=*/polynomials.cos * right});
@@ -496,11 +476,11 @@ PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator>
 operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
           Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
-  typename Result::PolynomialsByAngularFrequency periodic;
   auto aperiodic = left.aperiodic_ / right;
+  typename Result::PolynomialsByAngularFrequency periodic;
+  periodic.reserve(left.periodic_.size());
   for (auto const& [ω, polynomials] : left.periodic_) {
-    periodic.emplace_hint(
-        periodic.cend(),
+    periodic.emplace_back(
         ω,
         typename Result::Polynomials{/*sin=*/polynomials.sin / right,
                                      /*cos=*/polynomials.cos / right});
@@ -816,7 +796,7 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
                                         ldegree_ + rdegree_,
                                         Evaluator>;
   std::vector<typename Result::Series> series;
-  series.reserve(left.series_.size());
+  series.reserve(right.series_.size());
   for (int i = 0; i < right.series_.size(); ++i) {
     Instant const origin = right.series_[i].origin();
     series.push_back(left.AtOrigin(origin) * right.series_[i]);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -89,7 +89,7 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   // times.
   std::vector<typename Result::AngularFrequencyAndPolynomials> periodic;
   periodic.reserve(left.periodic_.size() + right.periodic_.size() +
-                   left.periodic_.size() * right.periodic_.size());
+                   2 * left.periodic_.size() * right.periodic_.size());
   for (auto const& [ω, polynomials] : left.periodic_) {
     periodic.emplace_back(
         ω,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -203,7 +203,7 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
     FirstPart const first_part(
         typename FirstPart::Polynomial({}, origin_),
         {{ω,
-          {/*sin=*/typename FirstPart::Polynomial(polynomials.cos ),
+          {/*sin=*/typename FirstPart::Polynomial(polynomials.cos),
            /*cos=*/typename FirstPart::Polynomial(-polynomials.sin)}}});
     result += (first_part(t2) - first_part(t1)) / ω * Radian;
 

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -859,10 +859,8 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     Instant const origin = right.series_[i].origin();
     auto const integrand = PointwiseInnerProduct(
         left.AtOrigin(origin) * weight.AtOrigin(origin), right.series_[i]);
-    auto const integral =
-        quadrature::GaussLegendre<ldegree_ + rdegree_ + wdegree_>(
-            integrand, right.bounds_[i], right.bounds_[i + 1]);
-    result += integral;
+    auto const primitive = integrand.Primitive();
+    result += primitive(right.bounds_[i + 1]) - primitive(right.bounds_[i]);
   }
   return result / (t_max - t_min);
 }
@@ -893,10 +891,8 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     Instant const origin = left.series_[i].origin();
     auto const integrand = PointwiseInnerProduct(
         left.series_[i], right.AtOrigin(origin) * weight.AtOrigin(origin));
-    auto const integral =
-        quadrature::GaussLegendre<ldegree_ + rdegree_ + wdegree_>(
-            integrand, left.bounds_[i], left.bounds_[i + 1]);
-    result += integral;
+    auto const primitive = integrand.Primitive();
+    result += primitive(left.bounds_[i + 1]) - primitive(left.bounds_[i]);
   }
   return result / (t_max - t_min);
 }

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -92,6 +92,8 @@ template<typename Value, typename Argument, int degree_,
          template<typename, typename, int> class Evaluator>
 class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
  public:
+  using Result = Value;
+
   // Equivalent to:
   //   std::tuple<Value,
   //              Derivative<Value, Argument>,
@@ -205,6 +207,8 @@ template<typename Value, typename Argument, int degree_,
 class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
     : public Polynomial<Value, Point<Argument>> {
  public:
+  using Result = Value;
+
   // Equivalent to:
   //   std::tuple<Value,
   //              Derivative<Value, Argument>,


### PR DESCRIPTION
Use `vector` instead of `map`, avoid copies, do more `reserve`.  Overall this saves about 30% of the CPU.

Optimize #2400.