### PR TITLE
Fix some untranslated strings

### DIFF
--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -64,6 +64,7 @@ Localization {
 
 
     // OrbitAnalyser
+    #Principia_OrbitAnalyser_Precesses = (precesses)
     #Principia_OrbitAnalyser_Title = Orbit analysis
     #Principia_OrbitAnalyser_Duration_GroundTrackCycles = \u0020(<<1>> ground track cycles)  // <<1>> ground_track_cycles.FormatN(0)
     #Principia_OrbitAnalyser_Duration_Revolutions = <<1>> sidereal revolutions\n<<2>> nodal revolutions<<3>>\n<<4>> anomalistic revolutions  // <<3>> duration_in_ground_track_cycles

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -65,6 +65,7 @@ Localization {
 
 
     // OrbitAnalyser
+    #Principia_OrbitAnalyser_Precesses = （进动）
     #Principia_OrbitAnalyser_Title = 轨道分析器
     #Principia_OrbitAnalyser_Duration_GroundTrackCycles = （<<1>>地面周期）  // <<1>> ground_track_cycles.FormatN(0)
     // See below for the sources for the terms for the various kinds of periods.

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -222,12 +222,12 @@ Localization {
     // TODO(phl): Missing localization here.
     #Principia_MapNode_Planned = Planned
     #Principia_MapNode_Predicted = Predicted
-    #Principia_MapNode_Periapsis = Periapsis
-    #Principia_MapNode_Apoapsis = Apoapsis
+    #Principia_MapNode_Periapsis = 近地点
+    #Principia_MapNode_Apoapsis = 远地点
     #Principia_MapNode_ApsisHeader = <<1>> <<2>> <<3>> :\n<<4>> m  // <<1>>: source; <<2>>: celestial_name; <<3>>: apsis_name; <<4>>: celestial.GetAltitude(position).FormatN(0).
     #Principia_MapNode_ApsisCaptionLine2 = <<1>> m/s  // <<1>>: speed.FormatN(0).
-    #Principia_MapNode_AscendingNode = Ascending Node
-    #Principia_MapNode_DescendingNode = Descending Node
+    #Principia_MapNode_AscendingNode = 升交点
+    #Principia_MapNode_DescendingNode = 降交点
     #Principia_MapNode_NodeHeader = <<1>> <<2>> :\n<<3>>  // <<1>>: source; <<2>>: node_name; <<3>>: plane.
     #Principia_MapNode_NodeCaptionLine2 = <<1>> m/s  // <<1>>: properties.velocity.z.FormatN(0)
     #Principia_MapNode_ApproachHeader = <<1>> Target Approach : <<2>> m  // <<1>>: source, <<2>>: separation.FormatN(0).

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -87,7 +87,7 @@ internal static class Formatters {
     CelestialBody primary) {
     double half_width_angle = (interval.max - interval.min) / 2;
     if (half_width_angle > Math.PI) {
-      return "(precesses)";
+      return Localizer.Format("#Principia_OrbitAnalyser_Precesses");
     }
     double half_width_distance = half_width_angle * primary.Radius;
     string formatted_distance = half_width_distance > 1000

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -60,7 +60,7 @@ internal static class Formatters {
     double half_width = (interval.max - interval.min) / 2;
     double midpoint = interval.min + half_width;
     if (half_width > Math.PI) {
-      return "(precesses)";
+      return Localizer.Format("#Principia_OrbitAnalyser_Precesses");
     }
     const double degree = Math.PI / 180;
     int fractional_digits =
@@ -87,7 +87,6 @@ internal static class Formatters {
     CelestialBody primary) {
     double half_width_angle = (interval.max - interval.min) / 2;
     if (half_width_angle > Math.PI) {
-      // TODO(egg): Translate.
       return "(precesses)";
     }
     double half_width_distance = half_width_angle * primary.Radius;


### PR DESCRIPTION
Add the hardcoded `(precesses)` to the localization files; translate some terms whose translation is easy.

Some untranslated strings remain, but those will have to wait until Goldbach.