### PR TITLE
Changed Forkable::ancestry_ to an absl::InlinedVector.

### DIFF
--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -1,0 +1,166 @@
+
+// .\Release\x64\benchmarks.exe --benchmark_filter=DiscreteTrajectory
+
+#include "physics/discrete_trajectory.hpp"
+
+#include "base/not_null.hpp"
+#include "benchmark/benchmark.h"
+#include "geometry/frame.hpp"
+#include "ksp_plugin/frames.hpp"
+
+namespace principia {
+namespace physics {
+
+using base::not_null;
+using geometry::Frame;
+using geometry::Handedness;
+using geometry::Inertial;
+using geometry::Instant;
+using geometry::Velocity;
+using ksp_plugin::World;
+using quantities::si::Second;
+
+namespace {
+
+// Creates a trajectory with the given number of steps.
+std::unique_ptr<DiscreteTrajectory<World>> CreateTrajectory(int const steps) {
+  auto trajectory = std::make_unique<DiscreteTrajectory<World>>();
+  DegreesOfFreedom<World> const d(World::origin, Velocity<World>());
+  Instant t;
+  for (int i = 0; i < steps; i++, t += Second) {
+    trajectory->Append(t, d);
+  }
+  return trajectory;
+}
+
+// Forks |parent| at a position |pos| of the way through.
+// |parent| should be nonempty.
+// |pos| should be in [0, 1].
+not_null<DiscreteTrajectory<World>*> ForkAt(DiscreteTrajectory<World>& parent,
+                                            float const pos) {
+  CHECK(!parent.Empty());
+  CHECK_GE(pos, 0);
+  CHECK_LE(pos, 1);
+  Instant const desired_fork_time =
+      parent.t_min() + (parent.t_max() - parent.t_min()) * pos;
+  auto const fork_it = parent.LowerBound(desired_fork_time);
+  return parent.NewForkWithCopy(fork_it->time);
+}
+
+}  // namespace
+
+void BM_DiscreteTrajectoryFront(benchmark::State& state) {
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    fork->front();
+  }
+}
+
+void BM_DiscreteTrajectoryBack(benchmark::State& state) {
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    fork->back();
+  }
+}
+
+void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    fork->begin();
+  }
+}
+
+void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    fork->end();
+  }
+}
+
+void BM_DiscreteTrajectoryCreateDestroy(benchmark::State& state) {
+  int const steps = state.range(0);
+  for (auto _ : state) {
+    CreateTrajectory(steps);
+  }
+}
+
+void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
+  int const steps = state.range(0);
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+      CreateTrajectory(steps);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    for (auto it = fork->begin(); it != fork->end(); ++it) {
+    }
+  }
+}
+
+void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
+  int const steps = state.range(0);
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+      CreateTrajectory(steps);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    for (auto it = fork->end(); it != fork->begin(); --it) {
+    }
+  }
+}
+
+void BM_DiscreteTrajectoryFind(benchmark::State& state) {
+  int const steps = state.range(0);
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+      CreateTrajectory(steps);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    // These times are in different segments of the fork.
+    fork->Find(Instant() + 333 * Second);
+    fork->Find(Instant() + 667 * Second);
+    fork->Find(Instant() + 833 * Second);
+  }
+}
+
+void BM_DiscreteTrajectoryLowerBound(benchmark::State& state) {
+  int const steps = state.range(0);
+  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+      CreateTrajectory(steps);
+  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
+  fork = ForkAt(*fork, 0.75);
+
+  for (auto _ : state) {
+    // These times are in different segments of the fork.
+    fork->LowerBound(Instant() + 333 * Second);
+    fork->LowerBound(Instant() + 667 * Second);
+    fork->LowerBound(Instant() + 833 * Second);
+  }
+}
+
+BENCHMARK(BM_DiscreteTrajectoryFront);
+BENCHMARK(BM_DiscreteTrajectoryBack);
+BENCHMARK(BM_DiscreteTrajectoryBegin);
+BENCHMARK(BM_DiscreteTrajectoryEnd);
+BENCHMARK(BM_DiscreteTrajectoryCreateDestroy)->Range(8, 1024);
+BENCHMARK(BM_DiscreteTrajectoryIterate)->Range(8, 1024);
+BENCHMARK(BM_DiscreteTrajectoryReverseIterate)->Range(8, 1024);
+BENCHMARK(BM_DiscreteTrajectoryFind)->Range(8, 1024);
+BENCHMARK(BM_DiscreteTrajectoryLowerBound)->Range(8, 1024);
+
+}  // namespace physics
+}  // namespace principia

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -11,6 +11,7 @@
 namespace principia {
 namespace physics {
 
+using base::make_not_null_unique;
 using base::not_null;
 using geometry::Frame;
 using geometry::Handedness;
@@ -23,12 +24,12 @@ using quantities::si::Second;
 namespace {
 
 // Creates a trajectory with the given number of steps.
-std::unique_ptr<DiscreteTrajectory<World>> CreateTrajectory(int const steps) {
-  auto trajectory = std::make_unique<DiscreteTrajectory<World>>();
-  DegreesOfFreedom<World> const d(World::origin, Velocity<World>());
+not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateTrajectory(
+    int const steps) {
+  auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
   Instant t;
-  for (int i = 0; i < steps; i++, t += Second) {
-    trajectory->Append(t, d);
+  for (int i = 0; i < steps; i++, t += 1 * Second) {
+    trajectory->Append(t, {World::origin, World::unmoving});
   }
   return trajectory;
 }
@@ -37,7 +38,7 @@ std::unique_ptr<DiscreteTrajectory<World>> CreateTrajectory(int const steps) {
 // |parent| should be nonempty.
 // |pos| should be in [0, 1].
 not_null<DiscreteTrajectory<World>*> ForkAt(DiscreteTrajectory<World>& parent,
-                                            float const pos) {
+                                            double const pos) {
   CHECK(!parent.Empty());
   CHECK_GE(pos, 0);
   CHECK_LE(pos, 1);
@@ -50,9 +51,10 @@ not_null<DiscreteTrajectory<World>*> ForkAt(DiscreteTrajectory<World>& parent,
 }  // namespace
 
 void BM_DiscreteTrajectoryFront(benchmark::State& state) {
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     fork->front();
@@ -60,9 +62,10 @@ void BM_DiscreteTrajectoryFront(benchmark::State& state) {
 }
 
 void BM_DiscreteTrajectoryBack(benchmark::State& state) {
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     fork->back();
@@ -70,9 +73,10 @@ void BM_DiscreteTrajectoryBack(benchmark::State& state) {
 }
 
 void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     fork->begin();
@@ -80,9 +84,10 @@ void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
 }
 
 void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory = CreateTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     fork->end();
@@ -98,10 +103,10 @@ void BM_DiscreteTrajectoryCreateDestroy(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
   int const steps = state.range(0);
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
       CreateTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     for (auto it = fork->begin(); it != fork->end(); ++it) {
@@ -111,10 +116,10 @@ void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
   int const steps = state.range(0);
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
       CreateTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     for (auto it = fork->end(); it != fork->begin(); --it) {
@@ -124,10 +129,10 @@ void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryFind(benchmark::State& state) {
   int const steps = state.range(0);
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
       CreateTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     // These times are in different segments of the fork.
@@ -139,10 +144,10 @@ void BM_DiscreteTrajectoryFind(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryLowerBound(benchmark::State& state) {
   int const steps = state.range(0);
-  std::unique_ptr<DiscreteTrajectory<World>> trajectory =
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
       CreateTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> fork = ForkAt(*trajectory, 0.5);
-  fork = ForkAt(*fork, 0.75);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
   for (auto _ : state) {
     // These times are in different segments of the fork.

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -84,10 +84,11 @@ class ForkableIterator {
   void CheckNormalizedIfEnd();
 
   // |ancestry_| is never empty.  |current_| is an iterator in the timeline
-  // for |ancestry_.back()|.  |current_| may be at end.
+  // for |ancestry_.back()|.  |current_| may be at end. The inline size of 3
+  // for |ancestry_| is intended to cover a trajectory's history, psychohistory,
+  // and prediction.
   TimelineConstIterator current_;
-  absl::InlinedVector<not_null<Tr4jectory const*>, 2>
-      ancestry_;  // Pointers not owned.
+  absl::InlinedVector<not_null<Tr4jectory const*>, 3> ancestry_;
 
   template<typename, typename, typename>
   friend class Forkable;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -85,7 +85,7 @@ class ForkableIterator {
 
   // |ancestry_| is never empty.  |current_| is an iterator in the timeline
   // for |ancestry_.back()|.  |current_| may be at end. The inline size of 3
-  // for |ancestry_| is intended to cover a trajectory's history, psychohistory,
+  // for |ancestry_| is intended to cover a vessel's history, psychohistory,
   // and prediction.
   TimelineConstIterator current_;
   absl::InlinedVector<not_null<Tr4jectory const*>, 3> ancestry_;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -1,12 +1,12 @@
 ﻿
 #pragma once
 
-#include <deque>
-#include <optional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "base/not_null.hpp"
 #include "geometry/named_quantities.hpp"
 #include "serialization/physics.pb.h"
@@ -84,9 +84,10 @@ class ForkableIterator {
   void CheckNormalizedIfEnd();
 
   // |ancestry_| is never empty.  |current_| is an iterator in the timeline
-  // for |ancestry_.front()|.  |current_| may be at end.
+  // for |ancestry_.back()|.  |current_| may be at end.
   TimelineConstIterator current_;
-  std::deque<not_null<Tr4jectory const*>> ancestry_;  // Pointers not owned.
+  absl::InlinedVector<not_null<Tr4jectory const*>, 2>
+      ancestry_;  // Pointers not owned.
 
   template<typename, typename, typename>
   friend class Forkable;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -91,7 +91,6 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator--() {
       current_ = *ancestor->position_in_parent_timeline_;
       ancestor = ancestor->parent_;
       ancestry_.push_back(ancestor);
-
     } while (current_ == ancestor->timeline_end() &&
              ancestor->parent_ != nullptr);
     return *that();

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -15,14 +15,14 @@ template<typename Tr4jectory, typename It3rator, typename Traits>
 not_null<Tr4jectory const*>
 ForkableIterator<Tr4jectory, It3rator, Traits>::trajectory() const {
   CHECK(!ancestry_.empty());
-  return ancestry_.back();
+  return ancestry_.front();
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 bool ForkableIterator<Tr4jectory, It3rator, Traits>::operator==(
     It3rator const& right) const {
   DCHECK_EQ(trajectory(), right.trajectory());
-  // The comparison of iterators is faster than the comparison of deques, so if
+  // The comparison of iterators is faster than the comparison of vectors, so if
   // this function returns false (which it does repeatedly in loops), it might
   // as well do so quickly.  There is a complication, however, because the two
   // iterators may not point to the same container, and we believe that
@@ -43,11 +43,11 @@ bool ForkableIterator<Tr4jectory, It3rator, Traits>::operator!=(
 template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator++() {
   CHECK(!ancestry_.empty());
-  CHECK(current_ != ancestry_.front()->timeline_end());
+  CHECK(current_ != ancestry_.back()->timeline_end());
 
   // Check if there is a next child in the ancestry.
-  auto ancestry_it = ancestry_.begin();
-  if (++ancestry_it != ancestry_.end()) {
+  auto ancestry_it = ancestry_.rbegin();
+  if (++ancestry_it != ancestry_.rend()) {
     // There is a next child.  See if we reached its fork time.
     Instant const& current_time = Traits::time(current_);
     not_null<Tr4jectory const*> child = *ancestry_it;
@@ -58,8 +58,8 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator++() {
       // a different time or the end of the children.
       do {
         current_ = child->timeline_begin();  // May be at end.
-        ancestry_.pop_front();
-        if (++ancestry_it == ancestry_.end()) {
+        ancestry_.pop_back();
+        if (++ancestry_it == ancestry_.rend()) {
           break;
         }
         child = *ancestry_it;
@@ -81,7 +81,7 @@ template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator--() {
   CHECK(!ancestry_.empty());
 
-  not_null<Tr4jectory const*> ancestor = ancestry_.front();
+  not_null<Tr4jectory const*> ancestor = ancestry_.back();
   if (current_ == ancestor->timeline_begin()) {
     CHECK_NOTNULL(ancestor->parent_);
     // At the beginning of the first timeline.  Push the parent in front of the
@@ -90,7 +90,8 @@ It3rator& ForkableIterator<Tr4jectory, It3rator, Traits>::operator--() {
     do {
       current_ = *ancestor->position_in_parent_timeline_;
       ancestor = ancestor->parent_;
-      ancestry_.push_front(ancestor);
+      ancestry_.push_back(ancestor);
+
     } while (current_ == ancestor->timeline_end() &&
              ancestor->parent_ != nullptr);
     return *that();
@@ -110,19 +111,19 @@ ForkableIterator<Tr4jectory, It3rator, Traits>::current() const {
 template<typename Tr4jectory, typename It3rator, typename Traits>
 void ForkableIterator<Tr4jectory, It3rator, Traits>::NormalizeIfEnd() {
   CHECK(!ancestry_.empty());
-  if (current_ == ancestry_.front()->timeline_end() &&
-      ancestry_.size() > 1) {
-    ancestry_.erase(ancestry_.begin(), --ancestry_.end());
-    current_ = ancestry_.front()->timeline_end();
+  if (current_ == ancestry_.back()->timeline_end() && ancestry_.size() > 1) {
+    // TODO(rlahaye): This takes linear time because it runs all the
+    // destructors, maybe?
+    ancestry_ = {ancestry_.front()};
+    current_ = ancestry_.back()->timeline_end();
   }
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 void ForkableIterator<Tr4jectory, It3rator, Traits>::CheckNormalizedIfEnd() {
   // Checking if the trajectory is a root is faster than obtaining the end of
-  // the front of the deque, so it should be done first.
-  CHECK(ancestry_.size() == 1 ||
-        current_ != ancestry_.front()->timeline_end());
+  // the back of the vector, so it should be done first.
+  CHECK(ancestry_.size() == 1 || current_ != ancestry_.back()->timeline_end());
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -187,7 +188,7 @@ template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
   not_null<Tr4jectory const*> const ancestor = that();
   It3rator iterator;
-  iterator.ancestry_.push_front(ancestor);
+  iterator.ancestry_.push_back(ancestor);
   iterator.current_ = ancestor->timeline_end();
   iterator.CheckNormalizedIfEnd();
   return iterator;
@@ -215,10 +216,10 @@ Find(Instant const& time) const {
   // Go up the ancestry chain until we find a timeline that covers |time| (that
   // is, |time| is after the first time of the timeline).  Set |current_| to
   // the location of |time|, which may be |end()|.  The ancestry has |forkable|
-  // at the back, and the object containing |current_| at the front.
+  // at the front, and the object containing |current_| at the back.
   Tr4jectory const* ancestor = that();
   do {
-    iterator.ancestry_.push_front(ancestor);
+    iterator.ancestry_.push_back(ancestor);
     if (!ancestor->timeline_empty() &&
         Traits::time(ancestor->timeline_begin()) <= time) {
       iterator.current_ = ancestor->timeline_find(time);  // May be at end.
@@ -247,7 +248,7 @@ LowerBound(Instant const& time) const {
   // Go up the ancestry chain until we find a (nonempty) timeline that covers
   // |time| (that is, |time| is on or after the first time of the timeline).
   do {
-    iterator.ancestry_.push_front(ancestor);
+    iterator.ancestry_.push_back(ancestor);
     if (!ancestor->timeline_empty() &&
         Traits::time(ancestor->timeline_begin()) <= time) {
       // We have found a timeline that covers |time|.  Find where |time| falls
@@ -268,12 +269,12 @@ LowerBound(Instant const& time) const {
         // Check if we have a more nested fork with a point before |time|.  Go
         // down the ancestry looking for a timeline that is nonempty and not
         // forked at the same point as its parent.
-        auto ancestry_it = iterator.ancestry_.begin();
+        auto ancestry_it = iterator.ancestry_.rbegin();
         auto fork_points_it = fork_points.begin();
         for (;;) {
           ++ancestry_it;
           ++fork_points_it;
-          if (ancestry_it == iterator.ancestry_.end()) {
+          if (ancestry_it == iterator.ancestry_.rend()) {
             // We didn't find an interesting fork in the ancestry, so we stop
             // here and |NormalizeIfEnd| will return a proper |End|.
             CHECK(fork_points_it == fork_points.end());
@@ -285,7 +286,10 @@ LowerBound(Instant const& time) const {
             // We found an interesting timeline, i.e. one that is nonempty and
             // not forked at the fork point of its parent.  Cut the ancestry and
             // return the beginning of that timeline.
-            iterator.ancestry_.erase(iterator.ancestry_.begin(), ancestry_it);
+            // TODO(rlahaye): This takes linear time because it runs all the
+            // destructors, maybe?
+            iterator.ancestry_ = {ancestry_it, iterator.ancestry_.rend()};
+            ancestry_it = iterator.ancestry_.rbegin();
             iterator.current_ = (*ancestry_it)->timeline_begin();
             break;
           }
@@ -511,7 +515,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::Wrap(
   // at the back, and the object containing |current_| at the front.
   not_null<Tr4jectory const*> ancest0r = that();
   do {
-    iterator.ancestry_.push_front(ancest0r);
+    iterator.ancestry_.push_back(ancest0r);
     if (ancestor == ancest0r) {
       iterator.current_ = position_in_ancestor_timeline;  // May be at end.
       iterator.CheckNormalizedIfEnd();

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -1,4 +1,4 @@
-﻿
+
 #pragma once
 
 #include <deque>
@@ -283,7 +283,8 @@ LowerBound(Instant const& time) const {
             // We found an interesting timeline, i.e. one that is nonempty and
             // not forked at the fork point of its parent.  Cut the ancestry and
             // return the beginning of that timeline.
-            iterator.ancestry_ = {ancestry_it, iterator.ancestry_.rend()};
+            iterator.ancestry_.erase(ancestry_it.base(),
+                                     iterator.ancestry_.end());
             ancestry_it = iterator.ancestry_.rbegin();
             iterator.current_ = (*ancestry_it)->timeline_begin();
             break;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -111,7 +111,7 @@ template<typename Tr4jectory, typename It3rator, typename Traits>
 void ForkableIterator<Tr4jectory, It3rator, Traits>::NormalizeIfEnd() {
   CHECK(!ancestry_.empty());
   if (current_ == ancestry_.back()->timeline_end() && ancestry_.size() > 1) {
-    ancestry_ = {ancestry_.front()};
+    ancestry_.erase(ancestry_.begin() + 1, ancestry_.end());
     current_ = ancestry_.back()->timeline_end();
   }
 }
@@ -236,7 +236,7 @@ LowerBound(Instant const& time) const {
   It3rator iterator;
   Tr4jectory const* ancestor = that();
 
-  // This queue is parallel to |iterator.ancestry_|, and each entry is an
+  // This vector is parallel to |iterator.ancestry_|, and each entry is an
   // iterator in the corresponding ancestry timeline.  Note that we use a
   // |nullopt| sentinel for the innermost timeline.
   absl::InlinedVector<std::optional<TimelineConstIterator>, 3> fork_points;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -112,8 +112,6 @@ template<typename Tr4jectory, typename It3rator, typename Traits>
 void ForkableIterator<Tr4jectory, It3rator, Traits>::NormalizeIfEnd() {
   CHECK(!ancestry_.empty());
   if (current_ == ancestry_.back()->timeline_end() && ancestry_.size() > 1) {
-    // TODO(rlahaye): This takes linear time because it runs all the
-    // destructors, maybe?
     ancestry_ = {ancestry_.front()};
     current_ = ancestry_.back()->timeline_end();
   }
@@ -286,8 +284,6 @@ LowerBound(Instant const& time) const {
             // We found an interesting timeline, i.e. one that is nonempty and
             // not forked at the fork point of its parent.  Cut the ancestry and
             // return the beginning of that timeline.
-            // TODO(rlahaye): This takes linear time because it runs all the
-            // destructors, maybe?
             iterator.ancestry_ = {ancestry_it, iterator.ancestry_.rend()};
             ancestry_it = iterator.ancestry_.rbegin();
             iterator.current_ = (*ancestry_it)->timeline_begin();

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -746,10 +746,15 @@ TEST_F(ForkableTest, IteratorLowerBoundInterestingTimeline) {
   not_null<FakeTrajectory*> const fork =
       trajectory_.NewFork(trajectory_.timeline_find(t0_));
   fork->push_back(t2_);
+  not_null<FakeTrajectory*> const fork2 =
+      fork->NewFork(fork->timeline_find(t2_));
+  fork2->push_back(t3_);
 
-  auto it = fork->LowerBound(t1_);
-  EXPECT_EQ(*it, t2_);
-  EXPECT_EQ(it, --fork->end());
+  auto lower_bound_it = fork2->LowerBound(t1_);
+  auto it1 = ++(fork2->begin());
+  EXPECT_EQ(*lower_bound_it, t2_);
+  EXPECT_EQ(*it1, t2_);
+  EXPECT_EQ(lower_bound_it, it1);
 }
 
 TEST_F(ForkableTest, FrontBack) {

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -750,8 +750,8 @@ TEST_F(ForkableTest, IteratorLowerBoundInterestingTimeline) {
       fork->NewFork(fork->timeline_find(t2_));
   fork2->push_back(t3_);
 
-  auto lower_bound_it = fork2->LowerBound(t1_);
-  auto it1 = ++(fork2->begin());
+  auto const lower_bound_it = fork2->LowerBound(t1_);
+  auto const it1 = ++(fork2->begin());
   EXPECT_EQ(*lower_bound_it, t2_);
   EXPECT_EQ(*it1, t2_);
   EXPECT_EQ(lower_bound_it, it1);

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -739,6 +739,19 @@ TEST_F(ForkableTest, IteratorLowerBoundSuccess) {
   EXPECT_EQ(t5_, *it.current());
 }
 
+TEST_F(ForkableTest, IteratorLowerBoundInterestingTimeline) {
+  // Test for the "interesting timeline" branch of Iterator::LowerBound.
+  trajectory_.push_back(t0_);
+
+  not_null<FakeTrajectory*> const fork =
+      trajectory_.NewFork(trajectory_.timeline_find(t0_));
+  fork->push_back(t2_);
+
+  auto it = fork->LowerBound(t1_);
+  EXPECT_EQ(*it, t2_);
+  EXPECT_EQ(it, --fork->end());
+}
+
 TEST_F(ForkableTest, FrontBack) {
   trajectory_.push_back(t1_);
   trajectory_.push_back(t2_);


### PR DESCRIPTION
Previously it was a deque.
This change elides allocations in most cases.

Note that as part of the change, the direction of ancestry was reversed
(i.e. front and back have been swapped). This is only a notational
change and has no effect.

The inlined size of two was decided upon by analyzing [a journal](https://drive.google.com/file/d/1HZarUaRBwpAPdNdPCyndqu-CIiwegv9x/view?usp=sharing). Most (~80%) instances of ancestry_ eventually got to size 2, whereas only 10% got to size 3.

I also ran the benchmarks. I wasn't sure which ones to run, so I ran all of them. The results are
[attached here](https://github.com/mockingbirdnest/Principia/files/5448752/bench.txt).

Some context: At some point I noticed my game had become laggy and profiled it to see why. It turned out that a lot of time was being spent allocating/deallocating Forkable::ancestry_. Changing it to an InlinedVector reduced time per frame spent waiting on Principia from ~40ms to ~7ms.
