### PR TITLE
Don't pass dot to the frequency analysis functions

### DIFF
--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -105,6 +105,8 @@ FixedVector<Product<ScalarLeft, ScalarRight>, rows> operator*(
 template<typename Scalar, int rows>
 class FixedStrictlyLowerTriangularMatrix final {
  public:
+  // TODO(phl): Use the |rows_| style.
+  static constexpr int size = rows;
   static constexpr int dimension = rows * (rows - 1) / 2;
 
   constexpr FixedStrictlyLowerTriangularMatrix();

--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -20,49 +20,30 @@ using quantities::Primitive;
 using quantities::Product;
 using quantities::Time;
 
-// In this file Dot is a templated functor that implements the dot product
-// between two functors and a weight.  Its declaration must look like:
-//
-// class Dot {
-//  public:
-//   ...
-//   template<typename LFunction, typename RFunction, typename Weight>
-//   Product<std::invoke_result_t<LFunction, Instant>,
-//           std::invoke_result_t<RFunction, Instant>>
-//   operator()(LFunction const& left,
-//              RFunction const& right,
-//              Weight const& weight) const;
-//   ...
-//};
-//
-// Where the implementation of Dot may assume that Weight is a Poisson series
-// returning a double.
+// In this file the |Function| must have an |InnerProduct| with |PoissonSeries|
+// or |PiecewisePoissonSeries|.
 
 // Computes the precise mode of a quasi-periodic |function|, assuming that the
 // mode is over the interval |fft_mode| (so named because it has presumably been
 // obtained using FFT).  See [Cha95].
 template<typename Function,
          int wdegree_,
-         typename Dot,
          template<typename, typename, int> class Evaluator>
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Dot const& dot);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 // Computes the Кудрявцев projection of |function| on a basis with angular
 // frequency ω and maximum degree |degree_|.  See [Kud07].
-// TODO(phl): We really need multiple angular frequencies.
 template<int degree_,
          typename Function,
-         int wdegree_, typename Dot,
+         int wdegree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(AngularFrequency const& ω,
            Function const& function,
-           PoissonSeries<double, wdegree_, Evaluator> const& weight,
-           Dot const& dot);
+           PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 // AngularFrequencyCalculator is a templated functor that implements the
 // extraction of the most relevant frequency out of a (mostly periodic)
@@ -84,13 +65,12 @@ Projection(AngularFrequency const& ω,
 // the algorithm, it does so by returning std::nullopt.
 template<int degree_,
          typename Function,
-         typename AngularFrequencyCalculator, int wdegree_, typename Dot,
+         typename AngularFrequencyCalculator, int wdegree_,
          template<typename, typename, int> class Evaluator>
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 IncrementalProjection(Function const& function,
                       AngularFrequencyCalculator const& calculator,
-                      PoissonSeries<double, wdegree_, Evaluator> const& weight,
-                      Dot const& dot);
+                      PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 }  // namespace internal_frequency_analysis
 

--- a/numerics/frequency_analysis.hpp
+++ b/numerics/frequency_analysis.hpp
@@ -32,7 +32,9 @@ template<typename Function,
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight);
+    PoissonSeries<double, wdegree_, Evaluator> const& weight,
+    Instant const& t_min,
+    Instant const& t_max);
 
 // Computes the Кудрявцев projection of |function| on a basis with angular
 // frequency ω and maximum degree |degree_|.  See [Kud07].
@@ -43,7 +45,9 @@ template<int degree_,
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(AngularFrequency const& ω,
            Function const& function,
-           PoissonSeries<double, wdegree_, Evaluator> const& weight);
+           PoissonSeries<double, wdegree_, Evaluator> const& weight,
+           Instant const& t_min,
+           Instant const& t_max);
 
 // AngularFrequencyCalculator is a templated functor that implements the
 // extraction of the most relevant frequency out of a (mostly periodic)
@@ -70,7 +74,9 @@ template<int degree_,
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 IncrementalProjection(Function const& function,
                       AngularFrequencyCalculator const& calculator,
-                      PoissonSeries<double, wdegree_, Evaluator> const& weight);
+                      PoissonSeries<double, wdegree_, Evaluator> const& weight,
+                      Instant const& t_min,
+                      Instant const& t_max);
 
 }  // namespace internal_frequency_analysis
 

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -34,23 +34,27 @@ template<typename Function,
 AngularFrequency PreciseMode(
     Interval<AngularFrequency> const& fft_mode,
     Function const& function,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight) {
+    PoissonSeries<double, wdegree_, Evaluator> const& weight,
+    Instant const& t_min,
+    Instant const& t_max) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Degree0 =
       PoissonSeries<typename Hilbert<Value>::NormalizedType, 0, Evaluator>;
 
-  auto amplitude = [&function, &weight](AngularFrequency const& ω) {
-    constexpr int dimension = Hilbert<Value>::dimension;
-    Instant const& t0 = weight.origin();
-    std::array<Degree0, 2 * dimension> const basis =
-        PoissonSeriesBasisGenerator<Degree0, dimension>::Basis(ω, t0);
-    typename Hilbert<Value>::InnerProductType result{};
-    for (int i = 0; i < basis.size(); ++i) {
-      auto const amplitude = InnerProduct(function, basis[i], weight);
-      result += amplitude * amplitude;
-    }
-    return result;
-  };
+  auto amplitude =
+      [&function, t_min, t_max, &weight](AngularFrequency const& ω) {
+        constexpr int dimension = Hilbert<Value>::dimension;
+        Instant const& t0 = weight.origin();
+        std::array<Degree0, 2 * dimension> const basis =
+            PoissonSeriesBasisGenerator<Degree0, dimension>::Basis(ω, t0);
+        typename Hilbert<Value>::InnerProductType result{};
+        for (int i = 0; i < basis.size(); ++i) {
+          auto const amplitude =
+              InnerProduct(function, basis[i], weight, t_min, t_max);
+          result += amplitude * amplitude;
+        }
+        return result;
+      };
 
   return Brent(amplitude,
                fft_mode.min,
@@ -65,7 +69,9 @@ template<int degree_,
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 Projection(AngularFrequency const& ω,
            Function const& function,
-           PoissonSeries<double, wdegree_, Evaluator> const& weight) {
+           PoissonSeries<double, wdegree_, Evaluator> const& weight,
+           Instant const& t_min,
+           Instant const& t_max) {
   std::optional<AngularFrequency> optional_ω = ω;
 
   // A calculator that returns optional_ω once and then stops.
@@ -77,7 +83,8 @@ Projection(AngularFrequency const& ω,
 
   return IncrementalProjection<degree_>(function,
                                         angular_frequency_calculator,
-                                        weight);
+                                        weight,
+                                        t_min, t_max);
 }
 
 template<int degree_,
@@ -87,7 +94,9 @@ template<int degree_,
 PoissonSeries<std::invoke_result_t<Function, Instant>, degree_, Evaluator>
 IncrementalProjection(Function const& function,
                       AngularFrequencyCalculator const& calculator,
-                      PoissonSeries<double, wdegree_, Evaluator> const& weight) {
+                      PoissonSeries<double, wdegree_, Evaluator> const& weight,
+                      Instant const& t_min,
+                      Instant const& t_max) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Norm = typename Hilbert<Value>::NormType;
   using Norm² = typename Hilbert<Value>::InnerProductType;
@@ -125,8 +134,8 @@ IncrementalProjection(Function const& function,
   // iteration m it contains Aⱼ⁽ᵐ⁻¹⁾.
   UnboundedVector<double> A(basis_size, uninitialized);
 
-  Norm² const F₀ = InnerProduct(function, basis[0], weight);
-  Norm² const Q₀₀ = InnerProduct(basis[0], basis[0], weight);
+  Norm² const F₀ = InnerProduct(function, basis[0], weight, t_min, t_max);
+  Norm² const Q₀₀ = InnerProduct(basis[0], basis[0], weight, t_min, t_max);
   α[0][0] = 1 / Sqrt(Q₀₀);
   A[0] = F₀ / Q₀₀;
 
@@ -137,12 +146,12 @@ IncrementalProjection(Function const& function,
   for (;;) {
     for (int m = m_begin; m < basis_size; ++m) {
       // Contains Fₘ.
-      Norm² const F = InnerProduct(f, basis[m], weight);
+      Norm² const F = InnerProduct(f, basis[m], weight, t_min, t_max);
 
       // This vector contains Qₘⱼ.
       UnboundedVector<Norm²> Q(m + 1, uninitialized);
       for (int j = 0; j <= m; ++j) {
-        Q[j] = InnerProduct(basis[m], basis[j], weight);
+        Q[j] = InnerProduct(basis[m], basis[j], weight, t_min, t_max);
       }
 
       // This vector contains Bⱼ⁽ᵐ⁾.

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -136,8 +136,11 @@ TEST_F(FrequencyAnalysisTest, PreciseModeScalar) {
 
   // The precise analysis is only limited by our ability to pinpoint the
   // maximum.
-  auto const precise_mode = PreciseMode(
-      mode, sin, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const precise_mode =
+      PreciseMode(mode,
+                  sin,
+                  apodization::Hann<HornerEvaluator>(t_min, t_max),
+                  t_min, t_max);
   EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(4.7e-11_⑴)));
 }
 
@@ -177,8 +180,11 @@ TEST_F(FrequencyAnalysisTest, PreciseModeVector) {
 
   // The precise analysis is only limited by our ability to pinpoint the
   // maximum.
-  auto const precise_mode = PreciseMode(
-      mode, sin, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const precise_mode =
+      PreciseMode(mode,
+                  sin,
+                  apodization::Hann<HornerEvaluator>(t_min, t_max),
+                  t_min, t_max);
   EXPECT_THAT(precise_mode, RelativeErrorFrom(ω, IsNear(4.0e-11_⑴)));
 }
 
@@ -197,24 +203,33 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesScalarProjection) {
   Instant const t_max = t0_ + 100 * Radian / ω;
 
   // Projection on a 4th degree basis accurately reconstructs the function.
-  auto const projection4 = Projection<4>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection4 =
+      Projection<4>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection4(t0_ + i * Radian / ω),
                 AlmostEquals(series(t0_ + i * Radian / ω), 0, 2688));
   }
 
   // Projection on a 5th degree basis is also accurate.
-  auto const projection5 = Projection<5>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection5 =
+      Projection<5>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection5(t0_ + i * Radian / ω),
                 AlmostEquals(series(t0_ + i * Radian / ω), 0, 8000));
   }
 
   // Projection on a 3rd degree basis introduces significant errors.
-  auto const projection3 = Projection<3>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection3 =
+      Projection<3>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection3(t0_ + i * Radian / ω),
                 RelativeErrorFrom(series(t0_ + i * Radian / ω),
@@ -266,24 +281,33 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesVectorProjection) {
   Instant const t_max = t0_ + 100 * Radian / ω;
 
   // Projection on a 4th degree basis accurately reconstructs the function.
-  auto const projection4 = Projection<4>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection4 =
+      Projection<4>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection4(t0_ + i * Radian / ω),
                 AlmostEquals(series(t0_ + i * Radian / ω), 0, 4016));
   }
 
   // Projection on a 5th degree basis is also accurate.
-  auto const projection5 = Projection<5>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection5 =
+      Projection<5>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection5(t0_ + i * Radian / ω),
                 AlmostEquals(series(t0_ + i * Radian / ω), 0, 5376));
   }
 
   // Projection on a 3rd degree basis introduces significant errors.
-  auto const projection3 = Projection<3>(
-      ω, series, apodization::Hann<HornerEvaluator>(t_min, t_max));
+  auto const projection3 =
+      Projection<3>(ω,
+                    series,
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection3(t0_ + i * Radian / ω),
                 RelativeErrorFrom(series(t0_ + i * Radian / ω),
@@ -328,7 +352,8 @@ TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
   auto const projection4 =
       Projection<4>(ω,
                     piecewise_series,
-                    apodization::Hann<HornerEvaluator>(t_min, t_max));
+                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection4(t0_ + i * Radian / ω),
                 RelativeErrorFrom(series(t0_ + i * Radian / ω),
@@ -389,10 +414,10 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionNoSecular) {
   // Projection on a 4th degree basis reconstructs the function with a decent
   // accuracy.
   auto const projection4 =
-      IncrementalProjection<4>(
-          series.value(),
-          angular_frequency_calculator,
-          apodization::Hann<HornerEvaluator>(t_min, t_max));
+      IncrementalProjection<4>(series.value(),
+                               angular_frequency_calculator,
+                               apodization::Hann<HornerEvaluator>(t_min, t_max),
+                               t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
@@ -454,10 +479,10 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionSecular) {
   // Projection on a 4th degree basis reconstructs the function with a decent
   // accuracy.
   auto const projection4 =
-      IncrementalProjection<4>(
-          series,
-          angular_frequency_calculator,
-          apodization::Hann<HornerEvaluator>(t_min, t_max));
+      IncrementalProjection<4>(series,
+                               angular_frequency_calculator,
+                               apodization::Hann<HornerEvaluator>(t_min, t_max),
+                               t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -316,7 +316,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesVectorProjection) {
 }
 
 TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
-  AngularFrequency const ω = 6.66543 * π * Radian / Second;
+  AngularFrequency const ω = 0.0566543 * π * Radian / Second;
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> amplitude_distribution(-10.0, 10.0);
   std::uniform_real_distribution<> perturbation_distribution(-1e-6, 1e-6);
@@ -332,7 +332,7 @@ TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
   // Build a series that is based on |series| with different perturbations over
   // different intervals.
   PiecewiseSeries4 piecewise_series({t0_, t0_ + 1 * Second}, series);
-  for (int i = 1; i < 3; ++i) {
+  for (int i = 1; i < 10; ++i) {
     auto const perturbation_sin =
         random_polynomial4_(t0_, random, perturbation_distribution);
     auto const perturbation_cos =
@@ -347,17 +347,18 @@ TEST_F(FrequencyAnalysisTest, PiecewisePoissonSeriesProjection) {
   Instant const t_min = piecewise_series.t_min();
   Instant const t_max = piecewise_series.t_max();
 
-  // Projection on a 4th degree basis.  The errors are of the order of the
-  // perturbation.
+  // Projection on a 4th degree basis.  The approximation is only as good as the
+  // Gauss-Legendre integration.
   auto const projection4 =
       Projection<4>(ω,
                     piecewise_series,
-                    apodization::Hann<HornerEvaluator>(t_min, t_max),
+                    apodization::Dirichlet<HornerEvaluator>(t_min, t_max),
                     t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
-    EXPECT_THAT(projection4(t0_ + i * Radian / ω),
-                RelativeErrorFrom(series(t0_ + i * Radian / ω),
-                                  AllOf(Gt(6.2e-9), Lt(3.2e-4))));
+    EXPECT_THAT(
+        projection4(t_min + i * (t_max - t_min) / 100),
+        RelativeErrorFrom(series(t0_ + i * (t_max - t_min) / 100),
+                          AllOf(Gt(4.4e-8), Lt(6.5e-2))));
   }
 }
 

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -90,13 +90,13 @@ DotImplementation::operator()(LFunction const& left,
   // PiecewisePoissonSeriesProjection doesn't yield a reasonable solution.  This
   // doesn't happen with real life functions, which are much smoother than the
   // test functions.
-  return Dot<std::invoke_result_t<LFunction, Instant>,
-             std::invoke_result_t<RFunction, Instant>,
-             LFunction::degree,
-             RFunction::degree,
-             Weight::degree,
-             HornerEvaluator,
-             /*points=*/30>(left, right, weight, t_min_, t_max_);
+  return InnerProduct<std::invoke_result_t<LFunction, Instant>,
+                      std::invoke_result_t<RFunction, Instant>,
+                      LFunction::degree,
+                      RFunction::degree,
+                      Weight::degree,
+                      HornerEvaluator,
+                      /*points=*/30>(left, right, weight, t_min_, t_max_);
 }
 
 class FrequencyAnalysisTest : public ::testing::Test {

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -259,18 +259,15 @@ std::ostream& operator<<(
 // Technically the weight function must be nonnegative for this to be an inner
 // product.  Not sure how this works with the flat-top windows, which can be
 // negative.  Note that the result is normalized by dividing by (t_max - t_min).
-// NOTE(phl): |points| is currently unused but ensures that the template has the
-// same profile as the one for |PiecewisePoissonSeries|.
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
-         int points = 0>
+         template<typename, typename, int> class Evaluator>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max);
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max);
 
 // A function defined by Poisson series piecewise.  Each of the Poisson series
 // making up the function applies over the semi-open interval
@@ -357,19 +354,19 @@ class PiecewisePoissonSeries {
   template<typename L, typename R, int l, int r, int w,
            template<typename, typename, int> class E, int p>
   typename Hilbert<L, R>::InnerProductType
-  friend Dot(PoissonSeries<L, l, E> const& left,
-             PiecewisePoissonSeries<R, r, E> const& right,
-             PoissonSeries<double, w, E> const& weight,
-             Instant const& t_min,
-             Instant const& t_max);
+  friend InnerProduct(PoissonSeries<L, l, E> const& left,
+                      PiecewisePoissonSeries<R, r, E> const& right,
+                      PoissonSeries<double, w, E> const& weight,
+                      Instant const& t_min,
+                      Instant const& t_max);
   template<typename L, typename R, int l, int r, int w,
            template<typename, typename, int> class E, int p>
   typename Hilbert<L, R>::InnerProductType
-  friend Dot(PiecewisePoissonSeries<L, l, E> const& left,
-             PoissonSeries<R, r, E> const& right,
-             PoissonSeries<double, w, E> const& weight,
-             Instant const& t_min,
-             Instant const& t_max);
+  friend InnerProduct(PiecewisePoissonSeries<L, l, E> const& left,
+                      PoissonSeries<R, r, E> const& right,
+                      PoissonSeries<double, w, E> const& weight,
+                      Instant const& t_min,
+                      Instant const& t_max);
   template<typename V, int d,
            template<typename, typename, int> class E,
            typename O>
@@ -457,44 +454,44 @@ template<typename LValue, typename RValue,
          template<typename, typename, int> class Evaluator,
          int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight);
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
          int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max);
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max);
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
          int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight);
+InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight);
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
          int points = (ldegree_ + rdegree_ + wdegree_) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max);
+InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max);
 
 }  // namespace internal_poisson_series
 
-using internal_poisson_series::Dot;
+using internal_poisson_series::InnerProduct;
 using internal_poisson_series::PiecewisePoissonSeries;
 using internal_poisson_series::PoissonSeries;
 

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -60,6 +60,10 @@ using quantities::Product;
 using quantities::Quotient;
 using quantities::Time;
 
+// The trigonometric functions are by default assumed to look like a polynomial
+// of this degree over an interval of a piecewise series.
+constexpr int estimated_trigonometric_degree = 1;
+
 // A Poisson series is the sum of terms of the form:
 //   aₙtⁿ      aₙₖ tⁿ sin ωₖ t      aₙₖ tⁿ cos ωₖ t
 // Terms of the first kind are called aperiodic, terms of the second and third
@@ -452,7 +456,9 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
-         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
+         int points = (ldegree_ + estimated_trigonometric_degree +
+                       rdegree_ + estimated_trigonometric_degree +
+                       wdegree_ + estimated_trigonometric_degree) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
              PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -461,7 +467,9 @@ InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
-         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
+         int points = (ldegree_ + estimated_trigonometric_degree +
+                       rdegree_ + estimated_trigonometric_degree +
+                       wdegree_ + estimated_trigonometric_degree) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
              PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -472,7 +480,9 @@ InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
-         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
+         int points = (ldegree_ + estimated_trigonometric_degree +
+                       rdegree_ + estimated_trigonometric_degree +
+                       wdegree_ + estimated_trigonometric_degree) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
              PoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -481,7 +491,9 @@ InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
          template<typename, typename, int> class Evaluator,
-         int points = (ldegree_ + rdegree_ + wdegree_) / 2>
+         int points = (ldegree_ + estimated_trigonometric_degree +
+                       rdegree_ + estimated_trigonometric_degree +
+                       wdegree_ + estimated_trigonometric_degree) / 2>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
              PoissonSeries<RValue, rdegree_, Evaluator> const& right,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -588,14 +588,13 @@ std::ostream& operator<<(
 
 template<typename LValue, typename RValue,
          int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
-         int points>
+         template<typename, typename, int> class Evaluator>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max) {
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max) {
   auto const integrand = PointwiseInnerProduct(left, right) * weight;
   auto const primitive = integrand.Primitive();
   return (primitive(t_max) - primitive(t_min)) / (t_max - t_min);
@@ -856,10 +855,13 @@ template<typename LValue, typename RValue,
          template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight) {
-  return Dot<LValue, RValue, ldegree_, rdegree_, wdegree_, Evaluator, points>(
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight) {
+  return InnerProduct<LValue, RValue,
+                      ldegree_, rdegree_, wdegree_,
+                      Evaluator,
+                      points>(
       left, right, weight, right.t_min(), right.t_max());
 }
 
@@ -868,11 +870,11 @@ template<typename LValue, typename RValue,
          template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max) {
+InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max) {
   using Result =
       Primitive<typename Hilbert<LValue, RValue>::InnerProductType, Time>;
   Result result{};
@@ -893,11 +895,14 @@ template<typename LValue, typename RValue,
          template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight) {
-  return Dot<LValue, RValue, ldegree_, rdegree_, wdegree_, Evaluator, points>(
-      left, right, weight, left.t_min(), left.t_max());
+InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight) {
+  return InnerProduct<LValue, RValue,
+                      ldegree_, rdegree_, wdegree_,
+                      Evaluator,
+                      points>(
+       left, right, weight, left.t_min(), left.t_max());
 }
 
 template<typename LValue, typename RValue,
@@ -905,11 +910,11 @@ template<typename LValue, typename RValue,
          template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
-    PoissonSeries<RValue, rdegree_, Evaluator> const& right,
-    PoissonSeries<double, wdegree_, Evaluator> const& weight,
-    Instant const& t_min,
-    Instant const& t_max) {
+InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+             PoissonSeries<RValue, rdegree_, Evaluator> const& right,
+             PoissonSeries<double, wdegree_, Evaluator> const& weight,
+             Instant const& t_min,
+             Instant const& t_max) {
   using Result =
       Primitive<typename Hilbert<LValue, RValue>::InnerProductType, Time>;
   Result result{};

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -240,15 +240,15 @@ TEST_F(PoissonSeriesTest, Primitive) {
                    expected_primitive(5 * Second), 1, 2));
 }
 
-TEST_F(PoissonSeriesTest, Dot) {
+TEST_F(PoissonSeriesTest, InnerProduct) {
   Instant const t_min = t0_;
   Instant const t_max = t0_ + 3 * Second;
   // Computed using Mathematica.
-  EXPECT_THAT(Dot(*pa_,
-                  *pb_,
-                  apodization::Hann<HornerEvaluator>(t_min, t_max),
-                  t_min,
-                  t_max),
+  EXPECT_THAT(InnerProduct(*pa_,
+                           *pb_,
+                           apodization::Hann<HornerEvaluator>(t_min, t_max),
+                           t_min,
+                           t_max),
               AlmostEquals(-381.25522770148542400, 71));
 }
 
@@ -450,20 +450,20 @@ TEST_F(PiecewisePoissonSeriesTest, ActionMultiorigin) {
   }
 }
 
-TEST_F(PiecewisePoissonSeriesTest, Dot) {
-  double const d1 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
+TEST_F(PiecewisePoissonSeriesTest, InnerProduct) {
+  double const d1 = InnerProduct<double, double, 0, 0, 0, HornerEvaluator, 8>(
       pp_, p_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  double const d2 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
+  double const d2 = InnerProduct<double, double, 0, 0, 0, HornerEvaluator, 8>(
       p_, pp_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
   EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 0));
   EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 0));
 }
 
-TEST_F(PiecewisePoissonSeriesTest, DotMultiorigin) {
+TEST_F(PiecewisePoissonSeriesTest, InnerProductMultiorigin) {
   auto const p = p_.AtOrigin(t0_ + 2 * Second);
-  double const d1 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
+  double const d1 = InnerProduct<double, double, 0, 0, 0, HornerEvaluator, 8>(
       pp_, p, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
-  double const d2 = Dot<double, double, 0, 0, 0, HornerEvaluator, 8>(
+  double const d2 = InnerProduct<double, double, 0, 0, 0, HornerEvaluator, 8>(
       p, pp_, apodization::Dirichlet<HornerEvaluator>(t0_, t0_ + 2 * Second));
   EXPECT_THAT(d1, AlmostEquals((3 * π - 26) / (8 * π), 0));
   EXPECT_THAT(d2, AlmostEquals((3 * π - 26) / (8 * π), 0));

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -207,6 +207,7 @@ template<typename Value, typename Argument, int degree_,
 class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
     : public Polynomial<Value, Point<Argument>> {
  public:
+  // TODO(phl): Use the |Value_| style.
   using Result = Value;
 
   // Equivalent to:

--- a/numerics/quadrature_body.hpp
+++ b/numerics/quadrature_body.hpp
@@ -34,6 +34,8 @@ Primitive<std::invoke_result_t<Function, Argument>, Argument> GaussLegendre(
     Function const& function,
     Argument const& lower_bound,
     Argument const& upper_bound) {
+  static_assert(points < LegendreRoots.size,
+                "No table for Gauss-Legendre with the chosen number of points");
   return Gauss<points>(function,
                        lower_bound,
                        upper_bound,


### PR DESCRIPTION
Also:
1. Rename `Dot` into `InnerProduct` to be consistent with the `Hilbert` trait.
1. Fix the `PiecewisePoissonSeriesProjection` test.

#2400 