### PR TITLE
Fourier

### DIFF
--- a/geometry/cartesian_product_body.hpp
+++ b/geometry/cartesian_product_body.hpp
@@ -144,7 +144,9 @@ class CartesianProductVectorSpace<Scalar, Tuple,
       Tuple const& left,
       Scalar const& right);
 
-  FORCE_INLINE(static constexpr) Apply<Quotient, Tuple> Divide(
+  // SFINAEd out unless the division is defined.
+  template<typename TupleQuotient = Apply<Quotient, Tuple>>
+  FORCE_INLINE(static constexpr) TupleQuotient Divide(
       Tuple const& left,
       Scalar const& right);
 };
@@ -168,11 +170,10 @@ constexpr auto CartesianProductVectorSpace<
 }
 
 template<typename Scalar, typename Tuple, std::size_t... indices>
-constexpr auto CartesianProductVectorSpace<
-    Scalar, Tuple,
-    std::index_sequence<indices...>>::Divide(Tuple const& left,
-                                             Scalar const& right)
-    -> Apply<Quotient, Tuple> {
+template<typename TupleQuotient>
+constexpr TupleQuotient
+CartesianProductVectorSpace<Scalar, Tuple, std::index_sequence<indices...>>::
+    Divide(Tuple const& left, Scalar const& right) {
   return {std::get<indices>(left) / right...};
 }
 

--- a/geometry/interval_body.hpp
+++ b/geometry/interval_body.hpp
@@ -17,7 +17,7 @@ Difference<T> Interval<T>::measure() const {
 
 template<typename T>
 T Interval<T>::midpoint() const {
-  return max >= min ? min + measure() / 2 : NaN<T>;
+  return max >= min ? min + measure() / 2 : min + NaN<Difference<T>>;
 }
 
 template<typename T>

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -306,9 +307,8 @@ class PiecewisePoissonSeries {
   // Gauss-Legendre quadrature on each subinterval, where the number of points
   // is chosen assuming that the periods of periodic terms are all large
   // compared to the subintervals.
-  // If apodization is desired, the |*this| should be multiplied by an
-  // apodization function, and |FourierTransform| should be called on the
-  // product.
+  // If apodization is desired, |*this| should be multiplied by an apodization
+  // function, and |FourierTransform| should be called on the product.
   // |*this| must outlive the resulting function.
   std::function<Complexification<Value>(AngularFrequency const&)>
   FourierTransform() const;

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -286,6 +286,8 @@ class PiecewisePoissonSeries {
  public:
   static constexpr int degree = degree_;
   using Series = PoissonSeries<Value, degree_, Evaluator>;
+  using Spectrum = std::function<Complexification<Primitive<Value, Time>>(
+      AngularFrequency const&)>;
 
   PiecewisePoissonSeries(Interval<Instant> const& interval,
                          Series const& series);
@@ -302,7 +304,11 @@ class PiecewisePoissonSeries {
   // t must be in the interval [t_min, t_max].
   Value operator()(Instant const& t) const;
 
-  // Returns the Fourier transform of this Poisson series on [t_min, t_max].
+  // Returns the Fourier transform of this piecewise Poisson series.
+  // The function is taken to be 0 outside [t_min, t_max].
+  // The convention used is ∫ f(t) exp(-iωt) dt, corresponding to Mathematica’s
+  // FourierParameters -> {1, -1} for FourierTransform (the “pure mathematics;
+  // systems engineering”).
   // When evaluated at a given frequency, the Fourier transform is computed by
   // Gauss-Legendre quadrature on each subinterval, where the number of points
   // is chosen assuming that the periods of periodic terms are all large
@@ -310,8 +316,7 @@ class PiecewisePoissonSeries {
   // If apodization is desired, |*this| should be multiplied by an apodization
   // function, and |FourierTransform| should be called on the product.
   // |*this| must outlive the resulting function.
-  std::function<Complexification<Value>(AngularFrequency const&)>
-  FourierTransform() const;
+  Spectrum FourierTransform() const;
 
   template<typename V, int d, template<typename, typename, int> class E>
   PiecewisePoissonSeries& operator+=(PoissonSeries<V, d, E> const& right);

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "geometry/complexification.hpp"
 #include "geometry/hilbert.hpp"
 #include "geometry/interval.hpp"
 #include "geometry/named_quantities.hpp"
@@ -51,6 +52,7 @@ FORWARD_DECLARE_FUNCTION_FROM(
 namespace numerics {
 namespace internal_poisson_series {
 
+using geometry::Complexification;
 using geometry::Hilbert;
 using geometry::Instant;
 using geometry::Interval;
@@ -297,6 +299,18 @@ class PiecewisePoissonSeries {
 
   // t must be in the interval [t_min, t_max].
   Value operator()(Instant const& t) const;
+
+  // Returns the Fourier transform of this Poisson series on [t_min, t_max].
+  // When evaluated at a given frequency, the Fourier transform is computed by
+  // Gauss-Legendre quadrature on each subinterval, where the number of points
+  // is chosen assuming that the periods of periodic terms are all large
+  // compared to the subintervals.
+  // If apodization is desired, the |*this| should be multiplied by an
+  // apodization function, and |FourierTransform| should be called on the
+  // product.
+  // |*this| must outlive the resulting function.
+  std::function<Complexification<Value>(AngularFrequency const&)>
+  FourierTransform() const;
 
   template<typename V, int d, template<typename, typename, int> class E>
   PiecewisePoissonSeries& operator+=(PoissonSeries<V, d, E> const& right);

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -656,8 +656,8 @@ Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
 template<typename Value,
          int degree_,
          template<typename, typename, int> class Evaluator>
-std::function<Complexification<Value>(AngularFrequency const&)>
-PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
+auto PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const
+    -> Spectrum {
   // TODO(egg): consider pre-evaluating |*this| at all points used by the
   // Gaussian quadratures, removing the lifetime requirement on |*this| and
   // potentially speeding up repeated evaluations of the Fourier transform.
@@ -670,12 +670,12 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
           [&f = series_[k], t0, ω](
               Instant const& t) -> Complexification<Value> {
             return f(t) * Complexification<double>{Cos(ω * (t - t0)),
-                                                   Sin(ω * (t - t0))};
+                                                   -Sin(ω * (t - t0))};
           },
           bounds_[k],
           bounds_[k + 1]);
     }
-    return integral / time_domain.measure();
+    return integral;
   };
 }
 

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -1,6 +1,8 @@
 ﻿
 #pragma once
 
+#include "numerics/poisson_series.hpp"
+
 #include <algorithm>
 #include <functional>
 #include <map>
@@ -8,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "numerics/poisson_series.hpp"
 #include "numerics/quadrature.hpp"
 #include "numerics/ulp_distance.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -29,16 +30,14 @@ using quantities::Variation;
 using quantities::si::Radian;
 namespace si = quantities::si;
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 typename PoissonSeries<Primitive<Value, Time>, degree_ + 1, Evaluator>::
     Polynomials
-    AngularFrequencyPrimitive(
-        AngularFrequency const& ω,
-        typename PoissonSeries<Value, degree_, Evaluator>::Polynomials const&
-            polynomials) {
+AngularFrequencyPrimitive(
+    AngularFrequency const& ω,
+    typename PoissonSeries<Value, degree_, Evaluator>::Polynomials const&
+        polynomials) {
   using Result = PoissonSeries<Primitive<Value, Time>, degree_ + 1, Evaluator>;
 
   // Integration by parts.
@@ -65,12 +64,9 @@ typename PoissonSeries<Primitive<Value, Time>, degree_ + 1, Evaluator>::
 // A helper for multiplication of Poisson series and pointwise inner product.
 // The functor Product must take a pair of Poisson series with the types of left
 // and right and return a suitable Poisson series.
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator,
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator,
          typename Product>
 auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
               PoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -128,10 +124,8 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
                 std::move(periodic));
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     Polynomial const& aperiodic,
     PolynomialsByAngularFrequency const& periodic)
@@ -139,18 +133,14 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
                     Polynomial(aperiodic),
                     PolynomialsByAngularFrequency(periodic)) {}
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 Instant const& PoissonSeries<Value, degree_, Evaluator>::origin() const {
   return origin_;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 Value PoissonSeries<Value, degree_, Evaluator>::operator()(
     Instant const& t) const {
   Value result = aperiodic_.Evaluate(t);
@@ -161,10 +151,8 @@ Value PoissonSeries<Value, degree_, Evaluator>::operator()(
   return result;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
     Instant const& origin) const {
@@ -178,20 +166,19 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
     double const sin_ω_shift = Sin(ω * shift);
     Polynomial const sin_at_origin = polynomials.sin.AtOrigin(origin);
     Polynomial const cos_at_origin = polynomials.cos.AtOrigin(origin);
-    periodic.emplace_back(
-        ω,
-        Polynomials{
-            /*sin=*/sin_at_origin * cos_ω_shift - cos_at_origin * sin_ω_shift,
-            /*cos=*/sin_at_origin * sin_ω_shift + cos_at_origin * cos_ω_shift});
+    periodic.emplace_back(ω,
+                          Polynomials{/*sin=*/sin_at_origin * cos_ω_shift -
+                                              cos_at_origin * sin_ω_shift,
+                                      /*cos=*/sin_at_origin * sin_ω_shift +
+                                              cos_at_origin * cos_ω_shift});
   }
-  return {
-      TrustedPrivateConstructor{}, std::move(aperiodic), std::move(periodic)};
+  return {TrustedPrivateConstructor{},
+          std::move(aperiodic),
+          std::move(periodic)};
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<quantities::Primitive<Value, Time>, degree_ + 1, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
   using Result =
@@ -207,10 +194,8 @@ PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
   return Result{aperiodic, periodic};
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 quantities::Primitive<Value, Time>
 PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
                                                     Instant const& t2) const {
@@ -229,8 +214,10 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
     result += (first_part(t2) - first_part(t1)) / ω * Radian;
 
     if constexpr (degree_ != 0) {
-      auto const sin_polynomial = -polynomials.cos.template Derivative<1>();
-      auto const cos_polynomial = polynomials.sin.template Derivative<1>();
+      auto const sin_polynomial =
+          -polynomials.cos.template Derivative<1>();
+      auto const cos_polynomial =
+          polynomials.sin.template Derivative<1>();
       SecondPart const second_part(typename SecondPart::Polynomial({}, origin_),
                                    {{ω,
                                      {/*sin=*/sin_polynomial,
@@ -241,10 +228,8 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
   return result;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     PrivateConstructor,
     Polynomial aperiodic,
@@ -306,10 +291,8 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
   }
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     TrustedPrivateConstructor,
     Polynomial aperiodic,
@@ -318,10 +301,8 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
       aperiodic_(std::move(aperiodic)),
       periodic_(std::move(periodic)) {}
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator+=(
@@ -330,10 +311,8 @@ PoissonSeries<Value, degree_, Evaluator>::operator+=(
   return *this;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator-=(
@@ -342,21 +321,17 @@ PoissonSeries<Value, degree_, Evaluator>::operator-=(
   return *this;
 }
 
-template<typename Value,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Value, rdegree_, Evaluator> operator+(
     PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   return right;
 }
 
-template<typename Value,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Value, rdegree_, Evaluator> operator-(
-    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value, int rdegree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Value, rdegree_, Evaluator>
+operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, rdegree_, Evaluator>;
   auto aperiodic = -right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -372,14 +347,11 @@ PoissonSeries<Value, rdegree_, Evaluator> operator-(
           std::move(periodic)};
 }
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator+(
-    PoissonSeries<Value, ldegree_, Evaluator> const& left,
-    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
+operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
+          PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   auto aperiodic = left.aperiodic_ + right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -430,14 +402,11 @@ PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator+(
           std::move(periodic)};
 }
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator-(
-    PoissonSeries<Value, ldegree_, Evaluator> const& left,
-    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
+operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
+          PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   auto aperiodic = left.aperiodic_ - right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -488,14 +457,11 @@ PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator-(
           std::move(periodic)};
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
-    Scalar const& left,
-    PoissonSeries<Value, degree_, Evaluator> const& right) {
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>
+operator*(Scalar const& left,
+          PoissonSeries<Value, degree_, Evaluator> const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left * right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -511,14 +477,11 @@ PoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
           std::move(periodic)};
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
-    PoissonSeries<Value, degree_, Evaluator> const& left,
-    Scalar const& right) {
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Product<Value, Scalar>, degree_, Evaluator>
+operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
+          Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left.aperiodic_ * right;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -534,14 +497,11 @@ PoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
           std::move(periodic)};
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
-PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
-    PoissonSeries<Value, degree_, Evaluator> const& left,
-    Scalar const& right) {
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
+PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator>
+operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
+          Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left.aperiodic_ / right;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -557,12 +517,9 @@ PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
           std::move(periodic)};
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -570,18 +527,17 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       [](typename PoissonSeries<LValue, ldegree_, Evaluator>::Polynomial const&
              left,
          typename PoissonSeries<RValue, rdegree_, Evaluator>::Polynomial const&
-             right) { return left * right; };
+             right) {
+    return left * right;
+  };
 
   return Multiply<LValue, RValue, ldegree_, rdegree_, Evaluator>(
       left, right, product);
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PoissonSeries<typename Hilbert<LValue, RValue>::InnerProductType,
               ldegree_ + rdegree_,
               Evaluator>
@@ -591,16 +547,16 @@ PointwiseInnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       [](typename PoissonSeries<LValue, ldegree_, Evaluator>::Polynomial const&
              left,
          typename PoissonSeries<RValue, rdegree_, Evaluator>::Polynomial const&
-             right) { return PointwiseInnerProduct(left, right); };
+             right) {
+    return PointwiseInnerProduct(left, right);
+  };
 
   return Multiply<LValue, RValue, ldegree_, rdegree_, Evaluator>(
       left, right, product);
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 std::ostream& operator<<(
     std::ostream& out,
     PoissonSeries<Value, degree_, Evaluator> const& series) {
@@ -614,7 +570,7 @@ std::ostream& operator<<(
       if (!is_start_of_output) {
         out << " + ";
       }
-      out << "(" << polynomials.sin << ") * Sin(" << quantities::DebugString(ω)
+      out <<"(" << polynomials.sin << ") * Sin(" << quantities::DebugString(ω)
           << " * (T - " << series.origin_ << "))";
       is_start_of_output = false;
     }
@@ -644,21 +600,18 @@ InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return (primitive(t_max) - primitive(t_min)) / (t_max - t_min);
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, degree_, Evaluator>::PiecewisePoissonSeries(
     Interval<Instant> const& interval,
     Series const& series)
-    : bounds_({interval.min, interval.max}), series_(/*count=*/1, series) {
+    : bounds_({interval.min, interval.max}),
+      series_(/*count=*/1, series) {
   CHECK_LT(Time{}, interval.measure());
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 void PiecewisePoissonSeries<Value, degree_, Evaluator>::Append(
     Interval<Instant> const& interval,
     Series const& series) {
@@ -668,26 +621,20 @@ void PiecewisePoissonSeries<Value, degree_, Evaluator>::Append(
   series_.push_back(series);
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 Instant PiecewisePoissonSeries<Value, degree_, Evaluator>::t_min() const {
   return bounds_.front();
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 Instant PiecewisePoissonSeries<Value, degree_, Evaluator>::t_max() const {
   return bounds_.back();
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
     Instant const& t) const {
   if (t == bounds_.back()) {
@@ -699,8 +646,8 @@ Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
   // t belongs.
   auto const it = std::upper_bound(bounds_.cbegin(), bounds_.cend(), t);
   CHECK(it != bounds_.cbegin())
-      << "Unexpected result looking up " << t << " in " << bounds_.front()
-      << " .. " << bounds_.back();
+      << "Unexpected result looking up " << t << " in "
+      << bounds_.front() << " .. " << bounds_.back();
   CHECK(it != bounds_.cend())
       << t << " is outside of " << bounds_.front() << " .. " << bounds_.back();
   return series_[it - bounds_.cbegin() - 1](t);
@@ -733,10 +680,8 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
   };
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PiecewisePoissonSeries<Value, degree_, Evaluator>&
 PiecewisePoissonSeries<Value, degree_, Evaluator>::operator+=(
@@ -745,10 +690,8 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::operator+=(
   return *this;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PiecewisePoissonSeries<Value, degree_, Evaluator>&
 PiecewisePoissonSeries<Value, degree_, Evaluator>::operator-=(
@@ -757,28 +700,23 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::operator-=(
   return *this;
 }
 
-template<typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, degree_, Evaluator>::PiecewisePoissonSeries(
     std::vector<Instant> const& bounds,
     std::vector<PoissonSeries<Value, degree_, Evaluator>> const& series)
-    : bounds_(bounds), series_(series) {}
+    : bounds_(bounds),
+      series_(series) {}
 
-template<typename Value,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator+(
     PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
   return right;
 }
 
-template<typename Value,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator-(
     PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PiecewisePoissonSeries<Value, rdegree_, Evaluator>;
@@ -790,11 +728,8 @@ PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator-(
   return Result(right.bounds_, series);
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
     Scalar const& left,
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& right) {
@@ -808,11 +743,8 @@ PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
   return Result(right.bounds_, series);
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& left,
     Scalar const& right) {
@@ -826,11 +758,8 @@ PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
   return Result(left.bounds_, series);
 }
 
-template<typename Scalar,
-         typename Value,
-         int degree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Scalar, typename Value, int degree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& left,
     Scalar const& right) {
@@ -850,11 +779,8 @@ PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
 // TODO(phl): All these origin changes might be expensive, see if we can factor
 // them.
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -869,11 +795,8 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator+(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -888,11 +811,8 @@ operator+(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -907,11 +827,8 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename Value,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename Value, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator-(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -926,12 +843,8 @@ operator-(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename LValue, typename RValue, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -947,12 +860,8 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         template<typename, typename, int>
-         class Evaluator>
+template<typename LValue, typename RValue, int ldegree_, int rdegree_,
+         template<typename, typename, int> class Evaluator>
 PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -968,13 +877,9 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         int wdegree_,
-         template<typename, typename, int>
-         class Evaluator,
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_, int wdegree_,
+         template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
@@ -987,13 +892,9 @@ InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       left, right, weight, right.t_min(), right.t_max());
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         int wdegree_,
-         template<typename, typename, int>
-         class Evaluator,
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_, int wdegree_,
+         template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
@@ -1016,13 +917,9 @@ InnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return result / (t_max - t_min);
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         int wdegree_,
-         template<typename, typename, int>
-         class Evaluator,
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_, int wdegree_,
+         template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
@@ -1035,13 +932,9 @@ InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
        left, right, weight, left.t_min(), left.t_max());
 }
 
-template<typename LValue,
-         typename RValue,
-         int ldegree_,
-         int rdegree_,
-         int wdegree_,
-         template<typename, typename, int>
-         class Evaluator,
+template<typename LValue, typename RValue,
+         int ldegree_, int rdegree_, int wdegree_,
+         template<typename, typename, int> class Evaluator,
          int points>
 typename Hilbert<LValue, RValue>::InnerProductType
 InnerProduct(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -655,9 +655,8 @@ Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
 
 template<typename Value,
          int degree_,
-         template<typename, typename, int>
-         class Evaluator>
-inline std::function<Complexification<Value>(AngularFrequency const&)>
+         template<typename, typename, int> class Evaluator>
+std::function<Complexification<Value>(AngularFrequency const&)>
 PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
   // TODO(egg): consider pre-evaluating |*this| at all points used by the
   // Gaussian quadratures, removing the lifetime requirement on |*this| and
@@ -669,7 +668,7 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
     for (int k = 0; k < series_.size(); ++k) {
       integral += quadrature::GaussLegendre<std::max(1, (degree_ + 1) / 2)>(
           [&f = series_[k], t0, ω](
-              Instant const t) -> Complexification<Value> {
+              Instant const& t) -> Complexification<Value> {
             return f(t) * Complexification<double>{Cos(ω * (t - t0)),
                                                    Sin(ω * (t - t0))};
           },

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -1,8 +1,6 @@
 ﻿
 #pragma once
 
-#include "numerics/poisson_series.hpp"
-
 #include <algorithm>
 #include <functional>
 #include <map>
@@ -10,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "numerics/poisson_series.hpp"
 #include "numerics/quadrature.hpp"
 #include "numerics/ulp_distance.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -30,14 +29,16 @@ using quantities::Variation;
 using quantities::si::Radian;
 namespace si = quantities::si;
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 typename PoissonSeries<Primitive<Value, Time>, degree_ + 1, Evaluator>::
     Polynomials
-AngularFrequencyPrimitive(
-    AngularFrequency const& ω,
-    typename PoissonSeries<Value, degree_, Evaluator>::Polynomials const&
-        polynomials) {
+    AngularFrequencyPrimitive(
+        AngularFrequency const& ω,
+        typename PoissonSeries<Value, degree_, Evaluator>::Polynomials const&
+            polynomials) {
   using Result = PoissonSeries<Primitive<Value, Time>, degree_ + 1, Evaluator>;
 
   // Integration by parts.
@@ -64,9 +65,12 @@ AngularFrequencyPrimitive(
 // A helper for multiplication of Poisson series and pointwise inner product.
 // The functor Product must take a pair of Poisson series with the types of left
 // and right and return a suitable Poisson series.
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          typename Product>
 auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
               PoissonSeries<RValue, rdegree_, Evaluator> const& right,
@@ -124,8 +128,10 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
                 std::move(periodic));
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     Polynomial const& aperiodic,
     PolynomialsByAngularFrequency const& periodic)
@@ -133,14 +139,18 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
                     Polynomial(aperiodic),
                     PolynomialsByAngularFrequency(periodic)) {}
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 Instant const& PoissonSeries<Value, degree_, Evaluator>::origin() const {
   return origin_;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 Value PoissonSeries<Value, degree_, Evaluator>::operator()(
     Instant const& t) const {
   Value result = aperiodic_.Evaluate(t);
@@ -151,8 +161,10 @@ Value PoissonSeries<Value, degree_, Evaluator>::operator()(
   return result;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
     Instant const& origin) const {
@@ -166,19 +178,20 @@ PoissonSeries<Value, degree_, Evaluator>::AtOrigin(
     double const sin_ω_shift = Sin(ω * shift);
     Polynomial const sin_at_origin = polynomials.sin.AtOrigin(origin);
     Polynomial const cos_at_origin = polynomials.cos.AtOrigin(origin);
-    periodic.emplace_back(ω,
-                          Polynomials{/*sin=*/sin_at_origin * cos_ω_shift -
-                                              cos_at_origin * sin_ω_shift,
-                                      /*cos=*/sin_at_origin * sin_ω_shift +
-                                              cos_at_origin * cos_ω_shift});
+    periodic.emplace_back(
+        ω,
+        Polynomials{
+            /*sin=*/sin_at_origin * cos_ω_shift - cos_at_origin * sin_ω_shift,
+            /*cos=*/sin_at_origin * sin_ω_shift + cos_at_origin * cos_ω_shift});
   }
-  return {TrustedPrivateConstructor{},
-          std::move(aperiodic),
-          std::move(periodic)};
+  return {
+      TrustedPrivateConstructor{}, std::move(aperiodic), std::move(periodic)};
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<quantities::Primitive<Value, Time>, degree_ + 1, Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
   using Result =
@@ -194,8 +207,10 @@ PoissonSeries<Value, degree_, Evaluator>::Primitive() const {
   return Result{aperiodic, periodic};
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 quantities::Primitive<Value, Time>
 PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
                                                     Instant const& t2) const {
@@ -214,10 +229,8 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
     result += (first_part(t2) - first_part(t1)) / ω * Radian;
 
     if constexpr (degree_ != 0) {
-      auto const sin_polynomial =
-          -polynomials.cos.template Derivative<1>();
-      auto const cos_polynomial =
-          polynomials.sin.template Derivative<1>();
+      auto const sin_polynomial = -polynomials.cos.template Derivative<1>();
+      auto const cos_polynomial = polynomials.sin.template Derivative<1>();
       SecondPart const second_part(typename SecondPart::Polynomial({}, origin_),
                                    {{ω,
                                      {/*sin=*/sin_polynomial,
@@ -228,8 +241,10 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
   return result;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     PrivateConstructor,
     Polynomial aperiodic,
@@ -291,8 +306,10 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
   }
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
     TrustedPrivateConstructor,
     Polynomial aperiodic,
@@ -301,8 +318,10 @@ PoissonSeries<Value, degree_, Evaluator>::PoissonSeries(
       aperiodic_(std::move(aperiodic)),
       periodic_(std::move(periodic)) {}
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator+=(
@@ -311,8 +330,10 @@ PoissonSeries<Value, degree_, Evaluator>::operator+=(
   return *this;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PoissonSeries<Value, degree_, Evaluator>&
 PoissonSeries<Value, degree_, Evaluator>::operator-=(
@@ -321,17 +342,21 @@ PoissonSeries<Value, degree_, Evaluator>::operator-=(
   return *this;
 }
 
-template<typename Value, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Value, rdegree_, Evaluator> operator+(
     PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   return right;
 }
 
-template<typename Value, int rdegree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Value, rdegree_, Evaluator>
-operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Value, rdegree_, Evaluator> operator-(
+    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, rdegree_, Evaluator>;
   auto aperiodic = -right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -347,11 +372,14 @@ operator-(PoissonSeries<Value, rdegree_, Evaluator> const& right) {
           std::move(periodic)};
 }
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
-operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
-          PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator+(
+    PoissonSeries<Value, ldegree_, Evaluator> const& left,
+    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   auto aperiodic = left.aperiodic_ + right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -402,11 +430,14 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           std::move(periodic)};
 }
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
-operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
-          PoissonSeries<Value, rdegree_, Evaluator> const& right) {
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator> operator-(
+    PoissonSeries<Value, ldegree_, Evaluator> const& left,
+    PoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>;
   auto aperiodic = left.aperiodic_ - right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -457,11 +488,14 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           std::move(periodic)};
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>
-operator*(Scalar const& left,
-          PoissonSeries<Value, degree_, Evaluator> const& right) {
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
+    Scalar const& left,
+    PoissonSeries<Value, degree_, Evaluator> const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left * right.aperiodic_;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -477,11 +511,14 @@ operator*(Scalar const& left,
           std::move(periodic)};
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Product<Value, Scalar>, degree_, Evaluator>
-operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
-          Scalar const& right) {
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
+    PoissonSeries<Value, degree_, Evaluator> const& left,
+    Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left.aperiodic_ * right;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -497,11 +534,14 @@ operator*(PoissonSeries<Value, degree_, Evaluator> const& left,
           std::move(periodic)};
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
-PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator>
-operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
-          Scalar const& right) {
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
+PoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
+    PoissonSeries<Value, degree_, Evaluator> const& left,
+    Scalar const& right) {
   using Result = PoissonSeries<Product<Scalar, Value>, degree_, Evaluator>;
   auto aperiodic = left.aperiodic_ / right;
   typename Result::PolynomialsByAngularFrequency periodic;
@@ -517,9 +557,12 @@ operator/(PoissonSeries<Value, degree_, Evaluator> const& left,
           std::move(periodic)};
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -527,17 +570,18 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       [](typename PoissonSeries<LValue, ldegree_, Evaluator>::Polynomial const&
              left,
          typename PoissonSeries<RValue, rdegree_, Evaluator>::Polynomial const&
-             right) {
-    return left * right;
-  };
+             right) { return left * right; };
 
   return Multiply<LValue, RValue, ldegree_, rdegree_, Evaluator>(
       left, right, product);
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PoissonSeries<typename Hilbert<LValue, RValue>::InnerProductType,
               ldegree_ + rdegree_,
               Evaluator>
@@ -547,16 +591,16 @@ PointwiseInnerProduct(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
       [](typename PoissonSeries<LValue, ldegree_, Evaluator>::Polynomial const&
              left,
          typename PoissonSeries<RValue, rdegree_, Evaluator>::Polynomial const&
-             right) {
-    return PointwiseInnerProduct(left, right);
-  };
+             right) { return PointwiseInnerProduct(left, right); };
 
   return Multiply<LValue, RValue, ldegree_, rdegree_, Evaluator>(
       left, right, product);
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 std::ostream& operator<<(
     std::ostream& out,
     PoissonSeries<Value, degree_, Evaluator> const& series) {
@@ -570,7 +614,7 @@ std::ostream& operator<<(
       if (!is_start_of_output) {
         out << " + ";
       }
-      out <<"(" << polynomials.sin << ") * Sin(" << quantities::DebugString(ω)
+      out << "(" << polynomials.sin << ") * Sin(" << quantities::DebugString(ω)
           << " * (T - " << series.origin_ << "))";
       is_start_of_output = false;
     }
@@ -586,12 +630,16 @@ std::ostream& operator<<(
   return out;
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         int wdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          int points>
-typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+typename Hilbert<LValue, RValue>::InnerProductType Dot(
+    PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
     Instant const& t_min,
@@ -601,18 +649,21 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return (primitive(t_max) - primitive(t_min)) / (t_max - t_min);
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, degree_, Evaluator>::PiecewisePoissonSeries(
     Interval<Instant> const& interval,
     Series const& series)
-    : bounds_({interval.min, interval.max}),
-      series_(/*count=*/1, series) {
+    : bounds_({interval.min, interval.max}), series_(/*count=*/1, series) {
   CHECK_LT(Time{}, interval.measure());
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 void PiecewisePoissonSeries<Value, degree_, Evaluator>::Append(
     Interval<Instant> const& interval,
     Series const& series) {
@@ -622,20 +673,26 @@ void PiecewisePoissonSeries<Value, degree_, Evaluator>::Append(
   series_.push_back(series);
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 Instant PiecewisePoissonSeries<Value, degree_, Evaluator>::t_min() const {
   return bounds_.front();
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 Instant PiecewisePoissonSeries<Value, degree_, Evaluator>::t_max() const {
   return bounds_.back();
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
     Instant const& t) const {
   if (t == bounds_.back()) {
@@ -647,15 +704,44 @@ Value PiecewisePoissonSeries<Value, degree_, Evaluator>::operator()(
   // t belongs.
   auto const it = std::upper_bound(bounds_.cbegin(), bounds_.cend(), t);
   CHECK(it != bounds_.cbegin())
-      << "Unexpected result looking up " << t << " in "
-      << bounds_.front() << " .. " << bounds_.back();
+      << "Unexpected result looking up " << t << " in " << bounds_.front()
+      << " .. " << bounds_.back();
   CHECK(it != bounds_.cend())
       << t << " is outside of " << bounds_.front() << " .. " << bounds_.back();
   return series_[it - bounds_.cbegin() - 1](t);
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
+inline std::function<Complexification<Value>(AngularFrequency const&)>
+PiecewisePoissonSeries<Value, degree_, Evaluator>::FourierTransform() const {
+  // TODO(egg): consider pre-evaluating |*this| at all points used by the
+  // Gaussian quadratures, removing the lifetime requirement on |*this| and
+  // potentially speeding up repeated evaluations of the Fourier transform.
+  return [this](AngularFrequency const& ω) {
+    Interval<Instant> const time_domain{t_min(), t_max()};
+    Instant const t0 = time_domain.midpoint();
+    Primitive<Complexification<Value>, Instant> integral;
+    for (int k = 0; k < series_.size(); ++k) {
+      integral += quadrature::GaussLegendre<std::max(1, (degree_ + 1) / 2)>(
+          [&f = series_[k], t0, ω](
+              Instant const t) -> Complexification<Value> {
+            return f(t) * Complexification<double>{Cos(ω * (t - t0)),
+                                                   Sin(ω * (t - t0))};
+          },
+          bounds_[k],
+          bounds_[k + 1]);
+    }
+    return integral / time_domain.measure();
+  };
+}
+
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PiecewisePoissonSeries<Value, degree_, Evaluator>&
 PiecewisePoissonSeries<Value, degree_, Evaluator>::operator+=(
@@ -664,8 +750,10 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::operator+=(
   return *this;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 template<typename V, int d, template<typename, typename, int> class E>
 PiecewisePoissonSeries<Value, degree_, Evaluator>&
 PiecewisePoissonSeries<Value, degree_, Evaluator>::operator-=(
@@ -674,23 +762,28 @@ PiecewisePoissonSeries<Value, degree_, Evaluator>::operator-=(
   return *this;
 }
 
-template<typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, degree_, Evaluator>::PiecewisePoissonSeries(
     std::vector<Instant> const& bounds,
     std::vector<PoissonSeries<Value, degree_, Evaluator>> const& series)
-    : bounds_(bounds),
-      series_(series) {}
+    : bounds_(bounds), series_(series) {}
 
-template<typename Value, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator+(
     PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
   return right;
 }
 
-template<typename Value, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator-(
     PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
   using Result = PiecewisePoissonSeries<Value, rdegree_, Evaluator>;
@@ -702,8 +795,11 @@ PiecewisePoissonSeries<Value, rdegree_, Evaluator> operator-(
   return Result(right.bounds_, series);
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
     Scalar const& left,
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& right) {
@@ -717,8 +813,11 @@ PiecewisePoissonSeries<Product<Scalar, Value>, degree_, Evaluator> operator*(
   return Result(right.bounds_, series);
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& left,
     Scalar const& right) {
@@ -732,8 +831,11 @@ PiecewisePoissonSeries<Product<Value, Scalar>, degree_, Evaluator> operator*(
   return Result(left.bounds_, series);
 }
 
-template<typename Scalar, typename Value, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Scalar,
+         typename Value,
+         int degree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
     PiecewisePoissonSeries<Value, degree_, Evaluator> const& left,
     Scalar const& right) {
@@ -753,8 +855,11 @@ PiecewisePoissonSeries<Quotient<Value, Scalar>, degree_, Evaluator> operator/(
 // TODO(phl): All these origin changes might be expensive, see if we can factor
 // them.
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -769,8 +874,11 @@ operator+(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator+(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -785,8 +893,11 @@ operator+(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -801,8 +912,11 @@ operator-(PoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename Value, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Value, std::max(ldegree_, rdegree_), Evaluator>
 operator-(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
           PoissonSeries<Value, rdegree_, Evaluator> const& right) {
@@ -817,8 +931,12 @@ operator-(PiecewisePoissonSeries<Value, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename LValue, typename RValue, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -834,8 +952,12 @@ operator*(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return Result(right.bounds_, series);
 }
 
-template<typename LValue, typename RValue, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         template<typename, typename, int>
+         class Evaluator>
 PiecewisePoissonSeries<Product<LValue, RValue>, ldegree_ + rdegree_, Evaluator>
 operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
           PoissonSeries<RValue, rdegree_, Evaluator> const& right) {
@@ -851,24 +973,32 @@ operator*(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return Result(left.bounds_, series);
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         int wdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          int points>
-typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+typename Hilbert<LValue, RValue>::InnerProductType Dot(
+    PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   return Dot<LValue, RValue, ldegree_, rdegree_, wdegree_, Evaluator, points>(
       left, right, weight, right.t_min(), right.t_max());
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         int wdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          int points>
-typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
+typename Hilbert<LValue, RValue>::InnerProductType Dot(
+    PoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PiecewisePoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
     Instant const& t_min,
@@ -888,24 +1018,32 @@ Dot(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
   return result / (t_max - t_min);
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         int wdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          int points>
-typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+typename Hilbert<LValue, RValue>::InnerProductType Dot(
+    PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight) {
   return Dot<LValue, RValue, ldegree_, rdegree_, wdegree_, Evaluator, points>(
       left, right, weight, left.t_min(), left.t_max());
 }
 
-template<typename LValue, typename RValue,
-         int ldegree_, int rdegree_, int wdegree_,
-         template<typename, typename, int> class Evaluator,
+template<typename LValue,
+         typename RValue,
+         int ldegree_,
+         int rdegree_,
+         int wdegree_,
+         template<typename, typename, int>
+         class Evaluator,
          int points>
-typename Hilbert<LValue, RValue>::InnerProductType
-Dot(PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
+typename Hilbert<LValue, RValue>::InnerProductType Dot(
+    PiecewisePoissonSeries<LValue, ldegree_, Evaluator> const& left,
     PoissonSeries<RValue, rdegree_, Evaluator> const& right,
     PoissonSeries<double, wdegree_, Evaluator> const& weight,
     Instant const& t_min,

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -18,6 +18,7 @@
 #include "quantities/si.hpp"
 #include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/is_near.hpp"
+#include "testing_utilities/numerics_matchers.hpp"
 #include "testing_utilities/vanishes_before.hpp"
 
 namespace principia {
@@ -43,6 +44,7 @@ using quantities::si::Second;
 using testing_utilities::AlmostEquals;
 using testing_utilities::IsNear;
 using testing_utilities::VanishesBefore;
+using testing_utilities::RelativeErrorFrom;
 using testing_utilities::operator""_⑴;
 
 class PoissonSeriesTest : public ::testing::Test {
@@ -231,7 +233,7 @@ TEST_F(PoissonSeriesTest, Fourier) {
         return f_fourier_transform(ω).Norm²();
       };
   EXPECT_THAT(Brent(f_power_spectrum, 0.9 * ω, 1.1 * ω, std::greater<>{}),
-              IsNear(4.117_⑴ * Radian / Second));
+              RelativeErrorFrom(ω, IsNear(0.03_⑴)));
   // A peak arising from the finite interval.
   EXPECT_THAT(Brent(f_power_spectrum,
                     0 * Radian / Second,
@@ -247,7 +249,7 @@ TEST_F(PoissonSeriesTest, Fourier) {
         return fw_fourier_transform(ω).Norm²();
       };
   EXPECT_THAT(Brent(fw_power_spectrum, 0.9 * ω, 1.1 * ω, std::greater<>{}),
-              IsNear(+3.979_⑴ * Radian / Second));
+              RelativeErrorFrom(ω, IsNear(0.005_⑴)));
   // Hann filters out the interval; this search for a second maximum converges
   // to its boundary.
   EXPECT_THAT(Brent(fw_power_spectrum,
@@ -435,17 +437,22 @@ TEST_F(PiecewisePoissonSeriesTest, Action) {
     auto const s2 = pp_ + p_;
     EXPECT_THAT(s1(t0_ + 0.5 * Second),
                 AlmostEquals((10 - 3 * Sqrt(2)) / 4, 0));
-    EXPECT_THAT(s1(t0_ + 1.5 * Second), AlmostEquals((6 + Sqrt(2)) / 4, 0));
+    EXPECT_THAT(s1(t0_ + 1.5 * Second),
+                AlmostEquals((6 + Sqrt(2)) / 4, 0));
     EXPECT_THAT(s2(t0_ + 0.5 * Second),
                 AlmostEquals((10 - 3 * Sqrt(2)) / 4, 0));
-    EXPECT_THAT(s2(t0_ + 1.5 * Second), AlmostEquals((6 + Sqrt(2)) / 4, 0));
+    EXPECT_THAT(s2(t0_ + 1.5 * Second),
+                AlmostEquals((6 + Sqrt(2)) / 4, 0));
   }
   {
     auto const d1 = p_ - pp_;
     auto const d2 = pp_ - p_;
-    EXPECT_THAT(d1(t0_ + 0.5 * Second), AlmostEquals((2 + Sqrt(2)) / 4, 1));
-    EXPECT_THAT(d1(t0_ + 1.5 * Second), AlmostEquals((6 + 5 * Sqrt(2)) / 4, 0));
-    EXPECT_THAT(d2(t0_ + 0.5 * Second), AlmostEquals((-2 - Sqrt(2)) / 4, 1));
+    EXPECT_THAT(d1(t0_ + 0.5 * Second),
+                AlmostEquals((2 + Sqrt(2)) / 4, 1));
+    EXPECT_THAT(d1(t0_ + 1.5 * Second),
+                AlmostEquals((6 + 5 * Sqrt(2)) / 4, 0));
+    EXPECT_THAT(d2(t0_ + 0.5 * Second),
+                AlmostEquals((-2 - Sqrt(2)) / 4, 1));
     EXPECT_THAT(d2(t0_ + 1.5 * Second),
                 AlmostEquals((-6 - 5 * Sqrt(2)) / 4, 0));
   }
@@ -470,17 +477,22 @@ TEST_F(PiecewisePoissonSeriesTest, ActionMultiorigin) {
     auto const s2 = pp_ + p;
     EXPECT_THAT(s1(t0_ + 0.5 * Second),
                 AlmostEquals((10 - 3 * Sqrt(2)) / 4, 1));
-    EXPECT_THAT(s1(t0_ + 1.5 * Second), AlmostEquals((6 + Sqrt(2)) / 4, 0));
+    EXPECT_THAT(s1(t0_ + 1.5 * Second),
+                AlmostEquals((6 + Sqrt(2)) / 4, 0));
     EXPECT_THAT(s2(t0_ + 0.5 * Second),
                 AlmostEquals((10 - 3 * Sqrt(2)) / 4, 1));
-    EXPECT_THAT(s2(t0_ + 1.5 * Second), AlmostEquals((6 + Sqrt(2)) / 4, 0));
+    EXPECT_THAT(s2(t0_ + 1.5 * Second),
+                AlmostEquals((6 + Sqrt(2)) / 4, 0));
   }
   {
     auto const d1 = p - pp_;
     auto const d2 = pp_ - p;
-    EXPECT_THAT(d1(t0_ + 0.5 * Second), AlmostEquals((2 + Sqrt(2)) / 4, 0, 2));
-    EXPECT_THAT(d1(t0_ + 1.5 * Second), AlmostEquals((6 + 5 * Sqrt(2)) / 4, 0));
-    EXPECT_THAT(d2(t0_ + 0.5 * Second), AlmostEquals((-2 - Sqrt(2)) / 4, 0, 2));
+    EXPECT_THAT(d1(t0_ + 0.5 * Second),
+                AlmostEquals((2 + Sqrt(2)) / 4, 0, 2));
+    EXPECT_THAT(d1(t0_ + 1.5 * Second),
+                AlmostEquals((6 + 5 * Sqrt(2)) / 4, 0));
+    EXPECT_THAT(d2(t0_ + 0.5 * Second),
+                AlmostEquals((-2 - Sqrt(2)) / 4, 0, 2));
     EXPECT_THAT(d2(t0_ + 1.5 * Second),
                 AlmostEquals((-6 - 5 * Sqrt(2)) / 4, 0));
   }

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -127,15 +127,15 @@ TEST_F(PoissonSeriesTest, VectorSpace) {
   }
   {
     auto const sum = *pa_ + *pb_;
-    EXPECT_THAT(
-        sum(t0_ + 1 * Second),
-        AlmostEquals((*pa_)(t0_ + 1 * Second) + (*pb_)(t0_ + 1 * Second), 1));
+    EXPECT_THAT(sum(t0_ + 1 * Second),
+                AlmostEquals((*pa_)(t0_ + 1 * Second) +
+                                 (*pb_)(t0_ + 1 * Second), 1));
   }
   {
     auto const difference = *pa_ - *pb_;
-    EXPECT_THAT(
-        difference(t0_ + 1 * Second),
-        AlmostEquals((*pa_)(t0_ + 1 * Second) - (*pb_)(t0_ + 1 * Second), 0));
+    EXPECT_THAT(difference(t0_ + 1 * Second),
+                AlmostEquals((*pa_)(t0_ + 1 * Second) -
+                                 (*pb_)(t0_ + 1 * Second), 0));
   }
   {
     auto const left_product = 3 * *pa_;
@@ -156,9 +156,9 @@ TEST_F(PoissonSeriesTest, VectorSpace) {
 
 TEST_F(PoissonSeriesTest, Algebra) {
   auto const product = *pa_ * *pb_;
-  EXPECT_THAT(
-      product(t0_ + 1 * Second),
-      AlmostEquals((*pa_)(t0_ + 1 * Second) * (*pb_)(t0_ + 1 * Second), 6, 38));
+  EXPECT_THAT(product(t0_ + 1 * Second),
+              AlmostEquals((*pa_)(t0_ + 1 * Second) *
+                               (*pb_)(t0_ + 1 * Second), 6, 38));
 }
 
 TEST_F(PoissonSeriesTest, AtOrigin) {
@@ -177,25 +177,32 @@ TEST_F(PoissonSeriesTest, AtOrigin) {
 
 TEST_F(PoissonSeriesTest, PointwiseInnerProduct) {
   using Degree2 = PoissonSeries<Displacement<World>, 2, HornerEvaluator>;
-  Degree2::Polynomial::Coefficients const coefficients_a(
-      {Displacement<World>({0 * Metre, 0 * Metre, 1 * Metre}),
-       Velocity<World>(
-           {0 * Metre / Second, 1 * Metre / Second, 0 * Metre / Second}),
-       Vector<Acceleration, World>({1 * Metre / Second / Second,
+  Degree2::Polynomial::Coefficients const coefficients_a({
+      Displacement<World>({0 * Metre,
+                            0 * Metre,
+                            1 * Metre}),
+      Velocity<World>({0 * Metre / Second,
+                        1 * Metre / Second,
+                        0 * Metre / Second}),
+      Vector<Acceleration, World>({1 * Metre / Second / Second,
                                     0 * Metre / Second / Second,
                                     0 * Metre / Second / Second})});
-  Degree2::Polynomial::Coefficients const coefficients_b(
-      {Displacement<World>({0 * Metre, 2 * Metre, 3 * Metre}),
-       Velocity<World>(
-           {-1 * Metre / Second, 1 * Metre / Second, 0 * Metre / Second}),
-       Vector<Acceleration, World>({1 * Metre / Second / Second,
-                                    1 * Metre / Second / Second,
-                                    -2 * Metre / Second / Second})});
+  Degree2::Polynomial::Coefficients const coefficients_b({
+      Displacement<World>({0 * Metre,
+                           2 * Metre,
+                           3 * Metre}),
+      Velocity<World>({-1 * Metre / Second,
+                       1 * Metre / Second,
+                       0 * Metre / Second}),
+      Vector<Acceleration, World>({1 * Metre / Second / Second,
+                                   1 * Metre / Second / Second,
+                                   -2 * Metre / Second / Second})});
   Degree2 const pa(Degree2::Polynomial({coefficients_a}, t0_), {{}});
   Degree2 const pb(Degree2::Polynomial({coefficients_b}, t0_), {{}});
 
   auto const product = PointwiseInnerProduct(pa, pb);
-  EXPECT_THAT(product(t0_ + 1 * Second), AlmostEquals(5 * Metre * Metre, 0));
+  EXPECT_THAT(product(t0_ + 1 * Second),
+              AlmostEquals(5 * Metre * Metre, 0));
 }
 
 TEST_F(PoissonSeriesTest, Fourier) {
@@ -285,11 +292,10 @@ TEST_F(PoissonSeriesTest, Primitive) {
                 AlmostEquals(expected_primitive(i * Second), 0, 6));
   }
 
-  EXPECT_THAT(pb_->Integrate(t0_ + 5 * Second, t0_ + 13 * Second),
-              AlmostEquals(expected_primitive(13 * Second) -
-                               expected_primitive(5 * Second),
-                           1,
-                           2));
+  EXPECT_THAT(
+      pb_->Integrate(t0_ + 5 * Second, t0_ + 13 * Second),
+      AlmostEquals(expected_primitive(13 * Second) -
+                   expected_primitive(5 * Second), 1, 2));
 }
 
 TEST_F(PoissonSeriesTest, InnerProduct) {

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -1,6 +1,7 @@
 ﻿
 #include "numerics/poisson_series.hpp"
 
+#include <functional>
 #include <limits>
 #include <memory>
 

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -106,8 +106,7 @@ TEST_F(PoissonSeriesTest, Evaluate) {
   EXPECT_THAT((*pa_)(t0_ + 1 * Second),
               AlmostEquals(3 + 11 * Sin(1 * Radian) + 15 * Cos(1 * Radian) +
                                27 * Sin(2 * Radian) + 31 * Cos(2 * Radian),
-                           0,
-                           1));
+                           0, 1));
   EXPECT_THAT((*pb_)(t0_ + 1 * Second),
               AlmostEquals(7 + 19 * Sin(1 * Radian) + 23 * Cos(1 * Radian) +
                                35 * Sin(3 * Radian) + 39 * Cos(3 * Radian),


### PR DESCRIPTION
Add a continuous Fourier transform on piecewise Poisson series, for use in Chapront’s frequency search to refine the output of the DFT.

Another flying buttress for #2400.

The autoformatter went wild again; kept some of what it did where some code was egregiously poorly formatted (`4* Sqrt(2)`???).