### PR TITLE
Improve the Poisson series implementation

### DIFF
--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -86,7 +86,17 @@ typename Hilbert<std::invoke_result_t<LFunction, Instant>,
 DotImplementation::operator()(LFunction const& left,
                               RFunction const& right,
                               Weight const& weight) const {
-  return Dot(left, right, weight, t_min_, t_max_);
+  // We need to use a large number of points otherwise the test
+  // PiecewisePoissonSeriesProjection doesn't yield a reasonable solution.  This
+  // doesn't happen with real life functions, which are much smoother than the
+  // test functions.
+  return Dot<std::invoke_result_t<LFunction, Instant>,
+             std::invoke_result_t<RFunction, Instant>,
+             LFunction::degree,
+             RFunction::degree,
+             Weight::degree,
+             HornerEvaluator,
+             /*points=*/30>(left, right, weight, t_min_, t_max_);
 }
 
 class FrequencyAnalysisTest : public ::testing::Test {
@@ -370,7 +380,7 @@ TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection4(t0_ + i * Radian / ω),
                 RelativeErrorFrom(series(t0_ + i * Radian / ω),
-                                  AllOf(Gt(2.1e-7), Lt(8.8e-4))));
+                                  AllOf(Gt(6.2e-9), Lt(3.2e-4))));
   }
 }
 

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -170,7 +170,7 @@ TEST_F(FrequencyAnalysisTest, PreciseModeScalar) {
   // maximum.
   auto const precise_mode = PreciseMode(
       mode, sin, apodization::Hann<HornerEvaluator>(t_min, t_max), dot);
-  EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(6.4e-11_⑴)));
+  EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(4.7e-11_⑴)));
 }
 
 TEST_F(FrequencyAnalysisTest, PreciseModeVector) {
@@ -213,7 +213,7 @@ TEST_F(FrequencyAnalysisTest, PreciseModeVector) {
   // maximum.
   auto const precise_mode = PreciseMode(
       mode, sin, apodization::Hann<HornerEvaluator>(t_min, t_max), dot);
-  EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(5.3e-10_⑴)));
+  EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(4.0e-11_⑴)));
 }
 
 TEST_F(FrequencyAnalysisTest, PoissonSeriesScalarProjection) {
@@ -328,7 +328,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesVectorProjection) {
 }
 
 TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
-  AngularFrequency const ω = 666.543 * π * Radian / Second;
+  AngularFrequency const ω = 6.66543 * π * Radian / Second;
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> amplitude_distribution(-10.0, 10.0);
   std::uniform_real_distribution<> perturbation_distribution(-1e-6, 1e-6);

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -351,7 +351,7 @@ class PiecewisePoissonSeries {
   friend operator*(PiecewisePoissonSeries<L, l, E> const& left,
                    PoissonSeries<R, r, E> const& right);
   template<typename L, typename R, int l, int r, int w,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> class E, int p>
   typename Hilbert<L, R>::InnerProductType
   friend Dot(PoissonSeries<L, l, E> const& left,
              PiecewisePoissonSeries<R, r, E> const& right,
@@ -359,7 +359,7 @@ class PiecewisePoissonSeries {
              Instant const& t_min,
              Instant const& t_max);
   template<typename L, typename R, int l, int r, int w,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> class E, int p>
   typename Hilbert<L, R>::InnerProductType
   friend Dot(PiecewisePoissonSeries<L, l, E> const& left,
              PoissonSeries<R, r, E> const& right,
@@ -448,9 +448,12 @@ PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right);
 
+// TODO(phl): Remove the parameter |points| in the templates below and the
+// exporting of Dot from the namespace once we have a smarter Gauss integrator.
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -458,7 +461,8 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -468,7 +472,8 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -476,7 +481,8 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -486,6 +492,7 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 
 }  // namespace internal_poisson_series
 
+using internal_poisson_series::Dot;
 using internal_poisson_series::PiecewisePoissonSeries;
 using internal_poisson_series::PoissonSeries;
 

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -452,8 +452,6 @@ PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right);
 
-// TODO(phl): Remove the parameter |points| in the templates below and the
-// exporting of Dot from the namespace once we have a smarter Gauss integrator.
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -259,9 +259,12 @@ std::ostream& operator<<(
 // Technically the weight function must be nonnegative for this to be an inner
 // product.  Not sure how this works with the flat-top windows, which can be
 // negative.  Note that the result is normalized by dividing by (t_max - t_min).
+// NOTE(phl): |points| is currently unused but ensures that the template has the
+// same profile as the one for |PiecewisePoissonSeries|.
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points = 0>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -85,6 +85,8 @@ class PoissonSeries {
   using PolynomialsByAngularFrequency =
       std::vector<std::pair<AngularFrequency, Polynomials>>;
 
+  // The |periodic| vector may contain frequencies that are negative or zero, as
+  // well as repeated frequencies.  It is not expected to be ordered.
   PoissonSeries(Polynomial const& aperiodic,
                 PolynomialsByAngularFrequency const& periodic);
 
@@ -108,9 +110,18 @@ class PoissonSeries {
   PoissonSeries& operator-=(PoissonSeries<V, d, E> const& right);
 
  private:
+  // Similar to the public constructor, but passing by copy allows moves, which
+  // is useful for internal algorithms.
   struct PrivateConstructor {};
-
   PoissonSeries(PrivateConstructor,
+                Polynomial aperiodic,
+                PolynomialsByAngularFrequency periodic);
+
+  // Similar to the previous constructor, except that the |periodic| vector is
+  // used verbatim, without sorting or normalization, which is useful for
+  // internal algorithms which produce positive, ordered frequencies.
+  struct TrustedPrivateConstructor {};
+  PoissonSeries(TrustedPrivateConstructor,
                 Polynomial aperiodic,
                 PolynomialsByAngularFrequency periodic);
 

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -69,7 +69,7 @@ template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
 class PoissonSeries {
  public:
-  static const int degree = degree_;
+  static constexpr int degree = degree_;
   using Polynomial =
       numerics::PolynomialInMonomialBasis<Value, Instant, degree_, Evaluator>;
 
@@ -277,6 +277,7 @@ template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
 class PiecewisePoissonSeries {
  public:
+  static constexpr int degree = degree_;
   using Series = PoissonSeries<Value, degree_, Evaluator>;
 
   PiecewisePoissonSeries(Interval<Instant> const& interval,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -172,7 +172,9 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
                                       /*cos=*/sin_at_origin * sin_ω_shift +
                                               cos_at_origin * cos_ω_shift});
   }
-  return {TrustedPrivateConstructor{}, std::move(aperiodic), std::move(periodic)};
+  return {TrustedPrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
 template<typename Value, int degree_,
@@ -207,7 +209,7 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
     FirstPart const first_part(
         typename FirstPart::Polynomial({}, origin_),
         {{ω,
-          {/*sin=*/typename FirstPart::Polynomial(polynomials.cos ),
+          {/*sin=*/typename FirstPart::Polynomial(polynomials.cos),
            /*cos=*/typename FirstPart::Polynomial(-polynomials.sin)}}});
     result += (first_part(t2) - first_part(t1)) / ω * Radian;
 
@@ -914,7 +916,7 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
   for (int i = 0; i < left.series_.size(); ++i) {
     auto integrand = [i, &left, &right, &weight](Instant const& t) {
       return Hilbert<LValue, RValue>::InnerProduct(left.series_[i](t),
-                                                   right (t) * weight(t));
+                                                   right(t) * weight(t));
     };
     auto const integral = quadrature::GaussLegendre<points>(
         integrand, left.bounds_[i], left.bounds_[i + 1]);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -586,7 +586,8 @@ std::ostream& operator<<(
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> class Evaluator,
+         int points>
 typename Hilbert<LValue, RValue>::InnerProductType
 Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -871,9 +871,10 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   Result result{};
   auto const left_weight = left * weight;
   for (int i = 0; i < right.series_.size(); ++i) {
-    Instant const origin = right.series_[i].origin();
-    auto const integrand =
-        PointwiseInnerProduct(left_weight.AtOrigin(origin), right.series_[i]);
+    auto integrand = [i, &left_weight, &right](Instant const& t) {
+      return Hilbert<LValue, RValue>::InnerProduct(left_weight(t),
+                                                   right.series_[i](t));
+    };
     auto const integral =
         quadrature::GaussLegendre<(ldegree_ + rdegree_ + wdegree_) / 2>(
             integrand, right.bounds_[i], right.bounds_[i + 1]);
@@ -906,9 +907,10 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
   Result result{};
   auto const right_weight = right * weight;
   for (int i = 0; i < left.series_.size(); ++i) {
-    Instant const origin = left.series_[i].origin();
-    auto const integrand =
-        PointwiseInnerProduct(left.series_[i], right_weight.AtOrigin(origin));
+    auto integrand = [i, &right_weight, &left](Instant const& t) {
+      return Hilbert<LValue, RValue>::InnerProduct(left.series_[i](t),
+                                                   right_weight(t));
+    };
     auto const integral =
         quadrature::GaussLegendre<(ldegree_ + rdegree_ + wdegree_) / 2>(
             integrand, left.bounds_[i], left.bounds_[i + 1]);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -869,10 +869,11 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   using Result =
       Primitive<typename Hilbert<LValue, RValue>::InnerProductType, Time>;
   Result result{};
+  auto const left_weight = left * weight;
   for (int i = 0; i < right.series_.size(); ++i) {
     Instant const origin = right.series_[i].origin();
-    auto const integrand = PointwiseInnerProduct(
-        left.AtOrigin(origin) * weight.AtOrigin(origin), right.series_[i]);
+    auto const integrand =
+        PointwiseInnerProduct(left_weight.AtOrigin(origin), right.series_[i]);
     auto const integral =
         quadrature::GaussLegendre<(ldegree_ + rdegree_ + wdegree_) / 2>(
             integrand, right.bounds_[i], right.bounds_[i + 1]);
@@ -903,10 +904,11 @@ Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
   using Result =
       Primitive<typename Hilbert<LValue, RValue>::InnerProductType, Time>;
   Result result{};
+  auto const right_weight = right * weight;
   for (int i = 0; i < left.series_.size(); ++i) {
     Instant const origin = left.series_[i].origin();
-    auto const integrand = PointwiseInnerProduct(
-        left.series_[i], right.AtOrigin(origin) * weight.AtOrigin(origin));
+    auto const integrand =
+        PointwiseInnerProduct(left.series_[i], right_weight.AtOrigin(origin));
     auto const integral =
         quadrature::GaussLegendre<(ldegree_ + rdegree_ + wdegree_) / 2>(
             integrand, left.bounds_[i], left.bounds_[i + 1]);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -27,9 +27,7 @@ using quantities::Primitive;
 using quantities::Sin;
 using quantities::Time;
 using quantities::Variation;
-using quantities::si::Metre;
 using quantities::si::Radian;
-using quantities::si::Second;
 namespace si = quantities::si;
 
 template<typename Value, int degree_,

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -451,22 +451,22 @@ TEST_F(PiecewisePoissonSeriesTest, ActionMultiorigin) {
 }
 
 TEST_F(PiecewisePoissonSeriesTest, Dot) {
-  double const d1 = Dot(
+  double const d1 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
       pp_, p_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  double const d2 = Dot(
+  double const d2 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
       p_, pp_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 1));
-  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 1));
+  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 0));
+  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 0));
 }
 
 TEST_F(PiecewisePoissonSeriesTest, DotMultiorigin) {
   auto const p = p_.AtOrigin(t0_ + 2 * Second);
-  double const d1 = Dot(
+  double const d1 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
       pp_, p, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  double const d2 = Dot(
+  double const d2 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
       p, pp_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 1));
-  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 1));
+  EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 0));
+  EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 0));
 }
 
 }  // namespace numerics

--- a/numerics/root_finders.hpp
+++ b/numerics/root_finders.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 
 #include "base/array.hpp"
+#include "numerics/scale_b.h"
+#include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 
 namespace principia {
@@ -14,6 +16,7 @@ namespace internal_root_finders {
 
 using base::BoundedArray;
 using quantities::Derivative;
+using quantities::Sqrt;
 
 // Approximates a root of |f| between |lower_bound| and |upper_bound| by
 // bisection.  The result is less than one ULP from a root of any continuous


### PR DESCRIPTION
1. Add a private constructor that avoids sorting.
1. Reduce a bit the number of evaluations of trigonometric functions.
1. In the dot product, instead of using formal multiplication and formal integration, use evaluation followed by multiplication and Gauss integration.
1. Add a parameter to the dot product to specify the number of points to use (mostly for tests, the default should work in real life).

#2400.