### PR TITLE
Smart pointer with allocator support

### DIFF
--- a/base/box.hpp
+++ b/base/box.hpp
@@ -1,0 +1,184 @@
+// Allocator-based unique pointer implementation.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+namespace principia {
+namespace base {
+
+template <typename T, typename Allocator>
+class NullableBox;
+
+// Smart pointer that uses an allocator  (as opposed to a deleter like
+// unique_ptr does). The allocator has the same semantics as STL container
+// allocators.
+//
+// Can't be null unless moved out of (same semantics as base::not_null). Do not
+// use moved-from objects.
+template <typename T, typename Allocator = std::allocator<T>>
+class Box final {
+ public:
+  using pointer = T*;
+  using element_type = T;
+  using allocator_type = Allocator;
+  using allocator_traits = std::allocator_traits<Allocator>;
+
+  // Allocates memory but does not initialize the memory. Dangerous! Used with
+  // private T constructors.
+  static Box<T, Allocator> UnsafeMakeUninitialized();
+
+  // Constructs a Box from a NullableBox. CHECK-fails if null.
+  static Box<T, Allocator> FromNullableChecked(
+      NullableBox<T, Allocator>&& nullable);
+
+  // Primary constructor. Forwards arguments to T's constructor.
+  template <typename... Args>
+  explicit Box(Args&&... args);
+
+  // Move constructor. Nullifies |other|!
+  Box(Box&& other);
+
+  // Templated move constructor. Useful for upcasting.
+  //
+  // Only allowed when U* is implicitly convertible to T* and when the
+  // allocators are compatible.
+  template <typename U, typename E>
+  Box(Box<U, E>&& other);
+
+  // Move assignment operator. Equivalent to swap(|other|).
+  Box& operator=(Box&& other);
+
+  // Consumes this object and covnerts it into a NullableBox.
+  NullableBox<T, Allocator> IntoNullable() &&;
+
+  // Swaps with |other|.
+  void swap(Box& other);
+
+  // Returns a pointer to the managed object.
+  T* get() const;
+
+  // Dereferences pointer to the managed object.
+  typename std::add_lvalue_reference<T>::type operator*() const;
+  T* operator->() const;
+
+  // Equality.
+  bool operator==(T* other) const;
+  bool operator==(Box const& other) const;
+  bool operator!=(T* other) const;
+  bool operator!=(Box const& other) const;
+
+  // Ordering.
+  bool operator<(Box const& other) const;
+  bool operator<=(Box const& other) const;
+  bool operator>=(Box const& other) const;
+  bool operator>(Box const& other) const;
+
+ private:
+  struct UninitTag {};
+  struct NullTag {};
+  explicit Box(UninitTag);
+  explicit Box(NullTag);
+
+  // Invariant: not null.
+  NullableBox<T, Allocator> box_;
+
+  template <typename U, typename E>
+  friend class Box;
+};
+
+template <typename T, typename Allocator = std::allocator<T>>
+class NullableBox final {
+ public:
+  using pointer = T*;
+  using element_type = T;
+  using allocator_type = Allocator;
+  using allocator_traits = std::allocator_traits<Allocator>;
+
+  // Constraints on Allocator type.
+  static_assert(allocator_traits::is_always_equal::value,
+                "Allocator must be stateless");
+  static_assert(
+      std::is_same<typename allocator_traits::pointer, pointer>::value,
+      "Allocator pointer type must match");
+
+  // Construct a NullableBox from a Box by throwing away non-null guarantee.
+  NullableBox(Box<T>&& box);
+
+  // Construct a NullableBox from nullptr.
+  NullableBox(std::nullptr_t);
+
+  // Move constructor. Nullifies |other|.
+  NullableBox(NullableBox&& other);
+
+  // Templated move constructor. Useful for upcasting.
+  //
+  // Only allowed when U* is implicitly convertible to T* and when the
+  // allocators are compatible.
+  template <
+      typename U, typename E,
+      typename = typename std::enable_if<std::is_same<
+          typename allocator_traits::template rebind_alloc<U>, E>::value>::type>
+  NullableBox(NullableBox<U, E>&& other);
+
+  // Move assignment operator. Equivalent to swap(|other|).
+  NullableBox& operator=(NullableBox&& other);
+
+  // This is a move-only type.
+  NullableBox(NullableBox const& other) = delete;
+  NullableBox& operator=(NullableBox const& other) = delete;
+
+  // Destructor.
+  ~NullableBox();
+
+  // Consumes this object and convert it into a Box. CHECK-fails if null.
+  Box<T, Allocator> AssertNotNull() &&;
+
+  // Swaps with |other|.
+  void swap(NullableBox& other);
+
+  // Returns a pointer to the managed object.
+  T* get() const;
+
+  // Dereferences pointer to the managed object.
+  typename std::add_lvalue_reference<T>::type operator*() const;
+  T* operator->() const;
+
+  // Equality.
+  bool operator==(T* other) const;
+  bool operator==(NullableBox const& other) const;
+  bool operator!=(T* other) const;
+  bool operator!=(NullableBox const& other) const;
+
+  // Ordering.
+  bool operator<(NullableBox const& other) const;
+  bool operator<=(NullableBox const& other) const;
+  bool operator>=(NullableBox const& other) const;
+  bool operator>(NullableBox const& other) const;
+
+ private:
+  // Allocates a T without constructing it.
+  explicit NullableBox();
+
+  // Invariant: ptr_ was allocated with Allocator or is null.
+  T* ptr_;
+
+  template <typename U, typename E>
+  friend class NullableBox;
+
+  template <typename U, typename E>
+  friend class Box;
+};
+
+template <typename T, typename Allocator>
+void swap(Box<T, Allocator>& lhs, Box<T, Allocator>& rhs);
+
+template <typename T, typename Allocator>
+void swap(NullableBox<T, Allocator>& lhs, NullableBox<T, Allocator>& rhs);
+
+}  // namespace base
+}  // namespace principia
+
+#include "base/box_body.hpp"

--- a/base/box_body.hpp
+++ b/base/box_body.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+#include "glog/logging.h"
+
+namespace principia {
+namespace base {
+
+template <typename T, typename Allocator>
+Box<T, Allocator> Box<T, Allocator>::UnsafeMakeUninitialized() {
+  return Box<T, Allocator>(UninitTag());
+}
+
+template <typename T, typename Allocator>
+Box<T, Allocator> Box<T, Allocator>::FromNullableChecked(
+    NullableBox<T, Allocator>&& nullable) {
+  CHECK(nullable.get() != nullptr);
+  Box<T, Allocator> box{NullTag()};
+  box.box_.swap(nullable);
+  return box;
+}
+
+template <typename T, typename Allocator>
+template <typename... Args>
+Box<T, Allocator>::Box(Args&&... args) : box_() {
+  Allocator alloc;
+  allocator_traits::construct(alloc, box_.get(), std::forward<Args>(args)...);
+}
+
+template <typename T, typename Allocator>
+Box<T, Allocator>::Box(Box&& other) : box_(std::move(other.box_)) {}
+
+template <typename T, typename Allocator>
+template <typename U, typename E>
+Box<T, Allocator>::Box(Box<U, E>&& other) : box_(std::move(other.box_)) {}
+
+template <typename T, typename Allocator>
+Box<T, Allocator>::Box(Box<T, Allocator>::UninitTag) : box_() {}
+
+template <typename T, typename Allocator>
+Box<T, Allocator>::Box(Box<T, Allocator>::NullTag) : box_(nullptr) {}
+
+template <typename T, typename Allocator>
+Box<T, Allocator>& Box<T, Allocator>::operator=(Box<T, Allocator>&& other) {
+  box_.swap(other.box_);
+  return *this;
+}
+template <typename T, typename Allocator>
+NullableBox<T, Allocator> Box<T, Allocator>::IntoNullable() && {
+  return std::move(box_);
+}
+
+template <typename T, typename Allocator>
+void Box<T, Allocator>::swap(Box& other) {
+  box_.swap(other.box_);
+}
+
+template <typename T, typename Allocator>
+T* Box<T, Allocator>::get() const {
+  return box_.get();
+}
+
+template <typename T, typename Allocator>
+typename std::add_lvalue_reference<T>::type Box<T, Allocator>::operator*()
+    const {
+  return *box_;
+}
+template <typename T, typename Allocator>
+T* Box<T, Allocator>::operator->() const {
+  return box_.operator->();
+}
+
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator==(T* other) const {
+  return box_ == other;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator==(Box const& other) const {
+  return box_ == other.box_;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator!=(T* other) const {
+  return box_ != other;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator!=(Box const& other) const {
+  return box_ != other.box_;
+}
+
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator<(Box const& other) const {
+  return box_ < other.box_;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator<=(Box const& other) const {
+  return box_ <= other.box_;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator>=(Box const& other) const {
+  return box_ >= other.box_;
+}
+template <typename T, typename Allocator>
+bool Box<T, Allocator>::operator>(Box const& other) const {
+  return box_ > other.box_;
+}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>::NullableBox(Box<T>&& box) : ptr_(nullptr) {
+  *this = std::move(box).IntoNullable();
+}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>::NullableBox(std::nullptr_t) : ptr_(nullptr) {}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>::NullableBox(NullableBox&& other) : ptr_(nullptr) {
+  swap(other);
+}
+
+template <typename T, typename Allocator>
+template <typename U, typename E, typename>
+NullableBox<T, Allocator>::NullableBox(NullableBox<U, E>&& other) {
+  ptr_ = other.ptr_;
+  other.ptr_ = nullptr;
+}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>::NullableBox() {
+  Allocator alloc;
+  ptr_ = allocator_traits::allocate(alloc, 1);
+}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>& NullableBox<T, Allocator>::operator=(
+    NullableBox<T, Allocator>&& other) {
+  this->swap(other);
+  return *this;
+}
+
+template <typename T, typename Allocator>
+NullableBox<T, Allocator>::~NullableBox() {
+  if (ptr_ != nullptr) {
+    Allocator alloc;
+    allocator_traits::destroy(alloc, ptr_);
+    allocator_traits::deallocate(alloc, ptr_, 1);
+  }
+}
+
+template <typename T, typename Allocator>
+
+Box<T, Allocator> NullableBox<T, Allocator>::AssertNotNull() && {
+  return Box<T, Allocator>::FromNullableChecked(std::move(*this));
+}
+
+template <typename T, typename Allocator>
+void NullableBox<T, Allocator>::swap(NullableBox& other) {
+  std::swap(ptr_, other.ptr_);
+}
+
+template <typename T, typename Allocator>
+T* NullableBox<T, Allocator>::get() const {
+  return ptr_;
+}
+
+template <typename T, typename Allocator>
+typename std::add_lvalue_reference<T>::type
+NullableBox<T, Allocator>::operator*() const {
+  return *ptr_;
+}
+template <typename T, typename Allocator>
+T* NullableBox<T, Allocator>::operator->() const {
+  return ptr_;
+}
+
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator==(T* other) const {
+  return ptr_ == other;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator==(NullableBox const& other) const {
+  return ptr_ == other.ptr_;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator!=(T* other) const {
+  return ptr_ != other;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator!=(NullableBox const& other) const {
+  return ptr_ != other.ptr_;
+}
+
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator<(NullableBox const& other) const {
+  return ptr_ < other.ptr_;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator<=(NullableBox const& other) const {
+  return ptr_ <= other.ptr_;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator>=(NullableBox const& other) const {
+  return ptr_ >= other.ptr_;
+}
+template <typename T, typename Allocator>
+bool NullableBox<T, Allocator>::operator>(NullableBox const& other) const {
+  return ptr_ > other.ptr_;
+}
+
+template <typename T, typename Allocator>
+void swap(Box<T, Allocator>& lhs, Box<T, Allocator>& rhs) {
+  lhs.swap(rhs);
+}
+
+template <typename T, typename Allocator>
+void swap(NullableBox<T, Allocator>& lhs, NullableBox<T, Allocator>& rhs) {
+  lhs.swap(rhs);
+}
+
+}  // namespace base
+}  // namespace principia

--- a/base/box_test.cpp
+++ b/base/box_test.cpp
@@ -1,0 +1,322 @@
+#include "base/box.hpp"
+
+#include <string>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace principia {
+namespace base {
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Not;
+using ::testing::NotNull;
+using ::testing::Pointee;
+
+// Class which counts how many times its constructor and destructor were called.
+class CtorDtorCounter {
+ public:
+  CtorDtorCounter(int& ctor_count, int& dtor_count) : dtor_count_(&dtor_count) {
+    ++ctor_count;
+  }
+
+  ~CtorDtorCounter() { ++*dtor_count_; }
+
+ private:
+  int* dtor_count_;
+};
+
+TEST(BoxTest, Lifecycle) {
+  int ctor_count = 0;
+  int dtor_count = 0;
+
+  {
+    Box<CtorDtorCounter> box(ctor_count, dtor_count);
+
+    EXPECT_EQ(ctor_count, 1);
+    EXPECT_EQ(dtor_count, 0);
+  }
+  EXPECT_EQ(ctor_count, 1);
+  EXPECT_EQ(dtor_count, 1);
+}
+
+TEST(BoxTest, UnsafeMakeUninitialized) {
+  int ctor_count = 0;
+  int dtor_count = 0;
+
+  {
+    Box<CtorDtorCounter> box = Box<CtorDtorCounter>::UnsafeMakeUninitialized();
+    EXPECT_EQ(ctor_count, 0);
+    EXPECT_EQ(dtor_count, 0);
+    new (box.get()) CtorDtorCounter(ctor_count, dtor_count);
+
+    EXPECT_EQ(ctor_count, 1);
+    EXPECT_EQ(dtor_count, 0);
+  }
+  EXPECT_EQ(ctor_count, 1);
+  EXPECT_EQ(dtor_count, 1);
+};
+
+TEST(BoxTest, FromNullableChecked) {
+  NullableBox<int> a = Box<int>(12345);
+  Box<int> b = Box<int>::FromNullableChecked(std::move(a));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(BoxDeathTest, FromNullableCheckFail) {
+  NullableBox<int> null_box = nullptr;
+  EXPECT_DEATH(Box<int>::FromNullableChecked(std::move(null_box)),
+               "!= nullptr");
+}
+
+TEST(BoxTest, MoveConstructor) {
+  Box<int> a(12345);
+  EXPECT_THAT(a, Pointee(12345));
+
+  Box<int> b(std::move(a));
+  EXPECT_THAT(b, Pointee(12345));
+  EXPECT_THAT(a, IsNull());
+}
+
+class FooClass {};
+class FooSubclass : public FooClass {};
+
+TEST(BoxTest, PointerCastConstructor) {
+  Box<FooSubclass> foo_sub;
+  FooClass* ptr = foo_sub.get();
+  Box<FooClass> foo(std::move(foo_sub));
+  EXPECT_EQ(foo.get(), ptr);
+}
+
+TEST(BoxTest, MoveAssignment) {
+  // Must be equivalent to swap.
+  Box<int> a(12345);
+  Box<int> b(0xabcde);
+
+  a = std::move(b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(BoxTest, IntoNullable) {
+  Box<int> a(12345);
+  NullableBox<int> b = std::move(a).IntoNullable();
+  EXPECT_THAT(a, IsNull());
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(BoxTest, Swap) {
+  Box<int> a(12345);
+  Box<int> b(0xabcde);
+
+  a.swap(b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(BoxTest, StdSwap) {
+  Box<int> a(12345);
+  Box<int> b(0xabcde);
+
+  using std::swap;
+  swap(a, b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(BoxTest, Dereference) {
+  Box<std::string> a("foo");
+  EXPECT_EQ(*a, "foo");
+  EXPECT_EQ(a->size(), 3);
+}
+
+TEST(BoxTest, Equality) {
+  Box<int> a(12345);
+  Box<int> b(0xabcde);
+
+  EXPECT_TRUE(a == a);
+  EXPECT_TRUE(b == b);
+  EXPECT_FALSE(a != a);
+  EXPECT_FALSE(b != b);
+
+  EXPECT_FALSE(a == b);
+  EXPECT_FALSE(b == a);
+  EXPECT_TRUE(a != b);
+  EXPECT_TRUE(b != a);
+
+  EXPECT_TRUE(a == a.get());
+  EXPECT_TRUE(a != b.get());
+  EXPECT_FALSE(a != a.get());
+  EXPECT_FALSE(a == b.get());
+}
+
+TEST(BoxTest, NullptrEquality) {
+  Box<int> a(12345);
+  EXPECT_TRUE(a != nullptr);
+  EXPECT_FALSE(a == nullptr);
+
+  // Move out of a. Now a is null.
+  Box<int>(std::move(a));
+
+  EXPECT_TRUE(a == nullptr);
+  EXPECT_FALSE(a != nullptr);
+}
+
+TEST(BoxTest, Ordering) {
+  Box<int> a(12345);
+  Box<int> b(0xabcde);
+
+  EXPECT_EQ(a < b, a.get() < b.get());
+  EXPECT_EQ(a > b, a.get() > b.get());
+  EXPECT_EQ(a <= b, a.get() < b.get());
+  EXPECT_EQ(a >= b, a.get() > b.get());
+  EXPECT_TRUE(a <= a);
+  EXPECT_TRUE(a >= a);
+}
+
+// Example of constructing a Box containing a type with a private constructor.
+
+struct PrivateCtor {
+ private:
+  explicit PrivateCtor(int i) : i(i) {}
+
+ public:
+  static Box<PrivateCtor> FactoryFn(int i) {
+    auto box = Box<PrivateCtor>::UnsafeMakeUninitialized();
+    new (box.get()) PrivateCtor(i);  // Placement new.
+    return box;
+  }
+
+  int i;
+};
+
+TEST(BoxTest, PrivateConstructor) {
+  Box<PrivateCtor> box = PrivateCtor::FactoryFn(2);
+  EXPECT_EQ(box->i, 2);
+}
+
+TEST(NullableBoxTest, FromBox) {
+  NullableBox<int> box = Box<int>(2);
+  EXPECT_THAT(box, Pointee(2));
+}
+
+TEST(NullableBoxTest, FromNullptr) {
+  NullableBox<int> box = nullptr;
+  EXPECT_THAT(box, IsNull());
+};
+
+TEST(NullableBoxTest, MoveConstructor) {
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b(std::move(a));
+  EXPECT_THAT(b, Pointee(12345));
+  EXPECT_THAT(a, IsNull());
+}
+
+TEST(NullableBoxTest, PointerCastConstructor) {
+  NullableBox<FooSubclass> foo_sub = Box<FooSubclass>();
+  FooClass* ptr = foo_sub.get();
+  NullableBox<FooClass> foo(std::move(foo_sub));
+  EXPECT_EQ(foo.get(), ptr);
+}
+
+TEST(NullableBoxTest, MoveAssignment) {
+  // Must be equivalent to swap.
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b = Box<int>(0xabcde);
+
+  a = std::move(b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(NullableBoxTest, IntoBoxChecked) {
+  NullableBox<int> a = Box<int>(12345);
+  Box<int> b = std::move(a).AssertNotNull();
+  EXPECT_THAT(a, IsNull());
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(NullableBoxDeathTest, IntoBoxCheckFail) {
+  NullableBox<int> null_box = nullptr;
+  EXPECT_DEATH(std::move(null_box).AssertNotNull(), "!= nullptr");
+}
+
+TEST(NullableBoxTest, Swap) {
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b = Box<int>(0xabcde);
+
+  a.swap(b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(NullableBoxTest, StdSwap) {
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b = Box<int>(0xabcde);
+
+  using std::swap;
+  swap(a, b);
+
+  EXPECT_THAT(a, Pointee(0xabcde));
+  EXPECT_THAT(b, Pointee(12345));
+}
+
+TEST(NullableBoxTest, Dereference) {
+  NullableBox<std::string> a = Box<std::string>("foo");
+  EXPECT_EQ(*a, "foo");
+  EXPECT_EQ(a->size(), 3);
+}
+
+TEST(NullableBoxTest, Equality) {
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b = Box<int>(0xabcde);
+
+  EXPECT_TRUE(a == a);
+  EXPECT_TRUE(b == b);
+  EXPECT_FALSE(a != a);
+  EXPECT_FALSE(b != b);
+
+  EXPECT_FALSE(a == b);
+  EXPECT_FALSE(b == a);
+  EXPECT_TRUE(a != b);
+  EXPECT_TRUE(b != a);
+
+  EXPECT_TRUE(a == a.get());
+  EXPECT_TRUE(a != b.get());
+  EXPECT_FALSE(a != a.get());
+  EXPECT_FALSE(a == b.get());
+}
+
+TEST(NullableBoxTest, NullptrEquality) {
+  NullableBox<int> a = Box<int>(12345);
+  EXPECT_TRUE(a != nullptr);
+  EXPECT_FALSE(a == nullptr);
+
+  // Move out of a. Now a is null.
+  NullableBox<int> b = nullptr;
+
+  EXPECT_TRUE(b == nullptr);
+  EXPECT_FALSE(b != nullptr);
+}
+
+TEST(NullableBoxTest, Ordering) {
+  NullableBox<int> a = Box<int>(12345);
+  NullableBox<int> b = Box<int>(0xabcde);
+
+  EXPECT_EQ(a < b, a.get() < b.get());
+  EXPECT_EQ(a > b, a.get() > b.get());
+  EXPECT_EQ(a <= b, a.get() < b.get());
+  EXPECT_EQ(a >= b, a.get() > b.get());
+  EXPECT_TRUE(a <= a);
+  EXPECT_TRUE(a >= a);
+}
+
+}  // namespace base
+}  // namespace principia

--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "astronomy/frames.hpp"
-#include "base/not_null.hpp"
+#include "base/box.hpp"
 #include "benchmark/benchmark.h"
 #include "geometry/named_quantities.hpp"
 #include "numerics/newhall.hpp"
@@ -18,7 +18,7 @@
 namespace principia {
 
 using astronomy::ICRS;
-using base::not_null;
+using base::Box;
 using geometry::Displacement;
 using geometry::Instant;
 using quantities::Variation;
@@ -95,9 +95,9 @@ void BM_NewhallApproximationDisplacement(benchmark::State& state) {
 using ResultЧебышёвDouble = ЧебышёвSeries<double>;
 using ResultЧебышёвDisplacement = ЧебышёвSeries<Displacement<ICRS>>;
 using ResultMonomialDouble =
-    not_null<std::unique_ptr<Polynomial<double, Instant>>>;
+    Box<Polynomial<double, Instant>>;
 using ResultMonomialDisplacement =
-    not_null<std::unique_ptr<Polynomial<Displacement<ICRS>, Instant>>>;
+    Box<Polynomial<Displacement<ICRS>, Instant>>;
 
 BENCHMARK_TEMPLATE(
     BM_NewhallApproximationDouble,

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/box.hpp"
 #include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
 #include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
 #include "integrators/methods.hpp"
@@ -16,6 +17,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_flight_plan {
 
+using base::Box;
 using base::Error;
 using base::make_not_null_unique;
 using base::Status;
@@ -141,7 +143,7 @@ void FlightPlan::ForgetBefore(Instant const& time,
 
   // Detach the first coast to keep, truncate its beginning, and reattach it
   // to a new root.
-  std::unique_ptr<DiscreteTrajectory<Barycentric>> new_first_coast =
+  Box<DiscreteTrajectory<Barycentric>> new_first_coast =
       segments_[*first_to_keep]->DetachFork();
   new_first_coast->ForgetBefore(time);
   root_ = make_not_null_unique<DiscreteTrajectory<Barycentric>>();

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -372,7 +372,7 @@ Part::Part(PartId const part_id,
       mass_(mass),
       inertia_tensor_(inertia_tensor),
       rigid_motion_(std::move(rigid_motion)),
-      prehistory_(make_not_null_unique<DiscreteTrajectory<Barycentric>>()),
+      prehistory_(Box<DiscreteTrajectory<Barycentric>>()),
       subset_node_(make_not_null_unique<Subset<Part>::Node>()),
       deletion_callback_(std::move(deletion_callback)) {
   prehistory_->Append(astronomy::InfinitePast,

--- a/ksp_plugin/part.hpp
+++ b/ksp_plugin/part.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "base/box.hpp"
 #include "base/disjoint_sets.hpp"
 #include "ksp_plugin/frames.hpp"
 #include "ksp_plugin/identification.hpp"
@@ -24,6 +25,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_part {
 
+using base::Box;
 using base::not_null;
 using base::Subset;
 using geometry::Bivector;
@@ -199,7 +201,7 @@ class Part final {
   // to make it convenient to hook the |psychohistory_| even if there is no
   // point in the |history_| (it's not possible to fork-at-last an empty root
   // trajectory, but it works for a non-root).
-  not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> prehistory_;
+  Box<DiscreteTrajectory<Barycentric>> prehistory_;
   // The |history_| is nearly always not null, except in some transient
   // situations.  It's a fork of the |prehistory_|.
   DiscreteTrajectory<Barycentric>* history_ = nullptr;

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/box.hpp"
 #include "base/map_util.hpp"
 #include "geometry/identity.hpp"
 #include "ksp_plugin/integrators.hpp"
@@ -18,6 +19,7 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_pile_up {
 
+using base::Box;
 using base::check_not_null;
 using base::FindOrDie;
 using base::make_not_null_unique;
@@ -76,7 +78,7 @@ PileUp::PileUp(
       ephemeris_(ephemeris),
       adaptive_step_parameters_(std::move(adaptive_step_parameters)),
       fixed_step_parameters_(std::move(fixed_step_parameters)),
-      history_(make_not_null_unique<DiscreteTrajectory<Barycentric>>()),
+      history_(Box<DiscreteTrajectory<Barycentric>>()),
       deletion_callback_(std::move(deletion_callback)) {
   LOG(INFO) << "Constructing pile up at " << this;
   MechanicalSystem<Barycentric, NonRotatingPileUp> mechanical_system;
@@ -259,7 +261,7 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
     }
   } else {
     DiscreteTrajectory<Barycentric>* psychohistory = nullptr;
-    not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history =
+    Box<DiscreteTrajectory<Barycentric>> history =
         DiscreteTrajectory<Barycentric>::ReadFromMessage(
             message.history(),
             /*forks=*/{&psychohistory});
@@ -356,7 +358,7 @@ PileUp::PileUp(
     std::list<not_null<Part*>>&& parts,
     Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters,
     Ephemeris<Barycentric>::FixedStepParameters fixed_step_parameters,
-    not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history,
+    Box<DiscreteTrajectory<Barycentric>> history,
     DiscreteTrajectory<Barycentric>* const psychohistory,
     Bivector<AngularMomentum, NonRotatingPileUp> const& angular_momentum,
     not_null<Ephemeris<Barycentric>*> const ephemeris,

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "absl/synchronization/mutex.h"
+#include "base/box.hpp"
 #include "base/not_null.hpp"
 #include "base/status.hpp"
 #include "geometry/frame.hpp"
@@ -34,6 +35,7 @@ FORWARD_DECLARE_FROM(part, class, Part);
 
 namespace internal_pile_up {
 
+using base::Box;
 using base::not_null;
 using base::Status;
 using geometry::Arbitrary;
@@ -150,7 +152,7 @@ class PileUp {
       std::list<not_null<Part*>>&& parts,
       Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters,
       Ephemeris<Barycentric>::FixedStepParameters fixed_step_parameters,
-      not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history,
+      Box<DiscreteTrajectory<Barycentric>> history,
       DiscreteTrajectory<Barycentric>* psychohistory,
       Bivector<AngularMomentum, NonRotatingPileUp> const& angular_momentum,
       not_null<Ephemeris<Barycentric>*> ephemeris,
@@ -205,7 +207,7 @@ class PileUp {
   // integrated with a fixed step using |fixed_instance_|, except in the
   // presence of intrinsic acceleration.  It is authoritative in the sense that
   // it is never going to change.
-  not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history_;
+  Box<DiscreteTrajectory<Barycentric>> history_;
 
   // The |psychohistory_| is the recent past trajectory of the pile-up.  Since
   // we need to draw something between the last point of the |history_| and the

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
+#include "base/box.hpp"
 #include "base/jthread.hpp"
 #include "base/status.hpp"
 #include "ksp_plugin/celestial.hpp"
@@ -26,6 +27,8 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_vessel {
 
+using base::Box;
+using base::NullableBox;
 using base::not_null;
 using base::Status;
 using geometry::Instant;
@@ -230,11 +233,11 @@ class Vessel {
   // parameters.
   Status FlowPrognostication(
       PrognosticatorParameters prognosticator_parameters,
-      std::unique_ptr<DiscreteTrajectory<Barycentric>>& prognostication);
+      NullableBox<DiscreteTrajectory<Barycentric>>& prognostication);
 
   // Publishes the prognostication if the computation was not cancelled.
   void SwapPrognostication(
-      std::unique_ptr<DiscreteTrajectory<Barycentric>>& prognostication,
+      NullableBox<DiscreteTrajectory<Barycentric>>& prognostication,
       Status const& status);
 
   // Appends to |trajectory| the centre of mass of the trajectories of the parts
@@ -247,7 +250,7 @@ class Vessel {
   // Attaches the given |trajectory| to the end of the |psychohistory_| to
   // become the new |prediction_|.
   void AttachPrediction(
-      not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> trajectory);
+      Box<DiscreteTrajectory<Barycentric>> trajectory);
 
   GUID const guid_;
   std::string name_;
@@ -272,7 +275,7 @@ class Vessel {
   base::jthread prognosticator_;
 
   // See the comments in pile_up.hpp for an explanation of the terminology.
-  not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history_;
+  Box<DiscreteTrajectory<Barycentric>> history_;
   DiscreteTrajectory<Barycentric>* psychohistory_ = nullptr;
 
   // The |prediction_| is forked off the end of the |psychohistory_|.
@@ -280,7 +283,7 @@ class Vessel {
 
   // The |prognostication_| is a root trajectory that's computed asynchronously
   // and may or may not be used as a prediction;
-  std::unique_ptr<DiscreteTrajectory<Barycentric>> prognostication_
+  NullableBox<DiscreteTrajectory<Barycentric>> prognostication_
       GUARDED_BY(prognosticator_lock_);
 
   std::unique_ptr<FlightPlan> flight_plan_;

--- a/numerics/newhall.hpp
+++ b/numerics/newhall.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "base/not_null.hpp"
+#include "base/box.hpp"
 #include "geometry/named_quantities.hpp"
 #include "numerics/чебышёв_series.hpp"
 #include "numerics/polynomial.hpp"
@@ -14,7 +14,7 @@ namespace principia {
 namespace numerics {
 namespace internal_newhall {
 
-using base::not_null;
+using base::Box;
 using geometry::Instant;
 using quantities::Variation;
 
@@ -48,7 +48,7 @@ NewhallApproximationInMonomialBasis(std::vector<Vector> const& q,
 // Same as above but the |degree| is not a constant expression.
 template<typename Vector,
          template<typename, typename, int> class Evaluator>
-not_null<std::unique_ptr<Polynomial<Vector, Instant>>>
+Box<Polynomial<Vector, Instant>>
 NewhallApproximationInMonomialBasis(int degree,
                                     std::vector<Vector> const& q,
                                     std::vector<Variation<Vector>> const& v,

--- a/numerics/newhall_body.hpp
+++ b/numerics/newhall_body.hpp
@@ -14,7 +14,6 @@ namespace principia {
 namespace numerics {
 namespace internal_newhall {
 
-using base::make_not_null_unique;
 using geometry::Barycentre;
 using quantities::Exponentiation;
 using quantities::Frequency;
@@ -225,7 +224,7 @@ NewhallApproximationInMonomialBasis(std::vector<Vector> const& q,
 
 #define PRINCIPIA_NEWHALL_APPROXIMATION_IN_MONOMIAL_BASIS_CASE(degree)    \
   case (degree):                                                          \
-    return make_not_null_unique<                                          \
+    return Box<                                          \
         PolynomialInMonomialBasis<Vector, Instant, (degree), Evaluator>>( \
         NewhallApproximationInMonomialBasis<Vector, (degree), Evaluator>( \
             q, v,                                                         \
@@ -233,7 +232,7 @@ NewhallApproximationInMonomialBasis(std::vector<Vector> const& q,
             error_estimate))
 
 template<typename Vector, template<typename, typename, int> class Evaluator>
-not_null<std::unique_ptr<Polynomial<Vector, Instant>>>
+Box<Polynomial<Vector, Instant>>
 NewhallApproximationInMonomialBasis(int degree,
                                     std::vector<Vector> const& q,
                                     std::vector<Variation<Vector>> const& v,

--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "base/box.hpp"
 #include "base/macros.hpp"
 #include "base/not_null.hpp"
 #include "base/traits.hpp"
@@ -42,6 +43,7 @@ FORWARD_DECLARE_FUNCTION_FROM(
 namespace numerics {
 namespace internal_polynomial {
 
+using base::Box;
 using base::is_instance_of_v;
 using base::not_constructible;
 using base::not_null;
@@ -88,7 +90,7 @@ class Polynomial {
   // The evaluator is not part of the serialization because it's fine to read
   // with a different evaluator than the one the polynomial was written with.
   template<template<typename, typename, int> typename Evaluator>
-  static not_null<std::unique_ptr<Polynomial>> ReadFromMessage(
+  static Box<Polynomial> ReadFromMessage(
       serialization::Polynomial const& message);
 };
 

--- a/numerics/polynomial_body.hpp
+++ b/numerics/polynomial_body.hpp
@@ -321,14 +321,14 @@ std::vector<std::string> TupleSerializer<Tuple, size, size>::TupleDebugString(
 
 #define PRINCIPIA_POLYNOMIAL_DEGREE_VALUE_CASE(value)                  \
   case value:                                                          \
-    return make_not_null_unique<                                       \
+    return Box<                                                        \
         PolynomialInMonomialBasis<Value, Argument, value, Evaluator>>( \
         PolynomialInMonomialBasis<Value, Argument, value, Evaluator>:: \
             ReadFromMessage(message))
 
 template<typename Value_, typename Argument_>
 template<template<typename, typename, int> typename Evaluator>
-not_null<std::unique_ptr<Polynomial<Value_, Argument_>>>
+Box<Polynomial<Value_, Argument_>>
 Polynomial<Value_, Argument_>::ReadFromMessage(
     serialization::Polynomial const& message) {
   // 24 is the largest exponent that we can serialize for Quantity.

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -24,7 +24,6 @@ namespace internal_continuous_trajectory {
 
 using base::dynamic_cast_not_null;
 using base::Error;
-using base::make_not_null_unique;
 using geometry::Interval;
 using numerics::EstrinEvaluator;
 using numerics::PoissonSeries;
@@ -367,14 +366,13 @@ void ContinuousTrajectory<Frame>::WriteToMessage(
 
 template<typename Frame>
 template<typename, typename>
-not_null<std::unique_ptr<ContinuousTrajectory<Frame>>>
+Box<ContinuousTrajectory<Frame>>
 ContinuousTrajectory<Frame>::ReadFromMessage(
       serialization::ContinuousTrajectory const& message) {
   bool const is_pre_cohen = message.series_size() > 0;
   bool const is_pre_fatou = !message.has_checkpoint_time();
 
-  not_null<std::unique_ptr<ContinuousTrajectory<Frame>>> continuous_trajectory =
-      std::make_unique<ContinuousTrajectory<Frame>>(
+  Box<ContinuousTrajectory<Frame>> continuous_trajectory(
           Time::ReadFromMessage(message.step()),
           Length::ReadFromMessage(message.tolerance()));
   if (is_pre_cohen) {
@@ -475,13 +473,11 @@ template<typename Frame>
 ContinuousTrajectory<Frame>::ContinuousTrajectory()
     : checkpointer_(/*reader=*/nullptr, /*writer=*/nullptr) {}
 
-template<typename Frame>
+template <typename Frame>
 ContinuousTrajectory<Frame>::InstantPolynomialPair::InstantPolynomialPair(
     Instant const t_max,
-    not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
-        polynomial)
-    : t_max(t_max),
-      polynomial(std::move(polynomial)) {}
+    Box<Polynomial<Displacement<Frame>, Instant>> polynomial)
+    : t_max(t_max), polynomial(std::move(polynomial)) {}
 
 template<typename Frame>
 Instant ContinuousTrajectory<Frame>::t_min_locked() const {
@@ -505,8 +501,8 @@ Instant ContinuousTrajectory<Frame>::t_max_locked() const {
   return polynomials_.crbegin()->t_max;
 }
 
-template<typename Frame>
-not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
+template <typename Frame>
+Box<Polynomial<Displacement<Frame>, Instant>>
 ContinuousTrajectory<Frame>::NewhallApproximationInMonomialBasis(
     int degree,
     std::vector<Displacement<Frame>> const& q,

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -66,7 +66,7 @@ class TestableContinuousTrajectory : public ContinuousTrajectory<Frame> {
   using ContinuousTrajectory<Frame>::ContinuousTrajectory;
 
   // Mock the Newhall factory.
-  not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
+  Box<Polynomial<Displacement<Frame>, Instant>>
   NewhallApproximationInMonomialBasis(
       int degree,
       std::vector<Displacement<Frame>> const& q,
@@ -83,7 +83,7 @@ class TestableContinuousTrajectory : public ContinuousTrajectory<Frame> {
            Instant const& t_min,
            Instant const& t_max,
            Displacement<Frame>& error_estimate,
-           not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>&
+           Box<Polynomial<Displacement<Frame>, Instant>>&
                polynomial));
 
   Status LockAndComputeBestNewhallApproximation(
@@ -99,7 +99,7 @@ class TestableContinuousTrajectory : public ContinuousTrajectory<Frame> {
 };
 
 template<typename Frame>
-not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
+Box<Polynomial<Displacement<Frame>, Instant>>
 TestableContinuousTrajectory<Frame>::NewhallApproximationInMonomialBasis(
     int degree,
     std::vector<Displacement<Frame>> const& q,
@@ -111,8 +111,8 @@ TestableContinuousTrajectory<Frame>::NewhallApproximationInMonomialBasis(
                 Displacement<Frame>, Instant, /*degree=*/1, HornerEvaluator>;
   typename P::Coefficients const coefficients = {Displacement<Frame>(),
                                                  Velocity<Frame>()};
-  not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
-      polynomial = make_not_null_unique<P>(coefficients, Instant());
+  Box<Polynomial<Displacement<Frame>, Instant>> polynomial =
+      Box<P>(coefficients, Instant());
   FillNewhallApproximationInMonomialBasis(degree,
                                           q, v,
                                           t_min, t_max,

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <vector>
 
+#include "base/box.hpp"
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
@@ -62,6 +63,7 @@ class DiscreteTrajectoryIterator
 
 namespace internal_discrete_trajectory {
 
+using base::Box;
 using base::not_null;
 using geometry::Instant;
 using geometry::Position;
@@ -110,12 +112,12 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   // trajectory.  |fork| must be a non-empty root and must start at or after the
   // last time of this trajectory.  If it has a point at the last time of this
   // trajectory, that point is ignored.
-  void AttachFork(not_null<std::unique_ptr<DiscreteTrajectory<Frame>>> fork);
+  void AttachFork(Box<DiscreteTrajectory<Frame>> fork);
 
   // This object must not be a root.  It is detached from its parent and becomes
   // a root.  A point corresponding to the fork point is prepended to this
   // object (so it's never empty) and an owning pointer to it is returned.
-  not_null<std::unique_ptr<DiscreteTrajectory<Frame>>> DetachFork();
+  Box<DiscreteTrajectory<Frame>> DetachFork();
 
   // Appends one point to the trajectory.
   void Append(Instant const& time,
@@ -171,7 +173,7 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   // be null at entry; they may be null at exit.
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
-  static not_null<std::unique_ptr<DiscreteTrajectory>> ReadFromMessage(
+  static Box<DiscreteTrajectory> ReadFromMessage(
       serialization::DiscreteTrajectory const& message,
       std::vector<DiscreteTrajectory<Frame>**> const& forks);
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -64,7 +64,6 @@ namespace internal_discrete_trajectory {
 using astronomy::InfiniteFuture;
 using astronomy::InfinitePast;
 using base::Flags;
-using base::make_not_null_unique;
 using base::ZfpCompressor;
 using geometry::Displacement;
 using numerics::FitHermiteSpline;
@@ -115,7 +114,7 @@ DiscreteTrajectory<Frame>::NewForkAtLast() {
 
 template<typename Frame>
 void DiscreteTrajectory<Frame>::AttachFork(
-    not_null<std::unique_ptr<DiscreteTrajectory<Frame>>> fork) {
+    Box<DiscreteTrajectory<Frame>> fork) {
   CHECK(fork->is_root());
   CHECK(!this->Empty());
 
@@ -160,7 +159,7 @@ void DiscreteTrajectory<Frame>::AttachFork(
 }
 
 template<typename Frame>
-not_null<std::unique_ptr<DiscreteTrajectory<Frame>>>
+Box<DiscreteTrajectory<Frame>>
 DiscreteTrajectory<Frame>::DetachFork() {
   CHECK(!this->is_root());
 
@@ -345,11 +344,11 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
 
 template<typename Frame>
 template<typename, typename>
-not_null<std::unique_ptr<DiscreteTrajectory<Frame>>>
+Box<DiscreteTrajectory<Frame>>
 DiscreteTrajectory<Frame>::ReadFromMessage(
     serialization::DiscreteTrajectory const& message,
     std::vector<DiscreteTrajectory<Frame>**> const& forks) {
-  auto trajectory = make_not_null_unique<DiscreteTrajectory>();
+  auto trajectory = Box<DiscreteTrajectory>();
   CHECK(std::all_of(forks.begin(),
                     forks.end(),
                     [](DiscreteTrajectory<Frame>** const fork) {

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -472,8 +472,7 @@ TEST_F(DiscreteTrajectoryTest, AttachFork) {
   massive_trajectory_->Append(t1_, d1_);
   massive_trajectory_->Append(t2_, d2_);
 
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> fork1 =
-      make_not_null_unique<DiscreteTrajectory<World>>();
+  Box<DiscreteTrajectory<World>> fork1 = Box<DiscreteTrajectory<World>>();
   fork1->Append(t3_, d3_);
   not_null<DiscreteTrajectory<World>*> const fork2 =
       fork1->NewForkWithoutCopy(t3_);
@@ -708,7 +707,7 @@ TEST_F(DiscreteTrajectoryTest, TrajectorySerializationSuccess) {
   DiscreteTrajectory<World>* deserialized_fork1 = nullptr;
   DiscreteTrajectory<World>* deserialized_fork2 = nullptr;
   DiscreteTrajectory<World>* deserialized_fork3 = nullptr;
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const
+  Box<DiscreteTrajectory<World>> const
       deserialized_trajectory =
           DiscreteTrajectory<World>::ReadFromMessage(message,
                                                      {&deserialized_fork1,
@@ -867,7 +866,7 @@ TEST_F(DiscreteTrajectoryTest, Downsampling) {
 
 TEST_F(DiscreteTrajectoryTest, DownsamplingSerialization) {
   DiscreteTrajectory<World> circle;
-  auto deserialized_circle = make_not_null_unique<DiscreteTrajectory<World>>();
+  auto deserialized_circle = Box<DiscreteTrajectory<World>>();
   circle.SetDownsampling(/*max_dense_intervals=*/50,
                          /*tolerance=*/1 * Milli(Metre));
   deserialized_circle->SetDownsampling(/*max_dense_intervals=*/50,

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
+#include "base/box.hpp"
 #include "base/not_null.hpp"
 #include "base/status.hpp"
 #include "geometry/grassmann.hpp"
@@ -31,6 +32,7 @@ namespace principia {
 namespace physics {
 namespace internal_ephemeris {
 
+using base::Box;
 using base::Error;
 using base::not_null;
 using base::Status;
@@ -414,7 +416,7 @@ class Ephemeris {
   std::vector<not_null<ContinuousTrajectory<Frame>*>> trajectories_;
 
   std::map<not_null<MassiveBody const*>,
-           not_null<std::unique_ptr<ContinuousTrajectory<Frame>>>>
+           Box<ContinuousTrajectory<Frame>>>
       bodies_to_trajectories_;
 
   AccuracyParameters const accuracy_parameters_;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "astronomy/epoch.hpp"
+#include "base/box.hpp"
 #include "base/jthread.hpp"
 #include "base/macros.hpp"
 #include "base/map_util.hpp"
@@ -32,6 +33,7 @@ namespace physics {
 namespace internal_ephemeris {
 
 using astronomy::J2000;
+using base::Box;
 using base::dynamic_cast_not_null;
 using base::Error;
 using base::FindOrDie;
@@ -268,7 +270,7 @@ Ephemeris<Frame>::Ephemeris(
 
     auto const [it, inserted] = bodies_to_trajectories_.emplace(
         body.get(),
-        std::make_unique<ContinuousTrajectory<Frame>>(
+        Box<ContinuousTrajectory<Frame>>(
             fixed_step_parameters_.step_,
             accuracy_parameters_.fitting_tolerance_));
     CHECK(inserted);
@@ -778,7 +780,7 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
   ephemeris->trajectories_.clear();
   for (auto const& trajectory : message.trajectory()) {
     not_null<MassiveBody const*> const body = ephemeris->bodies_[index].get();
-    not_null<std::unique_ptr<ContinuousTrajectory<Frame>>>
+    Box<ContinuousTrajectory<Frame>>
         deserialized_trajectory =
             ContinuousTrajectory<Frame>::ReadFromMessage(trajectory);
     ephemeris->trajectories_.push_back(deserialized_trajectory.get());

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "absl/container/inlined_vector.h"
+#include "base/box.hpp"
 #include "base/not_null.hpp"
 #include "geometry/named_quantities.hpp"
 #include "serialization/physics.pb.h"
@@ -178,7 +179,7 @@ class Forkable {
   // time as the last point of this object.  |fork| is attached to this object
   // as a child at the end of the timeline.  The caller must then delete the
   // first point of |fork|'s timeline.
-  void AttachForkToCopiedBegin(not_null<std::unique_ptr<Tr4jectory>> fork);
+  void AttachForkToCopiedBegin(Box<Tr4jectory> fork);
 
   // This object must not be a root.  It is detached from its parent and becomes
   // a root.  All the children which were fork at this object's fork time are
@@ -186,7 +187,7 @@ class Forkable {
   // requires the caller to ensure that this object's timeline is not empty and
   // that its beginning properly represents the fork time.  Returns an owning
   // pointer to this object.
-  not_null<std::unique_ptr<Tr4jectory>> DetachForkWithCopiedBegin();
+  Box<Tr4jectory> DetachForkWithCopiedBegin();
 
   // Deletes all forks for times (strictly) greater than |time|.  |time| must be
   // at or after the fork time of this trajectory, if any.
@@ -217,7 +218,7 @@ class Forkable {
   // There may be several forks starting from the same time, hence the multimap.
   // A level of indirection is needed to avoid referencing an incomplete type in
   // CRTP.
-  using Children = std::multimap<Instant, std::unique_ptr<Tr4jectory>>;
+  using Children = std::multimap<Instant, Box<Tr4jectory>>;
 
   // Null for a root.
   Tr4jectory* parent_ = nullptr;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -15,6 +15,7 @@ namespace principia {
 namespace physics {
 namespace internal_forkable {
 
+using base::Box;
 using base::not_null;
 using geometry::Instant;
 

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -355,10 +355,10 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::NewFork(
   } else {
     time = Traits::time(timeline_it);
   }
-  auto const child_it = children_.emplace(time, std::make_unique<Tr4jectory>());
+  auto const child_it = children_.emplace(time, Box<Tr4jectory>());
 
   // Now set the members of the child object.
-  std::unique_ptr<Tr4jectory> const& child_forkable = child_it->second;
+  Box<Tr4jectory> const& child_forkable = child_it->second;
   child_forkable->parent_ = that();
   child_forkable->position_in_parent_children_ = child_it;
   child_forkable->position_in_parent_timeline_ = timeline_it;
@@ -368,7 +368,7 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::NewFork(
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 void Forkable<Tr4jectory, It3rator, Traits>::AttachForkToCopiedBegin(
-    not_null<std::unique_ptr<Tr4jectory>> fork) {
+    Box<Tr4jectory> fork) {
   CHECK(fork->is_root());
   CHECK(!fork->timeline_empty());
   auto const fork_timeline_begin = fork->timeline_begin();
@@ -400,7 +400,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::AttachForkToCopiedBegin(
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
-not_null<std::unique_ptr<Tr4jectory>>
+Box<Tr4jectory>
 Forkable<Tr4jectory, It3rator, Traits>::DetachForkWithCopiedBegin() {
   CHECK(!is_root());
 

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -14,7 +14,6 @@ namespace principia {
 namespace physics {
 namespace internal_forkable {
 
-using base::make_not_null_unique;
 using base::not_constructible;
 using geometry::Instant;
 using quantities::si::Second;
@@ -335,14 +334,7 @@ TEST_F(ForkableTest, DeleteForkSuccess) {
 TEST_F(ForkableDeathTest, AttachForkWithCopiedBeginError) {
   EXPECT_DEATH({
     trajectory_.push_back(t1_);
-    not_null<FakeTrajectory*> const fork =
-        trajectory_.NewFork(trajectory_.timeline_find(t1_));
-    trajectory_.AttachForkToCopiedBegin(std::unique_ptr<FakeTrajectory>(fork));
-  }, "is_root");
-  EXPECT_DEATH({
-    trajectory_.push_back(t1_);
-    not_null<std::unique_ptr<FakeTrajectory>> fork =
-        make_not_null_unique<FakeTrajectory>();
+    Box<FakeTrajectory> fork{};
     trajectory_.AttachForkToCopiedBegin(std::move(fork));
   }, "timeline_empty");
 }
@@ -352,8 +344,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginSuccess) {
   trajectory_.push_back(t2_);
   trajectory_.push_back(t3_);
 
-  not_null<std::unique_ptr<FakeTrajectory>> fork1 =
-      make_not_null_unique<FakeTrajectory>();
+  Box<FakeTrajectory> fork1{};
   fork1->push_back(t3_);
   not_null<FakeTrajectory*> const fork2 =
       fork1->NewFork(fork1->timeline_find(t3_));
@@ -377,8 +368,7 @@ TEST_F(ForkableTest, AttachForkWithCopiedBeginEmpty) {
   trajectory_.push_back(t1_);
   not_null<FakeTrajectory*> const fork1 =
       trajectory_.NewFork(trajectory_.timeline_find(t1_));
-  not_null<std::unique_ptr<FakeTrajectory>> fork2 =
-      make_not_null_unique<FakeTrajectory>();
+  Box<FakeTrajectory> fork2{};
   fork2->push_back(t3_);
   fork1->AttachForkToCopiedBegin(std::move(fork2));
 }


### PR DESCRIPTION
Second part of a two-part fix for #2899.

This change adds a new smart pointer class, `Box`, which is equivalent to `not_null<std::unique_ptr>` except that it is parameterized on an allocator instead of a deleter. Because it is within the `principia` namespace, it will automatically use the allocator from #2900 when the header from #2900 is present.
Unlike `std::unique_ptr`, there is no way to construct a `Box` from a raw pointer—it cannot be verified that the raw pointer was constructed with the `Box`'s allocator. For the case of classes with private constructors, there is a factory function in `Box` which allocates memory for an object without constructing it; the object can then be constructed with placement `new`.

A nullable version is also provided.

This change also replaces `not_null<std::unique_ptr>` with `Box` in `ContinuousTrajectory` and `DiscreteTrajectory`. Many other files which transferred unique_ptrs into or out of trajectories had to be changed as well.