### PR TITLE
Update all predictions at the same time

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -18,6 +18,7 @@
 #include <psapi.h>
 #endif
 
+#include "absl/strings/str_split.h"
 #include "astronomy/epoch.hpp"
 #include "astronomy/time_scales.hpp"
 #include "base/array.hpp"
@@ -1174,10 +1175,10 @@ void __cdecl principia__UpdateCelestialHierarchy(Plugin const* const plugin,
 }
 
 void __cdecl principia__UpdatePrediction(Plugin const* const plugin,
-                                         char const* const vessel_guid) {
-  journal::Method<journal::UpdatePrediction> m({plugin, vessel_guid});
+                                         char const* const vessel_guids) {
+  journal::Method<journal::UpdatePrediction> m({plugin, vessel_guids});
   CHECK_NOTNULL(plugin);
-  plugin->UpdatePrediction(vessel_guid);
+  plugin->UpdatePrediction(absl::StrSplit(vessel_guids, '\x1F'));
   return m.Return();
 }
 

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -335,8 +335,8 @@ class Plugin {
       Ephemeris<Barycentric>::AdaptiveStepParameters const&
           prediction_adaptive_step_parameters) const;
 
-  // Updates the prediction for the vessel with guid |vessel_guid|.
-  void UpdatePrediction(GUID const& vessel_guid) const;
+  // Updates the prediction for the vessels with guids in |vessel_guids|.
+  void UpdatePrediction(std::vector<GUID> const& vessel_guids) const;
 
   virtual void CreateFlightPlan(GUID const& vessel_guid,
                                 Instant const& final_time,

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -411,7 +411,6 @@ public partial class PrincipiaPluginAdapter
         main_vessel != null && MapView.MapIsEnabled;
 
     if (ready_to_draw_active_vessel_trajectory) {
-      plugin_.UpdatePrediction(main_vessel.id.ToString());
       string target_id =
           FlightGlobals.fetch.VesselTarget?.GetVessel()?.id.ToString();
       if (!plotting_frame_selector_.target_override &&
@@ -423,7 +422,10 @@ public partial class PrincipiaPluginAdapter
                 main_vessel.id.ToString());
         plugin_.VesselSetPredictionAdaptiveStepParameters(
             target_id, adaptive_step_parameters);
-        plugin_.UpdatePrediction(target_id);
+        plugin_.UpdatePrediction(
+            string.Join("\x1F", main_vessel.id.ToString(), target_id));
+      } else {
+        plugin_.UpdatePrediction(main_vessel.id.ToString());
       }
     }
   }

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -709,7 +709,7 @@ TEST_F(PluginIntegrationTest, Prediction) {
 
   // Polling for the integration to happen.
   do {
-    plugin.UpdatePrediction(vessel_guid);
+    plugin.UpdatePrediction({vessel_guid});
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
   } while (plugin.GetVessel(vessel_guid)->prediction().Size() != 15);

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -411,7 +411,7 @@ TEST_F(PluginTest, Serialization) {
                              inserted);
   plugin->AdvanceTime(HistoryTime(time, 6), Angle());
   plugin->CatchUpLaggingVessels(collided_vessels);
-  plugin->UpdatePrediction(satellite);
+  plugin->UpdatePrediction({satellite});
 
   // The call to |UpdatePrediction| above may guard the ephemeris and delay
   // forgetting the histories until after the plugin is serialized below.  To
@@ -913,7 +913,7 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeAfterPredictionFork) {
   plugin_->CatchUpLaggingVessels(collided_vessels);
   EXPECT_CALL(plugin_->mock_ephemeris(), t_min_locked)
       .WillRepeatedly(Return(HistoryTime(time, 0)));
-  plugin_->UpdatePrediction(guid);
+  plugin_->UpdatePrediction({guid});
   plugin_->InsertOrKeepVessel(guid,
                               "v" + guid,
                               SolarSystemFactory::Earth,

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -2181,7 +2181,9 @@ message UpdatePrediction {
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
                                  (is_subject) = true];
-    required string vessel_guid = 2;
+    // Separated by ASCII unit separators.
+    // TODO(phl): Change this to a repeated field.
+    required string vessel_guids = 2;
   }
   optional In in = 1;
 }


### PR DESCRIPTION
Fix #2824.
The renderer only has a target vessel when we are in the target frame; otherwise, from the point of view of the plugin, it is like any other vessel; by stopping all prognosticators but the main vessel’s and, immediately afterwards, all prognosticators but the target vessel’s, we stop the prognosticator of the main vessel—and thus its prediction is never recomputed.