### PR TITLE
Number manœuvres idiomatically, tweak time-related words

### DIFF
--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -156,13 +156,13 @@ Localization {
     #Principia_FlightPlan_TotalΔv = 共计 Δv：<<1>> m/s  // <<1>>: Δv.ToString("0.000").
     #Principia_FlightPlan_Delete = 删除当前计划
     #Principia_FlightPlan_Rebase = 变基
-    #Principia_FlightPlan_ManœuvreHeader = 轨道机动 #<<1>>
-    #Principia_FlightPlan_UpcomingManœuvre = 即將执行轨道机动 #<<1>>：
+    #Principia_FlightPlan_ManœuvreHeader = 第<<1>>轨道机动
+    #Principia_FlightPlan_UpcomingManœuvre = 即將执行第<<1>>轨道机动：
     #Principia_FlightPlan_IgnitionCountdown = 至点火时间 <<1>>
-    #Principia_FlightPlan_OngoingManœuvre = 进行中的轨道机动 #<<1>>：
+    #Principia_FlightPlan_OngoingManœuvre = 进行中的第<<1>>轨道机动：
     #Principia_FlightPlan_CutoffCountdown = 至关机时间 <<1>>
     #Principia_FlightPlan_ShowManœuvreOnNavball = 在导航球上显示
-    #Principia_FlightPlan_WarpToManœuvre = 加速至轨道机动起点
+    #Principia_FlightPlan_WarpToManœuvre = 时间加速至轨道机动开始时刻  // TODO(egg): if this does not fit, drop the leading two characters.
     #Principia_FlightPlan_Warning_AllManœuvresInThePast = 所有轨道机动已完成
     #Principia_FlightPlan_Coast = 停泊等待时间为 <<1>>  // <<1>> coast_duration
     #Principia_FlightPlan_CoastInOrbit = 停泊于 <<1>> 还需等待 <<2>>
@@ -174,21 +174,21 @@ Localization {
     #Principia_FlightPlan_StatusMessage_MaxSegment = 请增加“最大迭代步长”或避免与天体碰撞
     #Principia_FlightPlan_StatusMessage_Singularity = 积分器遇到奇点（可能是天体的中心）<<1>>  // <<1>> timeout
     #Principia_FlightPlan_StatusMessage_AvoidingCollision = 请避免与天体的碰撞
-    #Principia_FlightPlan_StatusMessage_Infinite = 轨道机动 #<<1>> 会产生无限或不确定的速度  // <<1>> Error Manœuvre
-    #Principia_FlightPlan_StatusMessage_Adjust = 调整轨道机动的持续时间 #<<1>>  // <<1>> Error Manœuvre
-    #Principia_FlightPlan_StatusMessage_OutRange1 = 轨道机动 #<<1>> 与 <<2>> 重叠 或者 <<3>>  // TODO(phl): Added <<3>> at a random place.
+    #Principia_FlightPlan_StatusMessage_Infinite = 第<<1>>轨道机动 会产生无限或不确定的速度  // <<1>> Error Manœuvre
+    #Principia_FlightPlan_StatusMessage_Adjust = 调整第<<1>>轨道机动的持续时间  // <<1>> Error Manœuvre
+    #Principia_FlightPlan_StatusMessage_OutRange1 = 第<<1>>轨道机动 与 <<2>> 重叠 或者 <<3>>  // TODO(phl): Added <<3>> at a random place.
     #Principia_FlightPlan_StatusMessage_OutRange2 = 轨道规划的开始
-    #Principia_FlightPlan_StatusMessage_OutRange3 = 轨道机动 #<<1>>
+    #Principia_FlightPlan_StatusMessage_OutRange3 = 第<<1>>轨道机动
     #Principia_FlightPlan_StatusMessage_OutRange4 = 轨道规划的最终
-    #Principia_FlightPlan_StatusMessage_OutRange5 = 轨道机动 #<<1>>
-    #Principia_FlightPlan_StatusMessage_OutRange6 = <<1>>调整轨道机动的初始时间或者持续时间 #<<2>>
+    #Principia_FlightPlan_StatusMessage_OutRange5 = 第<<1>>轨道机动
+    #Principia_FlightPlan_StatusMessage_OutRange6 = <<1>>调整第<<2>>轨道机动的初始时间或者持续时间
     #Principia_FlightPlan_StatusMessage_OutRange7 = 延长轨道规划时间或
     #Principia_FlightPlan_StatusMessage_TooShort = 轨道规划时间太短
     #Principia_FlightPlan_StatusMessage_Increase = 增加轨道规划步长
     #Principia_FlightPlan_StatusMessage_CantRebase = 在执行轨道机动期间无法重置轨道规划
     #Principia_FlightPlan_StatusMessage_WaitFinish = 移动轨道机动位置或等待机动完成
     #Principia_FlightPlan_StatusMessage_Last = 无法绘制最后一个轨道机动<<1>>，因为<<2>>；请尝试<<3>><<4>>。  // <<1>>: anomalous_manœuvres; <<2>>: status_message; <<3>>: remedy_message; <<4>>: #Principia_FlightPlan_StatusMessage_Last2.
-    #Principia_FlightPlan_StatusMessage_Last2 = 或者调节轨道机动#<<1>>
+    #Principia_FlightPlan_StatusMessage_Last2 = 或者调节第<<1>>轨道机动
     #Principia_FlightPlan_StatusMessage_Result = <<1>>；<<2>>。
 
     // BurnEditor
@@ -205,8 +205,8 @@ Localization {
     #Principia_BurnEditor_ActiveRCS = 模拟RCS推力
     #Principia_BurnEditor_InstantImpulse = 模拟瞬间冲量
     #Principia_BurnEditor_InertiallyFixed = 固定方向（自旋稳定）
-    #Principia_BurnEditor_TimeBase_StartOfFlightPlan = 时基：轨道规划开始
-    #Principia_BurnEditor_TimeBase_EndOfManœuvre = 时基：轨道机动终点 #<<1>>  // <<1>> index
+    #Principia_BurnEditor_TimeBase_StartOfFlightPlan = 计时起点：轨道规划开始
+    #Principia_BurnEditor_TimeBase_EndOfManœuvre = 计时起点：第<<1>>轨道机动结束时刻  // <<1>> index
     #Principia_BurnEditor_Δv = 轨道机动Δv：<<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = 持续时间：<<1>> s  // <<1>>: duration_.ToString("0.0").
     #Principia_BurnEditor_Warning_NoActiveEngines = 没用启用的引擎，自动切换为RCS模拟模式。

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -162,7 +162,7 @@ Localization {
     #Principia_FlightPlan_OngoingManœuvre = 进行中的第<<1>>轨道机动：
     #Principia_FlightPlan_CutoffCountdown = 至关机时间 <<1>>
     #Principia_FlightPlan_ShowManœuvreOnNavball = 在导航球上显示
-    #Principia_FlightPlan_WarpToManœuvre = 时间加速至轨道机动开始时刻  // TODO(egg): if this does not fit, drop the leading two characters.
+    #Principia_FlightPlan_WarpToManœuvre = 时间加速至轨道机动开始时刻
     #Principia_FlightPlan_Warning_AllManœuvresInThePast = 所有轨道机动已完成
     #Principia_FlightPlan_Coast = 停泊等待时间为 <<1>>  // <<1>> coast_duration
     #Principia_FlightPlan_CoastInOrbit = 停泊于 <<1>> 还需等待 <<2>>

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -156,10 +156,10 @@ Localization {
     #Principia_FlightPlan_TotalΔv = 共计 Δv：<<1>> m/s  // <<1>>: Δv.ToString("0.000").
     #Principia_FlightPlan_Delete = 删除当前计划
     #Principia_FlightPlan_Rebase = 变基
-    #Principia_FlightPlan_ManœuvreHeader = 第<<1>>轨道机动
-    #Principia_FlightPlan_UpcomingManœuvre = 即將执行第<<1>>轨道机动：
+    #Principia_FlightPlan_ManœuvreHeader = 第<<1>>次轨道机动
+    #Principia_FlightPlan_UpcomingManœuvre = 即將执行第<<1>>次轨道机动：
     #Principia_FlightPlan_IgnitionCountdown = 至点火时间 <<1>>
-    #Principia_FlightPlan_OngoingManœuvre = 进行中的第<<1>>轨道机动：
+    #Principia_FlightPlan_OngoingManœuvre = 进行中的第<<1>>次轨道机动：
     #Principia_FlightPlan_CutoffCountdown = 至关机时间 <<1>>
     #Principia_FlightPlan_ShowManœuvreOnNavball = 在导航球上显示
     #Principia_FlightPlan_WarpToManœuvre = 时间加速至轨道机动开始时刻
@@ -174,21 +174,21 @@ Localization {
     #Principia_FlightPlan_StatusMessage_MaxSegment = 请增加“最大迭代步长”或避免与天体碰撞
     #Principia_FlightPlan_StatusMessage_Singularity = 积分器遇到奇点（可能是天体的中心）<<1>>  // <<1>> timeout
     #Principia_FlightPlan_StatusMessage_AvoidingCollision = 请避免与天体的碰撞
-    #Principia_FlightPlan_StatusMessage_Infinite = 第<<1>>轨道机动 会产生无限或不确定的速度  // <<1>> Error Manœuvre
-    #Principia_FlightPlan_StatusMessage_Adjust = 调整第<<1>>轨道机动的持续时间  // <<1>> Error Manœuvre
-    #Principia_FlightPlan_StatusMessage_OutRange1 = 第<<1>>轨道机动 与 <<2>> 重叠 或者 <<3>>  // TODO(phl): Added <<3>> at a random place.
+    #Principia_FlightPlan_StatusMessage_Infinite = 第<<1>>次轨道机动 会产生无限或不确定的速度  // <<1>> Error Manœuvre
+    #Principia_FlightPlan_StatusMessage_Adjust = 调整第<<1>>次轨道机动的持续时间  // <<1>> Error Manœuvre
+    #Principia_FlightPlan_StatusMessage_OutRange1 = 第<<1>>次轨道机动 与 <<2>> 重叠 或者 <<3>>  // TODO(phl): Added <<3>> at a random place.
     #Principia_FlightPlan_StatusMessage_OutRange2 = 轨道规划的开始
-    #Principia_FlightPlan_StatusMessage_OutRange3 = 第<<1>>轨道机动
+    #Principia_FlightPlan_StatusMessage_OutRange3 = 第<<1>>次轨道机动
     #Principia_FlightPlan_StatusMessage_OutRange4 = 轨道规划的最终
-    #Principia_FlightPlan_StatusMessage_OutRange5 = 第<<1>>轨道机动
-    #Principia_FlightPlan_StatusMessage_OutRange6 = <<1>>调整第<<2>>轨道机动的初始时间或者持续时间
+    #Principia_FlightPlan_StatusMessage_OutRange5 = 第<<1>>次轨道机动
+    #Principia_FlightPlan_StatusMessage_OutRange6 = <<1>>调整第<<2>>次轨道机动的初始时间或者持续时间
     #Principia_FlightPlan_StatusMessage_OutRange7 = 延长轨道规划时间或
     #Principia_FlightPlan_StatusMessage_TooShort = 轨道规划时间太短
     #Principia_FlightPlan_StatusMessage_Increase = 增加轨道规划步长
     #Principia_FlightPlan_StatusMessage_CantRebase = 在执行轨道机动期间无法重置轨道规划
     #Principia_FlightPlan_StatusMessage_WaitFinish = 移动轨道机动位置或等待机动完成
     #Principia_FlightPlan_StatusMessage_Last = 无法绘制最后一个轨道机动<<1>>，因为<<2>>；请尝试<<3>><<4>>。  // <<1>>: anomalous_manœuvres; <<2>>: status_message; <<3>>: remedy_message; <<4>>: #Principia_FlightPlan_StatusMessage_Last2.
-    #Principia_FlightPlan_StatusMessage_Last2 = 或者调节第<<1>>轨道机动
+    #Principia_FlightPlan_StatusMessage_Last2 = 或者调节第<<1>>次轨道机动
     #Principia_FlightPlan_StatusMessage_Result = <<1>>；<<2>>。
 
     // BurnEditor
@@ -206,7 +206,7 @@ Localization {
     #Principia_BurnEditor_InstantImpulse = 模拟瞬间冲量
     #Principia_BurnEditor_InertiallyFixed = 固定方向（自旋稳定）
     #Principia_BurnEditor_TimeBase_StartOfFlightPlan = 计时起点：轨道规划开始
-    #Principia_BurnEditor_TimeBase_EndOfManœuvre = 计时起点：第<<1>>轨道机动结束时刻  // <<1>> index
+    #Principia_BurnEditor_TimeBase_EndOfManœuvre = 计时起点：第<<1>>次轨道机动结束时刻  // <<1>> index
     #Principia_BurnEditor_Δv = 轨道机动Δv：<<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = 持续时间：<<1>> s  // <<1>>: duration_.ToString("0.0").
     #Principia_BurnEditor_Warning_NoActiveEngines = 没用启用的引擎，自动切换为RCS模拟模式。


### PR DESCRIPTION
As alluded to in #2890,
> Some day we may want to change `轨道机动 #𝑛` to `第𝑛次轨道机动` (I suspect this is currently messing with the word order when it comes to referring to the final time of a manœuvre), but this will have to come in a subsequent release.

Use ordinals (in the linguistic sense, _i.e._, « 𝑛th manœuvre », rather than cardinals as in « manœuvre number 𝑛 ») as they don’t require any particular logic in Chinese (contrary to [English -st -nd -rd -th](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#en)).

Reworded starting and ending point to starting and ending time when referring to times.

Reworded 加速 to 时间加速 for « [time] warp »; 加速 simply means « accelerate », which is a lot more overloaded here than the original « warp ». 加速至轨道机动起点 « accelerate until manœuvre starting point » could have led to confusion, for which
时间加速至轨道机动开始时刻 « accelerate time until manœuvre starting time » should leave no room.

As a result of the numbering and point-to-time changes `轨道机动终点 #<<1>>` becomes `第<<1>>次轨道机动结束时`.

@Zaikarion pointed out that the term 时基 « time base » does not mean what we want it to.
Admittedly it is dubious in English to start with, as we are lifting its meaning of « time zero » from some obscure Apollo-Saturn documents. 时基 only has the more common [electronics-related](https://en.wikipedia.org/wiki/Time_base_generator) sense of « time base ». @Zaikarion suggested 计时起点 « timing start point ».

Screenshot of the flight plan UI, with changes highlighted:
![image](https://user-images.githubusercontent.com/2284290/108448913-de7c9480-7262-11eb-9023-1af7631fa840.png)

