### PR TITLE
Use MallocAllocator for unique_ptr on macOS.

### DIFF
--- a/base/allocated_by.hpp
+++ b/base/allocated_by.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+
+#include "base/not_constructible.hpp"
+
+namespace principia {
+namespace base {
+
+// Wrapped pointer.
+// Guaranteed to be allocated by Alloc.
+template<typename Alloc>
+class AllocatedBy {
+ public:
+  using allocator = Alloc;
+  using traits = std::allocator_traits<Alloc>;
+  using pointer = typename traits::pointer;
+  using element_type = typename traits::value_type;
+
+  // Default constructs as nullptr.
+  AllocatedBy() : ptr_(nullptr) {}
+
+  // Implicitly convertable from AllocatedBy<B> when B converts to Alloc.
+  template<typename B, typename = typename std::is_convertible<B, Alloc>>
+  AllocatedBy(AllocatedBy<B> other) : ptr_(other) {}
+
+  // Implicitly convertable from nullptr.
+  AllocatedBy(std::nullptr_t) : ptr_(nullptr) {}
+
+  // Implicitly convertable to T*.
+  operator pointer() const {
+    return ptr_;
+  }
+
+  // Dereference operator.
+  pointer operator->() const {
+    return ptr_;
+  }
+
+ private:
+  AllocatedBy(pointer ptr) : ptr_(ptr) {}
+  pointer ptr_;
+
+  template<typename B>
+  friend AllocatedBy<B> AssertAllocatedBy(
+      typename std::allocator_traits<B>::pointer);
+};
+
+// Factory function. By calling this, you assert that |ptr| was allocated by
+// |Alloc|. Typically used with allocator new.
+template<typename Alloc>
+AllocatedBy<Alloc> AssertAllocatedBy(
+    typename std::allocator_traits<Alloc>::pointer ptr) {
+  return AllocatedBy<Alloc>(ptr);
+}
+
+// Trait struct for AllocatedBy.
+// Used for template metaprogramming on AllocatedBy.
+template<typename T>
+struct AllocatedByTraits {};
+
+template<typename Alloc>
+struct AllocatedByTraits<AllocatedBy<Alloc>> {
+  using traits = std::allocator_traits<Alloc>;
+};
+
+}  // namespace base
+}  // namespace principia

--- a/base/allocated_by_test.cpp
+++ b/base/allocated_by_test.cpp
@@ -1,0 +1,80 @@
+#include "base/allocated_by.hpp"
+
+#include <memory>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace principia {
+namespace base {
+
+using testing::IsNull;
+using testing::Not;
+using testing::Pointee;
+
+TEST(AllocatedByTest, NullablePointer) {
+  // Test that AllocatedBy satisfies the NullablePointer C++ named
+  // requirement.
+
+  AllocatedBy<std::allocator<int>> a(nullptr);
+  EXPECT_THAT(a, IsNull());
+
+  AllocatedBy<std::allocator<int>> b = nullptr;
+  EXPECT_THAT(b, IsNull());
+
+  EXPECT_THAT(AllocatedBy<std::allocator<int>>(nullptr), IsNull());
+
+  std::vector<int> v(1);
+  auto c = AssertAllocatedBy<std::allocator<int>>(&v[0]);
+  EXPECT_THAT(c, Not(IsNull()));
+  EXPECT_THAT(c = nullptr, IsNull());
+  EXPECT_THAT(c, IsNull());
+
+  auto p = AssertAllocatedBy<std::allocator<int>>(&v[0]);
+  AllocatedBy<std::allocator<int>> q = nullptr;
+  EXPECT_FALSE(p == q);
+  EXPECT_TRUE(p != q);
+  EXPECT_FALSE(p == nullptr);
+  EXPECT_FALSE(nullptr == p);
+  EXPECT_TRUE(q == nullptr);
+  EXPECT_TRUE(nullptr == q);
+  EXPECT_TRUE(p != nullptr);
+  EXPECT_TRUE(nullptr != p);
+  EXPECT_FALSE(q != nullptr);
+  EXPECT_FALSE(nullptr != q);
+}
+
+TEST(AllocatedByTest, DefaultConstructor) {
+  EXPECT_THAT(AllocatedBy<std::allocator<int>>(), IsNull());
+}
+
+TEST(AllocatedByTest, Dereference) {
+  std::vector<std::string> v = {"foo"};
+  AllocatedBy<std::allocator<std::string>> p =
+      AssertAllocatedBy<std::allocator<std::string>>(&v[0]);
+
+  EXPECT_EQ(*p, "foo");
+  EXPECT_EQ(p->size(), 3);
+}
+
+TEST(AllocatedByTest, Lifecycle) {
+  std::vector<int> v(1);
+  int* ptr = &v[0];
+  auto asserted_ptr = AssertAllocatedBy<std::allocator<int>>(ptr);
+  EXPECT_EQ(asserted_ptr, ptr);
+}
+
+class Base {};
+class Sub : public Base {};
+
+TEST(AllocatedByTest, Upcasting) {
+  // Should compile.
+  AllocatedBy<std::allocator<Sub>> a = nullptr;
+  AllocatedBy<std::allocator<Base>> b = a;
+  EXPECT_THAT(b, IsNull());
+}
+
+}  // namespace base
+
+}  // namespace principia

--- a/base/allocator_deleter.hpp
+++ b/base/allocator_deleter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
+
+namespace principia {
+namespace base {
+
+// Deleter suitible for passing to std::unique_ptr that deletes using an
+// allocator instead of ::delete.
+template<typename Alloc>
+class AllocatorDeleter {
+ public:
+  using traits = std::allocator_traits<Alloc>;
+  using pointer = AllocatedBy<Alloc>;
+  using value_type = typename traits::value_type;
+
+  // We are only interested in stateless allocators.
+  static_assert(std::is_empty<Alloc>::value);
+
+  // Allocator deallocate requires the array size to be known so we can't handle
+  // array types.
+  static_assert(!std::is_array<typename traits::value_type>::value,
+                "Array types are not supported.");
+
+  constexpr AllocatorDeleter() = default;
+
+  // Implicitly convertible from allocators of compatible types.
+  // TODO(rnlahaye): check that allocator is compatible.
+  template<typename B,
+           typename = typename std::enable_if_t<
+               std::is_convertible<typename std::allocator_traits<B>::pointer,
+                                   typename traits::pointer>::value>>
+  AllocatorDeleter(const AllocatorDeleter<B>& d) {}
+
+  // Delete the managed object.
+  void operator()(value_type* ptr) {
+    // std::remove_const_t<value_type>* non_const_ptr =
+    //     const_cast<std::remove_const_t<value_type>*>(ptr);
+    auto non_const_ptr = ptr;
+    Alloc alloc;
+    traits::destroy(alloc, typename traits::pointer(non_const_ptr));
+    traits::deallocate(alloc, non_const_ptr, 1);
+  }
+};
+
+template<typename Alloc,
+         typename T = typename std::allocator_traits<Alloc>::value_type,
+         typename... Args>
+std::unique_ptr<T, AllocatorDeleter<Alloc>> MakeUniqueWithAllocator(
+    Args&&... args) {
+  return std::unique_ptr<T, AllocatorDeleter<Alloc>>(AssertAllocatedBy<Alloc>(
+      new (AllocateWith<Alloc>{}) T(std::forward<Args>(args)...)));
+}
+
+}  // namespace base
+}  // namespace principia

--- a/base/allocator_deleter_test.cpp
+++ b/base/allocator_deleter_test.cpp
@@ -1,0 +1,82 @@
+
+#include "base/allocator_deleter.hpp"
+
+#include <memory>
+
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
+#include "base/malloc_allocator.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace principia {
+namespace base {
+
+using testing::IsNull;
+using testing::Not;
+using testing::Pointee;
+
+// Class which counts how many times its constructor and destructor have been
+// called.
+class CtorDtorCounter {
+ public:
+  CtorDtorCounter(int& ctor_count, int& dtor_count) : dtor_count_(&dtor_count) {
+    ++ctor_count;
+  }
+
+  ~CtorDtorCounter() {
+    ++*dtor_count_;
+  }
+
+ private:
+  int* dtor_count_;
+};
+
+TEST(AllocatorDeleterTest, Lifecycle) {
+  // Create object.
+  int ctor_count = 0;
+  int dtor_count = 0;
+  CtorDtorCounter* p = AssertAllocatedBy<std::allocator<CtorDtorCounter>>(
+      new (AllocateWith<std::allocator<CtorDtorCounter>>{})
+          CtorDtorCounter(ctor_count, dtor_count));
+  EXPECT_EQ(ctor_count, 1);
+  EXPECT_EQ(dtor_count, 0);
+
+  AllocatorDeleter<std::allocator<CtorDtorCounter>> deleter;
+  deleter(AssertAllocatedBy<std::allocator<CtorDtorCounter>>(p));
+  EXPECT_EQ(ctor_count, 1);
+  EXPECT_EQ(dtor_count, 1);
+}
+
+TEST(AllocatorDeleterTest, MemberTypes) {
+  EXPECT_TRUE((std::is_same<AllocatorDeleter<std::allocator<int>>::pointer,
+                            AllocatedBy<std::allocator<int>>>::value));
+  EXPECT_TRUE((std::is_same<AllocatorDeleter<std::allocator<int>>::value_type,
+                            int>::value));
+}
+
+TEST(AllocatorDeleterTest, Upcasting) {
+  class Base {};
+  class Sub : public Base {};
+
+  AllocatorDeleter<std::allocator<Sub>> a;
+
+  AllocatorDeleter<std::allocator<Base>> b(a);
+}
+
+TEST(AllocatorDeleterTest, MakeUniqueWithAllocator) {
+  std::unique_ptr<int, AllocatorDeleter<std::allocator<int>>> owned =
+      MakeUniqueWithAllocator<std::allocator<int>>(2);
+
+  EXPECT_THAT(owned, Pointee(2));
+}
+
+TEST(AllocatorDeleterTest, ShareUnique) {
+  auto owned = MakeUniqueWithAllocator<std::allocator<int>>(2);
+  std::shared_ptr<int> shared = std::move(owned);
+
+  EXPECT_THAT(shared, Pointee(2));
+}
+
+}  // namespace base
+}  // namespace principia

--- a/base/allocator_new.hpp
+++ b/base/allocator_new.hpp
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "glog/logging.h"
+
+namespace principia {
+namespace base {
+// Tag type for passing to allocator new.
+template<typename Alloc>
+struct AllocateWith {
+  static_assert(std::is_empty<Alloc>::value, "|Alloc| must be stateless");
+};
+}  // namespace base
+}  // namespace principia
+
+// Placement new operator using allocators for allocation.
+// Should only be used for allocating single objects (for arrays and such, use
+// the allocator directly).
+template<typename Alloc>
+void* operator new(std::size_t count,
+                   principia::base::AllocateWith<Alloc>) noexcept {
+  constexpr size_t size =
+      sizeof(typename std::allocator_traits<Alloc>::value_type);
+  CHECK_EQ(count, size)
+      << "Number of bytes allocated must equal size of object.";
+  Alloc alloc;
+  auto p = std::allocator_traits<Alloc>::allocate(alloc, 1);
+  using non_const_T =
+      std::remove_const_t<typename std::allocator_traits<Alloc>::value_type>;
+  return const_cast<non_const_T*>(p);
+}
+
+// The corresponding delete operator.
+// Note that this is only called when a class constructor throws an exception.
+template<typename Alloc>
+void operator delete(void* ptr, principia::base::AllocateWith<Alloc>) noexcept {
+  using pointer = typename std::allocator_traits<Alloc>::pointer;
+  Alloc alloc;
+  std::allocator_traits<Alloc>::deallocate(alloc, static_cast<pointer>(ptr), 1);
+}

--- a/base/allocator_new_test.cpp
+++ b/base/allocator_new_test.cpp
@@ -1,0 +1,40 @@
+#include "base/allocator_new.hpp"
+
+#include <memory>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace principia {
+namespace base {
+
+using testing::IsNull;
+using testing::Not;
+using testing::Pointee;
+
+TEST(AllocatorNewTest, New) {
+  int* p = new (AllocateWith<std::allocator<int>>{}) int(2);
+  EXPECT_THAT(p, Pointee(2));
+  std::allocator<int>().deallocate(p, 1);
+}
+
+TEST(AllocatorNewTest, Const) {
+  int const* p = new (AllocateWith<std::allocator<int const>>{}) int const(2);
+  EXPECT_THAT(p, Pointee(2));
+  std::allocator<int const>().deallocate(p, 1);
+}
+
+TEST(AllocatorNewDeathTest, SizeMismatch) {
+  EXPECT_DEATH(new (AllocateWith<std::allocator<uint8_t>>{}) uint16_t,
+               "Number of bytes allocated must equal size of object.");
+}
+
+TEST(AllocatorNewTest, NonAllocatingPlacementNew) {
+  // Check that we didn't somehow break non-allocating placement new.
+  int a = 2;
+  new (&a) int(3);
+  EXPECT_EQ(a, 3);
+}
+
+}  // namespace base
+}  // namespace principia

--- a/base/macos_allocator_replacement_test.cpp
+++ b/base/macos_allocator_replacement_test.cpp
@@ -17,9 +17,7 @@
 #ifdef OS_MACOSX
 
 namespace principia {
-namespace magic {
-
-using base::MallocAllocator;
+namespace base {
 
 // AllocatorIs<container, alloc>() returns true iff container's allocator is
 // alloc.
@@ -29,7 +27,7 @@ constexpr bool AllocatorIs() {
 }
 
 // Test that the default allocators for various classes are overridden.
-TEST(PrincipiaMallocAllocatorTest, DefaultAllocators) {
+TEST(MacosAllocatorReplacementTest, DefaultAllocators) {
   // STL
   EXPECT_TRUE((AllocatorIs<std::vector<int>, MallocAllocator<int>>()));
   EXPECT_TRUE((AllocatorIs<std::deque<int>, MallocAllocator<int>>()));
@@ -42,7 +40,7 @@ TEST(PrincipiaMallocAllocatorTest, DefaultAllocators) {
                            MallocAllocator<std::pair<const int, int>>>()));
 }
 
-}  // namespace magic
+}  // namespace base
 }  // namespace principia
 
 #endif

--- a/base/macos_allocator_replacement_test.cpp
+++ b/base/macos_allocator_replacement_test.cpp
@@ -1,5 +1,6 @@
 
 // "macos_allocator_replacement.hpp" should be automagically included.
+#include "macos_allocator_replacement.hpp"
 
 #include <deque>
 #include <list>
@@ -9,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/allocator_deleter.hpp"
 #include "base/macros.hpp"
 #include "base/malloc_allocator.hpp"
 #include "gmock/gmock.h"
@@ -16,8 +18,32 @@
 
 #ifdef OS_MACOSX
 
+// namespace principia {
+// namespace std {
+
+// template<typename T,
+//          typename Deleter =
+//              ::std::conditional_t<!::std::is_array<T>::value,
+//                                   base::AllocatorDeleter<allocator<T>>,
+//                                   ::std::default_delete<T>>>
+// using unique_ptr = ::std::unique_ptr<T, Deleter>;
+
+// // C++ doesn't support function aliases, so we wrap make_unique instead.
+// template<typename T, typename... Args>
+// inline unique_ptr<T> make_unique(Args&&... args) {
+//   return base::MakeUniqueWithAllocator<allocator<T>>(
+//       std::forward<Args>(args)...);
+// }
+
+// }  // namespace std
+// }  // namespace principia
+
 namespace principia {
 namespace base {
+
+using testing::IsNull;
+using testing::Not;
+using testing::Pointee;
 
 // AllocatorIs<container, alloc>() returns true iff container's allocator is
 // alloc.
@@ -38,6 +64,23 @@ TEST(MacosAllocatorReplacementTest, DefaultAllocators) {
   EXPECT_TRUE((AllocatorIs<std::multiset<int>, MallocAllocator<int>>()));
   EXPECT_TRUE((AllocatorIs<std::multimap<int, int>,
                            MallocAllocator<std::pair<const int, int>>>()));
+}
+
+TEST(MacosAllocatorReplacementTest, UniquePtr) {
+  // For non-array types, MallocAllocator should be used.
+  EXPECT_TRUE((std::is_same<std::unique_ptr<int>::deleter_type,
+                            AllocatorDeleter<MallocAllocator<int>>>::value));
+
+  // For array types, ::std::default_deleter should be used.
+  EXPECT_TRUE((std::is_same<std::unique_ptr<int[]>::deleter_type,
+                            ::std::default_delete<int[]>>::value));
+
+  // std::make_unique should also work appropriately.
+  std::unique_ptr<int> p = std::make_unique<int>(2);
+  EXPECT_THAT(p, Pointee(2));
+
+  std::unique_ptr<int[]> arr = std::make_unique<int[]>(3);
+  EXPECT_THAT(arr, Not(IsNull()));
 }
 
 }  // namespace base

--- a/base/malloc_allocator.hpp
+++ b/base/malloc_allocator.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <type_traits>
 
 namespace principia {
 namespace base {
@@ -27,7 +28,7 @@ class MallocAllocator {
   }
 
   void deallocate(T* p, size_t n) {
-    free(p);
+    free(const_cast<std::remove_const_t<T>*>(p));
   }
 };
 

--- a/base/malloc_allocator_test.cpp
+++ b/base/malloc_allocator_test.cpp
@@ -38,5 +38,11 @@ TEST(MallocAllocatorTest, RoundTrip) {
   MallocAllocator<int>().deallocate(p, 1);
 }
 
+TEST(MallocAllocatorTest, Const) {
+  int const* p = MallocAllocator<int const>().allocate(1);
+  EXPECT_THAT(p, Not(IsNull()));
+  MallocAllocator<int const>().deallocate(p, 1);
+}
+
 }  // namespace base
 }  // namespace principia

--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <type_traits>
 
+#include "base/allocated_by.hpp"
 #include "base/macros.hpp"
 #include "base/not_constructible.hpp"
 #include "base/traits.hpp"
@@ -250,6 +251,11 @@ class not_null final {
   bool operator!=(pointer other) const;
   bool operator!=(not_null other) const;
 
+  template<typename Q>
+  bool operator==(Q other) const;
+  template<typename Q>
+  bool operator!=(Q other) const;
+
   // Ordering.
   bool operator<(not_null other) const;
   bool operator<=(not_null other) const;
@@ -323,6 +329,10 @@ not_null<Result> dynamic_cast_not_null(not_null<T*> const pointer);
 
 template<typename Result, typename T>
 not_null<Result> dynamic_cast_not_null(not_null<std::unique_ptr<T>>&& pointer);
+
+template<typename Result, typename Alloc>
+not_null<Result> dynamic_cast_not_null(
+    not_null<AllocatedBy<Alloc>> const pointer);
 
 }  // namespace base
 }  // namespace principia

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -9,6 +9,8 @@
 #include <optional>
 #include <vector>
 
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
 #include "geometry/sign.hpp"
 #include "glog/logging.h"
 #include "quantities/quantities.hpp"
@@ -17,6 +19,8 @@ namespace principia {
 namespace integrators {
 namespace internal_embedded_explicit_generalized_runge_kutta_nyström_integrator {  // NOLINT(whitespace/line_length)
 
+using base::AssertAllocatedBy;
+using base::AllocateWith;
 using base::make_not_null_unique;
 using geometry::Sign;
 using numerics::DoublePrecision;
@@ -272,7 +276,8 @@ not_null<std::unique_ptr<typename Integrator<
     ExplicitSecondOrderOrdinaryDifferentialEquation<Position>>::Instance>>
 EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Clone() const {
-  return std::unique_ptr<Instance>(new Instance(*this));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{}) Instance(*this)));
 }
 
 template<typename Method, typename Position>
@@ -309,13 +314,15 @@ Instance::ReadFromMessage(
         integrator) {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
-  return std::unique_ptr<Instance>(new Instance(problem,
-                                                append_state,
-                                                tolerance_to_error_ratio,
-                                                parameters,
-                                                time_step,
-                                                first_use,
-                                                integrator));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem,
+                   append_state,
+                   tolerance_to_error_ratio,
+                   parameters,
+                   time_step,
+                   first_use,
+                   integrator)));
 }
 
 template<typename Method, typename Position>
@@ -346,14 +353,15 @@ NewInstance(IntegrationProblem<ODE> const& problem,
             Parameters const& parameters) const {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
-  return std::unique_ptr<Instance>(
-      new Instance(problem,
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem,
                    append_state,
                    tolerance_to_error_ratio,
                    parameters,
                    /*time_step=*/parameters.first_time_step,
                    /*first_use=*/true,
-                   *this));
+                   *this)));
 }
 
 template<typename Method, typename Position>

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -9,6 +9,8 @@
 #include <optional>
 #include <vector>
 
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
 #include "geometry/sign.hpp"
 #include "glog/logging.h"
 #include "quantities/quantities.hpp"
@@ -17,6 +19,8 @@ namespace principia {
 namespace integrators {
 namespace internal_embedded_explicit_runge_kutta_nyström_integrator {
 
+using base::AssertAllocatedBy;
+using base::AllocateWith;
 using base::make_not_null_unique;
 using geometry::Sign;
 using numerics::DoublePrecision;
@@ -266,7 +270,8 @@ not_null<std::unique_ptr<typename Integrator<
     SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
 EmbeddedExplicitRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Clone() const {
-  return std::unique_ptr<Instance>(new Instance(*this));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{}) Instance(*this)));
 }
 
 template<typename Method, typename Position>
@@ -303,13 +308,15 @@ ReadFromMessage(
     EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator) {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
-  return std::unique_ptr<Instance>(new Instance(problem,
-                                                append_state,
-                                                tolerance_to_error_ratio,
-                                                parameters,
-                                                time_step,
-                                                first_use,
-                                                integrator));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem,
+                   append_state,
+                   tolerance_to_error_ratio,
+                   parameters,
+                   time_step,
+                   first_use,
+                   integrator)));
 }
 
 template<typename Method, typename Position>
@@ -340,14 +347,15 @@ NewInstance(IntegrationProblem<ODE> const& problem,
             Parameters const& parameters) const {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
-  return std::unique_ptr<Instance>(
-      new Instance(problem,
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem,
                    append_state,
                    tolerance_to_error_ratio,
                    parameters,
                    /*time_step=*/parameters.first_time_step,
                    /*first_use=*/true,
-                   *this));
+                   *this)));
 }
 
 template<typename Method, typename Position>

--- a/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
@@ -5,6 +5,8 @@
 
 #include <vector>
 
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
 #include "geometry/sign.hpp"
 #include "integrators/methods.hpp"
 #include "numerics/ulp_distance.hpp"
@@ -14,6 +16,8 @@ namespace principia {
 namespace integrators {
 namespace internal_symplectic_runge_kutta_nyström_integrator {
 
+using base::AllocateWith;
+using base::AssertAllocatedBy;
 using base::make_not_null_unique;
 using geometry::Sign;
 using numerics::DoublePrecision;
@@ -148,7 +152,8 @@ not_null<std::unique_ptr<typename Integrator<
     SpecialSecondOrderDifferentialEquation<Position>>::Instance>>
 SymplecticRungeKuttaNyströmIntegrator<Method, Position>::
 Instance::Clone() const {
-  return std::unique_ptr<Instance>(new Instance(*this));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{}) Instance(*this)));
 }
 
 template<typename Method, typename Position>
@@ -176,8 +181,9 @@ ReadFromMessage(
     AppendState const& append_state,
     Time const& step,
     SymplecticRungeKuttaNyströmIntegrator const& integrator) {
-  return std::unique_ptr<Instance>(
-      new Instance(problem, append_state, step, integrator));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem, append_state, step, integrator)));
 }
 
 template<typename Method, typename Position>
@@ -241,8 +247,9 @@ SymplecticRungeKuttaNyströmIntegrator<Method, Position>::NewInstance(
     Time const& step) const {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
-  return std::unique_ptr<Instance>(
-      new Instance(problem, append_state, step, *this));
+  return std::unique_ptr<Instance>(AssertAllocatedBy<std::allocator<Instance>>(
+      new (AllocateWith<std::allocator<Instance>>{})
+          Instance(problem, append_state, step, *this)));
 }
 
 template<typename Method, typename Position>

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "base/allocated_by.hpp"
 #include "benchmark/benchmark.h"
 #include "glog/logging.h"
 #include "gtest/gtest.h"
@@ -38,7 +39,8 @@ class PlayerTest : public ::testing::Test {
       : test_info_(testing::UnitTest::GetInstance()->current_test_info()),
         test_case_name_(test_info_->test_case_name()),
         test_name_(test_info_->name()),
-        plugin_(interface::principia__NewPlugin("MJD0", "MJD0", 0)) {}
+        plugin_(base::AssertAllocatedBy<std::allocator<ksp_plugin::Plugin>>(
+            interface::principia__NewPlugin("MJD0", "MJD0", 0))) {}
 
   template<typename Profile>
   bool RunIfAppropriate(serialization::Method const& method_in,

--- a/journal/recorder_test.cpp
+++ b/journal/recorder_test.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "base/allocated_by.hpp"
 #include "base/array.hpp"
 #include "base/hexadecimal.hpp"
 #include "base/version.hpp"
@@ -24,7 +25,8 @@ class RecorderTest : public testing::Test {
   RecorderTest()
       : test_name_(
             testing::UnitTest::GetInstance()->current_test_info()->name()),
-        plugin_(interface::principia__NewPlugin("MJD0", "MJD0", 0)),
+        plugin_(base::AssertAllocatedBy<std::allocator<ksp_plugin::Plugin>>(
+            interface::principia__NewPlugin("MJD0", "MJD0", 0))),
         recorder_(new Recorder(test_name_ + ".journal.hex")) {
     Recorder::Activate(recorder_);
   }

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -558,7 +558,9 @@ inline not_null<OrbitAnalysis*> NewOrbitAnalysis(
   analysis->primary_index =
       vessel_analysis->primary() == nullptr
           ? nullptr
-          : new int(plugin.CelestialIndexOfBody(*vessel_analysis->primary()));
+          : std::make_unique<int>(
+                plugin.CelestialIndexOfBody(*vessel_analysis->primary()))
+                .release();
 
   analysis->mission_duration = vessel_analysis->mission_duration() / Second;
   if (vessel_analysis->elements().has_value()) {

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "base/allocated_by.hpp"
 #include "base/array.hpp"
 #include "geometry/named_quantities.hpp"
 #include "geometry/orthogonal_map.hpp"
@@ -19,6 +20,7 @@
 namespace principia {
 namespace interface {
 
+using base::AssertAllocatedBy;
 using base::UniqueArray;
 using geometry::OrthogonalMap;
 using geometry::RigidTransformation;
@@ -144,7 +146,8 @@ inline bool NaNIndependentEq(double const left, double const right) {
 template<typename T>
 std::unique_ptr<T> TakeOwnership(T** const pointer) {
   CHECK_NOTNULL(pointer);
-  std::unique_ptr<T> owned_pointer(*pointer);
+  std::unique_ptr<T> owned_pointer(
+      AssertAllocatedBy<std::allocator<T>>(*pointer));
   *pointer = nullptr;
   return owned_pointer;
 }

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -415,12 +415,12 @@ void __cdecl principia__FlightPlanRenderedApsides(
                                   max_points,
                                   rendered_apoapsides,
                                   rendered_periapsides);
-  *apoapsides = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_apoapsides)),
-      plugin);
-  *periapsides = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_periapsides)),
-      plugin);
+  *apoapsides = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                    check_not_null(std::move(rendered_apoapsides)), plugin)
+                    .release();
+  *periapsides = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                     check_not_null(std::move(rendered_periapsides)), plugin)
+                     .release();
   return m.Return();
 }
 
@@ -444,9 +444,10 @@ void __cdecl principia__FlightPlanRenderedClosestApproaches(
       FromXYZ<Position<World>>(sun_world_position),
       max_points,
       rendered_closest_approaches);
-  *closest_approaches = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_closest_approaches)),
-      plugin);
+  *closest_approaches =
+      std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+          check_not_null(std::move(rendered_closest_approaches)), plugin)
+          .release();
   return m.Return();
 }
 
@@ -470,12 +471,12 @@ void __cdecl principia__FlightPlanRenderedNodes(Plugin const* const plugin,
                                 max_points,
                                 rendered_ascending,
                                 rendered_descending);
-  *ascending = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_ascending)),
-      plugin);
-  *descending = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_descending)),
-      plugin);
+  *ascending = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                   check_not_null(std::move(rendered_ascending)), plugin)
+                   .release();
+  *descending = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                    check_not_null(std::move(rendered_descending)), plugin)
+                    .release();
   return m.Return();
 }
 
@@ -507,9 +508,9 @@ Iterator* __cdecl principia__FlightPlanRenderedSegment(
     // start and we fail.
     rendered_trajectory->ForgetAfter(astronomy::InfinitePast);
   }
-  return m.Return(new TypedIterator<DiscreteTrajectory<World>>(
-      std::move(rendered_trajectory),
-      plugin));
+  return m.Return(std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                      std::move(rendered_trajectory), plugin)
+                      .release());
 }
 
 Status* __cdecl principia__FlightPlanReplace(Plugin const* const plugin,

--- a/ksp_plugin/interface_future.cpp
+++ b/ksp_plugin/interface_future.cpp
@@ -37,7 +37,8 @@ void __cdecl principia__FutureWaitForVesselToCatchUp(
   VesselSet collided_vessel_set;
   plugin->WaitForVesselToCatchUp(*owned_future, collided_vessel_set);
   *collided_vessels =
-      new TypedIterator<VesselSet>(std::move(collided_vessel_set));
+      std::make_unique<TypedIterator<VesselSet>>(std::move(collided_vessel_set))
+          .release();
   return m.Return();
 }
 

--- a/ksp_plugin/interface_iterator.cpp
+++ b/ksp_plugin/interface_iterator.cpp
@@ -84,7 +84,9 @@ Iterator* __cdecl principia__IteratorGetRP2LinesIterator(
       dynamic_cast<TypedIterator<RP2Lines<Length, Camera>> const*>(iterator));
   return m.Return(typed_iterator->Get<Iterator*>(
       [](RP2Line<Length, Camera> const& rp2_line) -> Iterator* {
-        return new TypedIterator<RP2Line<Length, Camera>>(rp2_line);
+        return std::make_unique<TypedIterator<RP2Line<Length, Camera>>>(
+                   rp2_line)
+            .release();
       }));
 }
 

--- a/ksp_plugin/interface_monitor.cpp
+++ b/ksp_plugin/interface_monitor.cpp
@@ -46,7 +46,7 @@ std::array<Monitor, monitor_count> monitors{};
 void __cdecl principia__MonitorSetName(int const i, char const* const name) {
   Monitor& monitor = monitors[i];
   if (monitor.name == nullptr) {
-    monitor.name = new std::string(name);
+    monitor.name = std::make_unique<std::string>(name).release();
   }
 }
 

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -163,7 +163,9 @@ Iterator* __cdecl principia__PlanetariumPlotFlightPlanSegment(
                              plugin->CurrentTime(),
                              /*reverse=*/false);
   }
-  return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
+  return m.Return(
+      std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(rp2_lines)
+          .release());
 }
 
 Iterator* __cdecl principia__PlanetariumPlotPrediction(
@@ -184,7 +186,9 @@ Iterator* __cdecl principia__PlanetariumPlotPrediction(
                                      prediction.end(),
                                      plugin->CurrentTime(),
                                      /*reverse=*/false);
-  return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
+  return m.Return(
+      std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(rp2_lines)
+          .release());
 }
 
 Iterator* __cdecl principia__PlanetariumPlotPsychohistory(
@@ -201,7 +205,9 @@ Iterator* __cdecl principia__PlanetariumPlotPsychohistory(
   // Do not plot the psychohistory when there is a target vessel as it is
   // misleading.
   if (plugin->renderer().HasTargetVessel()) {
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
+    return m.Return(std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(
+                        RP2Lines<Length, Camera>{})
+                        .release());
   } else {
     auto const& psychohistory = plugin->GetVessel(vessel_guid)->psychohistory();
     auto const rp2_lines =
@@ -212,7 +218,9 @@ Iterator* __cdecl principia__PlanetariumPlotPsychohistory(
                     psychohistory.end(),
                     plugin->CurrentTime(),
                     /*reverse=*/true);
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
+    return m.Return(
+        std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(rp2_lines)
+            .release());
   }
 }
 
@@ -237,7 +245,9 @@ Iterator* __cdecl principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
 
   // Do not plot the past when there is a target vessel as it is misleading.
   if (plugin->renderer().HasTargetVessel()) {
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
+    return m.Return(std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(
+                        RP2Lines<Length, Camera>{})
+                        .release());
   } else {
     auto const& celestial_trajectory =
         plugin->GetCelestial(celestial_index).trajectory();
@@ -250,7 +260,9 @@ Iterator* __cdecl principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
                                  /*last_time=*/plugin->CurrentTime(),
                                  /*now=*/plugin->CurrentTime(),
                                  /*reverse=*/true);
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
+    return m.Return(
+        std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(rp2_lines)
+            .release());
   }
 }
 
@@ -271,7 +283,9 @@ principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
 
   // Do not plot the past when there is a target vessel as it is misleading.
   if (plugin->renderer().HasTargetVessel()) {
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
+    return m.Return(std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(
+                        RP2Lines<Length, Camera>{})
+                        .release());
   } else {
     auto const& vessel = *plugin->GetVessel(vessel_guid);
     Instant const prediction_final_time = vessel.prediction().t_max();
@@ -288,7 +302,9 @@ principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
                                  /*last_time=*/final_time,
                                  /*now=*/plugin->CurrentTime(),
                                  /*reverse=*/false);
-    return m.Return(new TypedIterator<RP2Lines<Length, Camera>>(rp2_lines));
+    return m.Return(
+        std::make_unique<TypedIterator<RP2Lines<Length, Camera>>>(rp2_lines)
+            .release());
   }
 }
 

--- a/ksp_plugin/interface_renderer.cpp
+++ b/ksp_plugin/interface_renderer.cpp
@@ -55,12 +55,12 @@ void __cdecl principia__RenderedPredictionApsides(
                                   max_points,
                                   rendered_apoapsides,
                                   rendered_periapsides);
-  *apoapsides = new TypedIterator<DiscreteTrajectory<World>>(
+  *apoapsides = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
       check_not_null(std::move(rendered_apoapsides)),
-      plugin);
-  *periapsides = new TypedIterator<DiscreteTrajectory<World>>(
+      plugin).release();
+  *periapsides = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
       check_not_null(std::move(rendered_periapsides)),
-      plugin);
+      plugin).release();
   return m.Return();
 }
 
@@ -82,9 +82,10 @@ void __cdecl principia__RenderedPredictionClosestApproaches(
       FromXYZ<Position<World>>(sun_world_position),
       max_points,
       rendered_closest_approaches);
-  *closest_approaches = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_closest_approaches)),
-      plugin);
+  *closest_approaches =
+      std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+          check_not_null(std::move(rendered_closest_approaches)), plugin)
+          .release();
   return m.Return();
 }
 
@@ -107,12 +108,12 @@ void __cdecl principia__RenderedPredictionNodes(Plugin const* const plugin,
                                 max_points,
                                 rendered_ascending,
                                 rendered_descending);
-  *ascending = new TypedIterator<DiscreteTrajectory<World>>(
+  *ascending = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
       check_not_null(std::move(rendered_ascending)),
-      plugin);
-  *descending = new TypedIterator<DiscreteTrajectory<World>>(
-      check_not_null(std::move(rendered_descending)),
-      plugin);
+      plugin).release();
+  *descending = std::make_unique<TypedIterator<DiscreteTrajectory<World>>>(
+                    check_not_null(std::move(rendered_descending)), plugin)
+                    .release();
   return m.Return();
 }
 

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <utility>
 
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
 #include "base/map_util.hpp"
 #include "geometry/identity.hpp"
 #include "ksp_plugin/integrators.hpp"
@@ -18,6 +20,8 @@ namespace principia {
 namespace ksp_plugin {
 namespace internal_pile_up {
 
+using base::AllocateWith;
+using base::AssertAllocatedBy;
 using base::check_not_null;
 using base::FindOrDie;
 using base::make_not_null_unique;
@@ -220,20 +224,23 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
   std::unique_ptr<PileUp> pile_up;
   if (is_pre_cesàro) {
     if (is_pre_cartan) {
-      pile_up = std::unique_ptr<PileUp>(
-          new PileUp(std::move(parts),
-                     DefaultPsychohistoryParameters(),
-                     DefaultHistoryParameters(),
-                     DiscreteTrajectory<Barycentric>::ReadFromMessage(
-                         message.history(),
-                         /*forks=*/{}),
-                     /*psychohistory=*/nullptr,
-                     /*angular_momentum=*/{},
-                     ephemeris,
-                     std::move(deletion_callback)));
+      pile_up =
+          std::unique_ptr<PileUp>(AssertAllocatedBy<std::allocator<PileUp>>(
+              new (AllocateWith<std::allocator<PileUp>>{})
+                  PileUp(std::move(parts),
+                         DefaultPsychohistoryParameters(),
+                         DefaultHistoryParameters(),
+                         DiscreteTrajectory<Barycentric>::ReadFromMessage(
+                             message.history(),
+                             /*forks=*/{}),
+                         /*psychohistory=*/nullptr,
+                         /*angular_momentum=*/{},
+                         ephemeris,
+                         std::move(deletion_callback))));
     } else {
-      pile_up = std::unique_ptr<PileUp>(
-          new PileUp(
+      pile_up = std::unique_ptr<
+          PileUp>(AssertAllocatedBy<std::allocator<PileUp>>(
+          new (AllocateWith<std::allocator<PileUp>>{}) PileUp(
               std::move(parts),
               Ephemeris<Barycentric>::AdaptiveStepParameters::ReadFromMessage(
                   message.adaptive_step_parameters()),
@@ -245,7 +252,7 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
               /*psychohistory=*/nullptr,
               /*angular_momentum=*/{},
               ephemeris,
-              std::move(deletion_callback)));
+              std::move(deletion_callback))));
     }
     // Fork a psychohistory for compatibility if there is a non-authoritative
     // point.
@@ -264,8 +271,9 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
             message.history(),
             /*forks=*/{&psychohistory});
     if (is_pre_frobenius) {
-      pile_up = std::unique_ptr<PileUp>(
-          new PileUp(
+      pile_up = std::unique_ptr<
+          PileUp>(AssertAllocatedBy<std::allocator<PileUp>>(
+          new (AllocateWith<std::allocator<PileUp>>{}) PileUp(
               std::move(parts),
               Ephemeris<Barycentric>::AdaptiveStepParameters::ReadFromMessage(
                   message.adaptive_step_parameters()),
@@ -275,10 +283,11 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
               psychohistory,
               /*angular_momentum=*/{},
               ephemeris,
-              std::move(deletion_callback)));
+              std::move(deletion_callback))));
     } else {
-      pile_up = std::unique_ptr<PileUp>(
-          new PileUp(
+      pile_up = std::unique_ptr<
+          PileUp>(AssertAllocatedBy<std::allocator<PileUp>>(
+          new (AllocateWith<std::allocator<PileUp>>{}) PileUp(
               std::move(parts),
               Ephemeris<Barycentric>::AdaptiveStepParameters::ReadFromMessage(
                   message.adaptive_step_parameters()),
@@ -289,7 +298,7 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
               Bivector<AngularMomentum, NonRotatingPileUp>::ReadFromMessage(
                   message.angular_momentum()),
               ephemeris,
-              std::move(deletion_callback)));
+              std::move(deletion_callback))));
     }
   }
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -20,6 +20,8 @@
 #include "astronomy/solar_system_fingerprints.hpp"
 #include "astronomy/stabilize_ksp.hpp"
 #include "astronomy/time_scales.hpp"
+#include "base/allocated_by.hpp"
+#include "base/allocator_new.hpp"
 #include "base/file.hpp"
 #include "base/hexadecimal.hpp"
 #include "base/map_util.hpp"
@@ -64,6 +66,8 @@ using astronomy::KSPStabilizedSystemFingerprints;
 using astronomy::KSPStockSystemFingerprints;
 using astronomy::ParseTT;
 using astronomy::StabilizeKSP;
+using base::AllocateWith;
+using base::AssertAllocatedBy;
 using base::check_not_null;
 using base::dynamic_cast_not_null;
 using base::Error;
@@ -86,8 +90,8 @@ using geometry::Identity;
 using geometry::Normalize;
 using geometry::OddPermutation;
 using geometry::Permutation;
-using geometry::RigidTransformation;
 using geometry::R3x3Matrix;
+using geometry::RigidTransformation;
 using geometry::Sign;
 using physics::BarycentricRotatingDynamicFrame;
 using physics::BodyCentredBodyDirectionDynamicFrame;
@@ -1389,8 +1393,9 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
       Ephemeris<Barycentric>::AdaptiveStepParameters::ReadFromMessage(
           message.psychohistory_parameters());
   not_null<std::unique_ptr<Plugin>> plugin =
-      std::unique_ptr<Plugin>(new Plugin(history_parameters,
-                                         psychohistory_parameters));
+      std::unique_ptr<Plugin>(AssertAllocatedBy<std::allocator<Plugin>>(
+          new (AllocateWith<std::allocator<Plugin>>{})
+              Plugin(history_parameters, psychohistory_parameters)));
 
   plugin->game_epoch_ = Instant::ReadFromMessage(message.game_epoch());
   plugin->current_time_ = Instant::ReadFromMessage(message.current_time());

--- a/ksp_plugin_test/interface_planetarium_test.cpp
+++ b/ksp_plugin_test/interface_planetarium_test.cpp
@@ -64,7 +64,8 @@ TEST_F(InterfacePlanetariumTest, ConstructionDestruction) {
               Permutation<World, Navigation>::CoordinatePermutation::YXZ)
               .Forget<OrthogonalMap>())));
   EXPECT_CALL(*plugin_, FillPlanetarium(_, _, _))
-      .WillOnce(FillUniquePtr<2>(new MockPlanetarium));
+      .WillOnce(
+          FillUniquePtr<2>(std::make_unique<MockPlanetarium>().release()));
 
   Planetarium const* planetarium = principia__PlanetariumCreate(plugin_.get(),
                                                                 {100, 200, 300},

--- a/ksp_plugin_test/interface_renderer_test.cpp
+++ b/ksp_plugin_test/interface_renderer_test.cpp
@@ -60,9 +60,9 @@ class InterfaceRendererTest : public ::testing::Test {
 };
 
 TEST_F(InterfaceRendererTest, SetPlottingFrame) {
-  StrictMock<MockDynamicFrame<Barycentric, Navigation>>* const
-     mock_navigation_frame =
-         new StrictMock<MockDynamicFrame<Barycentric, Navigation>>;
+  auto mock_navigation_frame =
+      std::make_unique<StrictMock<MockDynamicFrame<Barycentric, Navigation>>>()
+          .release();
   EXPECT_CALL(*plugin_,
               FillBarycentricRotatingNavigationFrame(celestial_index,
                                                      parent_index,
@@ -81,9 +81,9 @@ TEST_F(InterfaceRendererTest, SetPlottingFrame) {
 }
 
 TEST_F(InterfaceRendererTest, Frenet) {
-  StrictMock<MockDynamicFrame<Barycentric, Navigation>>* const
-     mock_navigation_frame =
-         new StrictMock<MockDynamicFrame<Barycentric, Navigation>>;
+  auto mock_navigation_frame =
+      std::make_unique<StrictMock<MockDynamicFrame<Barycentric, Navigation>>>()
+          .release();
   EXPECT_CALL(*plugin_,
               FillBarycentricRotatingNavigationFrame(celestial_index,
                                                      parent_index,

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "astronomy/time_scales.hpp"
+#include "base/allocated_by.hpp"
 #include "base/file.hpp"
 #include "base/not_null.hpp"
 #include "base/pull_serializer.hpp"
@@ -36,6 +37,7 @@ namespace principia {
 namespace interface {
 
 using astronomy::operator""_TT;
+using base::AssertAllocatedBy;
 using base::check_not_null;
 using base::make_not_null_unique;
 using base::OFStream;
@@ -236,10 +238,8 @@ TEST_F(InterfaceTest, Log) {
 }
 
 TEST_F(InterfaceTest, NewPlugin) {
-  std::unique_ptr<Plugin> plugin(principia__NewPlugin(
-                                     "MJD1",
-                                     "MJD2",
-                                     planetarium_rotation));
+  std::unique_ptr<Plugin> plugin(AssertAllocatedBy<std::allocator<Plugin>>(
+      principia__NewPlugin("MJD1", "MJD2", planetarium_rotation)));
   EXPECT_THAT(plugin, Not(IsNull()));
 }
 
@@ -541,9 +541,9 @@ TEST_F(InterfaceTest, CelestialFromParent) {
 }
 
 TEST_F(InterfaceTest, NewNavigationFrame) {
-  StrictMock<MockDynamicFrame<Barycentric, Navigation>>* const
-      mock_navigation_frame =
-          new StrictMock<MockDynamicFrame<Barycentric, Navigation>>;
+  auto mock_navigation_frame =
+      std::make_unique<StrictMock<MockDynamicFrame<Barycentric, Navigation>>>()
+          .release();
 
   NavigationFrameParameters parameters = {
       serialization::BarycentricRotatingDynamicFrame::kExtensionFieldNumber,
@@ -571,9 +571,9 @@ TEST_F(InterfaceTest, NewNavigationFrame) {
 }
 
 TEST_F(InterfaceTest, NavballOrientation) {
-  StrictMock<MockDynamicFrame<Barycentric, Navigation>>* const
-     mock_navigation_frame =
-         new StrictMock<MockDynamicFrame<Barycentric, Navigation>>;
+  auto mock_navigation_frame =
+      std::make_unique<StrictMock<MockDynamicFrame<Barycentric, Navigation>>>()
+          .release();
   EXPECT_CALL(*plugin_,
               FillBarycentricRotatingNavigationFrame(celestial_index,
                                                 parent_index,

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 
+#include "base/allocated_by.hpp"
 #include "base/array.hpp"
 #include "base/hexadecimal.hpp"
 #include "ksp_plugin/frames.hpp"
@@ -24,6 +25,7 @@ namespace internal_plugin {
 
 using base::Array;
 using base::UniqueArray;
+using base::AssertAllocatedBy;
 using base::HexadecimalEncoder;
 using geometry::Bivector;
 using geometry::Trivector;
@@ -64,9 +66,10 @@ std::map<GUID, not_null<Vessel const*>> TestablePlugin::vessels() const {
 
 not_null<std::unique_ptr<TestablePlugin>> TestablePlugin::ReadFromMessage(
   serialization::Plugin const& message) {
-  std::unique_ptr<Plugin> plugin = Plugin::ReadFromMessage(message);
+  Plugin* plugin = Plugin::ReadFromMessage(message).release();
   return std::unique_ptr<TestablePlugin>(
-      static_cast<TestablePlugin*>(plugin.release()));
+      AssertAllocatedBy<std::allocator<TestablePlugin>>(
+          static_cast<TestablePlugin*>(plugin)));
 }
 
 class PluginCompatibilityTest : public testing::Test {

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -738,8 +738,8 @@ TEST_F(PluginTest, ForgetAllHistoriesBeforeWithFlightPlan) {
   Instant const time = initial_time + 1 * Second;
   Instant t_max = time;
 
-  auto* const mock_dynamic_frame =
-      new MockDynamicFrame<Barycentric, Navigation>();
+  auto const mock_dynamic_frame =
+      std::make_unique<MockDynamicFrame<Barycentric, Navigation>>().release();
   std::vector<not_null<DiscreteTrajectory<Barycentric>*>> trajectories = {
       make_not_null<DiscreteTrajectory<Barycentric>*>()};
   auto instance = make_not_null_unique<MockFixedStepSizeIntegrator<

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -59,11 +59,11 @@ class ApsidesTest : public ::testing::Test {
 TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
   Instant const t0;
   GravitationalParameter const μ = SolarGravitationalParameter;
-  auto const b = new MassiveBody(μ);
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<World>> initial_state;
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b));
+  auto const b =
+      bodies.emplace_back(std::make_unique<MassiveBody const>(μ)).get();
   initial_state.emplace_back(World::origin, World::unmoving);
 
   Ephemeris<World> ephemeris(
@@ -153,11 +153,10 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
 TEST_F(ApsidesTest, ComputeNodes) {
   Instant const t0;
   GravitationalParameter const μ = SolarGravitationalParameter;
-  auto const b = new MassiveBody(μ);
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<World>> initial_state;
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b));
+  bodies.emplace_back(std::make_unique<MassiveBody const>(μ));
   initial_state.emplace_back(World::origin, World::unmoving);
 
   Ephemeris<World> ephemeris(

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -848,25 +848,22 @@ TEST_P(EphemerisTest, ComputeGravitationalAccelerationMassiveBody) {
   auto const μ2 = 3 * SolarGravitationalParameter;
   auto const μ3 = 4 * SolarGravitationalParameter;
 
-  auto const b0 =
-      new OblateBody<ICRS>(μ0,
-                           RotatingBody<ICRS>::Parameters(1 * Metre,
-                                                          1 * Radian,
-                                                          t0_,
-                                                          4 * Radian / Second,
-                                                          0 * Radian,
-                                                          π / 2 * Radian),
-                           OblateBody<ICRS>::Parameters(j2, radius));
-  auto const b1 = new MassiveBody(μ1);
-  auto const b2 = new MassiveBody(μ2);
-  auto const b3 = new MassiveBody(μ3);
-
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   std::vector<DegreesOfFreedom<ICRS>> initial_state;
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b0));
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b1));
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b2));
-  bodies.emplace_back(std::unique_ptr<MassiveBody const>(b3));
+  auto const b0 = bodies
+                      .emplace_back(std::make_unique<OblateBody<ICRS>>(
+                          μ0,
+                          RotatingBody<ICRS>::Parameters(1 * Metre,
+                                                         1 * Radian,
+                                                         t0_,
+                                                         4 * Radian / Second,
+                                                         0 * Radian,
+                                                         π / 2 * Radian),
+                          OblateBody<ICRS>::Parameters(j2, radius)))
+                      .get();
+  auto const b1 = bodies.emplace_back(std::make_unique<MassiveBody>(μ1)).get();
+  auto const b2 = bodies.emplace_back(std::make_unique<MassiveBody>(μ2)).get();
+  auto const b3 = bodies.emplace_back(std::make_unique<MassiveBody>(μ3)).get();
 
   Velocity<ICRS> const v({0 * si::Unit<Speed>,
                           0 * si::Unit<Speed>,

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -4,6 +4,7 @@
 #include <list>
 #include <vector>
 
+#include "base/allocated_by.hpp"
 #include "base/not_constructible.hpp"
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
@@ -14,6 +15,7 @@ namespace principia {
 namespace physics {
 namespace internal_forkable {
 
+using base::AssertAllocatedBy;
 using base::make_not_null_unique;
 using base::not_constructible;
 using geometry::Instant;
@@ -337,7 +339,8 @@ TEST_F(ForkableDeathTest, AttachForkWithCopiedBeginError) {
     trajectory_.push_back(t1_);
     not_null<FakeTrajectory*> const fork =
         trajectory_.NewFork(trajectory_.timeline_find(t1_));
-    trajectory_.AttachForkToCopiedBegin(std::unique_ptr<FakeTrajectory>(fork));
+    trajectory_.AttachForkToCopiedBegin(std::unique_ptr<FakeTrajectory>(
+        AssertAllocatedBy<std::allocator<FakeTrajectory>>(fork)));
   }, "is_root");
   EXPECT_DEATH({
     trajectory_.push_back(t1_);

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1253,7 +1253,7 @@ void JournalProtoProcessor::ProcessInterchangeMessage(
       "extern \"C\"\n"
       "struct " + name + " {\n"
       "  static void* operator new(std::size_t size) {\n"
-      "    return ::operator new(size);\n"
+      "    return ::operator new (size, base::AllocateWith<std::allocator<" + name + ">>{});\n"
       "  };\n";
 
   // Second pass on the fields to actually generate the code.


### PR DESCRIPTION
This is the second version (replacing #2901) of the second part of the fix for #2899.

This change makes the deleter for `std::unique_ptr` on macOS default to `AllocatorDeleter`, which uses an allocator for deletion (using the same `principia::std` approach as in #2900). The default allocator is `std::allocator`, which aliases to `MallocAllocator` on macOS as of #2900. A corresponding `std::make_unique` is also provided.
The danger with this approach is that if you have code of the form `std::unique_ptr<Foo>(new Foo())`, it will cause undefined behavior when the pointer is deleted.

To avoid this UB, I set `AllocatorDeleter::pointer` to a wrapper class which *implicitly* converts *to* a `T*` but must be *explicitly* constructed *from* a `T*`. Consequently, to construct a unique pointer from a raw pointer you have to write `std::unique_ptr<Foo>(AssertAllocatedBy<std::allocator<Foo>(...))`. The code snippet from the previous paragraph would cause a compile error (albeit only on macOS). For the cases when `new` is necessary (private constructors), I provide a tagged placement new as suggested by @eggrobin. It is used like this: `new (AllocateWith<std::allocator<Foo>>{}) Foo(…)`. Thus, the snippet from the previous paragraph would be replaced by 
```C++
std::unique_ptr<Foo>(AssertAllocatedBy<std::allocator<Foo>(new (AllocateWith<std::allocator<Foo>>{}) Foo()))
```
This is somewhat wordy but the intention is clear (the verbosity could probably be reduced with better naming).

Unfortunately, this change is not as seamless as #2900. It requires code changes in the following places:
- Use of `new` in factory functions for classes with private constructors (bb1a411; 7 files). There isn't really any way around this; the existing `new` calls are what we are trying to remove. The code changes to the verbose form shown above.
- Use of `new` in tests for convenience (3fc4823; 7 files). Changed to use `std::make_unique`.
- `not_null` assumes `std::unique_ptr<T>::pointer` is `T*` and requires some fixes (ce6db1a; 3 files).
- There are a few owned raw pointers in boundary code. `AssertAllocatedBy` is required to turn them into unique pointers (
c44f898; 3 files).
- Sometimes a `unique_ptr` is constructed from another `unique_ptr` in an unusual way (a3b2611 and 4d3d18b; 2 files).

Additionally, I automatically fall back to `::std::unique_ptr` for the following types:
- Arrays (as in `T[]`, not `std::array`). The allocator deallocate function require the number of elements but that is not available to the deleter (neither `::std::allocator` nor `MallocAllocator` actually use this parameter AFAIK, but I still don't want to break the contract).
- `T` where `std::unique_ptr<T>` is constructed by non-Principia code. This is just one class (`google::compression::Compressor`) so I special case it.