### PR TITLE
Use parity in basis subspaces

### DIFF
--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -511,8 +511,8 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionSecular) {
                           ? AllOf(Gt(2.8e-10 * Metre), Lt(1.3e-6 * Metre))
                           : ω_index == 3
                                 ? AllOf(Gt(1.3e-13 * Metre), Lt(4.5e-9 * Metre))
-                                : AllOf(Gt(6.4e-17 * Metre),
-                                        Lt(9.8e-13 * Metre)))
+                                : AllOf(Gt(-1.0e-100 * Metre),
+                                        Lt(1.2e-12 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {
@@ -534,7 +534,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionSecular) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
         RelativeErrorFrom(series(t_min + i * (t_max - t_min) / 100),
-                          AllOf(Ge(0), Lt(4.5e-14))));
+                          AllOf(Ge(0), Lt(5.2e-14))));
   }
 }
 

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -441,7 +441,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionNoSecular) {
                     ? AllOf(Gt(2.0e-10 * Metre), Lt(5.3e-7 * Metre))
                     : ω_index == 2
                           ? AllOf(Gt(2.9e-13 * Metre), Lt(2.6e-9 * Metre))
-                          : AllOf(Gt(-1.0e-100 * Metre), Lt(4.3e-13 * Metre)))
+                          : AllOf(Gt(-1.0e-100 * Metre), Lt(7.1e-13 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {

--- a/numerics/frequency_analysis_test.cpp
+++ b/numerics/frequency_analysis_test.cpp
@@ -318,7 +318,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesVectorProjection) {
                        t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection4(t_min + i * Radian / ω),
-                AlmostEquals(series(t_min + i * Radian / ω), 0, 1536));
+                AlmostEquals(series(t_min + i * Radian / ω), 0, 4096));
   }
 
   // Projection on a 5th degree basis is also accurate.
@@ -329,7 +329,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesVectorProjection) {
                        t_min, t_max);
   for (int i = 0; i <= 100; ++i) {
     EXPECT_THAT(projection5(t_min + i * Radian / ω),
-                AlmostEquals(series(t_min + i * Radian / ω), 0, 1536));
+                AlmostEquals(series(t_min + i * Radian / ω), 0, 4096));
   }
 
   // Projection on a 3rd degree basis introduces significant errors.
@@ -441,7 +441,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionNoSecular) {
                     ? AllOf(Gt(2.0e-10 * Metre), Lt(5.3e-7 * Metre))
                     : ω_index == 2
                           ? AllOf(Gt(2.9e-13 * Metre), Lt(2.6e-9 * Metre))
-                          : AllOf(Gt(-1.0e-100 * Metre), Lt(7.1e-14 * Metre)))
+                          : AllOf(Gt(-1.0e-100 * Metre), Lt(4.3e-13 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {
@@ -463,7 +463,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionNoSecular) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
         RelativeErrorFrom(series.value()(t_min + i * (t_max - t_min) / 100),
-                          AllOf(Ge(0), Lt(4.8e-14))));
+                          AllOf(Ge(0), Lt(2.5e-13))));
   }
 }
 
@@ -512,7 +512,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionSecular) {
                           : ω_index == 3
                                 ? AllOf(Gt(1.3e-13 * Metre), Lt(4.5e-9 * Metre))
                                 : AllOf(Gt(6.4e-17 * Metre),
-                                        Lt(1.1e-13 * Metre)))
+                                        Lt(9.8e-13 * Metre)))
           << ω_index;
     }
     if (ω_index == ωs.size()) {
@@ -534,7 +534,7 @@ TEST_F(FrequencyAnalysisTest, PoissonSeriesIncrementalProjectionSecular) {
     EXPECT_THAT(
         projection4(t_min + i * (t_max - t_min) / 100),
         RelativeErrorFrom(series(t_min + i * (t_max - t_min) / 100),
-                          AllOf(Ge(0), Lt(4.4e-15))));
+                          AllOf(Ge(0), Lt(4.5e-14))));
   }
 }
 

--- a/numerics/poisson_series_basis.hpp
+++ b/numerics/poisson_series_basis.hpp
@@ -44,6 +44,8 @@ class PoissonSeriesSubspace {
   friend struct AperiodicSeriesGenerator;
   template<typename Series, int degree, int dimension, typename>
   friend struct PeriodicSeriesGenerator;
+  friend std::ostream& operator<<(std::ostream& out,
+                                  PoissonSeriesSubspace const& subspace);
 };
 
 // A generator for the Кудрявцев basis, i.e., functions of the
@@ -70,6 +72,9 @@ class PoissonSeriesBasisGenerator {
   static std::array<PoissonSeriesSubspace, 2 * dimension * (degree + 1)>
   Subspaces(AngularFrequency const& ω, Instant const& origin);
 };
+
+std::ostream& operator<<(std::ostream& out,
+                         PoissonSeriesSubspace const& subspace);
 
 }  // namespace internal_poisson_series_basis
 

--- a/numerics/poisson_series_basis_body.hpp
+++ b/numerics/poisson_series_basis_body.hpp
@@ -138,7 +138,7 @@ Polynomials PolynomialGenerator<Polynomial, dimension>::UnitPolynomials(
 
 inline bool PoissonSeriesSubspace::orthogonal(PoissonSeriesSubspace const v,
                                               PoissonSeriesSubspace const w) {
-  return v.coordinate_ != w.coordinate_;
+  return v.coordinate_ != w.coordinate_ || v.parity_ != w.parity_;
 }
 
 inline PoissonSeriesSubspace::PoissonSeriesSubspace(Coordinate coordinate,
@@ -230,12 +230,11 @@ std::array<PoissonSeriesSubspace, sizeof...(indices)> PeriodicSeriesGenerator<
       PoissonSeriesSubspace{
           static_cast<PoissonSeriesSubspace::Coordinate>(indices % dimension),
           // The parity of the trigonometric factors of the ith basis element is
-          // (i / dimension) % 2; the degrees its polynomial factor is
-          // i / (2 * dimension), so that the overall parity of that basis
-          // element is (i / dimension + i / (2 * dimension)) % 2, which
-          // simplifies to (3 * i / (2 * dimension)) % 2.
+          // ⌊i / dimension⌋ mod 2; the degrees its polynomial factor is
+          // ⌊i / (2 * dimension)⌋, so that the overall parity of that basis
+          // element is (⌊i / dimension⌋ + ⌊i / (2 * dimension)⌋) mod 2.
           static_cast<PoissonSeriesSubspace::Parity>(
-              (3 * indices / (2 * dimension)) % 2)}...};
+              (indices / dimension + indices / (2 * dimension)) % 2)}...};
 }
 
 
@@ -268,6 +267,12 @@ auto PoissonSeriesBasisGenerator<Series, degree>::Subspaces(
     -> std::array<PoissonSeriesSubspace, 2 * dimension*(degree + 1)> {
   return PeriodicSeriesGenerator<Series, degree, dimension>::Subspaces(ω,
                                                                        origin);
+}
+
+inline std::ostream& operator<<(std::ostream& out,
+                                PoissonSeriesSubspace const& subspace) {
+  return out << "{coordinate: " << static_cast<int>(subspace.coordinate_)
+             << ", parity: " << static_cast<int>(subspace.parity_) << "}";
 }
 
 }  // namespace internal_poisson_series_basis

--- a/numerics/poisson_series_basis_body.hpp
+++ b/numerics/poisson_series_basis_body.hpp
@@ -230,7 +230,7 @@ std::array<PoissonSeriesSubspace, sizeof...(indices)> PeriodicSeriesGenerator<
       PoissonSeriesSubspace{
           static_cast<PoissonSeriesSubspace::Coordinate>(indices % dimension),
           // The parity of the trigonometric factors of the ith basis element is
-          // ⌊i / dimension⌋ mod 2; the degrees its polynomial factor is
+          // ⌊i / dimension⌋ mod 2; the degree of its polynomial factor is
           // ⌊i / (2 * dimension)⌋, so that the overall parity of that basis
           // element is (⌊i / dimension⌋ + ⌊i / (2 * dimension)⌋) mod 2.
           static_cast<PoissonSeriesSubspace::Parity>(

--- a/numerics/poisson_series_basis_test.cpp
+++ b/numerics/poisson_series_basis_test.cpp
@@ -341,8 +341,6 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, Sqrt(3) / 2 * Metre}), 0));
 
-  LOG(ERROR)<<periodic_subspaces[1];
-  LOG(ERROR)<<periodic_subspaces[4];
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
                                                 periodic_subspaces[3]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],

--- a/numerics/poisson_series_basis_test.cpp
+++ b/numerics/poisson_series_basis_test.cpp
@@ -70,6 +70,7 @@ TEST_F(PoissonSeriesBasisTest, AperiodicVector) {
 
   Instant const t1 = t0_ + 2 * Second;
 
+  // Degree 0.
   EXPECT_EQ(Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre}),
             aperiodic[0](t1));
   EXPECT_EQ(Displacement<World>({0 * Metre, 1 * Metre, 0 * Metre}),
@@ -83,7 +84,14 @@ TEST_F(PoissonSeriesBasisTest, AperiodicVector) {
                                                 aperiodic_subspaces[1]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
                                                 aperiodic_subspaces[2]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                 aperiodic_subspaces[1]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[2]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                 aperiodic_subspaces[2]));
 
+  // Degree 1.
   EXPECT_EQ(Displacement<World>({2 * Metre, 0 * Metre, 0 * Metre}),
             aperiodic[3](t1));
   EXPECT_EQ(Displacement<World>({0 * Metre, 2 * Metre, 0 * Metre}),
@@ -91,13 +99,39 @@ TEST_F(PoissonSeriesBasisTest, AperiodicVector) {
   EXPECT_EQ(Displacement<World>({0 * Metre, 0 * Metre, 2 * Metre}),
             aperiodic[5](t1));
 
-  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
-                                                 aperiodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[3]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
                                                 aperiodic_subspaces[4]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
                                                 aperiodic_subspaces[5]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[5]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[5]));
 
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                 aperiodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[5]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                 aperiodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[5]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                 aperiodic_subspaces[5]));
+
+  // Degree 2.
   EXPECT_EQ(Displacement<World>({4 * Metre, 0 * Metre, 0 * Metre}),
             aperiodic[6](t1));
   EXPECT_EQ(Displacement<World>({0 * Metre, 4 * Metre, 0 * Metre}),
@@ -105,12 +139,134 @@ TEST_F(PoissonSeriesBasisTest, AperiodicVector) {
   EXPECT_EQ(Displacement<World>({0 * Metre, 0 * Metre, 4 * Metre}),
             aperiodic[8](t1));
 
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                 aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[6]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                 aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[7]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                 aperiodic_subspaces[8]));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                aperiodic_subspaces[8]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                 aperiodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                aperiodic_subspaces[8]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[7],
+                                                 aperiodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[7],
+                                                aperiodic_subspaces[8]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[8],
+                                                 aperiodic_subspaces[8]));
+
+  // Degree 3.
   EXPECT_EQ(Displacement<World>({8 * Metre, 0 * Metre, 0 * Metre}),
             aperiodic[9](t1));
   EXPECT_EQ(Displacement<World>({0 * Metre, 8 * Metre, 0 * Metre}),
             aperiodic[10](t1));
   EXPECT_EQ(Displacement<World>({0 * Metre, 0 * Metre, 8 * Metre}),
             aperiodic[11](t1));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[0],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[1],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[2],
+                                                aperiodic_subspaces[11]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                 aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[3],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[9]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                 aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[4],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                aperiodic_subspaces[10]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[5],
+                                                 aperiodic_subspaces[11]));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[6],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[7],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[7],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[7],
+                                                aperiodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[8],
+                                                aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[8],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[8],
+                                                aperiodic_subspaces[11]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[9],
+                                                 aperiodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[9],
+                                                aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[9],
+                                                aperiodic_subspaces[11]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[10],
+                                                 aperiodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[10],
+                                                aperiodic_subspaces[11]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(aperiodic_subspaces[11],
+                                                 aperiodic_subspaces[11]));
 }
 
 TEST_F(PoissonSeriesBasisTest, PeriodicScalar) {
@@ -144,6 +300,7 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
 
   Instant const t1 = t0_ + 2 * Second;
 
+  // Degree 0, Cos.
   EXPECT_THAT(
       periodic[0](t1),
       AlmostEquals(
@@ -163,7 +320,14 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
                                                 periodic_subspaces[1]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
                                                 periodic_subspaces[2]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                 periodic_subspaces[1]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[2]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                 periodic_subspaces[2]));
 
+  // Degree 0, Sin.
   EXPECT_THAT(
       periodic[3](t1),
       AlmostEquals(
@@ -177,13 +341,41 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, Sqrt(3) / 2 * Metre}), 0));
 
-  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
-                                                 periodic_subspaces[3]));
+  LOG(ERROR)<<periodic_subspaces[1];
+  LOG(ERROR)<<periodic_subspaces[4];
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[3]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
                                                 periodic_subspaces[4]));
   EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
                                                 periodic_subspaces[5]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[5]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[5]));
 
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                 periodic_subspaces[3]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[5]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                 periodic_subspaces[4]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[5]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                 periodic_subspaces[5]));
+
+  // Degree 1, Cos.
   EXPECT_THAT(
       periodic[6](t1),
       AlmostEquals(
@@ -196,6 +388,59 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       periodic[8](t1),
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, 1 * Metre}), 1));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[8]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                 periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[6]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                 periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[8]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                periodic_subspaces[7]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                 periodic_subspaces[8]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                 periodic_subspaces[6]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                periodic_subspaces[8]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[7],
+                                                 periodic_subspaces[7]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[7],
+                                                periodic_subspaces[8]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[8],
+                                                 periodic_subspaces[8]));
+
+  // Degree 1, Sin.
   EXPECT_THAT(
       periodic[9](t1),
       AlmostEquals(
@@ -209,6 +454,77 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, Sqrt(3) * Metre}), 0));
 
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                 periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[0],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[9]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                 periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[1],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                periodic_subspaces[10]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[2],
+                                                 periodic_subspaces[11]));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[3],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[4],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[5],
+                                                periodic_subspaces[11]));
+
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[6],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[7],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[7],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[7],
+                                                periodic_subspaces[11]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[8],
+                                                periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[8],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[8],
+                                                periodic_subspaces[11]));
+
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[9],
+                                                 periodic_subspaces[9]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[9],
+                                                periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[9],
+                                                periodic_subspaces[11]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[10],
+                                                 periodic_subspaces[10]));
+  EXPECT_TRUE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[10],
+                                                periodic_subspaces[11]));
+  EXPECT_FALSE(PoissonSeriesSubspace::orthogonal(periodic_subspaces[11],
+                                                 periodic_subspaces[11]));
+
+  // Degree 2, Cos.
   EXPECT_THAT(
       periodic[12](t1),
       AlmostEquals(
@@ -221,6 +537,8 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       periodic[14](t1),
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, 2 * Metre}), 1));
+
+  // Degree 2, Sin.
   EXPECT_THAT(
       periodic[15](t1),
       AlmostEquals(
@@ -234,6 +552,7 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, 2 * Sqrt(3) * Metre}), 0));
 
+  // Degree 3, Cos.
   EXPECT_THAT(
       periodic[18](t1),
       AlmostEquals(
@@ -246,6 +565,8 @@ TEST_F(PoissonSeriesBasisTest, PeriodicVector) {
       periodic[20](t1),
       AlmostEquals(
           Displacement<World>({0 * Metre, 0 * Metre, 4 * Metre}), 1));
+
+  // Degree 3, Sin.
   EXPECT_THAT(
       periodic[21](t1),
       AlmostEquals(

--- a/numerics/poisson_series_body.hpp
+++ b/numerics/poisson_series_body.hpp
@@ -22,6 +22,7 @@ namespace numerics {
 namespace internal_poisson_series {
 
 using quantities::Abs;
+using quantities::Angle;
 using quantities::Cos;
 using quantities::Infinity;
 using quantities::Sin;
@@ -260,10 +261,11 @@ template<typename Value,
          template<typename, typename, int> class Evaluator>
 Value PoissonSeries<Value, aperiodic_degree_, periodic_degree_, Evaluator>::
 operator()(Instant const& t) const {
+  Time const Δt = t - origin_;
   Value result = aperiodic_(t);
   for (auto const& [ω, polynomials] : periodic_) {
-    result += polynomials.sin(t) * Sin(ω * (t - origin_)) +
-              polynomials.cos(t) * Cos(ω * (t - origin_));
+    Angle const ωΔt = ω * Δt;
+    result += polynomials.sin(t) * Sin(ωΔt) + polynomials.cos(t) * Cos(ωΔt);
   }
   return result;
 }


### PR DESCRIPTION
Also a microoptimization of the evaluation of Poisson series.

#2400.