### PR TITLE
Improve ContinuousTrajectory checkpointing

### DIFF
--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -147,7 +147,7 @@ Status Checkpointer<Message>::ReadFromCheckpointAtOrBefore(
 template<typename Message>
 Status Checkpointer<Message>::ReadFromCheckpointAt(Instant const& t,
                                                    Reader const& reader) const {
-  typename std::map<Instant, Message::Checkpoint>::const_iterator it;
+  typename std::map<Instant, typename Message::Checkpoint>::const_iterator it;
   {
     absl::ReaderMutexLock l(&lock_);
     it = checkpoints_.find(t);

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -131,7 +131,7 @@ class ContinuousTrajectory : public Trajectory<Frame> {
       Checkpointer<serialization::ContinuousTrajectory>::Reader const& reader)
       const;
 
-  // Returns functions that can be passed to a |Checkpointer| to write this
+  // Return functions that can be passed to a |Checkpointer| to write this
   // trajectory to a checkpoint or read it back.
   Checkpointer<serialization::ContinuousTrajectory>::Writer
   MakeCheckpointerWriter();

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -518,6 +518,7 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
              DegreesOfFreedom<Frame>::ReadFromMessage(l.degrees_of_freedom())});
       }
 
+#if 0
       // Restore the other members to their state at the time of the checkpoint.
       if (last_points_.empty()) {
         polynomials_.clear();
@@ -543,6 +544,7 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
         }
       }
       last_accessed_polynomial_ = 0;  // Always valid.
+#endif
 
       return Status::OK;
     };

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -542,7 +542,7 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
           first_time_ = oldest_time;
         }
       }
-      last_accessed_polynomial_ = 0;  // Always valid.
+      last_accessed_polynomial_ = 0;  // Always a valid value.
 
       return Status::OK;
     };

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -518,7 +518,6 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
              DegreesOfFreedom<Frame>::ReadFromMessage(l.degrees_of_freedom())});
       }
 
-#if 0
       // Restore the other members to their state at the time of the checkpoint.
       if (last_points_.empty()) {
         polynomials_.clear();
@@ -544,7 +543,6 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
         }
       }
       last_accessed_polynomial_ = 0;  // Always valid.
-#endif
 
       return Status::OK;
     };

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -376,7 +376,7 @@ template<typename Frame>
 template<typename, typename>
 not_null<std::unique_ptr<ContinuousTrajectory<Frame>>>
 ContinuousTrajectory<Frame>::ReadFromMessage(
-      serialization::ContinuousTrajectory const& message) {
+    serialization::ContinuousTrajectory const& message) {
   bool const is_pre_cohen = message.series_size() > 0;
   bool const is_pre_fatou = !message.has_checkpoint_time();
   bool const is_pre_grassmann = message.has_adjusted_tolerance() &&
@@ -458,26 +458,17 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
 }
 
 template<typename Frame>
-Checkpointer<serialization::ContinuousTrajectory>&
-ContinuousTrajectory<Frame>::checkpointer() {
-  return *checkpointer_;
+void ContinuousTrajectory<Frame>::WriteToCheckpoint(Instant const& t) const {
+  checkpointer_->WriteToCheckpoint(t);
 }
 
 template<typename Frame>
-ContinuousTrajectory<Frame>::ContinuousTrajectory()
-    : checkpointer_(
-          make_not_null_unique<
-              Checkpointer<serialization::ContinuousTrajectory>>(
-          /*reader=*/nullptr,
-          /*writer=*/nullptr)) {}
-
-template<typename Frame>
-ContinuousTrajectory<Frame>::InstantPolynomialPair::InstantPolynomialPair(
-    Instant const t_max,
-    not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
-        polynomial)
-    : t_max(t_max),
-      polynomial(std::move(polynomial)) {}
+Status ContinuousTrajectory<Frame>::ReadFromCheckpointAt(
+    Instant const& t,
+    Checkpointer<serialization::ContinuousTrajectory>::Reader const& reader)
+    const {
+  return checkpointer_->ReadFromCheckpointAt(t, reader);
+}
 
 template<typename Frame>
 Checkpointer<serialization::ContinuousTrajectory>::Writer
@@ -513,6 +504,8 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
     return [this](
                serialization::ContinuousTrajectory::Checkpoint const& message) {
       absl::MutexLock l(&lock_);
+
+      // Load the members that are recorded in the checkpoint.
       adjusted_tolerance_ =
           Length::ReadFromMessage(message.adjusted_tolerance());
       is_unstable_ = message.is_unstable();
@@ -524,12 +517,55 @@ ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
             {Instant::ReadFromMessage(l.instant()),
              DegreesOfFreedom<Frame>::ReadFromMessage(l.degrees_of_freedom())});
       }
+
+      // Restore the other members to their state at the time of the checkpoint.
+      if (last_points_.empty()) {
+        polynomials_.clear();
+        first_time_ = std::nullopt;
+      } else {
+        // Locate the polynomial that ends at the first last_point_.  Note that
+        // we cannot use FindPolynomialForInstant because it calls lower_bound
+        // and we don't want to change its behaviour.
+        Instant const& oldest_time = last_points_.front().first;
+        // If oldest_time is the t_max of some polynomial, then the returned
+        // iterator points to the next polynomial.
+        auto const it =
+            std::upper_bound(polynomials_.begin(),
+                             polynomials_.end(),
+                             oldest_time,
+                             [](Instant const& left,
+                                InstantPolynomialPair const& right) {
+                               return left < right.t_max;
+                             });
+        polynomials_.erase(it, polynomials_.end());
+        if (polynomials_.empty()) {
+          first_time_ = oldest_time;
+        }
+      }
+      last_accessed_polynomial_ = 0;  // Always valid.
+
       return Status::OK;
     };
   } else {
     return nullptr;
   }
 }
+
+template<typename Frame>
+ContinuousTrajectory<Frame>::ContinuousTrajectory()
+    : checkpointer_(
+          make_not_null_unique<
+              Checkpointer<serialization::ContinuousTrajectory>>(
+          /*reader=*/nullptr,
+          /*writer=*/nullptr)) {}
+
+template<typename Frame>
+ContinuousTrajectory<Frame>::InstantPolynomialPair::InstantPolynomialPair(
+    Instant const t_max,
+    not_null<std::unique_ptr<Polynomial<Displacement<Frame>, Instant>>>
+        polynomial)
+    : t_max(t_max),
+      polynomial(std::move(polynomial)) {}
 
 template<typename Frame>
 Instant ContinuousTrajectory<Frame>::t_min_locked() const {

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -945,6 +945,8 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
   EXPECT_GE(100, checkpoint.degree_age());
   EXPECT_EQ(6, checkpoint.last_point_size());
 
+  // Read the trajectory and check that everything is identical up to the
+  // checkpoint.
   auto const trajectory_read =
       ContinuousTrajectory<World>::ReadFromMessage(message);
   EXPECT_EQ(trajectory_read->t_min(), trajectory->t_min());
@@ -955,6 +957,21 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
     EXPECT_EQ(trajectory_read->EvaluateDegreesOfFreedom(time),
               trajectory->EvaluateDegreesOfFreedom(time));
   }
+
+  // Extend the trajectory that was just read.
+  FillTrajectory(number_of_steps2,
+                 step,
+                 position_function,
+                 velocity_function,
+                 t0_ + number_of_steps1 * step,
+                 *trajectory_read);
+  EXPECT_EQ(trajectory_read->t_max(),
+            t0_ + (number_of_steps1 + number_of_steps2) * step);
+
+  // Reset to the checkpoint and check that the polynomials were truncated.
+  trajectory_read->ReadFromCheckpointAt(
+      checkpoint_time, trajectory_read->MakeCheckpointerReader());
+  EXPECT_EQ(trajectory_read->t_max(), checkpoint_time);
 }
 
 }  // namespace internal_continuous_trajectory

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -705,7 +705,7 @@ TEST_F(ContinuousTrajectoryTest, Serialization) {
 
   // Take a checkpoint and verify that the checkpointed data is properly
   // serialized.
-  trajectory->checkpointer().WriteToCheckpoint(trajectory->t_max());
+  trajectory->WriteToCheckpoint(trajectory->t_max());
   serialization::ContinuousTrajectory message;
   trajectory->WriteToMessage(&message);
   EXPECT_EQ(step / Second, message.step().magnitude());
@@ -772,7 +772,7 @@ TEST_F(ContinuousTrajectoryTest, PreCohenCompatibility) {
                  velocity_function,
                  t0_,
                  *trajectory);
-  trajectory->checkpointer().WriteToCheckpoint(trajectory->t_max());
+  trajectory->WriteToCheckpoint(trajectory->t_max());
 
   serialization::ContinuousTrajectory message;
   trajectory->WriteToMessage(&message);
@@ -859,7 +859,7 @@ TEST_F(ContinuousTrajectoryTest, PreGrassmannCompatibility) {
                  t0_,
                  *trajectory1);
   Instant const checkpoint_time = trajectory1->t_max();
-  trajectory1->checkpointer().WriteToCheckpoint(checkpoint_time);
+  trajectory1->WriteToCheckpoint(checkpoint_time);
 
   serialization::ContinuousTrajectory message1;
   trajectory1->WriteToMessage(&message1);
@@ -921,7 +921,7 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
                  t0_,
                  *trajectory);
   Instant const checkpoint_time = trajectory->t_max();
-  trajectory->checkpointer().WriteToCheckpoint(checkpoint_time);
+  trajectory->WriteToCheckpoint(checkpoint_time);
   FillTrajectory(number_of_steps2,
                  step,
                  position_function,

--- a/physics/continuous_trajectory_test.cpp
+++ b/physics/continuous_trajectory_test.cpp
@@ -920,6 +920,8 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
                  velocity_function,
                  t0_,
                  *trajectory);
+  EXPECT_EQ(t0_ + (((number_of_steps1 - 1) / 8) * 8 + 1) * step,
+            trajectory->t_max());
   Instant const checkpoint_time = trajectory->t_max();
   trajectory->WriteToCheckpoint(checkpoint_time);
   FillTrajectory(number_of_steps2,
@@ -928,6 +930,9 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
                  velocity_function,
                  t0_ + number_of_steps1 * step,
                  *trajectory);
+  EXPECT_EQ(
+      t0_ + (((number_of_steps1 + number_of_steps2 - 1) / 8) * 8 + 1) * step,
+      trajectory->t_max());
 
   serialization::ContinuousTrajectory message;
   trajectory->WriteToMessage(&message);
@@ -965,8 +970,9 @@ TEST_F(ContinuousTrajectoryTest, Checkpoint) {
                  velocity_function,
                  t0_ + number_of_steps1 * step,
                  *trajectory_read);
-  EXPECT_EQ(trajectory_read->t_max(),
-            t0_ + (number_of_steps1 + number_of_steps2) * step);
+  EXPECT_EQ(
+      t0_ + (((number_of_steps1 + number_of_steps2 - 1) / 8) * 8 + 1) * step,
+      trajectory->t_max());
 
   // Reset to the checkpoint and check that the polynomials were truncated.
   trajectory_read->ReadFromCheckpointAt(

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -863,7 +863,7 @@ void Ephemeris<Frame>::WriteToCheckpointIfNeeded(Instant const& time) const {
     if (checkpointer_->WriteToCheckpointIfNeeded(
             time, max_time_between_checkpoints)) {
       for (auto const& trajectory : trajectories_) {
-        trajectory->checkpointer().WriteToCheckpoint(time);
+        trajectory->WriteToCheckpoint(time);
       }
     }
   }


### PR DESCRIPTION
1. Change the API to avoid exposing the checkpointer and to make it possible for clients to create readers and writers.
2. Change the reader to fully rollback the trajectory to the time of the checkpoint, including the members not captured in the checkpoint.
3. Fix an error found by Clang.

#2400 take two.