### PR TITLE
Interrupt the orbit analysis if the mission duration changes

### DIFF
--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -172,10 +172,10 @@ class OrbitAnalysisTest : public ::testing::Test {
   std::tuple<OrbitalElements, OrbitRecurrence, OrbitGroundTrack>
   ElementsAndRecurrence(SP3Orbit const& orbit) {
     auto const earth_centred_trajectory = EarthCentredTrajectory(orbit);
-    auto const elements = OrbitalElements::ForTrajectory(
-                              *earth_centred_trajectory,
-                              earth_,
-                              MasslessBody{}).ValueOrDie();
+    auto elements = OrbitalElements::ForTrajectory(
+                        *earth_centred_trajectory,
+                        earth_,
+                        MasslessBody{}).ValueOrDie();
 
     {
       auto const identifier = (std::stringstream() << orbit.satellite).str();
@@ -221,14 +221,14 @@ class OrbitAnalysisTest : public ::testing::Test {
              129'602'768.13 * ArcSecond / (100 * JulianYear),
              1.089 * ArcSecond / Pow<2>(100 * JulianYear)},
             "1899-12-31T12:00:00"_TT);
-    auto const ground_track = OrbitGroundTrack::ForTrajectory(
+    auto ground_track = OrbitGroundTrack::ForTrajectory(
         *earth_centred_trajectory,
         earth_,
         {{/*epoch=*/J2000,
           /*mean_longitude_at_epoch=*/newcomb_mean_longitude(J2000),
           /*year*/ 2 * π * Radian /
-              newcomb_mean_longitude.EvaluateDerivative(J2000)}});
-    return {elements, recurrence, ground_track};
+              newcomb_mean_longitude.EvaluateDerivative(J2000)}}).ValueOrDie();
+    return {std::move(elements), recurrence, std::move(ground_track)};
   }
 
   SolarSystem<ICRS> earth_1957_;

--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -5,6 +5,7 @@
 
 #include "astronomy/orbit_recurrence.hpp"
 #include "astronomy/orbital_elements.hpp"
+#include "base/status_or.hpp"
 #include "geometry/interval.hpp"
 #include "physics/discrete_trajectory.hpp"
 #include "physics/rotating_body.hpp"
@@ -13,6 +14,7 @@ namespace principia {
 namespace astronomy {
 namespace internal_orbit_ground_track {
 
+using base::StatusOr;
 using geometry::Instant;
 using geometry::Interval;
 using physics::DiscreteTrajectory;
@@ -59,7 +61,7 @@ class OrbitGroundTrack {
   // |trajectory| as an orbit around |primary|; if |mean_sun| is provided,
   // sun-synchronicity is analysed.
   template<typename PrimaryCentred, typename Inertial>
-  static OrbitGroundTrack ForTrajectory(
+  static StatusOr<OrbitGroundTrack> ForTrajectory(
       DiscreteTrajectory<PrimaryCentred> const& trajectory,
       RotatingBody<Inertial> const& primary,
       std::optional<MeanSun> const& mean_sun);

--- a/astronomy/orbit_ground_track.hpp
+++ b/astronomy/orbit_ground_track.hpp
@@ -57,6 +57,12 @@ class OrbitGroundTrack {
     friend class OrbitGroundTrack;
   };
 
+  OrbitGroundTrack(OrbitGroundTrack const&) = delete;
+  OrbitGroundTrack(OrbitGroundTrack&&) = default;
+
+  OrbitGroundTrack& operator=(OrbitGroundTrack const&) = delete;
+  OrbitGroundTrack& operator=(OrbitGroundTrack&&) = default;
+
   // Returns an object that describes the properties of the ground track of
   // |trajectory| as an orbit around |primary|; if |mean_sun| is provided,
   // sun-synchronicity is analysed.

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -118,19 +118,19 @@ inline OrbitGroundTrack::EquatorCrossingLongitudes::EquatorCrossingLongitudes(
     : nominal_recurrence_(nominal_recurrence) {}
 
 template<typename PrimaryCentred, typename Inertial>
-OrbitGroundTrack OrbitGroundTrack::ForTrajectory(
+StatusOr<OrbitGroundTrack> OrbitGroundTrack::ForTrajectory(
     DiscreteTrajectory<PrimaryCentred> const& trajectory,
     RotatingBody<Inertial> const& primary,
     std::optional<MeanSun> const& mean_sun) {
   DiscreteTrajectory<PrimaryCentred> ascending_nodes;
   DiscreteTrajectory<PrimaryCentred> descending_nodes;
   OrbitGroundTrack ground_track;
-  ComputeNodes(trajectory.begin(),
-               trajectory.end(),
-               Vector<double, PrimaryCentred>({0, 0, 1}),
-               /*max_points=*/std::numeric_limits<int>::max(),
-               ascending_nodes,
-               descending_nodes);
+  RETURN_IF_ERROR(ComputeNodes(trajectory.begin(),
+                               trajectory.end(),
+                               Vector<double, PrimaryCentred>({0, 0, 1}),
+                               /*max_points=*/std::numeric_limits<int>::max(),
+                               ascending_nodes,
+                               descending_nodes));
   if (mean_sun.has_value()) {
     if (!ascending_nodes.Empty()) {
       ground_track.mean_solar_times_of_ascending_nodes_ =

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -31,6 +31,12 @@ using quantities::Time;
 
 class OrbitalElements {
  public:
+  OrbitalElements(OrbitalElements const&) = delete;
+  OrbitalElements(OrbitalElements&&) = default;
+
+  OrbitalElements& operator=(OrbitalElements const&) = delete;
+  OrbitalElements& operator=(OrbitalElements&&) = default;
+
   template<typename PrimaryCentred>
   static StatusOr<OrbitalElements> ForTrajectory(
       DiscreteTrajectory<PrimaryCentred> const& trajectory,

--- a/astronomy/orbital_elements.hpp
+++ b/astronomy/orbital_elements.hpp
@@ -15,6 +15,7 @@ namespace principia {
 namespace astronomy {
 namespace internal_orbital_elements {
 
+using base::Status;
 using base::StatusOr;
 using geometry::Instant;
 using geometry::Interval;
@@ -152,28 +153,28 @@ class OrbitalElements {
       DiscreteTrajectory<PrimaryCentred> const& trajectory);
 
   // |equinoctial_elements| must contain at least 2 elements.
-  static Time SiderealPeriod(
+  static StatusOr<Time> SiderealPeriod(
       std::vector<EquinoctialElements> const& equinoctial_elements);
 
   // |osculating| must contain at least 2 elements.
   // The resulting elements are averaged over one period, centred on
   // their |EquinoctialElements::t|.
-  static std::vector<EquinoctialElements> MeanEquinoctialElements(
+  static StatusOr<std::vector<EquinoctialElements>> MeanEquinoctialElements(
       std::vector<EquinoctialElements> const& osculating,
       Time const& period);
 
-  static std::vector<ClassicalElements> ToClassicalElements(
+  static StatusOr<std::vector<ClassicalElements>> ToClassicalElements(
       std::vector<EquinoctialElements> const& equinoctial_elements);
 
   // |mean_classical_elements_| must have been computed; sets
   // |anomalistic_period_|, |nodal_period_|, and |nodal_precession_|
   // accordingly. Note that this does not compute |sidereal_period_| (our mean
   // element computation is based on it, so it gets computed earlier).
-  void ComputePeriodsAndPrecession();
+  Status ComputePeriodsAndPrecession();
 
   // |radial_distances_| and |mean_classical_elements_| must have been computed;
   // sets |radial_distance_interval_| and |mean_*_interval_| accordingly.
-  void ComputeIntervals();
+  Status ComputeIntervals();
 
   std::vector<EquinoctialElements> osculating_equinoctial_elements_;
   std::vector<Length> radial_distances_;

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -46,7 +46,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
   orbital_elements.radial_distances_ = RadialDistances(trajectory);
   auto const sidereal_period =
       SiderealPeriod(orbital_elements.osculating_equinoctial_elements_);
-  RETURN_IF_ERROR(sidereal_period.status());
+  RETURN_IF_ERROR(sidereal_period);
   orbital_elements.sidereal_period_ = sidereal_period.ValueOrDie();
   if (!IsFinite(orbital_elements.sidereal_period_)) {
     // Guard against NaN sidereal periods (from hyperbolic orbits).
@@ -57,7 +57,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
   auto mean_equinoctial_elements =
       MeanEquinoctialElements(orbital_elements.osculating_equinoctial_elements_,
                               orbital_elements.sidereal_period_);
-  RETURN_IF_ERROR(mean_equinoctial_elements.status());
+  RETURN_IF_ERROR(mean_equinoctial_elements);
   orbital_elements.mean_equinoctial_elements_ =
       std::move(mean_equinoctial_elements).ValueOrDie();
   if (orbital_elements.mean_equinoctial_elements_.size() < 2) {
@@ -71,7 +71,7 @@ StatusOr<OrbitalElements> OrbitalElements::ForTrajectory(
   }
   auto mean_classical_elements =
       ToClassicalElements(orbital_elements.mean_equinoctial_elements_);
-  RETURN_IF_ERROR(mean_classical_elements.status());
+  RETURN_IF_ERROR(mean_classical_elements);
   orbital_elements.mean_classical_elements_ =
       std::move(mean_classical_elements).ValueOrDie();
   RETURN_IF_ERROR(orbital_elements.ComputePeriodsAndPrecession());

--- a/base/jthread.hpp
+++ b/base/jthread.hpp
@@ -7,6 +7,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include "base/not_null.hpp"
+#include "base/status.hpp"
 
 namespace principia {
 namespace base {
@@ -122,6 +123,13 @@ class this_stoppable_thread {
   template<typename Function, typename... Args>
   friend jthread MakeStoppableThread(Function&& f, Args&&... args);
 };
+
+#define RETURN_IF_STOPPED                                                     \
+  do {                                                                        \
+    if (base::this_stoppable_thread::get_stop_token().stop_requested()) {     \
+      return base::Status(base::Error::CANCELLED, "Cancelled by stop token"); \
+    }                                                                         \
+  } while (false)
 
 }  // namespace internal_jthread
 

--- a/base/jthread.hpp
+++ b/base/jthread.hpp
@@ -124,11 +124,13 @@ class this_stoppable_thread {
   friend jthread MakeStoppableThread(Function&& f, Args&&... args);
 };
 
-#define RETURN_IF_STOPPED                                                     \
-  do {                                                                        \
-    if (base::this_stoppable_thread::get_stop_token().stop_requested()) {     \
-      return base::Status(base::Error::CANCELLED, "Cancelled by stop token"); \
-    }                                                                         \
+#define RETURN_IF_STOPPED                                                   \
+  do {                                                                      \
+    if (::principia::base::this_stoppable_thread::get_stop_token()          \
+            .stop_requested()) {                                            \
+      return ::principia::base::Status(::principia::base::Error::CANCELLED, \
+                                       "Cancelled by stop token");          \
+    }                                                                       \
   } while (false)
 
 }  // namespace internal_jthread

--- a/base/jthread_body.hpp
+++ b/base/jthread_body.hpp
@@ -118,6 +118,12 @@ inline jthread::jthread(jthread&& other)
       thread_(std::move(other.thread_)) {}
 
 inline jthread& jthread::operator=(jthread&& other) {
+  if (stop_state_ != nullptr) {
+    stop_state_->request_stop();
+  }
+  if (thread_.joinable()) {
+    thread_.join();
+  }
   stop_state_ = std::move(other.stop_state_);
   thread_ = std::move(other.thread_);
   return *this;

--- a/base/status.hpp
+++ b/base/status.hpp
@@ -103,6 +103,10 @@ class Status final {
   std::string message_;
 };
 
+inline Status const& GetStatus(Status const& s) {
+  return s;
+}
+
 // Prints a human-readable representation of |s| to |os|.
 std::ostream& operator<<(std::ostream& os, Status const& s);
 
@@ -113,7 +117,8 @@ std::ostream& operator<<(std::ostream& os, Status const& s);
 #define RETURN_IF_ERROR(expr)                                                \
   do {                                                                       \
     /* Using _status below to avoid capture problems if expr is "status". */ \
-    ::principia::base::Status const _status = (expr);                        \
+    ::principia::base::Status const _status =                                \
+        (::principia::base::GetStatus(expr));                                \
     if (!_status.ok())                                                       \
       return _status;                                                        \
   } while (false)

--- a/base/status_or.hpp
+++ b/base/status_or.hpp
@@ -146,7 +146,7 @@ class StatusOr final {
   // Returns a reference to our current value, or fails if the status is not OK.
   T const& ValueOrDie() const&;
   T& ValueOrDie() &;
-  T const&& ValueOrDie() const&&;
+  T const&& ValueOrDie() const&&;  // NOLINT
   T&& ValueOrDie() &&;
 
  private:

--- a/base/status_or.hpp
+++ b/base/status_or.hpp
@@ -141,7 +141,10 @@ class StatusOr final {
   bool ok() const;
 
   // Returns a reference to our current value, or fails if the status is not OK.
-  T const& ValueOrDie() const;
+  T const& ValueOrDie() const&;
+  T& ValueOrDie() &;
+  T const&& ValueOrDie() const&&;
+  T&& ValueOrDie() &&;
 
  private:
   Status status_;

--- a/base/status_or.hpp
+++ b/base/status_or.hpp
@@ -118,9 +118,11 @@ class StatusOr final {
   // so it is convenient and sensible to be able to do |return T()|
   // when when the return type is |StatusOr<T>|.
   StatusOr(T const& value);  // NOLINT
+  StatusOr(T&& value);  // NOLINT
 
   // Copy constructor.
   StatusOr(StatusOr const& other) = default;
+  StatusOr(StatusOr&& other) = default;
 
   // Conversion copy constructor, |T| must be copy-constructible from |U|.
   template<typename U>
@@ -128,6 +130,7 @@ class StatusOr final {
 
   // Assignment operator.
   StatusOr& operator=(StatusOr const& other) = default;
+  StatusOr& operator=(StatusOr&& other) = default;
 
   // Conversion assignment operator, |T| must be copy-assignable from |U|.
   template<typename U>

--- a/base/status_or.hpp
+++ b/base/status_or.hpp
@@ -157,6 +157,9 @@ class StatusOr final {
   friend class StatusOr;
 };
 
+template<typename T>
+Status const& GetStatus(StatusOr<T> const& s);
+
 // Prints a human-readable representation of |x| to |os|.
 template<typename T>
 std::ostream& operator<<(std::ostream& os, StatusOr<T> const& x);

--- a/base/status_or_body.hpp
+++ b/base/status_or_body.hpp
@@ -104,7 +104,7 @@ T& StatusOr<T>::ValueOrDie() & {
 }
 
 template<typename T>
-T const&& StatusOr<T>::ValueOrDie() const&& {
+T const&& StatusOr<T>::ValueOrDie() const&& {  // NOLINT
   CHECK_OK(status());
   return std::move(*value_);
 }

--- a/base/status_or_body.hpp
+++ b/base/status_or_body.hpp
@@ -57,6 +57,12 @@ StatusOr<T>::StatusOr(T const& value) {
 }
 
 template<typename T>
+StatusOr<T>::StatusOr(T&& value) {
+  status_ = Status::OK;
+  value_ = std::move(value);
+}
+
+template<typename T>
 template<typename U>
 StatusOr<T>::StatusOr(StatusOr<U> const& other)
     : status_(other.status_) {

--- a/base/status_or_body.hpp
+++ b/base/status_or_body.hpp
@@ -116,6 +116,11 @@ T&& StatusOr<T>::ValueOrDie() && {
 }
 
 template<typename T>
+Status const& GetStatus(StatusOr<T> const& s) {
+  return s.status();
+}
+
+template<typename T>
 std::ostream& operator<<(std::ostream& os, StatusOr<T> const& x) {
   os << x.status();
   return os;

--- a/base/status_or_body.hpp
+++ b/base/status_or_body.hpp
@@ -86,11 +86,27 @@ bool StatusOr<T>::ok() const {
 }
 
 template<typename T>
-T const& StatusOr<T>::ValueOrDie() const {
-  if (!status_.ok()) {
-    LOG(FATAL) <<status_;
-  }
+T const& StatusOr<T>::ValueOrDie() const& {
+  CHECK_OK(status());
   return *value_;
+}
+
+template<typename T>
+T& StatusOr<T>::ValueOrDie() & {
+  CHECK_OK(status());
+  return *value_;
+}
+
+template<typename T>
+T const&& StatusOr<T>::ValueOrDie() const&& {
+  CHECK_OK(status());
+  return std::move(*value_);
+}
+
+template<typename T>
+T&& StatusOr<T>::ValueOrDie() && {
+  CHECK_OK(status());
+  return std::move(*value_);
 }
 
 template<typename T>

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -49,7 +49,8 @@ void OrbitAnalyser::RequestAnalysis(Parameters const& parameters) {
   guarded_parameters_ = {std::move(guard), parameters};
 }
 
-std::optional<OrbitAnalyser::Parameters> const& OrbitAnalyser::last_parameters() const {
+std::optional<OrbitAnalyser::Parameters> const& OrbitAnalyser::last_parameters()
+    const {
   return last_parameters_;
 }
 

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -56,7 +56,7 @@ std::optional<OrbitAnalyser::Parameters> const& OrbitAnalyser::last_parameters()
 void OrbitAnalyser::RefreshAnalysis() {
   absl::MutexLock l(&lock_);
   if (next_analysis_.has_value()) {
-    analysis_ = next_analysis_;
+    analysis_ = std::move(next_analysis_);
     next_analysis_.reset();
   }
 }

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -104,7 +104,6 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
          trajectory.back().time <
          parameters.first_time + parameters.mission_duration;
          t += parameters.mission_duration / 0x1p10) {
-      auto const flow_status = ephemeris_->FlowWithFixedStep(t, *instance);
       if (!ephemeris_->FlowWithFixedStep(t, *instance).ok()) {
         // TODO(egg): Report that the integration failed.
         break;

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -124,6 +124,7 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
     RotatingBody<Barycentric> const* primary = nullptr;
     auto smallest_osculating_period = Infinity<Time>;
     for (auto const body : ephemeris_->bodies()) {
+      RETURN_IF_STOPPED;
       auto const initial_osculating_elements =
           KeplerOrbit<Barycentric>{
               *body,
@@ -144,6 +145,7 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
       BodyCentredNonRotatingDynamicFrame<Barycentric, PrimaryCentred>
           body_centred(ephemeris_, primary);
       for (auto const& [time, degrees_of_freedom] : trajectory) {
+        RETURN_IF_STOPPED;
         primary_centred_trajectory.Append(
             time, body_centred.ToThisFrameAtTime(time)(degrees_of_freedom));
       }

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -169,7 +169,7 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
             OrbitGroundTrack::ForTrajectory(primary_centred_trajectory,
                                             *primary,
                                             /*mean_sun=*/std::nullopt);
-        RETURN_IF_ERROR(ground_track.status());
+        RETURN_IF_ERROR(ground_track);
         analysis.ground_track_ = std::move(ground_track).ValueOrDie();
         analysis.ResetRecurrence();
       }

--- a/ksp_plugin/orbit_analyser.hpp
+++ b/ksp_plugin/orbit_analyser.hpp
@@ -138,9 +138,6 @@ class OrbitAnalyser {
   // |parameters_| is set by the main thread; it is read and cleared by the
   // |analyser_| thread.
   std::optional<GuardedParameters> guarded_parameters_ GUARDED_BY(lock_);
-  // |requested_mission_duration_| is set by the |analyser_| thread; it is read
-  // by the main thread.  It is the |mission_duration| of the current 
-  std::optional<Time> requested_mission_duration_ GUARDED_BY(lock_);
   // |next_analysis_| is set by the |analyser_| thread; it is read and cleared
   // by the main thread.
   std::optional<Analysis> next_analysis_ GUARDED_BY(lock_);

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -513,9 +513,15 @@ void Vessel::RefreshOrbitAnalysis(Time const& mission_duration) {
     // default will do in the meantime.
     orbit_analyser_.emplace(ephemeris_, DefaultHistoryParameters());
   }
-  orbit_analyser_->RequestAnalysis(psychohistory_->back().time,
-                                   psychohistory_->back().degrees_of_freedom,
-                                   mission_duration);
+  if (orbit_analyser_->last_parameters().has_value() &&
+      orbit_analyser_->last_parameters()->mission_duration !=
+          mission_duration) {
+    orbit_analyser_->Restart();
+  }
+  orbit_analyser_->RequestAnalysis(
+      {.first_time = psychohistory_->back().time,
+       .first_degrees_of_freedom = psychohistory_->back().degrees_of_freedom,
+       .mission_duration = mission_duration});
   orbit_analyser_->RefreshAnalysis();
 }
 

--- a/ksp_plugin_test/orbit_analyser_test.cpp
+++ b/ksp_plugin_test/orbit_analyser_test.cpp
@@ -92,10 +92,11 @@ TEST_F(OrbitAnalyserTest, TOPEXPoséidon) {
       *topex_poséidon_.orbit(
           {StandardProduct3::SatelliteGroup::General, 1}).front();
   ephemeris_->Prolong(arc.begin()->time);
-  analyser.RequestAnalysis(arc.begin()->time,
-                           itrs_.FromThisFrameAtTime(arc.begin()->time)(
-                               arc.begin()->degrees_of_freedom),
-                           3 * Hour);
+  analyser.RequestAnalysis(
+      {.first_time = arc.begin()->time,
+       .first_degrees_of_freedom = itrs_.FromThisFrameAtTime(arc.begin()->time)(
+           arc.begin()->degrees_of_freedom),
+       .mission_duration = 3 * Hour});
   while (analyser.progress_of_next_analysis() != 1) {
     absl::SleepFor(absl::Milliseconds(10));
   }

--- a/physics/apsides.hpp
+++ b/physics/apsides.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "base/constant_function.hpp"
+#include "base/status.hpp"
 #include "physics/discrete_trajectory.hpp"
 #include "physics/trajectory.hpp"
 
@@ -12,6 +13,7 @@ namespace internal_apsides {
 
 using base::ConstantFunction;
 using base::Identically;
+using base::Status;
 using geometry::Vector;
 
 // Computes the apsides with respect to |reference| for the discrete trajectory
@@ -31,13 +33,13 @@ void ComputeApsides(Trajectory<Frame> const& reference,
 // |north| side to |descending|.
 // Nodes for which |predicate| returns false are excluded.
 template<typename Frame, typename Predicate = ConstantFunction<bool>>
-void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
-                  typename DiscreteTrajectory<Frame>::Iterator end,
-                  Vector<double, Frame> const& north,
-                  int max_points,
-                  DiscreteTrajectory<Frame>& ascending,
-                  DiscreteTrajectory<Frame>& descending,
-                  Predicate predicate = Identically(true));
+Status ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
+                    typename DiscreteTrajectory<Frame>::Iterator end,
+                    Vector<double, Frame> const& north,
+                    int max_points,
+                    DiscreteTrajectory<Frame>& ascending,
+                    DiscreteTrajectory<Frame>& descending,
+                    Predicate predicate = Identically(true));
 
 // TODO(egg): when we can usefully iterate over an arbitrary |Trajectory|, move
 // the following from |Ephemeris|.

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -130,7 +130,7 @@ void ComputeApsides(Trajectory<Frame> const& reference,
 }
 
 template<typename Frame, typename Predicate>
-void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
+Status ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
                   typename DiscreteTrajectory<Frame>::Iterator end,
                   Vector<double, Frame> const& north,
                   int const max_points,
@@ -148,6 +148,7 @@ void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
   std::optional<Speed> previous_z_speed;
 
   for (auto it = begin; it != end; ++it) {
+    RETURN_IF_STOPPED;
     auto const& [time, degrees_of_freedom] = *it;
     Length const z =
         (degrees_of_freedom.position() - Frame::origin).coordinates().z;
@@ -203,6 +204,7 @@ void ComputeNodes(typename DiscreteTrajectory<Frame>::Iterator begin,
     previous_z = z;
     previous_z_speed = z_speed;
   }
+  return Status::OK;
 }
 
 }  // namespace internal_apsides

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "base/array.hpp"
+#include "base/jthread.hpp"
 #include "numerics/root_finders.hpp"
 
 namespace principia {


### PR DESCRIPTION
In order to do that:
- refactor the orbit analyser a bit so that its thread can be restarted;
- fix the `operator=` of our implementation of `jthread`;
- introduce `RETURN_IF_STOPPED`;
- pepper it throughout `OrbitalElements` and related functions;
- avoid copies of large vectors, wherein we cannot `RETURN_IF_STOPPED`;
- in particular, update `Status` for move semantics (what year is this).

The analyser can lag a little bit when updating the mission duration during the actual analysis (as opposed to the integration), I think the remaining large atomic operations are vector destructions; not much we can easily do about those.

Drive-by changes: take an exclusive lock to swap, not a reader lock, don’t flow twice to the same time.