### PR TITLE
Only append the barycentre of the parts if it is after the end of the trajectory

### DIFF
--- a/journal/player.cpp
+++ b/journal/player.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <string>
 
+#include "absl/strings/match.h"
 #include "base/array.hpp"
 #include "base/get_line.hpp"
 #include "base/hexadecimal.hpp"
@@ -44,13 +45,14 @@ bool Player::Play(int const index) {
 
   // Check that the version of the journal matches that of the binary.  Remember
   // that a GetVersion message is logged in Recorder::Activate, so it's always
-  // present.
+  // present.  The |StartsWith| test below allows the "-dirty" suffix, which is
+  // typically present when debugging.
   if (method_in->HasExtension(serialization::GetVersion::extension)) {
     auto const& get_version_out =
         method_out_return->GetExtension(serialization::GetVersion::extension)
             .out();
     LOG_IF(FATAL,
-           get_version_out.version() != Version &&
+           !absl::StartsWith(Version, get_version_out.version())  &&
                (PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH == 0))
         << "Journal version is " << get_version_out.version()
         << ", running with a binary built at version " << Version

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -89,7 +89,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Crashes\2957\JOURNAL.20210423-105847)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Crashes\2931\JOURNAL.20210330-124441)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -109,7 +109,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
     auto* extension = method_in.MutableExtension(
         serialization::CatchUpLaggingVessels::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(1851148864528);
+    in->set_plugin(2109308527968);
   }
   serialization::Method method_out_return;
   {

--- a/journal/profiles.cpp
+++ b/journal/profiles.cpp
@@ -29,7 +29,7 @@ void Insert(std::uint64_t const address,
       const_cast<typename std::remove_cv<T>::type*>(pointer));
   auto const [it, inserted] = pointer_map.emplace(address, inserted_pointer);
   if (!inserted) {
-    CHECK_EQ(it->second, inserted_pointer);
+    CHECK_EQ(it->second, inserted_pointer) << address;
   }
 }
 


### PR DESCRIPTION
Fix #2641.
Fix #2931.
Fix #2967.