### PR TITLE
Refresh when getting, not when requesting

### DIFF
--- a/ksp_plugin/interface_vessel.cpp
+++ b/ksp_plugin/interface_vessel.cpp
@@ -63,6 +63,7 @@ OrbitAnalysis* __cdecl principia__VesselGetAnalysis(
                                                  ground_track_revolution});
   CHECK_NOTNULL(plugin);
   Vessel& vessel = *plugin->GetVessel(vessel_guid);
+  vessel.RefreshOrbitAnalysis();
   not_null<OrbitAnalysis*> const analysis =
       NewOrbitAnalysis(vessel.orbit_analysis(),
                        *plugin,
@@ -91,15 +92,15 @@ XYZ __cdecl principia__VesselNormal(Plugin const* const plugin,
   return m.Return(ToXYZ(plugin->VesselNormal(vessel_guid)));
 }
 
-void __cdecl principia__VesselRefreshAnalysis(Plugin* const plugin,
+void __cdecl principia__VesselRequestAnalysis(Plugin* const plugin,
                                               char const* const vessel_guid,
                                               double const mission_duration) {
-  journal::Method<journal::VesselRefreshAnalysis> m(
+  journal::Method<journal::VesselRequestAnalysis> m(
       {plugin, vessel_guid, mission_duration});
   CHECK_NOTNULL(plugin);
   Vessel& vessel = *plugin->GetVessel(vessel_guid);
   plugin->ClearOrbitAnalysersOfVesselsOtherThan(vessel);
-  vessel.RefreshOrbitAnalysis(mission_duration * Second);
+  vessel.RequestOrbitAnalysis(mission_duration * Second);
   return m.Return();
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -512,7 +512,7 @@ void Vessel::FillContainingPileUpsFromMessage(
   }
 }
 
-void Vessel::RefreshOrbitAnalysis(Time const& mission_duration) {
+void Vessel::RequestOrbitAnalysis(Time const& mission_duration) {
   if (!orbit_analyser_.has_value()) {
     // TODO(egg): perhaps we should get the history parameters from the plugin;
     // on the other hand, these are probably overkill for high orbits anyway,
@@ -530,7 +530,6 @@ void Vessel::RefreshOrbitAnalysis(Time const& mission_duration) {
       {.first_time = psychohistory_->back().time,
        .first_degrees_of_freedom = psychohistory_->back().degrees_of_freedom,
        .mission_duration = mission_duration});
-  orbit_analyser_->RefreshAnalysis();
 }
 
 void Vessel::ClearOrbitAnalyser() {
@@ -544,8 +543,14 @@ double Vessel::progress_of_orbit_analysis() const {
   return orbit_analyser_->progress_of_next_analysis();
 }
 
+void Vessel::RefreshOrbitAnalysis() {
+  if (orbit_analyser_.has_value()) {
+    orbit_analyser_->RefreshAnalysis();
+  }
+}
+
 OrbitAnalyser::Analysis* Vessel::orbit_analysis() {
-  return orbit_analyser_->analysis();
+  return orbit_analyser_.has_value() ? orbit_analyser_->analysis() : nullptr;
 }
 
 void Vessel::MakeAsynchronous() {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -190,10 +190,11 @@ class Vessel {
       PileUp::PileUpForSerializationIndex const&
           pile_up_for_serialization_index);
 
-  void RefreshOrbitAnalysis(Time const& mission_duration);
+  void RequestOrbitAnalysis(Time const& mission_duration);
   void ClearOrbitAnalyser();
 
   double progress_of_orbit_analysis() const;
+  void RefreshOrbitAnalysis();
   OrbitAnalyser::Analysis* orbit_analysis();
 
   static void MakeAsynchronous();

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -156,7 +156,7 @@ internal class OrbitAnalyser : VesselSupervisedWindowRenderer {
         // Keep refreshing the analysis (albeit at a reduced rate) even when the
         // analyser is not shown, so that the analysis button can display an
         // up-to-date one-line summary.
-        plugin.VesselRefreshAnalysis(vessel_guid, mission_duration_.value);
+        plugin.VesselRequestAnalysis(vessel_guid, mission_duration_.value);
       }
       OrbitAnalysis analysis = plugin.VesselGetAnalysis(
           vessel_guid,

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -2271,9 +2271,9 @@ message VesselNormal {
   optional Return return = 3;
 }
 
-message VesselRefreshAnalysis {
+message VesselRequestAnalysis {
   extend Method {
-    optional VesselRefreshAnalysis extension = 5160;
+    optional VesselRequestAnalysis extension = 5160;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin",


### PR DESCRIPTION
The call to refresh went to the wrong place when the two were split in #2839.
Rename the interface function accordingly.