### PR TITLE
Close planned orbit analyser if there is no flight plan

### DIFF
--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -642,6 +642,10 @@ internal class PlannedOrbitAnalyser : OrbitAnalyser {
   }
 
   protected override OrbitAnalysis GetAnalysis() {
+    if (!plugin.FlightPlanExists(predicted_vessel.id.ToString())) {
+      Hide();
+      return new OrbitAnalysis();
+    }
     return plugin.FlightPlanGetCoastAnalysis(predicted_vessel.id.ToString(),
                                              manual_revolutions_per_cycle,
                                              manual_days_per_cycle,


### PR DESCRIPTION
Fix #2974—which was indeed straightforward to reproduce, so this was tested in-game.