### PR TITLE
Change the way that checkpoints are serialized to allow multiple checkpoints

### DIFF
--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -26,23 +26,16 @@ using quantities::Time;
 // Instead, this class creates checkpoints that encapsulate all information
 // needed to reconstruct the timeline after a give point in time.  When
 // serializing a timeline, the pairs (time, data) are written up to the oldest
-// checkpoint, followed by the checkpoint itself.  When deserializing, the
-// timeline may be reconstructed as needed based on the checkpoint.
+// checkpoint, followed by the checkpoints themselves.  When deserializing, the
+// timeline may be reconstructed as needed based on the checkpoints.
 // Checkpoints must be created at regular intervals to ensure that the timeline
 // may be reconstructed fast enough.
-// Logically checkpoints would serialize to/deserialize from a specific message,
-// but for historical reasons they just fill some fields of a message that may
-// contain other information.
-//TODO(phl):Fix comments
 // This class is thread-safe.
 template<typename Message>
 class Checkpointer {
  public:
   // A function that reconstructs an object from a checkpoint as a side effect.
-  // It must return true iff the given message actually contained a checkpoint.
-  // If it returns false, it must leave the object in a state corresponding to
-  // its default initialization.  This function is expected to capture the
-  // object being deserialized.
+  // This function is expected to capture the object being deserialized.
   using Reader = std::function<void(typename Message::Checkpoint const&)>;
 
   // A function that writes an object to a checkpoint.  This function is
@@ -51,33 +44,30 @@ class Checkpointer {
 
   Checkpointer(Reader reader, Writer writer);
 
-  Instant oldest_checkpoint() const;
+  // Returns the oldest checkpoint in this object, or +∞ if no checkpoint was
+  // ever created.
+  Instant oldest_checkpoint() const EXCLUDES(lock_);
 
   // Creates a checkpoint at time |t|, which will be used to recreate the
   // timeline after |t|.  The checkpoint is constructed by calling the |Writer|
   // passed at construction.
-  void CreateUnconditionally(Instant const& t) EXCLUDES(lock_);
+  void WriteToCheckpoint(Instant const& t) EXCLUDES(lock_);
 
   // Same as above, but a checkpoint is only created if one was not created
-  // recently, as specified by |max_time_between_checkpoints|.
-  bool CreateIfNeeded(Instant const& t,
-                      Time const& max_time_between_checkpoints) EXCLUDES(lock_);
+  // recently, as specified by |max_time_between_checkpoints|.  Returns true iff
+  // a new checkpoint was created.
+  bool WriteToCheckpointIfNeeded(Instant const& t,
+                                 Time const& max_time_between_checkpoints)
+      EXCLUDES(lock_);
 
-  bool ReadFromOldestCheckpoint() const;
+  // Caller the |Reader| passed at construction to reconstruct an object using
+  // the oldest checkpoint.  Returns true iff this object contains at least one
+  // checkpoint.
+  bool ReadFromOldestCheckpoint() const EXCLUDES(lock_);
 
-  // If there exists a checkpoint, writes the oldest checkpoint to the |message|
-  // using protocol buffer merging and returns its time.  Otherwise returns +∞.
-  // The time returned by this function should be serialized and passed to
-  // |ReadFromMessage| when deserializing to ensure that checkpoints are
-  // preserved across serialization/deserialization cycles.
   void WriteToMessage(not_null<google::protobuf::RepeatedPtrField<
                           typename Message::Checkpoint>*> message) const
       EXCLUDES(lock_);
-
-  // Clears all the checkpoints in this checkpointer, and calls the |Reader|
-  // passed at construction to reconstruct the object from |message|.  If the
-  // |Reader| returns true (i.e., there was a checkpoint in the |message|),
-  // creates a new checkpoint in this checkpointer at the given time.
   static not_null<std::unique_ptr<Checkpointer>> ReadFromMessage(
       Reader reader,
       Writer writer,
@@ -85,7 +75,7 @@ class Checkpointer {
           message);
 
  private:
-  void CreateUnconditionallyLocked(Instant const& t)
+  void WriteToCheckpointLocked(Instant const& t)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   mutable absl::Mutex lock_;

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -43,7 +43,7 @@ class Checkpointer {
   // If it returns false, it must leave the object in a state corresponding to
   // its default initialization.  This function is expected to capture the
   // object being deserialized.
-  using Reader = std::function<bool(typename Message::Checkpoint const&)>;
+  using Reader = std::function<void(typename Message::Checkpoint const&)>;
 
   // A function that writes an object to a checkpoint.  This function is
   // expected to capture the object being serialized.
@@ -51,6 +51,8 @@ class Checkpointer {
 
   Checkpointer(Reader reader,
                Writer writer);
+
+  Instant oldest_checkpoint() const;
 
   // Creates a checkpoint at time |t|, which will be used to recreate the
   // timeline after |t|.  The checkpoint is constructed by calling the |Writer|

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -64,6 +64,8 @@ class Checkpointer {
   bool CreateIfNeeded(Instant const& t,
                       Time const& max_time_between_checkpoints) EXCLUDES(lock_);
 
+  bool ReadFromOldestCheckpoint() const;
+
   // If there exists a checkpoint, writes the oldest checkpoint to the |message|
   // using protocol buffer merging and returns its time.  Otherwise returns +∞.
   // The time returned by this function should be serialized and passed to

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -30,6 +30,9 @@ using quantities::Time;
 // timeline may be reconstructed as needed based on the checkpoints.
 // Checkpoints must be created at regular intervals to ensure that the timeline
 // may be reconstructed fast enough.
+// The |Message| must declare a nested message named |Checkpoint|, which must
+// have a field named |time| of type |Point|.  There must be a repeated field of
+// |Checkpoint|s in |Message|.
 // This class is thread-safe.
 template<typename Message>
 class Checkpointer {

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -34,15 +34,15 @@ using quantities::Time;
 template<typename Message>
 class Checkpointer {
  public:
-  // A function that reconstructs an object from a checkpoint as a side effect.
-  // This function is expected to capture the object being deserialized.
-  using Reader = std::function<void(typename Message::Checkpoint const&)>;
-
   // A function that writes an object to a checkpoint.  This function is
   // expected to capture the object being serialized.
   using Writer = std::function<void(not_null<typename Message::Checkpoint*>)>;
 
-  Checkpointer(Reader reader, Writer writer);
+  // A function that reconstructs an object from a checkpoint as a side effect.
+  // This function is expected to capture the object being deserialized.
+  using Reader = std::function<void(typename Message::Checkpoint const&)>;
+
+  Checkpointer(Writer writer, Reader reader);
 
   // Returns the oldest checkpoint in this object, or +∞ if no checkpoint was
   // ever created.
@@ -69,8 +69,8 @@ class Checkpointer {
                           typename Message::Checkpoint>*> message) const
       EXCLUDES(lock_);
   static not_null<std::unique_ptr<Checkpointer>> ReadFromMessage(
-      Reader reader,
       Writer writer,
+      Reader reader,
       google::protobuf::RepeatedPtrField<typename Message::Checkpoint> const&
           message);
 
@@ -79,8 +79,8 @@ class Checkpointer {
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   mutable absl::Mutex lock_;
-  Reader const reader_;
   Writer const writer_;
+  Reader const reader_;
 
   // The time field of the Checkpoint message may or may not be set.  The map
   // key is the source of truth.

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -63,10 +63,9 @@ class Checkpointer {
                                  Time const& max_time_between_checkpoints)
       EXCLUDES(lock_);
 
-  // Caller the |Reader| passed at construction to reconstruct an object using
-  // the oldest checkpoint.  Returns true iff this object contains at least one
-  // checkpoint.
-  bool ReadFromOldestCheckpoint() const EXCLUDES(lock_);
+  // Calls the |Reader| passed at construction to reconstruct an object using
+  // the oldest checkpoint.  Dies if this object contains no checkpoint.
+  void ReadFromOldestCheckpointOrDie() const EXCLUDES(lock_);
 
   void WriteToMessage(not_null<google::protobuf::RepeatedPtrField<
                           typename Message::Checkpoint>*> message) const

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -65,7 +65,7 @@ class Checkpointer {
 
   // Calls the |Reader| passed at construction to reconstruct an object using
   // the oldest checkpoint.  Dies if this object contains no checkpoint.
-  void ReadFromOldestCheckpointOrDie() const EXCLUDES(lock_);
+  void ReadFromOldestCheckpoint() const EXCLUDES(lock_);
 
   void WriteToMessage(not_null<google::protobuf::RepeatedPtrField<
                           typename Message::Checkpoint>*> message) const

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -49,8 +49,7 @@ class Checkpointer {
   // expected to capture the object being serialized.
   using Writer = std::function<void(not_null<typename Message::Checkpoint*>)>;
 
-  Checkpointer(Reader reader,
-               Writer writer);
+  Checkpointer(Reader reader, Writer writer);
 
   Instant oldest_checkpoint() const;
 

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -24,6 +24,15 @@ Instant Checkpointer<Message>::oldest_checkpoint() const {
 }
 
 template<typename Message>
+bool Checkpointer<Message>::ReadFromOldestCheckpoint() const {
+  if (!checkpoints_.empty()) {
+    reader_(checkpoints_.cbegin()->second);
+    return true;
+  }
+  return false;
+}
+
+template<typename Message>
 void Checkpointer<Message>::CreateUnconditionally(Instant const& t) {
   absl::MutexLock l(&lock_);
   CreateUnconditionallyLocked(t);

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -45,7 +45,7 @@ bool Checkpointer<Message>::WriteToCheckpointIfNeeded(
 }
 
 template<typename Message>
-void Checkpointer<Message>::ReadFromOldestCheckpointOrDie() const {
+void Checkpointer<Message>::ReadFromOldestCheckpoint() const {
   absl::ReaderMutexLock l(&lock_);
   CHECK(!checkpoints_.empty());
   reader_(checkpoints_.cbegin()->second);

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -32,33 +32,38 @@ bool Checkpointer<Message>::CreateIfNeeded(
 }
 
 template<typename Message>
-Instant Checkpointer<Message>::WriteToMessage(
-    not_null<Message*> const message) const {
+void Checkpointer<Message>::WriteToMessage(
+    not_null<google::protobuf::RepeatedPtrField<typename Message::Checkpoint>*>
+        message) const {
   absl::ReaderMutexLock l(&lock_);
-  if (checkpoints_.empty()) {
-    // TODO(phl): declare this next to Instant.
-    static Instant infinite_future = Instant() + quantities::Infinity<Time>;
-    return infinite_future;
-  } else {
-    message->MergeFrom(checkpoints_.cbegin()->second);
-    return checkpoints_.cbegin()->first;
+  for (const auto [time, checkpoint] : checkpoints_) {
+    typename Message::Checkpoint* const message_checkpoint = message->Add();
+    *message_checkpoint = checkpoint;
+    time.WriteToMessage(message_checkpoint->mutable_time());
   }
 }
 
 template<typename Message>
-void Checkpointer<Message>::ReadFromMessage(Instant const& t,
-                                            Message const& message) {
-  absl::MutexLock l(&lock_);
-  checkpoints_.clear();
-  if (reader_(message)) {
-    CreateUnconditionallyLocked(t);
+not_null<std::unique_ptr<Checkpointer<Message>>>
+Checkpointer<Message>::ReadFromMessage(
+    Reader reader,
+    Writer writer,
+    google::protobuf::RepeatedPtrField<typename Message::Checkpoint> const&
+        message) {
+  auto checkpointer =
+      std::make_unique<Checkpointer>(std::move(reader), std::move(writer));
+  for (const auto& checkpoint : message) {
+    Instant const time = Instant::ReadFromMessage(checkpoint.time());
+    checkpointer->checkpoints_.emplace(time, checkpoint);
   }
+  return std::move(checkpointer);
 }
 
 template<typename Message>
 void Checkpointer<Message>::CreateUnconditionallyLocked(Instant const& t) {
   lock_.AssertHeld();
-  auto const it = checkpoints_.emplace_hint(checkpoints_.end(), t, Message());
+  auto const it = checkpoints_.emplace_hint(
+      checkpoints_.end(), t, typename Message::Checkpoint());
   writer_(&it->second);
 }
 

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -26,16 +26,6 @@ Instant Checkpointer<Message>::oldest_checkpoint() const {
 }
 
 template<typename Message>
-bool Checkpointer<Message>::ReadFromOldestCheckpoint() const {
-  absl::ReaderMutexLock l(&lock_);
-  if (!checkpoints_.empty()) {
-    reader_(checkpoints_.cbegin()->second);
-    return true;
-  }
-  return false;
-}
-
-template<typename Message>
 void Checkpointer<Message>::WriteToCheckpoint(Instant const& t) {
   absl::MutexLock l(&lock_);
   WriteToCheckpointLocked(t);
@@ -52,6 +42,13 @@ bool Checkpointer<Message>::WriteToCheckpointIfNeeded(
     return true;
   }
   return false;
+}
+
+template<typename Message>
+void Checkpointer<Message>::ReadFromOldestCheckpointOrDie() const {
+  absl::ReaderMutexLock l(&lock_);
+  CHECK(!checkpoints_.empty());
+  reader_(checkpoints_.cbegin()->second);
 }
 
 template<typename Message>

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -12,9 +12,9 @@ namespace internal_checkpointer {
 using astronomy::InfiniteFuture;
 
 template<typename Message>
-Checkpointer<Message>::Checkpointer(Reader reader, Writer writer)
-    : reader_(std::move(reader)),
-      writer_(std::move(writer)) {}
+Checkpointer<Message>::Checkpointer(Writer writer, Reader reader)
+    : writer_(std::move(writer)),
+      reader_(std::move(reader)) {}
 
 template<typename Message>
 Instant Checkpointer<Message>::oldest_checkpoint() const {
@@ -69,12 +69,12 @@ void Checkpointer<Message>::WriteToMessage(
 template<typename Message>
 not_null<std::unique_ptr<Checkpointer<Message>>>
 Checkpointer<Message>::ReadFromMessage(
-    Reader reader,
     Writer writer,
+    Reader reader,
     google::protobuf::RepeatedPtrField<typename Message::Checkpoint> const&
         message) {
   auto checkpointer =
-      std::make_unique<Checkpointer>(std::move(reader), std::move(writer));
+      std::make_unique<Checkpointer>(std::move(writer), std::move(reader));
   for (const auto& checkpoint : message) {
     Instant const time = Instant::ReadFromMessage(checkpoint.time());
     checkpointer->checkpoints_.emplace(time, checkpoint);

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -13,6 +13,17 @@ Checkpointer<Message>::Checkpointer(Reader reader, Writer writer)
       writer_(std::move(writer)) {}
 
 template<typename Message>
+Instant Checkpointer<Message>::oldest_checkpoint() const {
+  absl::ReaderMutexLock l(&lock_);
+  if (checkpoints_.empty()) {
+    //TODO(phl): declare this next to Instant.
+    static Instant infinite_future = Instant() + quantities::Infinity<Time>;
+    return infinite_future;
+  }
+  return checkpoints_.cbegin()->first;
+}
+
+template<typename Message>
 void Checkpointer<Message>::CreateUnconditionally(Instant const& t) {
   absl::MutexLock l(&lock_);
   CreateUnconditionallyLocked(t);

--- a/physics/checkpointer_test.cpp
+++ b/physics/checkpointer_test.cpp
@@ -33,8 +33,8 @@ struct Message {
 class CheckpointerTest : public ::testing::Test {
  protected:
   CheckpointerTest()
-      : checkpointer_(reader_.AsStdFunction(),
-                      writer_.AsStdFunction()) {}
+      : checkpointer_(writer_.AsStdFunction(),
+                      reader_.AsStdFunction()) {}
 
   MockFunction<bool(Message::Checkpoint const&)> reader_;
   MockFunction<void(not_null<Message::Checkpoint*>)> writer_;
@@ -54,13 +54,15 @@ TEST_F(CheckpointerTest, WriteToCheckpointIfNeeded) {
 
   Instant const t2 = t1 + 8 * Second;
   EXPECT_CALL(writer_, Call(_)).Times(0);
-  checkpointer_.WriteToCheckpointIfNeeded(t2,
-                               /*max_time_between_checkpoints=*/10 * Second);
+  checkpointer_.WriteToCheckpointIfNeeded(
+      t2,
+      /*max_time_between_checkpoints=*/10 * Second);
 
   EXPECT_CALL(writer_, Call(_));
   Instant const t3 = t2 + 3 * Second;
-  checkpointer_.WriteToCheckpointIfNeeded(t3,
-                               /*max_time_between_checkpoints=*/10 * Second);
+  checkpointer_.WriteToCheckpointIfNeeded(
+      t3,
+      /*max_time_between_checkpoints=*/10 * Second);
 }
 
 TEST_F(CheckpointerTest, Serialization) {
@@ -77,8 +79,8 @@ TEST_F(CheckpointerTest, Serialization) {
   EXPECT_EQ(23, m.checkpoint[1].time().scalar().magnitude());
 
   auto const checkpointer =
-      Checkpointer<Message>::ReadFromMessage(reader_.AsStdFunction(),
-                                             writer_.AsStdFunction(),
+      Checkpointer<Message>::ReadFromMessage(writer_.AsStdFunction(),
+                                             reader_.AsStdFunction(),
                                              m.checkpoint);
   EXPECT_EQ(Instant() + 10 * Second, checkpointer->oldest_checkpoint());
 }

--- a/physics/checkpointer_test.cpp
+++ b/physics/checkpointer_test.cpp
@@ -41,34 +41,34 @@ class CheckpointerTest : public ::testing::Test {
   Checkpointer<Message> checkpointer_;
 };
 
-TEST_F(CheckpointerTest, CreateUnconditionally) {
+TEST_F(CheckpointerTest, WriteToCheckpoint) {
   Instant const t = Instant() + 10 * Second;
   EXPECT_CALL(writer_, Call(_));
-  checkpointer_.CreateUnconditionally(t);
+  checkpointer_.WriteToCheckpoint(t);
 }
 
-TEST_F(CheckpointerTest, CreateIfNeeded) {
+TEST_F(CheckpointerTest, WriteToCheckpointIfNeeded) {
   Instant const t1 = Instant() + 10 * Second;
   EXPECT_CALL(writer_, Call(_));
-  checkpointer_.CreateUnconditionally(t1);
+  checkpointer_.WriteToCheckpoint(t1);
 
   Instant const t2 = t1 + 8 * Second;
   EXPECT_CALL(writer_, Call(_)).Times(0);
-  checkpointer_.CreateIfNeeded(t2,
+  checkpointer_.WriteToCheckpointIfNeeded(t2,
                                /*max_time_between_checkpoints=*/10 * Second);
 
   EXPECT_CALL(writer_, Call(_));
   Instant const t3 = t2 + 3 * Second;
-  checkpointer_.CreateIfNeeded(t3,
+  checkpointer_.WriteToCheckpointIfNeeded(t3,
                                /*max_time_between_checkpoints=*/10 * Second);
 }
 
 TEST_F(CheckpointerTest, Serialization) {
   Instant t = Instant() + 10 * Second;
   EXPECT_CALL(writer_, Call(_)).Times(2);
-  checkpointer_.CreateUnconditionally(t);
+  checkpointer_.WriteToCheckpoint(t);
   t += 13 * Second;
-  checkpointer_.CreateUnconditionally(t);
+  checkpointer_.WriteToCheckpoint(t);
 
   Message m;
   checkpointer_.WriteToMessage(&m.checkpoint);

--- a/physics/checkpointer_test.cpp
+++ b/physics/checkpointer_test.cpp
@@ -80,7 +80,7 @@ TEST_F(CheckpointerTest, Serialization) {
       Checkpointer<Message>::ReadFromMessage(reader_.AsStdFunction(),
                                              writer_.AsStdFunction(),
                                              m.checkpoint);
-  // TODO(phl): Check the behaviour of the deserialized object.
+  EXPECT_EQ(Instant() + 10 * Second, checkpointer->oldest_checkpoint());
 }
 
 }  // namespace physics

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -114,13 +114,6 @@ class ContinuousTrajectory : public Trajectory<Frame> {
   // Ephemeris to create synchronized checkpoints of its state and that of its
   // trajectories.
   Checkpointer<serialization::ContinuousTrajectory>& checkpointer();
-  //TODO(phl): private?
-  void WriteToCheckpoint(
-      not_null<serialization::ContinuousTrajectory::Checkpoint*> message);
-  template<typename F = Frame,
-           typename = std::enable_if_t<base::is_serializable_v<F>>>
-  void ReadFromCheckpoint(
-      serialization::ContinuousTrajectory::Checkpoint const& message);
 
  protected:
   // For mocking.
@@ -143,6 +136,12 @@ class ContinuousTrajectory : public Trajectory<Frame> {
         polynomial;
   };
   using InstantPolynomialPairs = std::vector<InstantPolynomialPair>;
+
+  // Checkpointing support.
+  Checkpointer<serialization::ContinuousTrajectory>::Reader
+  MakeCheckpointerReader();
+  Checkpointer<serialization::ContinuousTrajectory>::Writer
+  MakeCheckpointerWriter();
 
   Instant t_min_locked() const REQUIRES_SHARED(lock_);
   Instant t_max_locked() const REQUIRES_SHARED(lock_);

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -138,10 +138,10 @@ class ContinuousTrajectory : public Trajectory<Frame> {
   using InstantPolynomialPairs = std::vector<InstantPolynomialPair>;
 
   // Checkpointing support.
-  Checkpointer<serialization::ContinuousTrajectory>::Reader
-  MakeCheckpointerReader();
   Checkpointer<serialization::ContinuousTrajectory>::Writer
   MakeCheckpointerWriter();
+  Checkpointer<serialization::ContinuousTrajectory>::Reader
+  MakeCheckpointerReader();
 
   Instant t_min_locked() const REQUIRES_SHARED(lock_);
   Instant t_max_locked() const REQUIRES_SHARED(lock_);

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -175,7 +175,9 @@ class ContinuousTrajectory : public Trajectory<Frame> {
   // Construction parameters;
   Time const step_;
   Length const tolerance_;
-  Checkpointer<serialization::ContinuousTrajectory> checkpointer_;
+  not_null<
+      std::unique_ptr<Checkpointer<serialization::ContinuousTrajectory>>>
+      checkpointer_;
 
   mutable absl::Mutex lock_;
 

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -119,7 +119,7 @@ class ContinuousTrajectory : public Trajectory<Frame> {
       not_null<serialization::ContinuousTrajectory::Checkpoint*> message);
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
-  bool ReadFromCheckpoint(
+  void ReadFromCheckpoint(
       serialization::ContinuousTrajectory::Checkpoint const& message);
 
  protected:

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -114,11 +114,13 @@ class ContinuousTrajectory : public Trajectory<Frame> {
   // Ephemeris to create synchronized checkpoints of its state and that of its
   // trajectories.
   Checkpointer<serialization::ContinuousTrajectory>& checkpointer();
+  //TODO(phl): private?
   void WriteToCheckpoint(
-      not_null<serialization::ContinuousTrajectory*> message);
+      not_null<serialization::ContinuousTrajectory::Checkpoint*> message);
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
-  bool ReadFromCheckpoint(serialization::ContinuousTrajectory const& message);
+  bool ReadFromCheckpoint(
+      serialization::ContinuousTrajectory::Checkpoint const& message);
 
  protected:
   // For mocking.

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -380,8 +380,6 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
   }
 
   if (is_pre_grassmann) {
-    // This compatibility code is rather iffy.  I am not sure that we would fare
-    // well on a pre-Fatou save.
     serialization::ContinuousTrajectory serialized_continuous_trajectory;
     auto* const checkpoint = serialized_continuous_trajectory.add_checkpoint();
     if (is_pre_fatou) {

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -334,7 +334,10 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
       serialization::ContinuousTrajectory const& message) {
   bool const is_pre_cohen = message.series_size() > 0;
   bool const is_pre_fatou = !message.has_checkpoint_time();
-  bool const is_pre_grassmann = message.checkpoint_size() == 0;
+  bool const is_pre_grassmann = message.has_adjusted_tolerance() &&
+                                message.has_is_unstable() &&
+                                message.has_degree() &&
+                                message.has_degree_age();
 
   not_null<std::unique_ptr<ContinuousTrajectory<Frame>>> continuous_trajectory =
       std::make_unique<ContinuousTrajectory<Frame>>(
@@ -406,7 +409,7 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerWriter(),
             message.checkpoint());
   }
-  //TODO(phl): Load from a checkpoint here.
+  continuous_trajectory->checkpointer_->ReadFromOldestCheckpoint();
 
   return continuous_trajectory;
 }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -442,8 +442,7 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
   if constexpr (base::is_serializable_v<Frame>) {
     return [this](
                serialization::ContinuousTrajectory::Checkpoint const& message) {
-      // This takes place with the trajectory unlocked because checkpointing is
-      // synchronized by the parent ephemeris.
+      absl::MutexLock l(&lock_);
       adjusted_tolerance_ =
           Length::ReadFromMessage(message.adjusted_tolerance());
       is_unstable_ = message.is_unstable();

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -309,6 +309,7 @@ template<typename Frame>
 void ContinuousTrajectory<Frame>::WriteToMessage(
       not_null<serialization::ContinuousTrajectory*> const message) const {
   absl::ReaderMutexLock l(&lock_);
+  CHECK_LT(checkpointer_->oldest_checkpoint(), InfiniteFuture);
   checkpointer_->WriteToMessage(message->mutable_checkpoint());
   step_.WriteToMessage(message->mutable_step());
   tolerance_.WriteToMessage(message->mutable_tolerance());
@@ -408,13 +409,7 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerReader(),
             message.checkpoint());
   }
-
-  // Normally the ephemeris will have created a checkpoint, but in tests and in
-  // legacy saves we may not have one.
-  if (continuous_trajectory->checkpointer_->oldest_checkpoint() <
-      InfiniteFuture) {
-    continuous_trajectory->checkpointer_->ReadFromOldestCheckpointOrDie();
-  }
+  continuous_trajectory->checkpointer_->ReadFromOldestCheckpointOrDie();
 
   return continuous_trajectory;
 }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -22,6 +22,7 @@ namespace principia {
 namespace physics {
 namespace internal_continuous_trajectory {
 
+using astronomy::InfiniteFuture;
 using base::dynamic_cast_not_null;
 using base::Error;
 using base::make_not_null_unique;
@@ -407,7 +408,13 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerReader(),
             message.checkpoint());
   }
-  continuous_trajectory->checkpointer_->ReadFromOldestCheckpoint();
+
+  // Normally the ephemeris will have created a checkpoint, but in tests and in
+  // legacy saves we may not have one.
+  if (continuous_trajectory->checkpointer_->oldest_checkpoint() <
+      InfiniteFuture) {
+    continuous_trajectory->checkpointer_->ReadFromOldestCheckpointOrDie();
+  }
 
   return continuous_trajectory;
 }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -409,7 +409,7 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerReader(),
             message.checkpoint());
   }
-  continuous_trajectory->checkpointer_->ReadFromOldestCheckpointOrDie();
+  continuous_trajectory->checkpointer_->ReadFromOldestCheckpoint();
 
   return continuous_trajectory;
 }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -441,8 +441,8 @@ ContinuousTrajectory<Frame>::MakeCheckpointerWriter() {
     return [this](
         not_null<
             serialization::ContinuousTrajectory::Checkpoint*> const message) {
-      // This takes place with the trajectory unlocked because checkpointing is
-      // synchronized by the parent ephemeris.
+      // This takes place with the trajectory unlocked because writing to a
+      // checkpoint is synchronized by the parent ephemeris.
       adjusted_tolerance_.WriteToMessage(message->mutable_adjusted_tolerance());
       message->set_is_unstable(is_unstable_);
       message->set_degree(degree_);
@@ -468,7 +468,8 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
   if constexpr (base::is_serializable_v<Frame>) {
     return [this](
                serialization::ContinuousTrajectory::Checkpoint const& message) {
-      absl::MutexLock l(&lock_);
+      // This takes place with the trajectory unlocked because reading from a
+      // checkpoint is synchronized by the parent ephemeris.
       adjusted_tolerance_ =
           Length::ReadFromMessage(message.adjusted_tolerance());
       is_unstable_ = message.is_unstable();

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -621,13 +621,15 @@ TEST_F(ContinuousTrajectoryTest, Serialization) {
     trajectory->WriteToMessage(&message);
     EXPECT_EQ(step / Second, message.step().magnitude());
     EXPECT_EQ(tolerance / Metre, message.tolerance().magnitude());
+    EXPECT_EQ(2, message.instant_polynomial_pair_size());
+    EXPECT_TRUE(message.has_first_time());
+
+    EXPECT_EQ(0, message.checkpoint_size());
     EXPECT_FALSE(message.has_adjusted_tolerance());
     EXPECT_FALSE(message.has_is_unstable());
     EXPECT_FALSE(message.has_degree());
     EXPECT_FALSE(message.has_degree_age());
     EXPECT_EQ(0, message.last_point_size());
-    EXPECT_EQ(2, message.instant_polynomial_pair_size());
-    EXPECT_TRUE(message.has_first_time());
 
     auto const trajectory_read =
         ContinuousTrajectory<World>::ReadFromMessage(message);
@@ -653,14 +655,23 @@ TEST_F(ContinuousTrajectoryTest, Serialization) {
     trajectory->WriteToMessage(&message);
     EXPECT_EQ(step / Second, message.step().magnitude());
     EXPECT_EQ(tolerance / Metre, message.tolerance().magnitude());
-    EXPECT_GE(message.adjusted_tolerance().magnitude(),
-              message.tolerance().magnitude());
-    EXPECT_TRUE(message.has_is_unstable());
-    EXPECT_EQ(3, message.degree());
-    EXPECT_GE(100, message.degree_age());
     EXPECT_EQ(2, message.instant_polynomial_pair_size());
     EXPECT_TRUE(message.has_first_time());
-    EXPECT_EQ(4, message.last_point_size());
+
+    EXPECT_EQ(1, message.checkpoint_size());
+    EXPECT_FALSE(message.has_adjusted_tolerance());
+    EXPECT_FALSE(message.has_is_unstable());
+    EXPECT_FALSE(message.has_degree());
+    EXPECT_FALSE(message.has_degree_age());
+    EXPECT_EQ(0, message.last_point_size());
+
+    auto const& checkpoint = message.checkpoint(0);
+    EXPECT_GE(checkpoint.adjusted_tolerance().magnitude(),
+              message.tolerance().magnitude());
+    EXPECT_TRUE(checkpoint.has_is_unstable());
+    EXPECT_EQ(3, checkpoint.degree());
+    EXPECT_GE(100, checkpoint.degree_age());
+    EXPECT_EQ(4, checkpoint.last_point_size());
 
     auto const trajectory_read =
         ContinuousTrajectory<World>::ReadFromMessage(message);

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -649,7 +649,7 @@ TEST_F(ContinuousTrajectoryTest, Serialization) {
 
   // Now take a checkpoint and verify that the checkpointed data is properly
   // serialized.
-  trajectory->checkpointer().CreateUnconditionally(trajectory->t_max());
+  trajectory->checkpointer().WriteToCheckpoint(trajectory->t_max());
   {
     serialization::ContinuousTrajectory message;
     trajectory->WriteToMessage(&message);
@@ -772,7 +772,7 @@ TEST_F(ContinuousTrajectoryTest, PreGrassmannCompatibility) {
                  t0_,
                  *trajectory1);
   Instant const checkpoint_time = trajectory1->t_max();
-  trajectory1->checkpointer().CreateUnconditionally(checkpoint_time);
+  trajectory1->checkpointer().WriteToCheckpoint(checkpoint_time);
 
   serialization::ContinuousTrajectory message1;
   trajectory1->WriteToMessage(&message1);
@@ -834,7 +834,7 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
                  t0_,
                  *trajectory);
   Instant const checkpoint_time = trajectory->t_max();
-  trajectory->checkpointer().CreateUnconditionally(checkpoint_time);
+  trajectory->checkpointer().WriteToCheckpoint(checkpoint_time);
   FillTrajectory(number_of_steps2,
                  step,
                  position_function,

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -743,6 +743,63 @@ TEST_F(ContinuousTrajectoryTest, PreCohenCompatibility) {
                 x().quantity().magnitude());
 }
 
+TEST_F(ContinuousTrajectoryTest, PreGrassmannCompatibility) {
+  int const number_of_steps = 30;
+  Time const step = 0.01 * Second;
+  Length const tolerance = 0.1 * Metre;
+
+  // Fill a ContinuousTrajectory and take a checkpoint.
+  auto position_function =
+      [this](Instant const t) {
+        return World::origin +
+            Displacement<World>({(t - t0_) * 3 * Metre / Second,
+                                 (t - t0_) * 5 * Metre / Second,
+                                 (t - t0_) * (-2) * Metre / Second});
+      };
+  auto velocity_function =
+      [](Instant const t) {
+        return Velocity<World>({3 * Metre / Second,
+                                5 * Metre / Second,
+                                -2 * Metre / Second});
+      };
+
+  auto const trajectory1 = std::make_unique<ContinuousTrajectory<World>>(
+                              step, tolerance);
+  FillTrajectory(number_of_steps,
+                 step,
+                 position_function,
+                 velocity_function,
+                 t0_,
+                 *trajectory1);
+  Instant const checkpoint_time = trajectory1->t_max();
+  trajectory1->checkpointer().CreateUnconditionally(checkpoint_time);
+
+  serialization::ContinuousTrajectory message1;
+  trajectory1->WriteToMessage(&message1);
+
+  // Fill the pre-Grassmann fields and clear the post-Grassmann fields.
+  serialization::ContinuousTrajectory pre_grassmann = message1;
+  EXPECT_EQ(1, pre_grassmann.checkpoint_size());
+  auto checkpoint = pre_grassmann.checkpoint(0);
+  *pre_grassmann.mutable_adjusted_tolerance() = checkpoint.adjusted_tolerance();
+  pre_grassmann.set_is_unstable(checkpoint.is_unstable());
+  pre_grassmann.set_degree(checkpoint.degree());
+  pre_grassmann.set_degree_age(checkpoint.degree_age());
+  pre_grassmann.mutable_last_point()->Swap(checkpoint.mutable_last_point());
+  // This is post-Fatou.
+  checkpoint_time.WriteToMessage(pre_grassmann.mutable_checkpoint_time());
+  pre_grassmann.clear_checkpoint();
+
+  // Read from the pre-Grassmann message, write to a separate message, and check
+  // that we get the same result.
+  auto const trajectory2 =
+      ContinuousTrajectory<World>::ReadFromMessage(pre_grassmann);
+  serialization::ContinuousTrajectory message2;
+  trajectory2->WriteToMessage(&message2);
+
+  EXPECT_THAT(message2, EqualsProto(message1));
+}
+
 TEST_F(ContinuousTrajectoryTest, Checkpoint) {
   int const number_of_steps1 = 30;
   int const number_of_steps2 = 20;

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -790,7 +790,7 @@ TEST_F(ContinuousTrajectoryTest, PreGrassmannCompatibility) {
   checkpoint_time.WriteToMessage(pre_grassmann.mutable_checkpoint_time());
   pre_grassmann.clear_checkpoint();
 
-  // Read from the pre-Grassmann message, write to a separate message, and check
+  // Read from the pre-Grassmann message, write to a second message, and check
   // that we get the same result.
   auto const trajectory2 =
       ContinuousTrajectory<World>::ReadFromMessage(pre_grassmann);

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -789,14 +789,17 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
   trajectory->WriteToMessage(&message);
   EXPECT_EQ(step / Second, message.step().magnitude());
   EXPECT_EQ(tolerance / Metre, message.tolerance().magnitude());
-  EXPECT_GE(message.adjusted_tolerance().magnitude(),
-            message.tolerance().magnitude());
-  EXPECT_TRUE(message.has_is_unstable());
-  EXPECT_EQ(3, message.degree());
-  EXPECT_GE(100, message.degree_age());
+  EXPECT_EQ(1, message.checkpoint_size());
   EXPECT_EQ(3, message.instant_polynomial_pair_size());
   EXPECT_TRUE(message.has_first_time());
-  EXPECT_EQ(6, message.last_point_size());
+
+  auto const& checkpoint = message.checkpoint(0);
+  EXPECT_GE(checkpoint.adjusted_tolerance().magnitude(),
+            message.tolerance().magnitude());
+  EXPECT_TRUE(checkpoint.has_is_unstable());
+  EXPECT_EQ(3, checkpoint.degree());
+  EXPECT_GE(100, checkpoint.degree_age());
+  EXPECT_EQ(6, checkpoint.last_point_size());
 
   auto const trajectory_read =
       ContinuousTrajectory<World>::ReadFromMessage(message);

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -301,7 +301,7 @@ class Ephemeris {
 
  private:
   // Checkpointing support.
-  void CreateCheckpointIfNeeded(Instant const& time) const
+  void WriteToCheckpointIfNeeded(Instant const& time) const
       SHARED_LOCKS_REQUIRED(lock_);
 
   Checkpointer<serialization::Ephemeris>::Reader MakeCheckpointerReader();

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -301,14 +301,18 @@ class Ephemeris {
 
  private:
   // Checkpointing support.
-  void WriteToCheckpoint(not_null<serialization::Ephemeris*> message);
+  void WriteToCheckpoint(
+      not_null<serialization::Ephemeris::Checkpoint*> message);
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
-  bool ReadFromCheckpoint(serialization::Ephemeris const& message);
+  void ReadFromCheckpoint(serialization::Ephemeris::Checkpoint const& message);
   void CreateCheckpointIfNeeded(Instant const& time) const
       SHARED_LOCKS_REQUIRED(lock_);
+
   Checkpointer<serialization::Ephemeris>::Reader
   static MakeCheckpointerReader(Ephemeris* ephemeris);
+  Checkpointer<serialization::Ephemeris>::Writer
+  static MakeCheckpointerWriter(Ephemeris* ephemeris);
 
   // Callbacks for the integrators.
   void AppendMassiveBodiesState(

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -276,7 +276,7 @@ class Ephemeris {
       serialization::Ephemeris const& message) EXCLUDES(lock_);
 
   // A |Guard| is an RAII object that protects a critical section against
-  // changes to |t_min| due to calls to |EventuallyForgetBefore|.
+  // changes to |t_min|.
   class Guard final {
    public:
     explicit Guard(not_null<Ephemeris<Frame> const*> ephemeris);
@@ -303,9 +303,8 @@ class Ephemeris {
   // Checkpointing support.
   void WriteToCheckpointIfNeeded(Instant const& time) const
       SHARED_LOCKS_REQUIRED(lock_);
-
-  Checkpointer<serialization::Ephemeris>::Reader MakeCheckpointerReader();
   Checkpointer<serialization::Ephemeris>::Writer MakeCheckpointerWriter();
+  Checkpointer<serialization::Ephemeris>::Reader MakeCheckpointerReader();
 
   // Callbacks for the integrators.
   void AppendMassiveBodiesState(

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -301,18 +301,11 @@ class Ephemeris {
 
  private:
   // Checkpointing support.
-  void WriteToCheckpoint(
-      not_null<serialization::Ephemeris::Checkpoint*> message);
-  template<typename F = Frame,
-           typename = std::enable_if_t<base::is_serializable_v<F>>>
-  void ReadFromCheckpoint(serialization::Ephemeris::Checkpoint const& message);
   void CreateCheckpointIfNeeded(Instant const& time) const
       SHARED_LOCKS_REQUIRED(lock_);
 
-  Checkpointer<serialization::Ephemeris>::Reader
-  static MakeCheckpointerReader(Ephemeris* ephemeris);
-  Checkpointer<serialization::Ephemeris>::Writer
-  static MakeCheckpointerWriter(Ephemeris* ephemeris);
+  Checkpointer<serialization::Ephemeris>::Reader MakeCheckpointerReader();
+  Checkpointer<serialization::Ephemeris>::Writer MakeCheckpointerWriter();
 
   // Callbacks for the integrators.
   void AppendMassiveBodiesState(

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -793,7 +793,10 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
             ephemeris->MakeCheckpointerReader(),
             message.checkpoint());
   }
-  CHECK(ephemeris->checkpointer_->ReadFromOldestCheckpoint());
+
+  // WriteToMessage always creates a checkpoint, and so does the compatibility
+  // code.
+  ephemeris->checkpointer_->ReadFromOldestCheckpointOrDie();
 
   // The ephemeris will need to be prolonged as needed when deserializing the
   // plugin.

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -885,7 +885,8 @@ Checkpointer<serialization::Ephemeris>::Reader
 Ephemeris<Frame>::MakeCheckpointerReader() {
   if constexpr (base::is_serializable_v<Frame>) {
     return [this](serialization::Ephemeris::Checkpoint const& message) {
-      absl::MutexLock l(&lock_);
+      // No locking here because reading from a checkpoint is synchronized by
+      // the caller.
       NewtonianMotionEquation equation;
       equation.compute_acceleration = [this](
           Instant const& t,

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -869,7 +869,7 @@ Checkpointer<serialization::Ephemeris>::Reader
 Ephemeris<Frame>::MakeCheckpointerReader() {
   if constexpr (base::is_serializable_v<Frame>) {
     return [this](serialization::Ephemeris::Checkpoint const& message) {
-      lock_.AssertHeld();
+      absl::MutexLock l(&lock_);
       NewtonianMotionEquation equation;
       equation.compute_acceleration = [this](
           Instant const& t,

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -796,7 +796,7 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
 
   // WriteToMessage always creates a checkpoint, and so does the compatibility
   // code.
-  ephemeris->checkpointer_->ReadFromOldestCheckpointOrDie();
+  ephemeris->checkpointer_->ReadFromOldestCheckpoint();
 
   // The ephemeris will need to be prolonged as needed when deserializing the
   // plugin.

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -793,7 +793,7 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
             ephemeris->MakeCheckpointerWriter(),
             message.checkpoint());
   }
-  //TODO(phl): Load from a checkpoint here.
+  CHECK(ephemeris->checkpointer_->ReadFromOldestCheckpoint());
 
   // The ephemeris will need to be prolonged as needed when deserializing the
   // plugin.
@@ -897,9 +897,9 @@ template<typename Frame>
 Checkpointer<serialization::Ephemeris>::Writer
 Ephemeris<Frame>::MakeCheckpointerWriter() {
   if constexpr (base::is_serializable_v<Frame>) {
-    lock_.AssertReaderHeld();
     return [this](
                not_null<serialization::Ephemeris::Checkpoint*> const message) {
+      lock_.AssertReaderHeld();
       instance_->WriteToMessage(message->mutable_instance());
     };
   } else {

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -69,12 +69,13 @@ message ContinuousTrajectory {
   required bool is_unstable = 4;  // Pre-Grassmann.
   required int32 degree = 5;  // Pre-Grassmann.
   required int32 degree_age = 6;  // Pre-Grassmann.
-  repeated ChebyshevSeries series = 7;  // Pre-Cohen.
-  optional Point first_time = 8;
   repeated InstantaneousDegreesOfFreedom last_point = 9;  // Pre-Grassmann.
   optional Point checkpoint_time = 11;  // Added in Fatou, removed in Grassmann.
+  repeated ChebyshevSeries series = 7;  // Pre-Cohen.
+  optional Point first_time = 8;
   repeated InstantPolynomialPair
       instant_polynomial_pair = 10;  // Added in Cohen.
+  repeated Checkpoint checkpoint = 12;  // Added in Grassmann.
 }
 
 message DiscreteTrajectory {

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -51,22 +51,30 @@ message ContinuousTrajectory {
     required Point instant = 1;
     required Pair degrees_of_freedom = 2;
   }
-  required Quantity step = 1;
-  required Quantity tolerance = 2;
-  required Quantity adjusted_tolerance = 3;
-  required bool is_unstable = 4;
-  required int32 degree = 5;
-  required int32 degree_age = 6;
-  repeated ChebyshevSeries series = 7;  // Pre-Cohen.
-  optional Point first_time = 8;
-  repeated InstantaneousDegreesOfFreedom last_point = 9;
-  optional Point checkpoint_time = 11;  // Added in Fatou.
-  // Added in Cohen.
   message InstantPolynomialPair {
     required Point t_max = 1;
     required Polynomial polynomial = 2;
   }
-  repeated InstantPolynomialPair instant_polynomial_pair = 10;
+  message Checkpoint {
+    required Point time = 1;
+    required Quantity adjusted_tolerance = 2;
+    required bool is_unstable = 3;
+    required int32 degree = 4;
+    required int32 degree_age = 5;
+    repeated InstantaneousDegreesOfFreedom last_point = 6;
+  }
+  required Quantity step = 1;
+  required Quantity tolerance = 2;
+  required Quantity adjusted_tolerance = 3;  // Pre-Grassmann.
+  required bool is_unstable = 4;  // Pre-Grassmann.
+  required int32 degree = 5;  // Pre-Grassmann.
+  required int32 degree_age = 6;  // Pre-Grassmann.
+  repeated ChebyshevSeries series = 7;  // Pre-Cohen.
+  optional Point first_time = 8;
+  repeated InstantaneousDegreesOfFreedom last_point = 9;  // Pre-Grassmann.
+  optional Point checkpoint_time = 11;  // Added in Fatou, removed in Grassmann.
+  repeated InstantPolynomialPair
+      instant_polynomial_pair = 10;  // Added in Cohen.
 }
 
 message DiscreteTrajectory {
@@ -105,7 +113,6 @@ message DynamicFrame {
 }
 
 message Ephemeris {
-  // Added in Ἐρατοσθένης.
   message AccuracyParameters {
     required Quantity fitting_tolerance = 1;
     required double geopotential_tolerance = 2;
@@ -120,12 +127,17 @@ message Ephemeris {
     required FixedStepSizeIntegrator integrator = 1;
     required Quantity step = 2;
   }
+  message Checkpoint {
+    required Point time = 1;
+    required IntegratorInstance instance = 2;
+  }
   repeated MassiveBody body = 1;
   repeated ContinuousTrajectory trajectory = 2;
   optional AccuracyParameters accuracy_parameters = 10; // Added in Ἐρατοσθένης.
   required FixedStepParameters fixed_step_parameters = 7;
-  required IntegratorInstance instance = 9;
-  optional Point checkpoint_time = 12;  // Added in Fatou.
+  optional IntegratorInstance instance = 9;  // Pre-Grassmann.
+  optional Point checkpoint_time = 12;  // Added in Fatou, removed in Grassmann.
+  repeated Checkpoint checkpoint = 13;  // Added in Grassmann.
 
   // Pre-Fatou.
   reserved 11;

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -65,10 +65,10 @@ message ContinuousTrajectory {
   }
   required Quantity step = 1;
   required Quantity tolerance = 2;
-  required Quantity adjusted_tolerance = 3;  // Pre-Grassmann.
-  required bool is_unstable = 4;  // Pre-Grassmann.
-  required int32 degree = 5;  // Pre-Grassmann.
-  required int32 degree_age = 6;  // Pre-Grassmann.
+  optional Quantity adjusted_tolerance = 3;  // Pre-Grassmann.
+  optional bool is_unstable = 4;  // Pre-Grassmann.
+  optional int32 degree = 5;  // Pre-Grassmann.
+  optional int32 degree_age = 6;  // Pre-Grassmann.
   repeated InstantaneousDegreesOfFreedom last_point = 9;  // Pre-Grassmann.
   optional Point checkpoint_time = 11;  // Added in Fatou, removed in Grassmann.
   repeated ChebyshevSeries series = 7;  // Pre-Cohen.


### PR DESCRIPTION
Checkpoints now go in their separate message instead of in the parent message.

#2400, take two.