### PR TITLE
Extended mission in the analyser

### DIFF
--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -94,33 +94,6 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
     DiscreteTrajectory<Barycentric> trajectory;
     trajectory.Append(parameters.first_time,
                       parameters.first_degrees_of_freedom);
-    std::vector<not_null<DiscreteTrajectory<Barycentric>*>> trajectories = {
-        &trajectory};
-    auto instance = ephemeris_->NewInstance(
-        trajectories,
-        Ephemeris<Barycentric>::NoIntrinsicAccelerations,
-        analysed_trajectory_parameters_);
-    for (Instant t =
-             parameters.first_time + parameters.mission_duration / 0x1p10;
-         trajectory.back().time <
-         parameters.first_time + parameters.mission_duration;
-         t += parameters.mission_duration / 0x1p10) {
-      if (!ephemeris_->FlowWithFixedStep(t, *instance).ok()) {
-        // TODO(egg): Report that the integration failed.
-        break;
-      }
-      progress_of_next_analysis_ =
-          (trajectory.back().time - parameters.first_time) /
-          parameters.mission_duration;
-      RETURN_IF_STOPPED;
-    }
-    analysis.mission_duration_ =
-        trajectory.back().time - parameters.first_time;
-
-    // TODO(egg): |next_analysis_percentage_| only reflects the progress of the
-    // integration, but the analysis itself can take a while; this results in
-    // the progress bar being stuck at 100% while the elements and nodes are
-    // being computed.
 
     RotatingBody<Barycentric> const* primary = nullptr;
     auto smallest_osculating_period = Infinity<Time>;
@@ -141,6 +114,37 @@ Status OrbitAnalyser::RepeatedlyAnalyseOrbit() {
       }
     }
     if (primary != nullptr) {
+      std::vector<not_null<DiscreteTrajectory<Barycentric>*>> trajectories = {
+          &trajectory};
+      auto instance = ephemeris_->NewInstance(
+          trajectories,
+          Ephemeris<Barycentric>::NoIntrinsicAccelerations,
+          analysed_trajectory_parameters_);
+      Time const analysis_duration =
+          std::min(parameters.extended_mission_duration.value_or(
+                       parameters.mission_duration),
+                   std::max(2 * smallest_osculating_period,
+                            parameters.mission_duration));
+      for (Instant t = parameters.first_time + analysis_duration / 0x1p10;
+           trajectory.back().time < parameters.first_time + analysis_duration;
+           t += analysis_duration / 0x1p10) {
+        if (!ephemeris_->FlowWithFixedStep(t, *instance).ok()) {
+          // TODO(egg): Report that the integration failed.
+          break;
+        }
+        progress_of_next_analysis_ =
+            (trajectory.back().time - parameters.first_time) /
+            analysis_duration;
+        RETURN_IF_STOPPED;
+      }
+      analysis.mission_duration_ =
+          trajectory.back().time - parameters.first_time;
+
+      // TODO(egg): |next_analysis_percentage_| only reflects the progress of
+      // the integration, but the analysis itself can take a while; this results
+      // in the progress bar being stuck at 100% while the elements and nodes
+      // are being computed.
+
       using PrimaryCentred = Frame<enum class PrimaryCentredTag, NonRotating>;
       DiscreteTrajectory<PrimaryCentred> primary_centred_trajectory;
       BodyCentredNonRotatingDynamicFrame<Barycentric, PrimaryCentred>

--- a/ksp_plugin/orbit_analyser.hpp
+++ b/ksp_plugin/orbit_analyser.hpp
@@ -89,6 +89,9 @@ class OrbitAnalyser {
     Instant first_time;
     DegreesOfFreedom<Barycentric> first_degrees_of_freedom;
     Time mission_duration;
+    // The analyser may compute the trajectory up to |extended_mission_duration|
+    // to ensure that at least one revolution is analysed.
+    std::optional<Time> extended_mission_duration;
   };
 
   OrbitAnalyser(not_null<Ephemeris<Barycentric>*> ephemeris,


### PR DESCRIPTION
This allows the analyser to try to see one full revolution if the `mission_duration` appears to be too short. This will be useful in the flight plan to figure out what orbit the vessel would be in if the orbit were not interrupted by the next manœuvre.