### PR TITLE
Separate getting the analysis from refreshing it

### DIFF
--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -50,6 +50,28 @@ QP __cdecl principia__VesselFromParent(Plugin const* const plugin,
   return m.Return(ToQP(plugin->VesselFromParent(parent_index, vessel_guid)));
 }
 
+OrbitAnalysis* __cdecl principia__VesselGetAnalysis(
+    Plugin* const plugin,
+    char const* const vessel_guid,
+    int const* const revolutions_per_cycle,
+    int const* const days_per_cycle,
+    int const ground_track_revolution) {
+  journal::Method<journal::VesselGetAnalysis> m({plugin,
+                                                 vessel_guid,
+                                                 revolutions_per_cycle,
+                                                 days_per_cycle,
+                                                 ground_track_revolution});
+  CHECK_NOTNULL(plugin);
+  Vessel& vessel = *plugin->GetVessel(vessel_guid);
+  not_null<OrbitAnalysis*> analysis = NewOrbitAnalysis(vessel.orbit_analysis(),
+                                                       *plugin,
+                                                       revolutions_per_cycle,
+                                                       days_per_cycle,
+                                                       ground_track_revolution);
+  analysis->progress_of_next_analysis = vessel.progress_of_orbit_analysis();
+  return m.Return(analysis);
+}
+
 AdaptiveStepParameters __cdecl
 principia__VesselGetPredictionAdaptiveStepParameters(
     Plugin const* const plugin,
@@ -68,30 +90,15 @@ XYZ __cdecl principia__VesselNormal(Plugin const* const plugin,
   return m.Return(ToXYZ(plugin->VesselNormal(vessel_guid)));
 }
 
-OrbitAnalysis* __cdecl principia__VesselRefreshAnalysis(
-    Plugin* const plugin,
-    char const* const vessel_guid,
-    double const mission_duration,
-    int const* const revolutions_per_cycle,
-    int const* const days_per_cycle,
-    int const ground_track_revolution) {
-  journal::Method<journal::VesselRefreshAnalysis> m({plugin,
-                                                     vessel_guid,
-                                                     mission_duration,
-                                                     revolutions_per_cycle,
-                                                     days_per_cycle,
-                                                     ground_track_revolution});
+void __cdecl principia__VesselRefreshAnalysis(Plugin* const plugin,
+                                              char const* const vessel_guid,
+                                              double const mission_duration) {
+  journal::Method<journal::VesselRefreshAnalysis> m(
+      {plugin, vessel_guid, mission_duration});
   CHECK_NOTNULL(plugin);
   Vessel& vessel = *plugin->GetVessel(vessel_guid);
   plugin->ClearOrbitAnalysersOfVesselsOtherThan(vessel);
   vessel.RefreshOrbitAnalysis(mission_duration * Second);
-  not_null<OrbitAnalysis*> analysis = NewOrbitAnalysis(vessel.orbit_analysis(),
-                                                       *plugin,
-                                                       revolutions_per_cycle,
-                                                       days_per_cycle,
-                                                       ground_track_revolution);
-  analysis->progress_of_next_analysis = vessel.progress_of_orbit_analysis();
-  return m.Return(analysis);
 }
 
 void __cdecl principia__VesselSetPredictionAdaptiveStepParameters(

--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -63,11 +63,12 @@ OrbitAnalysis* __cdecl principia__VesselGetAnalysis(
                                                  ground_track_revolution});
   CHECK_NOTNULL(plugin);
   Vessel& vessel = *plugin->GetVessel(vessel_guid);
-  not_null<OrbitAnalysis*> analysis = NewOrbitAnalysis(vessel.orbit_analysis(),
-                                                       *plugin,
-                                                       revolutions_per_cycle,
-                                                       days_per_cycle,
-                                                       ground_track_revolution);
+  not_null<OrbitAnalysis*> const analysis =
+      NewOrbitAnalysis(vessel.orbit_analysis(),
+                       *plugin,
+                       revolutions_per_cycle,
+                       days_per_cycle,
+                       ground_track_revolution);
   analysis->progress_of_next_analysis = vessel.progress_of_orbit_analysis();
   return m.Return(analysis);
 }

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -148,17 +148,18 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
     var now = DateTime.UtcNow;
     if (vessel_guid == null) {
       orbit_description_ = null;
-    } else if (
-        !Shown() &&
-        (!last_background_analysis_time_.HasValue ||
-         (now - last_background_analysis_time_) > TimeSpan.FromSeconds(2))) {
-      last_background_analysis_time_ = now;
-      // Keep refreshing the analysis (albeit at a reduced rate) even when the
-      // analyser is not shown, so that the analysis button can display an
-      // up-to-date one-line summary.
-      OrbitAnalysis analysis = plugin.VesselRefreshAnalysis(
+    } else {
+      if (Shown() ||
+          (!last_background_analysis_time_.HasValue ||
+           (now - last_background_analysis_time_) > TimeSpan.FromSeconds(2))) {
+        last_background_analysis_time_ = now;
+        // Keep refreshing the analysis (albeit at a reduced rate) even when the
+        // analyser is not shown, so that the analysis button can display an
+        // up-to-date one-line summary.
+        plugin.VesselRefreshAnalysis(vessel_guid, mission_duration_.value);
+      }
+      OrbitAnalysis analysis = plugin.VesselGetAnalysis(
           vessel_guid,
-          mission_duration_.value,
           autodetect_recurrence_ ? null : (int?)revolutions_per_cycle_,
           autodetect_recurrence_ ? null : (int?)days_per_cycle_,
           ground_track_revolution_);
@@ -199,9 +200,8 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
           multiline_style,
           UnityEngine.GUILayout.Height(two_lines));
 
-    OrbitAnalysis analysis = plugin.VesselRefreshAnalysis(
+    OrbitAnalysis analysis = plugin.VesselGetAnalysis(
         predicted_vessel.id.ToString(),
-        mission_duration_.value,
         autodetect_recurrence_ ? null : (int?)revolutions_per_cycle_,
         autodetect_recurrence_ ? null : (int?)days_per_cycle_,
         ground_track_revolution_);

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -218,7 +218,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5175.
+  extensions 5000 to 5999;  // Last used: 5176.
 }
 
 message AdvanceTime {
@@ -2219,6 +2219,26 @@ message VesselFromParent {
   optional Return return = 3;
 }
 
+message VesselGetAnalysis {
+  extend Method {
+    optional VesselGetAnalysis extension = 5176;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+    optional int32 revolutions_per_cycle = 5;
+    optional int32 days_per_cycle = 6;
+    required int32 ground_track_revolution = 7;
+  }
+  message Return {
+    required OrbitAnalysis result = 1 [(is_produced) = true];
+    required fixed64 address = 2 [(address_of) = "result"];
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
 message VesselGetPredictionAdaptiveStepParameters {
   extend Method {
     optional VesselGetPredictionAdaptiveStepParameters extension = 5090;
@@ -2260,16 +2280,8 @@ message VesselRefreshAnalysis {
                                  (is_subject) = true];
     required string vessel_guid = 2;
     required double mission_duration = 4;
-    optional int32 revolutions_per_cycle = 5;
-    optional int32 days_per_cycle = 6;
-    required int32 ground_track_revolution = 7;
-  }
-  message Return {
-    required OrbitAnalysis result = 1 [(is_produced) = true];
-    required fixed64 address = 2 [(address_of) = "result"];
   }
   optional In in = 1;
-  optional Return return = 3;
 }
 
 message VesselSetPredictionAdaptiveStepParameters {


### PR DESCRIPTION
This will make it possible to reuse the orbit analyser UI for flight plan analyses, which are not constantly refreshed.