### PR TITLE
Optimization of integration

### DIFF
--- a/base/bits_body.hpp
+++ b/base/bits_body.hpp
@@ -19,6 +19,10 @@ constexpr int PowerOf2Le(int const n) {
 }
 
 constexpr int BitReversedIncrement(int const n, int const bits) {
+  if (bits == 0) {
+    CONSTEXPR_DCHECK(n == 0);
+    return 0;
+  }
   CONSTEXPR_DCHECK(n >= 0 && n < 1 << bits);
   CONSTEXPR_DCHECK(bits > 0 && bits < 32);
   // [War03], chapter 7.1 page 105.

--- a/base/bits_test.cpp
+++ b/base/bits_test.cpp
@@ -41,6 +41,8 @@ TEST(BitsTest, BitReversedIncrement) {
   EXPECT_EQ(0x2, BitReversedIncrement(0xC, 4));
   EXPECT_EQ(0x3, BitReversedIncrement(0xD, 4));
   EXPECT_EQ(0x1, BitReversedIncrement(0xE, 4));
+
+  EXPECT_EQ(0, BitReversedIncrement(0, 0));
 }
 
 }  // namespace base

--- a/geometry/complexification_body.hpp
+++ b/geometry/complexification_body.hpp
@@ -35,9 +35,8 @@ Complexification<Vector> Complexification<Vector>::Conjugate() const {
 template<typename Vector>
 typename Hilbert<Vector>::InnerProductType Complexification<Vector>::Norm²()
     const {
-  // TODO(egg): Hilbert::Norm².
-  return Hilbert<Vector>::InnerProduct(real_part_, real_part_) +
-         Hilbert<Vector>::InnerProduct(imaginary_part_, imaginary_part_);
+  return Hilbert<Vector>::Norm²(real_part_) +
+         Hilbert<Vector>::Norm²(imaginary_part_);
 }
 
 template<typename Vector>

--- a/geometry/hilbert.hpp
+++ b/geometry/hilbert.hpp
@@ -45,10 +45,11 @@ struct Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>
   using InnerProductType = Square<T>;
   static InnerProductType InnerProduct(T const& t1, T const& t2);
 
+  using Norm²Type = InnerProductType;
+  static Norm²Type Norm²(T const& t);
+
   using NormType = T;
   static NormType Norm(T const& t);
-
-  // TODO(egg): Hilbert::Norm².
 
   using NormalizedType = double;
 };
@@ -77,10 +78,11 @@ struct Hilbert<T, T,
       decltype(InnerProduct(std::declval<T>(), std::declval<T>()));
   static InnerProductType InnerProduct(T const& t1, T const& t2);
 
+  using Norm²Type = InnerProductType;
+  static Norm²Type Norm²(T const& t);
+
   using NormType = decltype(std::declval<T>().Norm());
   static NormType Norm(T const& t);
-
-  // TODO(egg): Hilbert::Norm².
 
   using NormalizedType = Quotient<T, NormType>;
 };

--- a/geometry/hilbert_body.hpp
+++ b/geometry/hilbert_body.hpp
@@ -5,6 +5,7 @@
 
 #include "geometry/grassmann.hpp"
 #include "quantities/elementary_functions.hpp"
+#include "hilbert.hpp"
 
 namespace principia {
 namespace geometry {
@@ -25,6 +26,12 @@ template<typename T>
 auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::
     InnerProduct(T const& t1, T const& t2) -> InnerProductType {
   return t1 * t2;
+}
+
+template<typename T>
+auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::Norm²(T const& t)
+    -> Norm²Type {
+  return t * t;
 }
 
 template<typename T>
@@ -51,6 +58,14 @@ auto Hilbert<T, T,
   // Is there a better way to avoid recursion than to put our fingers inside
   // grassmann?
   return internal_grassmann::InnerProduct(t1, t2);
+}
+
+template<typename T>
+auto Hilbert<T, T,
+             std::void_t<decltype(InnerProduct(std::declval<T>(),
+                                               std::declval<T>()))>>::
+Norm²(T const& t) -> Norm²Type {
+  return t.Norm²();
 }
 
 template<typename T>

--- a/geometry/hilbert_body.hpp
+++ b/geometry/hilbert_body.hpp
@@ -1,4 +1,4 @@
-
+ï»¿
 #pragma once
 
 #include "geometry/hilbert.hpp"
@@ -29,8 +29,8 @@ auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::
 }
 
 template<typename T>
-auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::Norm²(T const& t)
-    -> Norm²Type {
+auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::NormÂ²(T const& t)
+    -> NormÂ²Type {
   return t * t;
 }
 
@@ -64,8 +64,8 @@ template<typename T>
 auto Hilbert<T, T,
              std::void_t<decltype(InnerProduct(std::declval<T>(),
                                                std::declval<T>()))>>::
-Norm²(T const& t) -> Norm²Type {
-  return t.Norm²();
+NormÂ²(T const& t) -> NormÂ²Type {
+  return t.NormÂ²();
 }
 
 template<typename T>

--- a/geometry/hilbert_test.cpp
+++ b/geometry/hilbert_test.cpp
@@ -1,4 +1,4 @@
-#include "geometry/hilbert.hpp"
+ï»¿#include "geometry/hilbert.hpp"
 
 #include <type_traits>
 
@@ -38,7 +38,7 @@ TEST(HilbertTest, ScalarTypes) {
   static_assert(std::is_same_v<Length, H2::InnerProductType>);
 #if 0
   H2::NormType h2a;
-  H2::Norm²Type h2b;
+  H2::NormÂ²Type h2b;
 #endif
 
   using H3 = Hilbert<Length, Length>;
@@ -58,7 +58,7 @@ TEST(HilbertTest, VectorTypes) {
   static_assert(std::is_same_v<Length, H2::InnerProductType>);
 #if 0
   H2::NormType h2a;
-  H2::Norm²Type h2b;
+  H2::NormÂ²Type h2b;
 #endif
 
   using H3 = Hilbert<Trivector<Length, World>, Trivector<Length, World>>;
@@ -76,7 +76,7 @@ TEST(HilbertTest, ScalarValues) {
   EXPECT_EQ(6 * Metre, H2::InnerProduct(3, 2 * Metre));
 #if 0
   auto h2a = H2::Norm(6 * Metre);
-  auto h2b = H2::Norm²(6 * Metre);
+  auto h2b = H2::NormÂ²(6 * Metre);
 #endif
 
   using H3 = Hilbert<Length, Length>;
@@ -96,7 +96,7 @@ TEST(HilbertTest, VectorValues) {
   EXPECT_EQ(-32 * Metre, H2::InnerProduct(v1, v2));
 #if 0
   auto h2a = H2::Norm(v2);
-  auto h2b = H2::Norm²(v2);
+  auto h2b = H2::NormÂ²(v2);
 #endif
 
   using H3 = Hilbert<Vector<Length, World>, Vector<Length, World>>;
@@ -109,11 +109,11 @@ TEST(HilbertTest, OneParameter) {
 
   using H1 = Hilbert<double>;
   EXPECT_EQ(2, H1::Norm(2));
-  EXPECT_EQ(4, H1::Norm²(2));
+  EXPECT_EQ(4, H1::NormÂ²(2));
 
   using H3 = Hilbert<Vector<Length, World>>;
   EXPECT_EQ(Sqrt(77) * Metre, H3::Norm(v2));
-  EXPECT_EQ(77 * Metre * Metre, H3::Norm²(v2));
+  EXPECT_EQ(77 * Metre * Metre, H3::NormÂ²(v2));
 }
 
 TEST(HilbertTest, BadParameters) {

--- a/geometry/hilbert_test.cpp
+++ b/geometry/hilbert_test.cpp
@@ -37,7 +37,8 @@ TEST(HilbertTest, ScalarTypes) {
   static_assert(H2::dimension == 1);
   static_assert(std::is_same_v<Length, H2::InnerProductType>);
 #if 0
-  H2::NormType h2;
+  H2::NormType h2a;
+  H2::Norm²Type h2b;
 #endif
 
   using H3 = Hilbert<Length, Length>;
@@ -56,7 +57,8 @@ TEST(HilbertTest, VectorTypes) {
   static_assert(H2::dimension == 3);
   static_assert(std::is_same_v<Length, H2::InnerProductType>);
 #if 0
-  H2::NormType h2;
+  H2::NormType h2a;
+  H2::Norm²Type h2b;
 #endif
 
   using H3 = Hilbert<Trivector<Length, World>, Trivector<Length, World>>;
@@ -73,7 +75,8 @@ TEST(HilbertTest, ScalarValues) {
   using H2 = Hilbert<double, Length>;
   EXPECT_EQ(6 * Metre, H2::InnerProduct(3, 2 * Metre));
 #if 0
-  auto h2 = H2::Norm(6 * Metre);
+  auto h2a = H2::Norm(6 * Metre);
+  auto h2b = H2::Norm²(6 * Metre);
 #endif
 
   using H3 = Hilbert<Length, Length>;
@@ -92,7 +95,8 @@ TEST(HilbertTest, VectorValues) {
   using H2 = Hilbert<Vector<double, World>, Vector<Length, World>>;
   EXPECT_EQ(-32 * Metre, H2::InnerProduct(v1, v2));
 #if 0
-  auto h2 = H2::Norm(v2);
+  auto h2a = H2::Norm(v2);
+  auto h2b = H2::Norm²(v2);
 #endif
 
   using H3 = Hilbert<Vector<Length, World>, Vector<Length, World>>;
@@ -105,9 +109,11 @@ TEST(HilbertTest, OneParameter) {
 
   using H1 = Hilbert<double>;
   EXPECT_EQ(2, H1::Norm(2));
+  EXPECT_EQ(4, H1::Norm²(2));
 
   using H3 = Hilbert<Vector<Length, World>>;
   EXPECT_EQ(Sqrt(77) * Metre, H3::Norm(v2));
+  EXPECT_EQ(77 * Metre * Metre, H3::Norm²(v2));
 }
 
 TEST(HilbertTest, BadParameters) {

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -86,7 +86,6 @@ IncrementalProjection(Function const& function,
                       Instant const& t_max) {
   using Value = std::invoke_result_t<Function, Instant>;
   using Norm = typename Hilbert<Value>::NormType;
-  using Norm² = typename Hilbert<Value>::InnerProductType;
   using Normalized = typename Hilbert<Value>::NormalizedType;
   using Series = PoissonSeries<Value, degree_, Evaluator>;
 

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -8,7 +8,6 @@
 
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
-#include "geometry/hilbert.hpp"
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -31,7 +30,6 @@ namespace frequency_analysis {
 using geometry::Displacement;
 using geometry::Frame;
 using geometry::Handedness;
-using geometry::Hilbert;
 using geometry::Inertial;
 using geometry::Instant;
 using geometry::Vector;

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -365,7 +365,7 @@ PoissonSeries<Value, degree_, Evaluator>::Norm(
                                  (t_max - t_min) * max_ω / (2 * π * Radian)));
 
   auto integrand = [this, &weight](Instant const& t) {
-    return Hilbert<Value>::InnerProduct((*this)(t), (*this)(t)) * weight(t);
+    return Hilbert<Value>::Norm²((*this)(t)) * weight(t);
   };
   return Sqrt(quadrature::AutomaticClenshawCurtis(
                   integrand,

--- a/numerics/quadrature_body.hpp
+++ b/numerics/quadrature_body.hpp
@@ -129,8 +129,9 @@ ClenshawCurtisImplementation(
   // value corresponding to s = N.
   for (int direct = 1; direct <= N; ++direct) {
     f_cos_N⁻¹π[reverse] = cached_f_cos_N⁻¹π[direct];
-    f_cos_N⁻¹π[2 * N - reverse] = cached_f_cos_N⁻¹π[direct];  // [Gen72c] (5).
-    ++direct;
+    if (reverse > 0) {
+      f_cos_N⁻¹π[2 * N - reverse] = cached_f_cos_N⁻¹π[direct];  // [Gen72c] (5).
+    }
     reverse = BitReversedIncrement(reverse, log2_N);
   }
   f_cos_N⁻¹π[N] = cached_f_cos_N⁻¹π[0];

--- a/numerics/quadrature_body.hpp
+++ b/numerics/quadrature_body.hpp
@@ -190,9 +190,15 @@ void FillClenshawCurtisCache(
         f, lower_bound, upper_bound, cached_f_cos_N⁻¹π);
     // N/2 evaluations for f(cos πs/N) with s odd: the values for s even have
     // already been computed by the previous recursive call.
-    for (int s = 1; s < N; s += 2) {
+    //TODO(phl):comment order.
+    int reverse = 0;
+    for (int evaluations = 0; evaluations < N / 2; ++evaluations) {
+      int const s = 2 * reverse + 1;
       cached_f_cos_N⁻¹π.push_back(
           f(lower_bound + half_width * (1 + Cos(N⁻¹π * s))));
+      if constexpr (N > 2) {
+        reverse = BitReversedIncrement(reverse, log2_N - 1);
+      }
     }
   }
 }

--- a/numerics/quadrature_body.hpp
+++ b/numerics/quadrature_body.hpp
@@ -206,8 +206,7 @@ ClenshawCurtisImplementation(
        ++bit_reversed_s, s = BitReversedIncrement(s, log2_N)) {
     f_cos_N⁻¹π[s] = f_cos_N⁻¹π_bit_reversed[bit_reversed_s];
     if (s > 0) {
-      // [Gen72c] (5).
-      f_cos_N⁻¹π[2 * N - s] = f_cos_N⁻¹π_bit_reversed[bit_reversed_s];
+      f_cos_N⁻¹π[2 * N - s] = f_cos_N⁻¹π[s];  // [Gen72c] (5).
     }
   }
   f_cos_N⁻¹π[N] = f_cos_N⁻¹π_bit_reversed[0];

--- a/numerics/quadrature_test.cpp
+++ b/numerics/quadrature_test.cpp
@@ -127,7 +127,7 @@ TEST_F(QuadratureTest, Sin10) {
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
               AlmostEquals(ʃf, 2, 20));
-  EXPECT_THAT(evaluations, Eq(65537));
+  EXPECT_THAT(evaluations, AnyOf(Eq(65537), Eq(262145)));
 }
 
 }  // namespace quadrature

--- a/numerics/quadrature_test.cpp
+++ b/numerics/quadrature_test.cpp
@@ -73,7 +73,7 @@ TEST_F(QuadratureTest, Sin) {
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
               AlmostEquals(ʃf, 3, 4));
-  EXPECT_THAT(evaluations, Eq(134));
+  EXPECT_THAT(evaluations, Eq(65));
 }
 
 TEST_F(QuadratureTest, Sin2) {
@@ -126,9 +126,8 @@ TEST_F(QuadratureTest, Sin10) {
                   5.0 * Radian,
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
-              AlmostEquals(ʃf, 2, 277));
-  EXPECT_THAT(evaluations,
-              AnyOf(Eq(65551), Eq(131088), Eq(524306), Eq(1048595)));
+              AlmostEquals(ʃf, 2, 20));
+  EXPECT_THAT(evaluations, Eq(65537));
 }
 
 }  // namespace quadrature


### PR DESCRIPTION
1. Add `Norm²` which may be more efficient than `InnerProduct` of a vector with itself.
1. Change the Clenshaw-Curtis quadrature to cache function evaluations, thus cutting the overall number of evaluations by 2.

#2400.