### PR TITLE
Remove the shutdown bit from the prognosticator parameters

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -22,6 +22,7 @@ using astronomy::InfiniteFuture;
 using base::Contains;
 using base::Error;
 using base::FindOrDie;
+using base::jthread;
 using base::make_not_null_unique;
 using base::MakeStoppableThread;
 using geometry::BarycentreCalculator;
@@ -358,10 +359,7 @@ void Vessel::RefreshPrediction(Instant const& time) {
 }
 
 void Vessel::StopPrognosticator() {
-  if (prognosticator_.joinable()) {
-    prognosticator_.request_stop();
-    prognosticator_.join();
-  }
+  prognosticator_ = jthread();
 }
 
 std::string Vessel::ShortDebugString() const {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -566,6 +566,7 @@ Status Vessel::RepeatedlyFlowPrognostication() {
       }
       std::swap(prognosticator_parameters, prognosticator_parameters_);
     }
+    RETURN_IF_STOPPED;
 
     std::unique_ptr<DiscreteTrajectory<Barycentric>> prognostication;
     Status const status =

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -167,6 +167,7 @@ class Vessel {
   // have a last time at or before |time|.
   virtual void RefreshPrediction(Instant const& time);
 
+  // Stop the asynchronous prognosticator as soon as convenient.
   void StopPrognosticator();
 
   // Returns "vessel_name (GUID)".
@@ -206,7 +207,6 @@ class Vessel {
     Instant first_time;
     DegreesOfFreedom<Barycentric> first_degrees_of_freedom;
     Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters;
-    bool shutdown = false;
   };
   friend bool operator!=(PrognosticatorParameters const& left,
                          PrognosticatorParameters const& right);


### PR DESCRIPTION
It's no longer needed now that we have stoppable threads.