### PR TITLE
Return a Status when reading from a checkpoint

### DIFF
--- a/physics/checkpointer_test.cpp
+++ b/physics/checkpointer_test.cpp
@@ -7,6 +7,7 @@ namespace principia {
 namespace physics {
 
 using base::not_null;
+using base::Status;
 using geometry::Instant;
 using quantities::si::Second;
 using ::testing::MockFunction;
@@ -36,7 +37,7 @@ class CheckpointerTest : public ::testing::Test {
       : checkpointer_(writer_.AsStdFunction(),
                       reader_.AsStdFunction()) {}
 
-  MockFunction<bool(Message::Checkpoint const&)> reader_;
+  MockFunction<Status(Message::Checkpoint const&)> reader_;
   MockFunction<void(not_null<Message::Checkpoint*>)> writer_;
   Checkpointer<Message> checkpointer_;
 };


### PR DESCRIPTION
This had been discussed in the review of #2932, it will be needed now as the reanimator might need to report errors while integrating.

Also tighten locking now that the `Checkpointer` callbacks are no longer run under a lock.

#2400, take two.