### PR TITLE
Prevent Vessel::RepeatedlyFlowPrognostication from bypassing sleep call.

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -577,9 +577,12 @@ void Vessel::StartPrognosticatorIfNeeded() {
 }
 
 Status Vessel::RepeatedlyFlowPrognostication() {
+  std::chrono::steady_clock::time_point wakeup_time =
+      std::chrono::steady_clock::now();
   for (;;) {
+    std::this_thread::sleep_until(wakeup_time);
     // No point in going faster than 50 Hz.
-    std::chrono::steady_clock::time_point const wakeup_time =
+    wakeup_time =
         std::chrono::steady_clock::now() + std::chrono::milliseconds(20);
 
     RETURN_IF_STOPPED;
@@ -607,8 +610,6 @@ Status Vessel::RepeatedlyFlowPrognostication() {
       absl::MutexLock l(&prognosticator_lock_);
       SwapPrognostication(prognostication, status);
     }
-
-    std::this_thread::sleep_until(wakeup_time);
   }
   return Status::OK;
 }

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -577,7 +577,7 @@ void Vessel::StartPrognosticatorIfNeeded() {
 }
 
 Status Vessel::RepeatedlyFlowPrognostication() {
-  for (auto wakeup_time = std::chrono::steady_clock::now();;
+  for (std::chrono::steady_clock::time_point wakeup_time;;
        std::this_thread::sleep_until(wakeup_time)) {
     // No point in going faster than 50 Hz.
     wakeup_time =

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -577,14 +577,10 @@ void Vessel::StartPrognosticatorIfNeeded() {
 }
 
 Status Vessel::RepeatedlyFlowPrognostication() {
-  std::chrono::steady_clock::time_point wakeup_time =
-      std::chrono::steady_clock::now();
-  for (;;) {
-    std::this_thread::sleep_until(wakeup_time);
-    // No point in going faster than 50 Hz.
-    wakeup_time =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(20);
-
+  // No point in going faster than 50 Hz.
+  for (auto wakeup_time = std::chrono::steady_clock::now();;
+       wakeup_time += std::chrono::milliseconds(20),
+            std::this_thread::sleep_until(wakeup_time)) {
     RETURN_IF_STOPPED;
 
     std::optional<PrognosticatorParameters> prognosticator_parameters;

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -577,10 +577,11 @@ void Vessel::StartPrognosticatorIfNeeded() {
 }
 
 Status Vessel::RepeatedlyFlowPrognostication() {
-  // No point in going faster than 50 Hz.
   for (auto wakeup_time = std::chrono::steady_clock::now();;
-       wakeup_time += std::chrono::milliseconds(20),
-            std::this_thread::sleep_until(wakeup_time)) {
+       std::this_thread::sleep_until(wakeup_time)) {
+    // No point in going faster than 50 Hz.
+    wakeup_time =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(20);
     RETURN_IF_STOPPED;
 
     std::optional<PrognosticatorParameters> prognosticator_parameters;


### PR DESCRIPTION
Previously, Vessel::RepeatedlyFlowPrognostication would loop without sleeping while prognosticator_parameters_ was empty (because the continue bypasses the std::this_thread::sleep_until call). This resulted in the thread spending 40% of its time calling std::chrono::steady_clock::now and another 20% dealing with the mutex (see attached screenshot).
![too_much_now](https://user-images.githubusercontent.com/71856888/108651906-a0a48980-7477-11eb-91f7-0d956c82e5d3.png)

This change moves the std::this_thread::sleep_until call to the beginning of the loop where it cannot be bypassed.
