### PR TITLE
Make ephemeris flows interruptible and stop unused prognosticators

### DIFF
--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
+#include "base/jthread.hpp"
 #include "base/status.hpp"
 #include "ksp_plugin/celestial.hpp"
 #include "ksp_plugin/flight_plan.hpp"
@@ -170,6 +171,8 @@ class Vessel {
   // have a last time at or before |time|.
   virtual void RefreshPrediction(Instant const& time);
 
+  void StopPrognosticator();
+
   // Returns "vessel_name (GUID)".
   std::string ShortDebugString() const;
 
@@ -220,7 +223,7 @@ class Vessel {
 
   // Run by the |prognosticator_| thread to periodically recompute the
   // prognostication.
-  void RepeatedlyFlowPrognostication();
+  Status RepeatedlyFlowPrognostication();
 
   // Runs the integrator to compute the |prognostication_| based on the given
   // parameters.
@@ -265,7 +268,7 @@ class Vessel {
   // that reading it clears it.
   std::optional<PrognosticatorParameters> prognosticator_parameters_
       GUARDED_BY(prognosticator_lock_);
-  std::thread prognosticator_;
+  base::jthread prognosticator_;
 
   // See the comments in pile_up.hpp for an explanation of the terminology.
   not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history_;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "astronomy/epoch.hpp"
+#include "base/jthread.hpp"
 #include "base/macros.hpp"
 #include "base/map_util.hpp"
 #include "base/not_null.hpp"
@@ -410,6 +411,7 @@ Ephemeris<Frame>::NewInstance(
           Instant const& t,
           std::vector<Position<Frame>> const& positions,
           std::vector<Vector<Acceleration, Frame>>& accelerations) {
+    RETURN_IF_STOPPED;
     Error const error =
         ComputeMasslessBodiesGravitationalAccelerations(t,
                                                         positions,
@@ -460,6 +462,7 @@ Status Ephemeris<Frame>::FlowWithAdaptiveStep(
       Instant const& t,
       std::vector<Position<Frame>> const& positions,
       std::vector<Vector<Acceleration, Frame>>& accelerations) {
+    RETURN_IF_STOPPED;
     Error const error =
         ComputeMasslessBodiesGravitationalAccelerations(t,
                                                         positions,
@@ -492,6 +495,7 @@ Status Ephemeris<Frame>::FlowWithAdaptiveStep(
           std::vector<Position<Frame>> const& positions,
           std::vector<Velocity<Frame>> const& velocities,
           std::vector<Vector<Acceleration, Frame>>& accelerations) {
+        RETURN_IF_STOPPED;
         Error const error =
             ComputeMasslessBodiesGravitationalAccelerations(t,
                                                             positions,


### PR DESCRIPTION
This improves performance when looking at multiple vessels in quick succession in the tracking station.