### PR TITLE
Correctly compute the lever arm when there is a CoM offset.

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -226,7 +226,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
         Part.ForceHolder holder) {
       return new PartCentredForceHolder{
           force_in_world_coordinates_ = holder.force,
-          lever_arm_in_world_coordinates_ = holder.pos - part.rb.position
+          lever_arm_in_world_coordinates_ = holder.pos - part.rb.worldCenterOfMass
       };
     }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -226,7 +226,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
         Part.ForceHolder holder) {
       return new PartCentredForceHolder{
           force_in_world_coordinates_ = holder.force,
-          lever_arm_in_world_coordinates_ = holder.pos - part.rb.worldCenterOfMass
+          lever_arm_in_world_coordinates_ =
+              holder.pos - part.rb.worldCenterOfMass
       };
     }
 


### PR DESCRIPTION
Fix #2808.

This was missed in #2604, when addressing #2560.