### PR TITLE
Check that the version of the binary matches that of the journal

### DIFF
--- a/journal/player.hpp
+++ b/journal/player.hpp
@@ -8,6 +8,8 @@
 
 #include "serialization/journal.pb.h"
 
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
+
 namespace principia {
 namespace journal {
 

--- a/journal/player.hpp
+++ b/journal/player.hpp
@@ -8,7 +8,7 @@
 
 #include "serialization/journal.pb.h"
 
-#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 0
 
 namespace principia {
 namespace journal {


### PR DESCRIPTION
The referenced bug was a pilot error: I was replaying with Germain (at head, really) a journal created with Гельфонд.  Confusion ensued.  I am adding a check to help me next time this happens.

As part of investigating this I realized that the calls to `SerializePlugin` that happen when replaying may not match those of the journal, presumably because the state of the plugin is different from that at the time of journaling.  This manifests itself as mismatching `DeleteString` not finding a pointer in the map.  I presume that this happens because differences in floating point computations lead to differences e.g., in the size of trajectories.  This is unfortunate, but hard to fix.

Fix #2863.