### PR TITLE
Use a RecurringThread for the reanimator

### DIFF
--- a/base/recurring_thread.hpp
+++ b/base/recurring_thread.hpp
@@ -26,9 +26,9 @@ class BaseRecurringThread {
  protected:
   explicit BaseRecurringThread(std::chrono::milliseconds period);
 
-  std::chrono::milliseconds period() const;
+  Status RepeatedlyRunAction();
 
-  virtual Status RepeatedlyRunAction() = 0;
+  virtual Status RunAction() = 0;
 
  private:
   std::chrono::milliseconds const period_;
@@ -63,7 +63,7 @@ class RecurringThread : public BaseRecurringThread {
   std::optional<Output> Get();
 
  private:
-  Status RepeatedlyRunAction() override;
+  Status RunAction() override;
 
   Action const action_;
 
@@ -89,7 +89,7 @@ class RecurringThread<Input, void> : public BaseRecurringThread {
   void Put(Input input);
 
  private:
-  Status RepeatedlyRunAction() override;
+  Status RunAction() override;
 
   Action const action_;
 

--- a/base/recurring_thread_body.hpp
+++ b/base/recurring_thread_body.hpp
@@ -92,7 +92,7 @@ RecurringThread<Input, void>::RecurringThread(
 
 template<typename Input>
 void RecurringThread<Input, void>::Put(Input input) {
-  absl::MutexLock l(&input_output_lock_);
+  absl::MutexLock l(&input_lock_);
   input_ = std::move(input);
 }
 
@@ -100,7 +100,7 @@ template<typename Input>
 Status RecurringThread<Input, void>::RunAction() {
   std::optional<Input> input;
   {
-    absl::MutexLock l(&input_output_lock_);
+    absl::MutexLock l(&input_lock_);
     if (!input_.has_value()) {
       // No input, let's wait for it to appear.
       return Status::OK;

--- a/base/recurring_thread_body.hpp
+++ b/base/recurring_thread_body.hpp
@@ -8,15 +8,7 @@ namespace principia {
 namespace base {
 namespace internal_recurring_thread {
 
-template<typename Input, typename Output>
-RecurringThread<Input, Output>::RecurringThread(
-    Action action,
-    std::chrono::milliseconds const period)
-    : action_(std::move(action)),
-      period_(period) {}
-
-template<typename Input, typename Output>
-void RecurringThread<Input, Output>::Start() {
+void BaseRecurringThread::Start() {
   absl::MutexLock l(&jthread_lock_);
   if (!jthread_.joinable()) {
     jthread_ = MakeStoppableThread(
@@ -24,11 +16,24 @@ void RecurringThread<Input, Output>::Start() {
   }
 }
 
-template<typename Input, typename Output>
-void RecurringThread<Input, Output>::Stop() {
+void BaseRecurringThread::Stop() {
   absl::MutexLock l(&jthread_lock_);
   jthread_ = jthread();
 }
+
+BaseRecurringThread::BaseRecurringThread(std::chrono::milliseconds const period)
+    : period_(period) {}
+
+std::chrono::milliseconds BaseRecurringThread::period() const {
+  return period_;
+}
+
+template<typename Input, typename Output>
+RecurringThread<Input, Output>::RecurringThread(
+    Action action,
+    std::chrono::milliseconds const period)
+    : BaseRecurringThread(period),
+      action_(std::move(action)) {}
 
 template<typename Input, typename Output>
 void RecurringThread<Input, Output>::Put(Input input) {
@@ -50,7 +55,7 @@ template<typename Input, typename Output>
 Status RecurringThread<Input, Output>::RepeatedlyRunAction() {
   for (std::chrono::steady_clock::time_point wakeup_time;;
        std::this_thread::sleep_until(wakeup_time)) {
-    wakeup_time = std::chrono::steady_clock::now() + period_;
+    wakeup_time = std::chrono::steady_clock::now() + period();
     RETURN_IF_STOPPED;
 
     std::optional<Input> input;
@@ -71,6 +76,42 @@ Status RecurringThread<Input, Output>::RepeatedlyRunAction() {
       absl::MutexLock l(&input_output_lock_);
       output_ = std::move(status_or_output.ValueOrDie());
     }
+    RETURN_IF_STOPPED;
+  }
+}
+
+template<typename Input>
+RecurringThread<Input, void>::RecurringThread(
+    Action action,
+    std::chrono::milliseconds const period)
+    : BaseRecurringThread(period),
+      action_(std::move(action)) {}
+
+template<typename Input>
+void RecurringThread<Input, void>::Put(Input input) {
+  absl::MutexLock l(&input_output_lock_);
+  input_ = std::move(input);
+}
+
+template<typename Input>
+Status RecurringThread<Input, void>::RepeatedlyRunAction() {
+  for (std::chrono::steady_clock::time_point wakeup_time;;
+       std::this_thread::sleep_until(wakeup_time)) {
+    wakeup_time = std::chrono::steady_clock::now() + period();
+    RETURN_IF_STOPPED;
+
+    std::optional<Input> input;
+    {
+      absl::MutexLock l(&input_output_lock_);
+      if (!input_.has_value()) {
+        // No input, let's wait for it to appear.
+        continue;
+      }
+      std::swap(input, input_);
+    }
+    RETURN_IF_STOPPED;
+
+    Status status = action_(input.value());
     RETURN_IF_STOPPED;
   }
 }

--- a/base/recurring_thread_body.hpp
+++ b/base/recurring_thread_body.hpp
@@ -8,7 +8,7 @@ namespace principia {
 namespace base {
 namespace internal_recurring_thread {
 
-void BaseRecurringThread::Start() {
+inline void BaseRecurringThread::Start() {
   absl::MutexLock l(&jthread_lock_);
   if (!jthread_.joinable()) {
     jthread_ = MakeStoppableThread(
@@ -16,15 +16,16 @@ void BaseRecurringThread::Start() {
   }
 }
 
-void BaseRecurringThread::Stop() {
+inline void BaseRecurringThread::Stop() {
   absl::MutexLock l(&jthread_lock_);
   jthread_ = jthread();
 }
 
-BaseRecurringThread::BaseRecurringThread(std::chrono::milliseconds const period)
+inline BaseRecurringThread::BaseRecurringThread(
+    std::chrono::milliseconds const period)
     : period_(period) {}
 
-Status BaseRecurringThread::RepeatedlyRunAction() {
+inline Status BaseRecurringThread::RepeatedlyRunAction() {
   for (std::chrono::steady_clock::time_point wakeup_time;;
        std::this_thread::sleep_until(wakeup_time)) {
     wakeup_time = std::chrono::steady_clock::now() + period_;

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -426,7 +426,7 @@ class Ephemeris {
       std::unique_ptr<Checkpointer<serialization::Ephemeris>>> checkpointer_;
 
   // The techniques and terminology follow [Lov22].
-  RecurringThread<std::set<Instant>, std::nullptr_t> reanimator_;
+  RecurringThread<std::set<Instant>> reanimator_;
 
   // The fields above this line are fixed at construction and therefore not
   // protected.  Note that |ContinuousTrajectory| is thread-safe.  |lock_| is

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
-#include "base/jthread.hpp"
+#include "base/recurring_thread.hpp"
 #include "base/not_null.hpp"
 #include "base/status.hpp"
 #include "geometry/grassmann.hpp"
@@ -34,8 +34,8 @@ namespace physics {
 namespace internal_ephemeris {
 
 using base::Error;
-using base::jthread;
 using base::not_null;
+using base::RecurringThread;
 using base::Status;
 using geometry::Instant;
 using geometry::Position;
@@ -426,7 +426,7 @@ class Ephemeris {
       std::unique_ptr<Checkpointer<serialization::Ephemeris>>> checkpointer_;
 
   // The techniques and terminology follow [Lov22].
-  jthread reanimator_;
+  RecurringThread<std::set<Instant>, std::nullptr_t> reanimator_;
 
   // The fields above this line are fixed at construction and therefore not
   // protected.  Note that |ContinuousTrajectory| is thread-safe.  |lock_| is

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -251,6 +251,7 @@ Ephemeris<Frame>::Ephemeris(
 
   IntegrationProblem<NewtonianMotionEquation> problem;
   problem.equation = MakeMassiveBodiesNewtonianMotionEquation();
+  reanimator_.Start();
 
   typename NewtonianMotionEquation::SystemState& state = problem.initial_state;
   state.time = DoublePrecision<Instant>(initial_time);


### PR DESCRIPTION
Because `Reanimate` doesn't return a result (it modifies the `Ephemeris` directly) I am adding a specialization of `RecurringThread` for void output.  I am restructuring the code a bit by moving stuff that's common to all specializations in the base class.

#2400 take two.