### PR TITLE
Cleanups for the polynomials

### DIFF
--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -225,7 +225,7 @@ class OrbitAnalysisTest : public ::testing::Test {
         *earth_centred_trajectory,
         earth_,
         {{/*epoch=*/J2000,
-          /*mean_longitude_at_epoch=*/newcomb_mean_longitude.Evaluate(J2000),
+          /*mean_longitude_at_epoch=*/newcomb_mean_longitude(J2000),
           /*year*/ 2 * π * Radian /
               newcomb_mean_longitude.EvaluateDerivative(J2000)}});
     return {elements, recurrence, ground_track};

--- a/benchmarks/polynomial.cpp
+++ b/benchmarks/polynomial.cpp
@@ -93,7 +93,7 @@ void EvaluatePolynomialInMonomialBasis(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
-      result += p.Evaluate(argument);
+      result += p(argument);
       argument += Δargument;
     }
   }

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_test.cpp
@@ -134,10 +134,10 @@ TEST_F(EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegratorTest, Legendre) {
   for (ODE::SystemState const& state : solution) {
     double const x = (state.time.value - t_initial) / (1 * Second);
     double const error =
-        AbsoluteError(LegendrePolynomial<degree, EstrinEvaluator>().Evaluate(x),
+        AbsoluteError(LegendrePolynomial<degree, EstrinEvaluator>()(x),
                       state.positions[0].value);
     Variation<double> const derivative_error = AbsoluteError(
-        LegendrePolynomial<degree, EstrinEvaluator>().Derivative().Evaluate(x) /
+        LegendrePolynomial<degree, EstrinEvaluator>().Derivative()(x) /
             (1 * Second),
         state.velocities[0].value);
     max_error = std::max(max_error, error);

--- a/numerics/elliptic_functions.cpp
+++ b/numerics/elliptic_functions.cpp
@@ -78,9 +78,9 @@ void JacobiSNCNDNReduced(Angle const& u,
     u₀ = 0.5 * u₀;
   }
 
-  double const b₀1 = fukushima_b₀_maclaurin_m_1.Evaluate(m);
-  double const b₀2 = fukushima_b₀_maclaurin_m_2.Evaluate(m);
-  double const b₀3 = fukushima_b₀_maclaurin_m_3.Evaluate(m);
+  double const b₀1 = fukushima_b₀_maclaurin_m_1(m);
+  double const b₀2 = fukushima_b₀_maclaurin_m_2(m);
+  double const b₀3 = fukushima_b₀_maclaurin_m_3(m);
   PolynomialInMonomialBasis<double, double, 3, HornerEvaluator>
       fukushima_b₀_maclaurin_u₀²_3(std::make_tuple(0.0, b₀1, b₀2, b₀3));
   double const u₀² = (u₀ * u₀) / Pow<2>(Radian);
@@ -88,7 +88,7 @@ void JacobiSNCNDNReduced(Angle const& u,
   // We use the subscript i to indicate variables that are computed as part of
   // the iteration (Fukushima uses subscripts n and N).  This avoids confusion
   // between c (the result) and cᵢ (the intermediate numerator of c).
-  double bᵢ = fukushima_b₀_maclaurin_u₀²_3.Evaluate(u₀²);
+  double bᵢ = fukushima_b₀_maclaurin_u₀²_3(u₀²);
 
   Angle const uA = (1.76269 + 1.16357 * mc) * Radian;
   bool const may_have_cancellation = u > uA;

--- a/numerics/elliptic_integrals.cpp
+++ b/numerics/elliptic_integrals.cpp
@@ -1246,8 +1246,7 @@ Angle BulirschCel(double kc, double const nc, double a, double b) {
 template<int degree>
 double EllipticNomeQ(double const mc) {
   return mc *
-         EllipticNomeQMaclaurin<degree - 1, EstrinEvaluator>::polynomial.
-             Evaluate(mc);
+         EllipticNomeQMaclaurin<degree - 1, EstrinEvaluator>::polynomial(mc);
 }
 
 void FukushimaEllipticBD(double const mc, Angle& B_m, Angle& D_m) {
@@ -1267,60 +1266,60 @@ void FukushimaEllipticBD(double const mc, Angle& B_m, Angle& D_m) {
     double KX_mc;  // KX(mc).
     double EX_mc;  // EX(mc).
     if (mc < 0.01) {
-      KX_mc = fukushima_KX_maclaurin.Evaluate(mc);
-      EX_mc = mc * fukushima_EX_maclaurin.Evaluate(mc);
+      KX_mc = fukushima_KX_maclaurin(mc);
+      EX_mc = mc * fukushima_EX_maclaurin(mc);
     } else {
       double const mx = mc - 0.05;
-      KX_mc = fukushima_KX_taylor_0_05.Evaluate(mx);
-      EX_mc = fukushima_EX_taylor_0_05.Evaluate(mx);
+      KX_mc = fukushima_KX_taylor_0_05(mx);
+      EX_mc = fukushima_EX_taylor_0_05(mx);
     }
     // Equivalent to Fukushima’s code [Fuk18], but much simplified.
     double const one_over_two_KX_mc = 0.5 / KX_mc;
     B_m = (X_mc * (EX_mc - mc * KX_mc) + one_over_two_KX_mc) * Radian / m;
     D_m = X_mc * KX_mc * Radian - B_m;
   } else if (m <= 0.01) {
-    B_m = (-π * Radian) * fukushima_B٭X_maclaurin.Evaluate(m);
-    D_m = (π * Radian) * fukushima_EX_maclaurin.Evaluate(m);
+    B_m = (-π * Radian) * fukushima_B٭X_maclaurin(m);
+    D_m = (π * Radian) * fukushima_EX_maclaurin(m);
   } else if (m <= 0.1) {
     double const mx = 0.95 - mc;
-    B_m = fukushima_B_taylor_0_05.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_05.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_05(mx) * Radian;
+    D_m = fukushima_D_taylor_0_05(mx) * Radian;
   } else if (m <= 0.2) {
     double const mx = 0.85 - mc;
-    B_m = fukushima_B_taylor_0_15.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_15.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_15(mx) * Radian;
+    D_m = fukushima_D_taylor_0_15(mx) * Radian;
   } else if (m <= 0.3) {
     double const mx = 0.75 - mc;
-    B_m = fukushima_B_taylor_0_25.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_25.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_25(mx) * Radian;
+    D_m = fukushima_D_taylor_0_25(mx) * Radian;
   } else if (m <= 0.4) {
     double const mx = 0.65 - mc;
-    B_m = fukushima_B_taylor_0_35.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_35.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_35(mx) * Radian;
+    D_m = fukushima_D_taylor_0_35(mx) * Radian;
   } else if (m <= 0.5) {
     double const mx = 0.55 - mc;
-    B_m = fukushima_B_taylor_0_45.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_45.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_45(mx) * Radian;
+    D_m = fukushima_D_taylor_0_45(mx) * Radian;
   } else if (m <= 0.6) {
     double const mx = 0.45 - mc;
-    B_m = fukushima_B_taylor_0_55.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_55.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_55(mx) * Radian;
+    D_m = fukushima_D_taylor_0_55(mx) * Radian;
   } else if (m <= 0.7) {
     double const mx = 0.35 - mc;
-    B_m = fukushima_B_taylor_0_65.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_65.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_65(mx) * Radian;
+    D_m = fukushima_D_taylor_0_65(mx) * Radian;
   } else if (m <= 0.8) {
     double const mx = 0.25 - mc;
-    B_m = fukushima_B_taylor_0_75.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_75.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_75(mx) * Radian;
+    D_m = fukushima_D_taylor_0_75(mx) * Radian;
   } else if (m <= 0.85) {
     double const mx = 0.175 - mc;
-    B_m = fukushima_B_taylor_0_825.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_825.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_825(mx) * Radian;
+    D_m = fukushima_D_taylor_0_825(mx) * Radian;
   } else {
     double const mx = 0.125 - mc;
-    B_m = fukushima_B_taylor_0_875.Evaluate(mx) * Radian;
-    D_m = fukushima_D_taylor_0_875.Evaluate(mx) * Radian;
+    B_m = fukushima_B_taylor_0_875(mx) * Radian;
+    D_m = fukushima_D_taylor_0_875(mx) * Radian;
   }
 }
 
@@ -1496,27 +1495,27 @@ void FukushimaEllipticBsDsMaclaurinSeries(double const y,
                                           double const m,
                                           Angle& Σ_Bₗ_m_yˡ,
                                           Angle& Σ_Dₗ_m_yˡ) {
-  double const Fs1 = FukushimaEllipticFsMaclaurin1::polynomial.Evaluate(m);
-  double const Fs2 = FukushimaEllipticFsMaclaurin2::polynomial.Evaluate(m);
-  double const Fs3 = FukushimaEllipticFsMaclaurin3::polynomial.Evaluate(m);
-  double const Fs4 = FukushimaEllipticFsMaclaurin4::polynomial.Evaluate(m);
-  double const Fs5 = FukushimaEllipticFsMaclaurin5::polynomial.Evaluate(m);
-  double const Fs6 = FukushimaEllipticFsMaclaurin6::polynomial.Evaluate(m);
-  double const Fs7 = FukushimaEllipticFsMaclaurin7::polynomial.Evaluate(m);
-  double const Fs8 = FukushimaEllipticFsMaclaurin8::polynomial.Evaluate(m);
-  double const Fs9 = FukushimaEllipticFsMaclaurin9::polynomial.Evaluate(m);
-  double const Fs10 = FukushimaEllipticFsMaclaurin10::polynomial.Evaluate(m);
-  double const Fs11 = FukushimaEllipticFsMaclaurin11::polynomial.Evaluate(m);
+  double const Fs1 = FukushimaEllipticFsMaclaurin1::polynomial(m);
+  double const Fs2 = FukushimaEllipticFsMaclaurin2::polynomial(m);
+  double const Fs3 = FukushimaEllipticFsMaclaurin3::polynomial(m);
+  double const Fs4 = FukushimaEllipticFsMaclaurin4::polynomial(m);
+  double const Fs5 = FukushimaEllipticFsMaclaurin5::polynomial(m);
+  double const Fs6 = FukushimaEllipticFsMaclaurin6::polynomial(m);
+  double const Fs7 = FukushimaEllipticFsMaclaurin7::polynomial(m);
+  double const Fs8 = FukushimaEllipticFsMaclaurin8::polynomial(m);
+  double const Fs9 = FukushimaEllipticFsMaclaurin9::polynomial(m);
+  double const Fs10 = FukushimaEllipticFsMaclaurin10::polynomial(m);
+  double const Fs11 = FukushimaEllipticFsMaclaurin11::polynomial(m);
 
   auto const fukushima_elliptic_Ds_maclaurin =
       FukushimaEllipticDsBsMaclaurin<EstrinEvaluator>::MakeDsPolynomial(
       1.0, Fs1, Fs2, Fs3, Fs4, Fs5, Fs6, Fs7, Fs8, Fs9, Fs10, Fs11);
-  Σ_Dₗ_m_yˡ = fukushima_elliptic_Ds_maclaurin.Evaluate(y) * Radian;
+  Σ_Dₗ_m_yˡ = fukushima_elliptic_Ds_maclaurin(y) * Radian;
 
   auto const fukushima_elliptic_Bs_maclaurin =
       FukushimaEllipticDsBsMaclaurin<EstrinEvaluator>::MakeBsPolynomial(
       1.0, Fs1, Fs2, Fs3, Fs4, Fs5, Fs6, Fs7, Fs8, Fs9, Fs10, Fs11);
-  Σ_Bₗ_m_yˡ = fukushima_elliptic_Bs_maclaurin.Evaluate(y) * Radian;
+  Σ_Bₗ_m_yˡ = fukushima_elliptic_Bs_maclaurin(y) * Radian;
 }
 
 // See [Fuk12], section 3.4 and 3.5.
@@ -1527,36 +1526,36 @@ Angle FukushimaEllipticJsMaclaurinSeries(double const y,
   // is the degree in m (k in Fukushima's notation).
   PolynomialInMonomialBasis<double, double, 0, HornerEvaluator>
       fukushima_elliptic_Js_maclaurin_m_0(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_0_0.Evaluate(n)));
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_0_0(n)));
   PolynomialInMonomialBasis<double, double, 1, HornerEvaluator>
       fukushima_elliptic_Js_maclaurin_m_1(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_1_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_1_1.Evaluate(n)));
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_1_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_1_1(n)));
   PolynomialInMonomialBasis<double, double, 2, HornerEvaluator>
       fukushima_elliptic_Js_maclaurin_m_2(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_2_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_2_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_2_2.Evaluate(n)));
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_2_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_2_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_2_2(n)));
   PolynomialInMonomialBasis<double, double, 3, HornerEvaluator>
       fukushima_elliptic_Js_maclaurin_m_3(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_3_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_3_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_3_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_3_3.Evaluate(n)));
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_3_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_3_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_3_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_3_3(n)));
   PolynomialInMonomialBasis<double, double, 4, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_4(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_4_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_4_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_4_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_4_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_4_4.Evaluate(n)));
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_4_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_4_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_4_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_4_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_4_4(n)));
   // The first five coefficients Jₗ(n|m); the others are computed as needed.
   // TODO(egg): J₁(n|m) = 1/3; could we make it constexpr?
-  double const J₁ = fukushima_elliptic_Js_maclaurin_m_0.Evaluate(m);
-  double const J₂ = fukushima_elliptic_Js_maclaurin_m_1.Evaluate(m);
-  double const J₃ = fukushima_elliptic_Js_maclaurin_m_2.Evaluate(m);
-  double const J₄ = fukushima_elliptic_Js_maclaurin_m_3.Evaluate(m);
-  double const J₅ = fukushima_elliptic_Js_maclaurin_m_4.Evaluate(m);
+  double const J₁ = fukushima_elliptic_Js_maclaurin_m_0(m);
+  double const J₂ = fukushima_elliptic_Js_maclaurin_m_1(m);
+  double const J₃ = fukushima_elliptic_Js_maclaurin_m_2(m);
+  double const J₄ = fukushima_elliptic_Js_maclaurin_m_3(m);
+  double const J₅ = fukushima_elliptic_Js_maclaurin_m_4(m);
   // This function computes ∑ Jₗ(n|m) yˡ.  Since it has no constant term, we
   // compute it as y ∑ Jₗ(n|m) yˡ⁻¹.  In the remainder of this function,
   // |fukushima_elliptic_Js_maclaurin_y_*| is the polynomial ∑ Jₗ(n|m) yˡ⁻¹.
@@ -1567,96 +1566,96 @@ Angle FukushimaEllipticJsMaclaurinSeries(double const y,
     PolynomialInMonomialBasis<double, double, 4, EstrinEvaluator>
         fukushima_elliptic_Js_maclaurin_y_4(
             std::make_tuple(J₁, J₂, J₃, J₄, J₅));
-    return y * fukushima_elliptic_Js_maclaurin_y_4.Evaluate(y) * Radian;
+    return y * fukushima_elliptic_Js_maclaurin_y_4(y) * Radian;
   }
 
   PolynomialInMonomialBasis<double, double, 5, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_5(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_5_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_5_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_5_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_5_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_5_4.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_5_5.Evaluate(n)));
-  double const J₆ = fukushima_elliptic_Js_maclaurin_m_5.Evaluate(m);
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_5_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_5_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_5_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_5_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_5_4(n),
+                          fukushima_elliptic_Js_maclaurin_n_5_5(n)));
+  double const J₆ = fukushima_elliptic_Js_maclaurin_m_5(m);
   if (y <= 2.0727505e-03) {
     PolynomialInMonomialBasis<double, double, 5, EstrinEvaluator>
         fukushima_elliptic_js_maclaurin_y_5(
             std::make_tuple(J₁, J₂, J₃, J₄, J₅, J₆));
-    return y * fukushima_elliptic_js_maclaurin_y_5.Evaluate(y) * Radian;
+    return y * fukushima_elliptic_js_maclaurin_y_5(y) * Radian;
   }
 
   PolynomialInMonomialBasis<double, double, 6, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_6(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_6_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_4.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_5.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_6_6.Evaluate(n)));
-  double const J₇ = fukushima_elliptic_Js_maclaurin_m_6.Evaluate(m);
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_6_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_4(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_5(n),
+                          fukushima_elliptic_Js_maclaurin_n_6_6(n)));
+  double const J₇ = fukushima_elliptic_Js_maclaurin_m_6(m);
   if (y <= 5.0047026e-03) {
     PolynomialInMonomialBasis<double, double, 6, EstrinEvaluator>
         fukushima_elliptic_js_maclaurin_y_6(
             std::make_tuple(J₁, J₂, J₃, J₄, J₅, J₆, J₇));
-    return y * fukushima_elliptic_js_maclaurin_y_6.Evaluate(y) * Radian;
+    return y * fukushima_elliptic_js_maclaurin_y_6(y) * Radian;
   }
 
   PolynomialInMonomialBasis<double, double, 7, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_7(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_7_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_4.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_5.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_6.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_7_7.Evaluate(n)));
-  double const J₈ = fukushima_elliptic_Js_maclaurin_m_7.Evaluate(m);
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_7_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_4(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_5(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_6(n),
+                          fukushima_elliptic_Js_maclaurin_n_7_7(n)));
+  double const J₈ = fukushima_elliptic_Js_maclaurin_m_7(m);
   if (y <= 9.6961652e-03) {
     PolynomialInMonomialBasis<double, double, 7, EstrinEvaluator>
         fukushima_elliptic_js_maclaurin_y_7(
             std::make_tuple(J₁, J₂, J₃, J₄, J₅, J₆, J₇, J₈));
-    return y * fukushima_elliptic_js_maclaurin_y_7.Evaluate(y) * Radian;
+    return y * fukushima_elliptic_js_maclaurin_y_7(y) * Radian;
   }
 
   PolynomialInMonomialBasis<double, double, 8, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_8(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_8_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_4.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_5.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_6.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_7.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_8_8.Evaluate(n)));
-  double const J₉ = fukushima_elliptic_Js_maclaurin_m_8.Evaluate(m);
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_8_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_4(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_5(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_6(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_7(n),
+                          fukushima_elliptic_Js_maclaurin_n_8_8(n)));
+  double const J₉ = fukushima_elliptic_Js_maclaurin_m_8(m);
   if (y <= 1.6220210e-02) {
     PolynomialInMonomialBasis<double, double, 8, EstrinEvaluator>
         fukushima_elliptic_Js_maclaurin_y_8(
             std::make_tuple(J₁, J₂, J₃, J₄, J₅, J₆, J₇, J₈, J₉));
-    return y * fukushima_elliptic_Js_maclaurin_y_8.Evaluate(y) * Radian;
+    return y * fukushima_elliptic_Js_maclaurin_y_8(y) * Radian;
   }
 
   PolynomialInMonomialBasis<double, double, 9, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_m_9(
-          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_9_0.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_1.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_2.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_3.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_4.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_5.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_6.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_7.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_8.Evaluate(n),
-                          fukushima_elliptic_Js_maclaurin_n_9_9.Evaluate(n)));
-  double const J₁₀ = fukushima_elliptic_Js_maclaurin_m_9.Evaluate(m);
+          std::make_tuple(fukushima_elliptic_Js_maclaurin_n_9_0(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_1(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_2(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_3(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_4(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_5(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_6(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_7(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_8(n),
+                          fukushima_elliptic_Js_maclaurin_n_9_9(n)));
+  double const J₁₀ = fukushima_elliptic_Js_maclaurin_m_9(m);
   PolynomialInMonomialBasis<double, double, 9, EstrinEvaluator>
       fukushima_elliptic_Js_maclaurin_y_9(
           std::make_tuple(J₁, J₂, J₃, J₄, J₅, J₆, J₇, J₈, J₉, J₁₀));
-  return y * fukushima_elliptic_Js_maclaurin_y_9.Evaluate(y) * Radian;
+  return y * fukushima_elliptic_Js_maclaurin_y_9(y) * Radian;
 }
 
 Angle FukushimaT(double const t, double const h) {
@@ -1671,32 +1670,32 @@ Angle FukushimaT(double const t, double const h) {
   if (abs_z < 3.3306691e-16) {
     return t * Radian;
   } else if (abs_z < 2.3560805e-08) {
-    return t * FukushimaTMaclaurin1::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin1::polynomial(z) * Radian;
   } else if (abs_z < 9.1939631e-06) {
-    return t * FukushimaTMaclaurin2::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin2::polynomial(z) * Radian;
   } else if (abs_z < 1.7779240e-04) {
-    return t * FukushimaTMaclaurin3::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin3::polynomial(z) * Radian;
   } else if (abs_z < 1.0407839e-03) {
-    return t * FukushimaTMaclaurin4::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin4::polynomial(z) * Radian;
   } else if (abs_z < 3.3616998e-03) {
-    return t * FukushimaTMaclaurin5::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin5::polynomial(z) * Radian;
   } else if (abs_z < 7.7408014e-03) {
-    return t * FukushimaTMaclaurin6::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin6::polynomial(z) * Radian;
   } else if (abs_z < 1.4437181e-02) {
-    return t * FukushimaTMaclaurin7::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin7::polynomial(z) * Radian;
   } else if (abs_z < 2.3407312e-02) {
-    return t * FukushimaTMaclaurin8::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin8::polynomial(z) * Radian;
   } else if (abs_z < 3.4416203e-02) {
-    return t * FukushimaTMaclaurin9::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin9::polynomial(z) * Radian;
   } else if (z < 0.0) {
     double const r = Sqrt(h);
     return ArcTan(r * t) / r;
   } else if (abs_z < 4.7138547e-02) {
-    return t * FukushimaTMaclaurin10::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin10::polynomial(z) * Radian;
   } else if (abs_z < 6.1227405e-02) {
-    return t * FukushimaTMaclaurin11::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin11::polynomial(z) * Radian;
   } else if (abs_z < 7.6353468e-02) {
-    return t * FukushimaTMaclaurin12::polynomial.Evaluate(z) * Radian;
+    return t * FukushimaTMaclaurin12::polynomial(z) * Radian;
   } else {
     double const r = Sqrt(-h);
     double const rt = r * t;
@@ -2046,28 +2045,28 @@ Angle EllipticK(double const mʹ) {
     // The complementary nome.
     double const qʹ = EllipticNomeQ<14>(mʹ);
     // Use K′ = K(m′), see [Fuk09], equations (15) and (29).
-    double const Kʹ = elliptic_K_taylor_0_05.Evaluate(mʹ - 0.05);
+    double const Kʹ = elliptic_K_taylor_0_05(mʹ - 0.05);
     return -Kʹ * (1 / π) * std::log(qʹ) * Radian;
   } else if (m <= 0.1) {
-    return elliptic_K_taylor_0_05.Evaluate(m - 0.05) * Radian;
+    return elliptic_K_taylor_0_05(m - 0.05) * Radian;
   } else if (m <= 0.2) {
-    return elliptic_K_taylor_0_15.Evaluate(m - 0.15) * Radian;
+    return elliptic_K_taylor_0_15(m - 0.15) * Radian;
   } else if (m <= 0.3) {
-    return elliptic_K_taylor_0_25.Evaluate(m - 0.25) * Radian;
+    return elliptic_K_taylor_0_25(m - 0.25) * Radian;
   } else if (m <= 0.4) {
-    return elliptic_K_taylor_0_35.Evaluate(m - 0.35) * Radian;
+    return elliptic_K_taylor_0_35(m - 0.35) * Radian;
   } else if (m <= 0.5) {
-    return elliptic_K_taylor_0_45.Evaluate(m - 0.45) * Radian;
+    return elliptic_K_taylor_0_45(m - 0.45) * Radian;
   } else if (m <= 0.6) {
-    return elliptic_K_taylor_0_55.Evaluate(m - 0.55) * Radian;
+    return elliptic_K_taylor_0_55(m - 0.55) * Radian;
   } else if (m <= 0.7) {
-    return elliptic_K_taylor_0_65.Evaluate(m - 0.65) * Radian;
+    return elliptic_K_taylor_0_65(m - 0.65) * Radian;
   } else if (m <= 0.8) {
-    return elliptic_K_taylor_0_75.Evaluate(m - 0.75) * Radian;
+    return elliptic_K_taylor_0_75(m - 0.75) * Radian;
   } else if (m <= 0.85) {
-    return elliptic_K_taylor_0_825.Evaluate(m - 0.825) * Radian;
+    return elliptic_K_taylor_0_825(m - 0.825) * Radian;
   } else {
-    return elliptic_K_taylor_0_875.Evaluate(m - 0.875) * Radian;
+    return elliptic_K_taylor_0_875(m - 0.875) * Radian;
   }
 }
 

--- a/numerics/fast_sin_cos_2π.cpp
+++ b/numerics/fast_sin_cos_2π.cpp
@@ -80,7 +80,7 @@ void FastSinCos2π(double const cycles, double& sin, double& cos) {
   // argument, i.e., y * (s₁ + s₃ * y² + s₅ * (y² * y²)), avoids having a
   // multiplication by y at the end.
   double const s = s₁ * y + (s₃ + s₅ * y²) * y³;
-  double const c = cos_polynomial.Evaluate(y²);
+  double const c = cos_polynomial(y²);
 
   switch (quadrant) {
     case 0:

--- a/numerics/legendre_test.cpp
+++ b/numerics/legendre_test.cpp
@@ -12,24 +12,24 @@ class LegendreTest : public ::testing::Test {};
 
 TEST_F(LegendreTest, P3) {
   auto const p3 = LegendrePolynomial<3, HornerEvaluator>();
-  EXPECT_EQ(0, p3.Evaluate(0));
-  EXPECT_EQ(1, p3.Evaluate(1));
-  EXPECT_EQ(-1, p3.Evaluate(-1));
-  EXPECT_EQ(17, p3.Evaluate(2));
+  EXPECT_EQ(0, p3(0));
+  EXPECT_EQ(1, p3(1));
+  EXPECT_EQ(-1, p3(-1));
+  EXPECT_EQ(17, p3(2));
 }
 
 TEST_F(LegendreTest, P4) {
   auto const p4 = LegendrePolynomial<4, HornerEvaluator>();
-  EXPECT_EQ(3.0 / 8.0, p4.Evaluate(0));
-  EXPECT_EQ(1, p4.Evaluate(1));
-  EXPECT_EQ(1, p4.Evaluate(-1));
-  EXPECT_EQ(443.0 / 8.0, p4.Evaluate(2));
-  EXPECT_EQ(443.0 / 8.0, p4.Evaluate(-2));
+  EXPECT_EQ(3.0 / 8.0, p4(0));
+  EXPECT_EQ(1, p4(1));
+  EXPECT_EQ(1, p4(-1));
+  EXPECT_EQ(443.0 / 8.0, p4(2));
+  EXPECT_EQ(443.0 / 8.0, p4(-2));
 }
 
 TEST_F(LegendreTest, P16) {
   auto const p16 = LegendrePolynomial<16, HornerEvaluator>();
-  EXPECT_EQ(6435.0 / 32768.0, p16.Evaluate(0));
+  EXPECT_EQ(6435.0 / 32768.0, p16(0));
 }
 
 }  // namespace internal_legendre

--- a/numerics/newhall_test.cpp
+++ b/numerics/newhall_test.cpp
@@ -199,7 +199,7 @@ MonomialAdapter<degree> MonomialAdapter<degree>::NewhallApproximation(
 
 template<int degree>
 Length MonomialAdapter<degree>::Evaluate(Instant const& t) const {
-  return polynomial_.Evaluate(t);
+  return polynomial_(t);
 }
 
 template<int degree>
@@ -765,7 +765,7 @@ TEST_F(NewhallTest, NonConstantDegree) {
             /*degree=*/10,
             lengths, speeds, t_min_, t_max_, length_error_estimate);
 
-    EXPECT_THAT(RelativeError(approximation->Evaluate(t_min_),
+    EXPECT_THAT(RelativeError((*approximation)(t_min_),
                               length_function_1_(t_min_)), IsNear(9e-13_⑴));
 }
 

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -76,7 +76,7 @@ auto Multiply(PoissonSeries<LValue, ldegree_, Evaluator> const& left,
           Product,
           typename PoissonSeries<LValue, ldegree_, Evaluator>::Polynomial,
           typename PoissonSeries<RValue, rdegree_, Evaluator>::Polynomial>::
-          Result,
+          Value,
       ldegree_ + rdegree_,
       Evaluator>;
 

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -143,10 +143,10 @@ template<typename Value, int degree_,
          template<typename, typename, int> class Evaluator>
 Value PoissonSeries<Value, degree_, Evaluator>::operator()(
     Instant const& t) const {
-  Value result = aperiodic_.Evaluate(t);
+  Value result = aperiodic_(t);
   for (auto const& [ω, polynomials] : periodic_) {
-    result += polynomials.sin.Evaluate(t) * Sin(ω * (t - origin_)) +
-              polynomials.cos.Evaluate(t) * Cos(ω * (t - origin_));
+    result += polynomials.sin(t) * Sin(ω * (t - origin_)) +
+              polynomials.cos(t) * Cos(ω * (t - origin_));
   }
   return result;
 }
@@ -203,7 +203,7 @@ PoissonSeries<Value, degree_, Evaluator>::Integrate(Instant const& t1,
   using SecondPart = PoissonSeries<Variation<Value>, degree_ - 1, Evaluator>;
   auto const aperiodic_primitive = aperiodic_.Primitive();
   quantities::Primitive<Value, Time> result =
-      aperiodic_primitive.Evaluate(t2) - aperiodic_primitive.Evaluate(t1);
+      aperiodic_primitive(t2) - aperiodic_primitive(t1);
   for (auto const& [ω, polynomials] : periodic_) {
     // Integration by parts.
     FirstPart const first_part(

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -67,7 +67,7 @@ class Polynomial {
   // making the destructor protected and nonvirtual.
   virtual ~Polynomial() = default;
 
-  virtual Value Evaluate(Argument const& argument) const = 0;
+  virtual Value operator()(Argument const& argument) const = 0;
   virtual Derivative<Value, Argument> EvaluateDerivative(
       Argument const& argument) const = 0;
 
@@ -112,7 +112,7 @@ class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
       Value, Argument, higher_degree_, HigherEvaluator>() const;
 
   FORCE_INLINE(inline) Value
-  Evaluate(Argument const& argument) const override;
+  operator()(Argument const& argument) const override;
   FORCE_INLINE(inline) Derivative<Value, Argument>
   EvaluateDerivative(Argument const& argument) const override;
 
@@ -229,7 +229,7 @@ class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
       Value, Point<Argument>, higher_degree_, HigherEvaluator>() const;
 
   FORCE_INLINE(inline) Value
-  Evaluate(Point<Argument> const& argument) const override;
+  operator()(Point<Argument> const& argument) const override;
   FORCE_INLINE(inline) Derivative<Value, Argument>
   EvaluateDerivative(Point<Argument> const& argument) const override;
 

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -18,18 +18,18 @@
 
 namespace principia {
 namespace numerics {
-FORWARD_DECLARE_FROM(polynomial,
-                     TEMPLATE(typename Value, typename Argument, int degree_,
-                              template<typename, typename, int> class Evaluator)
-                              class,
-                     PolynomialInMonomialBasis);
+FORWARD_DECLARE_FROM(
+    polynomial,
+    TEMPLATE(typename Value, typename Argument, int degree_,
+            template<typename, typename, int> typename Evaluator) class,
+    PolynomialInMonomialBasis);
 }  // namespace numerics
 
 namespace mathematica {
 FORWARD_DECLARE_FUNCTION_FROM(
     mathematica,
     TEMPLATE(typename Value, typename Argument, int degree_,
-             template<typename, typename, int> class Evaluator,
+             template<typename, typename, int> typename Evaluator,
              typename OptionalExpressIn = std::nullopt_t) std::string,
     ToMathematicaExpression,
     (numerics::
@@ -52,15 +52,18 @@ using quantities::Primitive;
 using quantities::Product;
 using quantities::Quotient;
 
-// |Value| must belong to an affine space.  |Argument| must belong to a ring or
-// to Point based on a ring.
+// |Value_| must belong to an affine space.  |Argument_| must belong to a ring
+// or to Point based on a ring.
 // TODO(phl): We would like the base case to be the affine case (not limited to
 // Point) and the specialized case to check for the existence of Sum and Product
-// for Argument, and that works with Clang but not with VS2015.  Revisit once
+// for Argument_, and that works with Clang but not with VS2015.  Revisit once
 // MSFT has fixed their bugs.
-template<typename Value, typename Argument>
+template<typename Value_, typename Argument_>
 class Polynomial {
  public:
+  using Argument = Argument_;
+  using Value = Value_;
+
   // This virtual destructor makes this class and its subclasses non-literal, so
   // constexpr-ness is a bit of a lie for polynomials.
   // TODO(phl): Consider providing an explicit deleter function that would allow
@@ -83,16 +86,17 @@ class Polynomial {
 
   // The evaluator is not part of the serialization because it's fine to read
   // with a different evaluator than the one the polynomial was written with.
-  template<template<typename, typename, int> class Evaluator>
+  template<template<typename, typename, int> typename Evaluator>
   static not_null<std::unique_ptr<Polynomial>> ReadFromMessage(
       serialization::Polynomial const& message);
 };
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+class PolynomialInMonomialBasis : public Polynomial<Value_, Argument_> {
  public:
-  using Result = Value;
+  using Argument = Argument_;
+  using Value = Value;
 
   // Equivalent to:
   //   std::tuple<Value,
@@ -143,54 +147,54 @@ class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
   Coefficients coefficients_;
 
   template<typename V, typename A, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, r, E>
   friend operator-(PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename V, typename A, int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, std::max(l, r), E>
   friend operator+(PolynomialInMonomialBasis<V, A, l, E> const& left,
                    PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename V, typename A, int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, std::max(l, r), E>
   friend operator-(PolynomialInMonomialBasis<V, A, l, E> const& left,
                    PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<S, V>, A, d, E>
   friend operator*(S const& left,
                    PolynomialInMonomialBasis<V, A, d, E> const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<V, S>, A, d, E>
   friend operator*(PolynomialInMonomialBasis<V, A, d, E> const& left,
                    S const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Quotient<V, S>, A, d, E>
   friend operator/(PolynomialInMonomialBasis<V, A, d, E> const& left,
                    S const& right);
   template<typename L, typename R, typename A,
            int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<L, R>, A, l + r, E>
   friend operator*(
       PolynomialInMonomialBasis<L, A, l, E> const& left,
       PolynomialInMonomialBasis<R, A, r, E> const& right);
   template<typename L, typename R, typename A,
            int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<
       typename Hilbert<L, R>::InnerProductType, A, l + r, E>
   friend PointwiseInnerProduct(
       PolynomialInMonomialBasis<L, A, l, E> const& left,
       PolynomialInMonomialBasis<R, A, r, E> const& right);
   template<typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   friend std::ostream& operator<<(
       std::ostream& out,
       PolynomialInMonomialBasis<V, A, d, E> const& polynomial);
@@ -202,13 +206,13 @@ class PolynomialInMonomialBasis : public Polynomial<Value, Argument> {
       O express_in);
 };
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
-    : public Polynomial<Value, Point<Argument>> {
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+class PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>
+    : public Polynomial<Value_, Point<Argument_>> {
  public:
-  // TODO(phl): Use the |Value_| style.
-  using Result = Value;
+  using Argument = Argument_;
+  using Value = Value_;
 
   // Equivalent to:
   //   std::tuple<Value,
@@ -267,54 +271,54 @@ class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
   Point<Argument> origin_;
 
   template<typename V, typename A, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, r, E>
   friend operator-(PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename V, typename A, int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, std::max(l, r), E>
   friend operator+(PolynomialInMonomialBasis<V, A, l, E> const& left,
                    PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename V, typename A, int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<V, A, std::max(l, r), E>
   friend operator-(PolynomialInMonomialBasis<V, A, l, E> const& left,
                    PolynomialInMonomialBasis<V, A, r, E> const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<S, V>, A, d, E>
   friend operator*(S const& left,
                    PolynomialInMonomialBasis<V, A, d, E> const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<V, S>, A, d, E>
   friend operator*(PolynomialInMonomialBasis<V, A, d, E> const& left,
                    S const& right);
   template<typename S,
            typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Quotient<V, S>, A, d, E>
   friend operator/(PolynomialInMonomialBasis<V, A, d, E> const& left,
                    S const& right);
   template<typename L, typename R, typename A,
            int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<Product<L, R>, A, l + r, E>
   friend operator*(
       PolynomialInMonomialBasis<L, A, l, E> const& left,
       PolynomialInMonomialBasis<R, A, r, E> const& right);
   template<typename L, typename R, typename A,
            int l, int r,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   constexpr PolynomialInMonomialBasis<
       typename Hilbert<L, R>::InnerProductType, A, l + r, E>
   friend PointwiseInnerProduct(
       PolynomialInMonomialBasis<L, A, l, E> const& left,
       PolynomialInMonomialBasis<R, A, r, E> const& right);
   template<typename V, typename A, int d,
-           template<typename, typename, int> class E>
+           template<typename, typename, int> typename E>
   friend std::ostream& operator<<(
       std::ostream& out,
       PolynomialInMonomialBasis<V, A, d, E> const& polynomial);
@@ -329,19 +333,19 @@ class PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
 // Vector space of polynomials.
 
 template<typename Value, typename Argument, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator>
 operator+(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
               right);
 
 template<typename Value, typename Argument, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator>
 operator-(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
               right);
 
 template<typename Value, typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument,
                                     std::max(ldegree_, rdegree_), Evaluator>
 operator+(
@@ -350,7 +354,7 @@ operator+(
         right);
 
 template<typename Value, typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument,
                                     std::max(ldegree_, rdegree_), Evaluator>
 operator-(
@@ -360,7 +364,7 @@ operator-(
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Product<Scalar, Value>, Argument,
                                     degree_, Evaluator>
 operator*(Scalar const& left,
@@ -369,7 +373,7 @@ operator*(Scalar const& left,
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Product<Value, Scalar>, Argument,
                                     degree_, Evaluator>
 operator*(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
@@ -378,7 +382,7 @@ operator*(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Quotient<Value, Scalar>, Argument,
                                     degree_, Evaluator>
 operator/(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
@@ -389,7 +393,7 @@ operator/(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
 
 template<typename LValue, typename RValue,
          typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Product<LValue, RValue>, Argument,
                                     ldegree_ + rdegree_, Evaluator>
 operator*(
@@ -402,7 +406,7 @@ operator*(
 // vector-valued polynomials.
 template<typename LValue, typename RValue,
          typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<
     typename Hilbert<LValue, RValue>::InnerProductType, Argument,
     ldegree_ + rdegree_, Evaluator>
@@ -415,7 +419,7 @@ PointwiseInnerProduct(
 // Output.
 
 template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 std::ostream& operator<<(
     std::ostream& out,
     PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&

--- a/numerics/polynomial_body.hpp
+++ b/numerics/polynomial_body.hpp
@@ -46,12 +46,12 @@ using quantities::Time;
 // polynomial of the given degree, with zeros for the unneeded high-degree
 // terms.
 template<typename Value, typename Argument, int degree, int n,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          typename = std::make_index_sequence<degree + 1>>
 struct MonomialAtOrigin;
 
 template<typename Value, typename Argument, int degree, int n,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          std::size_t... k>
 struct MonomialAtOrigin<Value, Argument, degree, n,
                         Evaluator,
@@ -69,7 +69,7 @@ struct MonomialAtOrigin<Value, Argument, degree, n,
 };
 
 template<typename Value, typename Argument, int degree, int n,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          std::size_t... k>
 auto MonomialAtOrigin<Value, Argument, degree, n,
                       Evaluator,
@@ -85,12 +85,12 @@ auto MonomialAtOrigin<Value, Argument, degree, n,
 // using MonomialAtOrigin.  We need two helpers because changing the origin is
 // a quadratic operation in terms of the degree.
 template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          typename = std::make_index_sequence<degree_ + 1>>
 struct PolynomialAtOrigin;
 
 template<typename Value, typename Argument, int degree,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          std::size_t... indices>
 struct PolynomialAtOrigin<Value, Argument, degree, Evaluator,
                           std::index_sequence<indices...>> {
@@ -104,7 +104,7 @@ struct PolynomialAtOrigin<Value, Argument, degree, Evaluator,
 };
 
 template<typename Value, typename Argument, int degree,
-         template<typename, typename, int> class Evaluator,
+         template<typename, typename, int> typename Evaluator,
          std::size_t ...indices>
 auto PolynomialAtOrigin<Value, Argument, degree,
                         Evaluator,
@@ -283,10 +283,10 @@ std::vector<std::string> TupleSerializer<Tuple, size, size>::TupleDebugString(
         PolynomialInMonomialBasis<Value, Argument, value, Evaluator>:: \
             ReadFromMessage(message))
 
-template<typename Value, typename Argument>
-template<template<typename, typename, int> class Evaluator>
-not_null<std::unique_ptr<Polynomial<Value, Argument>>>
-Polynomial<Value, Argument>::ReadFromMessage(
+template<typename Value_, typename Argument_>
+template<template<typename, typename, int> typename Evaluator>
+not_null<std::unique_ptr<Polynomial<Value_, Argument_>>>
+Polynomial<Value_, Argument_>::ReadFromMessage(
     serialization::Polynomial const& message) {
   // 24 is the largest exponent that we can serialize for Quantity.
   switch (message.degree()) {
@@ -322,21 +322,21 @@ Polynomial<Value, Argument>::ReadFromMessage(
 
 #undef PRINCIPIA_POLYNOMIAL_DEGREE_VALUE_CASE
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-constexpr PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+constexpr PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
 PolynomialInMonomialBasis(Coefficients coefficients)
     : coefficients_(std::move(coefficients)) {}
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<int higher_degree_,
-         template<typename, typename, int> class HigherEvaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
-operator PolynomialInMonomialBasis<Value, Argument, higher_degree_,
+         template<typename, typename, int> typename HigherEvaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
+operator PolynomialInMonomialBasis<Value_, Argument_, higher_degree_,
                                    HigherEvaluator>() const {
   static_assert(degree_ <= higher_degree_);
-  using Result = PolynomialInMonomialBasis<Value, Argument, higher_degree_,
+  using Result = PolynomialInMonomialBasis<Value_, Argument_, higher_degree_,
                                            HigherEvaluator>;
   typename Result::Coefficients higher_coefficients;
   TupleAssigner<typename Result::Coefficients, Coefficients>::Assign(
@@ -344,42 +344,43 @@ operator PolynomialInMonomialBasis<Value, Argument, higher_degree_,
   return Result(higher_coefficients);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-Value PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+Value_ PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
 operator()(Argument const& argument) const {
   return Evaluator<Value, Argument, degree_>::Evaluate(coefficients_, argument);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-Derivative<Value, Argument>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+Derivative<Value_, Argument_>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
 EvaluateDerivative(Argument const& argument) const {
   return Evaluator<Value, Argument, degree_>::EvaluateDerivative(
       coefficients_, argument);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 constexpr int
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::degree() const {
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
+degree() const {
   return degree_;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-bool PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::is_zero()
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+bool PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::is_zero()
     const {
   return coefficients_ == Coefficients{};
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<int order>
 PolynomialInMonomialBasis<
-    Derivative<Value, Argument, order>, Argument, degree_ - order, Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+    Derivative<Value_, Argument_, order>, Argument_, degree_ - order, Evaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
 Derivative() const {
   return PolynomialInMonomialBasis<
              quantities::Derivative<Value, Argument, order>, Argument,
@@ -387,12 +388,12 @@ Derivative() const {
              TupleDerivation<Coefficients, order>::Derive(coefficients_));
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<typename, typename>
-PolynomialInMonomialBasis<Primitive<Value, Argument>, Argument,
+PolynomialInMonomialBasis<Primitive<Value_, Argument_>, Argument_,
                           degree_ + 1, Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
 Primitive() const {
   return PolynomialInMonomialBasis<
              quantities::Primitive<Value, Argument>, Argument,
@@ -401,27 +402,27 @@ Primitive() const {
                 Integrate(coefficients_));
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>&
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::operator+=(
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>&
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::operator+=(
     PolynomialInMonomialBasis const& right) {
   *this = *this + right;
   return *this;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>&
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::operator-=(
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>&
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::operator-=(
     PolynomialInMonomialBasis const& right) {
   *this = *this - right;
   return *this;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-void PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+void PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
     WriteToMessage(not_null<serialization::Polynomial*> message) const {
   message->set_degree(degree_);
   auto* const extension =
@@ -431,11 +432,11 @@ void PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
   // No |origin|.
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>
-PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::ReadFromMessage(
-    serialization::Polynomial const& message) {
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>
+PolynomialInMonomialBasis<Value_, Argument_, degree_, Evaluator>::
+ReadFromMessage(serialization::Polynomial const& message) {
   CHECK_EQ(degree_, message.degree()) << message.DebugString();
   CHECK(message.HasExtension(
            serialization::PolynomialInMonomialBasis::extension))
@@ -449,21 +450,21 @@ PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::ReadFromMessage(
   return PolynomialInMonomialBasis(coefficients);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 constexpr
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 PolynomialInMonomialBasis(Coefficients coefficients,
                           Point<Argument> const& origin)
     : coefficients_(std::move(coefficients)),
       origin_(origin) {}
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<int higher_degree_,
-         template<typename, typename, int> class HigherEvaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
-operator PolynomialInMonomialBasis<Value, Point<Argument>, higher_degree_,
+         template<typename, typename, int> typename HigherEvaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
+operator PolynomialInMonomialBasis<Value_, Point<Argument_>, higher_degree_,
                                    HigherEvaluator>() const {
   static_assert(degree_ <= higher_degree_);
   using Result = PolynomialInMonomialBasis<
@@ -474,64 +475,64 @@ operator PolynomialInMonomialBasis<Value, Point<Argument>, higher_degree_,
   return Result(higher_coefficients, origin_);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-Value PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+Value_ PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 operator()(Point<Argument> const& argument) const {
   return Evaluator<Value, Argument, degree_>::Evaluate(
       coefficients_, argument - origin_);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-Derivative<Value, Argument>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+Derivative<Value_, Argument_>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 EvaluateDerivative(Point<Argument> const& argument) const {
   return Evaluator<Value, Argument, degree_>::EvaluateDerivative(
       coefficients_, argument - origin_);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 constexpr int
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 degree() const {
   return degree_;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-bool PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+bool PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 is_zero() const {
   return coefficients_ == Coefficients{};
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-Point<Argument> const&
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+Point<Argument_> const&
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 origin() const {
   return origin_;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::AtOrigin(
-    Point<Argument> const& origin) const {
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
+AtOrigin(Point<Argument> const& origin) const {
   return PolynomialAtOrigin<Value, Argument, degree_, Evaluator>::
       MakePolynomial(coefficients_,
                      /*from_origin=*/origin_,
                      /*to_origin=*/origin);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<int order>
 PolynomialInMonomialBasis<
-    Derivative<Value, Argument, order>, Point<Argument>, degree_ - order,
+    Derivative<Value_, Argument_, order>, Point<Argument_>, degree_ - order,
     Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 Derivative() const {
   return PolynomialInMonomialBasis<
              quantities::Derivative<Value, Argument, order>, Point<Argument>,
@@ -540,12 +541,12 @@ Derivative() const {
              origin_);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
 template<typename, typename>
-PolynomialInMonomialBasis<Primitive<Value, Argument>, Point<Argument>,
+PolynomialInMonomialBasis<Primitive<Value_, Argument_>, Point<Argument_>,
                           degree_ + 1, Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 Primitive() const {
   return PolynomialInMonomialBasis<
              quantities::Primitive<Value, Argument>, Point<Argument>,
@@ -554,10 +555,10 @@ Primitive() const {
              origin_);
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>&
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>&
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 operator+=(PolynomialInMonomialBasis const& right) {
 #if PRINCIPIA_COMPILER_MSVC
   this->coefficients_ = this->coefficients_ + right.coefficients_;
@@ -567,10 +568,10 @@ operator+=(PolynomialInMonomialBasis const& right) {
   return *this;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>&
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>&
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 operator-=(PolynomialInMonomialBasis const& right) {
 #if PRINCIPIA_COMPILER_MSVC
   this->coefficients_ = this->coefficients_ - right.coefficients_;
@@ -580,9 +581,9 @@ operator-=(PolynomialInMonomialBasis const& right) {
   return *this;
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-void PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+void PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
     WriteToMessage(not_null<serialization::Polynomial*> message) const {
   message->set_degree(degree_);
   auto* const extension =
@@ -592,10 +593,10 @@ void PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
   origin_.WriteToMessage(extension->mutable_origin());
 }
 
-template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>
-PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
+template<typename Value_, typename Argument_, int degree_,
+         template<typename, typename, int> typename Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>
+PolynomialInMonomialBasis<Value_, Point<Argument_>, degree_, Evaluator>::
 ReadFromMessage(serialization::Polynomial const& message) {
   CHECK_EQ(degree_, message.degree()) << message.DebugString();
   CHECK(message.HasExtension(
@@ -611,7 +612,7 @@ ReadFromMessage(serialization::Polynomial const& message) {
 }
 
 template<typename Value, typename Argument, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator>
 operator+(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
               right) {
@@ -619,7 +620,7 @@ operator+(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
 }
 
 template<typename Value, typename Argument, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 constexpr PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator>
 operator-(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
               right) {
@@ -634,7 +635,7 @@ operator-(PolynomialInMonomialBasis<Value, Argument, rdegree_, Evaluator> const&
 }
 
 template<typename Value, typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Value, Argument,
                           std::max(ldegree_, rdegree_), Evaluator>
@@ -656,7 +657,7 @@ operator+(
 }
 
 template<typename Value, typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Value, Argument,
                           std::max(ldegree_, rdegree_), Evaluator>
@@ -679,7 +680,7 @@ operator-(
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Product<Scalar, Value>, Argument,
                           degree_, Evaluator>
@@ -698,7 +699,7 @@ operator*(Scalar const& left,
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Product<Value, Scalar>, Argument,
                           degree_, Evaluator>
@@ -717,7 +718,7 @@ operator*(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
 
 template<typename Scalar,
          typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Quotient<Value, Scalar>, Argument,
                           degree_, Evaluator>
@@ -736,7 +737,7 @@ operator/(PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&
 
 template<typename LValue, typename RValue,
          typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<Product<LValue, RValue>, Argument,
                           ldegree_ + rdegree_, Evaluator>
@@ -760,7 +761,7 @@ operator*(
 
 template<typename LValue, typename RValue,
          typename Argument, int ldegree_, int rdegree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 FORCE_INLINE(constexpr)
 PolynomialInMonomialBasis<
     typename Hilbert<LValue, RValue>::InnerProductType, Argument,
@@ -786,7 +787,7 @@ PointwiseInnerProduct(
 }
 
 template<typename Value, typename Argument, int degree_,
-         template<typename, typename, int> class Evaluator>
+         template<typename, typename, int> typename Evaluator>
 std::ostream& operator<<(
     std::ostream& out,
     PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator> const&

--- a/numerics/polynomial_body.hpp
+++ b/numerics/polynomial_body.hpp
@@ -347,7 +347,7 @@ operator PolynomialInMonomialBasis<Value, Argument, higher_degree_,
 template<typename Value, typename Argument, int degree_,
          template<typename, typename, int> class Evaluator>
 Value PolynomialInMonomialBasis<Value, Argument, degree_, Evaluator>::
-Evaluate(Argument const& argument) const {
+operator()(Argument const& argument) const {
   return Evaluator<Value, Argument, degree_>::Evaluate(coefficients_, argument);
 }
 
@@ -477,7 +477,7 @@ operator PolynomialInMonomialBasis<Value, Point<Argument>, higher_degree_,
 template<typename Value, typename Argument, int degree_,
          template<typename, typename, int> class Evaluator>
 Value PolynomialInMonomialBasis<Value, Point<Argument>, degree_, Evaluator>::
-Evaluate(Point<Argument> const& argument) const {
+operator()(Point<Argument> const& argument) const {
   return Evaluator<Value, Argument, degree_>::Evaluate(
       coefficients_, argument - origin_);
 }

--- a/numerics/polynomial_test.cpp
+++ b/numerics/polynomial_test.cpp
@@ -119,7 +119,7 @@ TEST_F(PolynomialTest, Coefficients) {
 TEST_F(PolynomialTest, Evaluate2V) {
   P2V const p(coefficients_);
   EXPECT_EQ(2, p.degree());
-  Displacement<World> const d = p.Evaluate(0.5 * Second);
+  Displacement<World> const d = p(0.5 * Second);
   Velocity<World> const v = p.EvaluateDerivative(0.5 * Second);
   EXPECT_THAT(d, AlmostEquals(Displacement<World>({0.25 * Metre,
                                                    0.5 * Metre,
@@ -134,7 +134,7 @@ TEST_F(PolynomialTest, Evaluate2A) {
   Instant const t0 = Instant() + 0.3 * Second;
   P2A const p(coefficients_, t0);
   EXPECT_EQ(2, p.degree());
-  Displacement<World> const d = p.Evaluate(t0 + 0.5 * Second);
+  Displacement<World> const d = p(t0 + 0.5 * Second);
   Velocity<World> const v = p.EvaluateDerivative(t0 + 0.5 * Second);
   EXPECT_THAT(d, AlmostEquals(Displacement<World>({0.25 * Metre,
                                                    0.5 * Metre,
@@ -155,7 +155,7 @@ TEST_F(PolynomialTest, Evaluate2P) {
                std::get<2>(coefficients_)},
               t0);
   EXPECT_EQ(2, p.degree());
-  Position<World> const d = p.Evaluate(t0 + 0.5 * Second);
+  Position<World> const d = p(t0 + 0.5 * Second);
   Velocity<World> const v = p.EvaluateDerivative(t0 + 0.5 * Second);
   EXPECT_THAT(d, AlmostEquals(World::origin + Displacement<World>({0.25 * Metre,
                                                                    0.5 * Metre,
@@ -176,7 +176,7 @@ TEST_F(PolynomialTest, Evaluate17) {
   P17::Coefficients const coefficients;
   P17 const p(coefficients);
   EXPECT_EQ(17, p.degree());
-  Displacement<World> const d = p.Evaluate(0.5 * Second);
+  Displacement<World> const d = p(0.5 * Second);
   EXPECT_THAT(d, AlmostEquals(Displacement<World>({0 * Metre,
                                                    0 * Metre,
                                                    0 * Metre}), 0));
@@ -186,7 +186,7 @@ TEST_F(PolynomialTest, Evaluate17) {
 TEST_F(PolynomialTest, Conversion) {
   P2V const p2v(coefficients_);
   P17 const p17 = P17(p2v);
-  Displacement<World> const d = p17.Evaluate(0.5 * Second);
+  Displacement<World> const d = p17(0.5 * Second);
   Velocity<World> const v = p17.EvaluateDerivative(0.5 * Second);
   EXPECT_THAT(d, AlmostEquals(Displacement<World>({0.25 * Metre,
                                                    0.5 * Metre,
@@ -200,35 +200,35 @@ TEST_F(PolynomialTest, VectorSpace) {
   P2V const p2v(coefficients_);
   {
     auto const p = p2v + p2v;
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     auto const expected =
         Displacement<World>({0 * Metre, 0 * Metre, 2 * Metre});
     EXPECT_THAT(actual, AlmostEquals(expected, 0));
   }
   {
     auto const p = p2v - p2v;
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     auto const expected =
         Displacement<World>({0 * Metre, 0 * Metre, 0 * Metre});
     EXPECT_THAT(actual, AlmostEquals(expected, 0));
   }
   {
     auto const p = 3.0 * Joule * p2v;
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     auto const expected = Vector<Product<Energy, Length>, World>(
                   {0 * Joule * Metre, 0 * Joule * Metre, 3 * Joule * Metre});
     EXPECT_THAT(actual, AlmostEquals(expected, 0));
   }
   {
     auto const p = p2v * (3.0 * Joule);
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     auto const expected = Vector<Product<Length, Energy>, World>(
                   {0 * Joule * Metre, 0 * Joule * Metre, 3 * Joule * Metre});
     EXPECT_THAT(actual, AlmostEquals(expected, 0));
   }
   {
     auto const p = p2v / (4.0 * Joule);
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     auto const expected = Vector<Quotient<Length, Energy>, World>(
                   {0 * Metre / Joule, 0 * Metre / Joule, 0.25 * Metre / Joule});
     EXPECT_THAT(actual, AlmostEquals(expected, 0));
@@ -245,23 +245,23 @@ TEST_F(PolynomialTest, Ring) {
                1 * Ampere / Second / Second / Second});
   auto const p = p2 * p3;
   {
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     EXPECT_THAT(actual, AlmostEquals(2 * Ampere * Kelvin, 0));
   }
   {
-    auto const actual = p.Evaluate(1 * Second);
+    auto const actual = p(1 * Second);
     EXPECT_THAT(actual, AlmostEquals(-8 * Ampere * Kelvin, 0));
   }
   {
-    auto const actual = p.Evaluate(-1 * Second);
+    auto const actual = p(-1 * Second);
     EXPECT_THAT(actual, AlmostEquals(-80 * Ampere * Kelvin, 0));
   }
   {
-    auto const actual = p.Evaluate(2 * Second);
+    auto const actual = p(2 * Second);
     EXPECT_THAT(actual, AlmostEquals(-350 * Ampere * Kelvin, 0));
   }
   {
-    auto const actual = p.Evaluate(-2 * Second);
+    auto const actual = p(-2 * Second);
     EXPECT_THAT(actual, AlmostEquals(-518 * Ampere * Kelvin, 0));
   }
 }
@@ -282,23 +282,23 @@ TEST_F(PolynomialTest, PointwiseInnerProduct) {
 
   auto const p = PointwiseInnerProduct(p2va, p2vb);
   {
-    auto const actual = p.Evaluate(0 * Second);
+    auto const actual = p(0 * Second);
     EXPECT_THAT(actual, AlmostEquals(3 * Metre * Metre, 0));
   }
   {
-    auto const actual = p.Evaluate(1 * Second);
+    auto const actual = p(1 * Second);
     EXPECT_THAT(actual, AlmostEquals(5 * Metre * Metre, 0));
   }
   {
-    auto const actual = p.Evaluate(-1 * Second);
+    auto const actual = p(-1 * Second);
     EXPECT_THAT(actual, AlmostEquals(1 * Metre * Metre, 0));
   }
   {
-    auto const actual = p.Evaluate(2 * Second);
+    auto const actual = p(2 * Second);
     EXPECT_THAT(actual, AlmostEquals(19 * Metre * Metre, 0));
   }
   {
-    auto const actual = p.Evaluate(-2 * Second);
+    auto const actual = p(-2 * Second);
     EXPECT_THAT(actual, AlmostEquals(11 * Metre * Metre, 0));
   }
 }
@@ -310,7 +310,7 @@ TEST_F(PolynomialTest, AtOrigin) {
   for (Instant t = Instant() - 10 * Second;
        t < Instant() + 10 * Second;
        t += 0.3 * Second) {
-    EXPECT_THAT(q.Evaluate(t), AlmostEquals(p.Evaluate(t), 0, 942));
+    EXPECT_THAT(q(t), AlmostEquals(p(t), 0, 942));
   }
 }
 
@@ -324,29 +324,29 @@ TEST_F(PolynomialTest, Derivative) {
                1 * Ampere / Second / Second / Second});
 
   EXPECT_EQ(3 * Kelvin / Second,
-            p2.Derivative<1>().Evaluate(0 * Second));
+            p2.Derivative<1>()(0 * Second));
   EXPECT_EQ(-16 * Kelvin / Second / Second,
-            p2.Derivative<2>().Evaluate(0 * Second));
+            p2.Derivative<2>()(0 * Second));
 
   EXPECT_EQ(-4 * Ampere / Second,
-            p3.Derivative<1>().Evaluate(0 * Second));
+            p3.Derivative<1>()(0 * Second));
   EXPECT_EQ(6 * Ampere / Second / Second,
-            p3.Derivative<2>().Evaluate(0 * Second));
+            p3.Derivative<2>()(0 * Second));
   EXPECT_EQ(6 * Ampere / Second / Second / Second,
-            p3.Derivative<3>().Evaluate(0 * Second));
+            p3.Derivative<3>()(0 * Second));
 }
 
 TEST_F(PolynomialTest, Primitive) {
   using P2 = PolynomialInMonomialBasis<Temperature, Time, 2, HornerEvaluator>;
   P2 const p2({1 * Kelvin, 3 * Kelvin / Second, -8 * Kelvin / Second / Second});
 
-  EXPECT_THAT(p2.Primitive().Evaluate(0 * Second),
+  EXPECT_THAT(p2.Primitive()(0 * Second),
               AlmostEquals(0 * Kelvin * Second, 0));
-  EXPECT_THAT(p2.Primitive().Evaluate(1 * Second),
+  EXPECT_THAT(p2.Primitive()(1 * Second),
               AlmostEquals(-1.0 / 6.0 * Kelvin * Second, 5));
-  EXPECT_THAT(p2.Primitive().Evaluate(-1 * Second),
+  EXPECT_THAT(p2.Primitive()(-1 * Second),
               AlmostEquals(19.0 / 6.0 * Kelvin * Second, 1));
-  EXPECT_THAT(p2.Primitive().Evaluate(2 * Second),
+  EXPECT_THAT(p2.Primitive()(2 * Second),
               AlmostEquals(-40.0 / 3.0 * Kelvin * Second, 1));
 }
 
@@ -355,8 +355,8 @@ TEST_F(PolynomialTest, EvaluateConstant) {
       horner_boltzmann(std::make_tuple(BoltzmannConstant));
   PolynomialInMonomialBasis<Entropy, Time, 0, EstrinEvaluator> const
       estrin_boltzmann(std::make_tuple(BoltzmannConstant));
-  EXPECT_THAT(horner_boltzmann.Evaluate(1729 * Second), Eq(BoltzmannConstant));
-  EXPECT_THAT(estrin_boltzmann.Evaluate(1729 * Second), Eq(BoltzmannConstant));
+  EXPECT_THAT(horner_boltzmann(1729 * Second), Eq(BoltzmannConstant));
+  EXPECT_THAT(estrin_boltzmann(1729 * Second), Eq(BoltzmannConstant));
   EXPECT_THAT(horner_boltzmann.EvaluateDerivative(1729 * Second),
               Eq(0 * Watt / Kelvin));
   EXPECT_THAT(estrin_boltzmann.EvaluateDerivative(1729 * Second),
@@ -369,8 +369,8 @@ TEST_F(PolynomialTest, EvaluateLinear) {
   PolynomialInMonomialBasis<Length, Time, 1, EstrinEvaluator> const
       estrin_light({0 * Metre, SpeedOfLight});
   constexpr Length light_second = Second * SpeedOfLight;
-  EXPECT_THAT(horner_light.Evaluate(1729 * Second), Eq(1729 * light_second));
-  EXPECT_THAT(estrin_light.Evaluate(1729 * Second), Eq(1729 * light_second));
+  EXPECT_THAT(horner_light(1729 * Second), Eq(1729 * light_second));
+  EXPECT_THAT(estrin_light(1729 * Second), Eq(1729 * light_second));
   EXPECT_THAT(horner_light.EvaluateDerivative(1729 * Second), Eq(SpeedOfLight));
   EXPECT_THAT(estrin_light.EvaluateDerivative(1729 * Second), Eq(SpeedOfLight));
 }
@@ -397,7 +397,7 @@ TEST_F(PolynomialTest, Serialization) {
             message);
     EXPECT_EQ(2, polynomial_read->degree());
     EXPECT_THAT(
-        polynomial_read->Evaluate(0.5 * Second),
+        (*polynomial_read)(0.5 * Second),
         AlmostEquals(
             Displacement<World>({0.25 * Metre, 0.5 * Metre, 1 * Metre}), 0));
     serialization::Polynomial message2;
@@ -425,7 +425,7 @@ TEST_F(PolynomialTest, Serialization) {
                    Instant>::ReadFromMessage<HornerEvaluator>(message);
     EXPECT_EQ(2, polynomial_read->degree());
     EXPECT_THAT(
-        polynomial_read->Evaluate(Instant() + 0.5 * Second),
+        (*polynomial_read)(Instant() + 0.5 * Second),
         AlmostEquals(
             Displacement<World>({0.25 * Metre, 0.5 * Metre, 1 * Metre}), 0));
     serialization::Polynomial message2;
@@ -452,7 +452,7 @@ TEST_F(PolynomialTest, Serialization) {
         Polynomial<Displacement<World>, Time>::ReadFromMessage<HornerEvaluator>(
             message);
     EXPECT_EQ(17, polynomial_read->degree());
-    EXPECT_THAT(polynomial_read->Evaluate(0.5 * Second),
+    EXPECT_THAT((*polynomial_read)(0.5 * Second),
                 AlmostEquals(
                     Displacement<World>({0 * Metre, 0 * Metre, 0 * Metre}), 0));
     serialization::Polynomial message2;

--- a/numerics/root_finders_test.cpp
+++ b/numerics/root_finders_test.cpp
@@ -324,7 +324,7 @@ TEST_F(RootFindersTest, SmoothMaximum) {
        59049.0 / 28700672000});
   auto const f = [&evaluations, &p](double const x) {
     ++evaluations;
-    return p.Evaluate(x);
+    return p(x);
   };
 
   evaluations = 0;

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -187,8 +187,8 @@ Position<Frame> ContinuousTrajectory<Frame>::EvaluatePosition(
   CHECK_GE(t_max_locked(), time);
   auto const it = FindPolynomialForInstant(time);
   CHECK(it != polynomials_.end());
-  auto const& polynomial = it->polynomial;
-  return polynomial->Evaluate(time) + Frame::origin;
+  auto const& polynomial = *it->polynomial;
+  return polynomial(time) + Frame::origin;
 }
 
 template<typename Frame>
@@ -199,8 +199,8 @@ Velocity<Frame> ContinuousTrajectory<Frame>::EvaluateVelocity(
   CHECK_GE(t_max_locked(), time);
   auto const it = FindPolynomialForInstant(time);
   CHECK(it != polynomials_.end());
-  auto const& polynomial = it->polynomial;
-  return polynomial->EvaluateDerivative(time);
+  auto const& polynomial = *it->polynomial;
+  return polynomial.EvaluateDerivative(time);
 }
 
 template<typename Frame>
@@ -211,9 +211,9 @@ DegreesOfFreedom<Frame> ContinuousTrajectory<Frame>::EvaluateDegreesOfFreedom(
   CHECK_GE(t_max_locked(), time);
   auto const it = FindPolynomialForInstant(time);
   CHECK(it != polynomials_.end());
-  auto const& polynomial = it->polynomial;
-  return DegreesOfFreedom<Frame>(polynomial->Evaluate(time) + Frame::origin,
-                                 polynomial->EvaluateDerivative(time));
+  auto const& polynomial = *it->polynomial;
+  return DegreesOfFreedom<Frame>(polynomial(time) + Frame::origin,
+                                 polynomial.EvaluateDerivative(time));
 }
 
 template<typename Frame>


### PR DESCRIPTION
1. Rename `Evaluate` into `operator()` to make polynomials *bona fide* functors.
1. Append `_` to the type template parameters to be able to reexport them (#572).
1. Use `typename` instead of `class` for the template template parameters.

Distantly related to #2400.