### PR TITLE
KSP 1.11.0, and an ancient bug

### DIFF
--- a/ksp_plugin_adapter/gl_lines.cs
+++ b/ksp_plugin_adapter/gl_lines.cs
@@ -149,7 +149,7 @@ internal static class GLLines {
     get {
       if (line_material_ == null) {
         line_material_ = new UnityEngine.Material(
-#if KSP_VERSION_1_10_1
+#if KSP_VERSION_1_11_0
             UnityEngine.Shader.Find("KSP/Particles/Additive"));
 #elif KSP_VERSION_1_7_3
             UnityEngine.Shader.Find("Particles/Additive"));

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1082,7 +1082,8 @@ public partial class PrincipiaPluginAdapter
     double Δt = Planetarium.TimeScale * Planetarium.fetch.fixedDeltaTime;
 
     QP main_body_degrees_of_freedom =
-        new QP{q = (XYZ)((FlightGlobals.currentMainBody ?? FlightGlobals.GetHomeBody()).position +
+        new QP{q = (XYZ)((FlightGlobals.currentMainBody ??
+                          FlightGlobals.GetHomeBody()).position +
                          Δt * krakensbane.FrameVel),
                p = (XYZ)(-krakensbane.FrameVel)};
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -281,12 +281,13 @@ public partial class PrincipiaPluginAdapter
           "error; it might get damaged.";
       bad_installation_dialog_.Show();
     }
-#if KSP_VERSION_1_10_1
+#if KSP_VERSION_1_11_0
     if (!(Versioning.version_major == 1 &&
           (Versioning.version_minor == 8 && Versioning.Revision == 1) ||
           (Versioning.version_minor == 9 && Versioning.Revision == 1) ||
-          (Versioning.version_minor == 10 && Versioning.Revision == 1))) {
-      string expected_version = "1.8.1, 1.9.1 and 1.10.1";
+          (Versioning.version_minor == 10 && Versioning.Revision == 1) ||
+          (Versioning.version_minor == 11 && Versioning.Revision == 0))) {
+      string expected_version = "1.8.1, 1.9.1, 1.10.1, and 1.11.0";
 #elif KSP_VERSION_1_7_3
     if (!(Versioning.version_major == 1 &&
           (Versioning.version_minor == 5 && Versioning.Revision == 1) ||
@@ -1081,8 +1082,8 @@ public partial class PrincipiaPluginAdapter
     double Δt = Planetarium.TimeScale * Planetarium.fetch.fixedDeltaTime;
 
     QP main_body_degrees_of_freedom =
-        new QP{q = (XYZ)(FlightGlobals.currentMainBody ??
-                             FlightGlobals.GetHomeBody()).position,
+        new QP{q = (XYZ)((FlightGlobals.currentMainBody ?? FlightGlobals.GetHomeBody()).position +
+                         Δt * krakensbane.FrameVel),
                p = (XYZ)(-krakensbane.FrameVel)};
 
     // NOTE(egg): Inserting vessels and parts has to occur in

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Debug\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_10_1</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;KSP_VERSION_1_11_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
@@ -28,7 +28,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Release\GameData\Principia\</OutputPath>
-    <DefineConstants>TRACE;KSP_VERSION_1_10_1</DefineConstants>
+    <DefineConstants>TRACE;KSP_VERSION_1_11_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
@@ -65,40 +65,40 @@
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Release' Or '$(Configuration)' == 'Debug'">
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\KSP Assemblies\1.10.1\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\KSP Assemblies\1.10.1\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\KSP Assemblies\1.11.0\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
It looks like the « ex nihilo » path had a bug. Previously, this path only was only taken when Principia took control of a new vessel:
- on liftoff this happens with vanishing krakensbane;
- for EVA kerbals the mass of the kerbal was probably too small for the displacement of the vessel to be noticeable—and Kerbals have their own weirdnesses when spawning anyway.

The new welding mechanic creates parts ex nihilo, including fairly heavy ones, so this is far more visible.

This may explain the « teleportation » aspect in https://github.com/mockingbirdnest/Principia/issues/2590#issuecomment-639648219:
> the position provided by KSP […] may differ significantly from the "real" one

It probably differed because it was misinterpreted: KSP should largely be consistent with us over small time spans.