### PR TITLE
Optimizations for DiscreteTrajectory

### DIFF
--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -136,9 +136,9 @@ void BM_DiscreteTrajectoryFind(benchmark::State& state) {
 
   for (auto _ : state) {
     // These times are in different segments of the fork.
-    fork->Find(Instant() + 333 * Second);
-    fork->Find(Instant() + 667 * Second);
-    fork->Find(Instant() + 833 * Second);
+    fork->Find(Instant() + 1.0 / 3.0 * steps * Second);
+    fork->Find(Instant() + 2.0 / 3.0 * steps * Second);
+    fork->Find(Instant() + 5.0 / 6.0 * steps * Second);
   }
 }
 
@@ -151,9 +151,9 @@ void BM_DiscreteTrajectoryLowerBound(benchmark::State& state) {
 
   for (auto _ : state) {
     // These times are in different segments of the fork.
-    fork->LowerBound(Instant() + 333 * Second);
-    fork->LowerBound(Instant() + 667 * Second);
-    fork->LowerBound(Instant() + 833 * Second);
+    fork->LowerBound(Instant() + 1.0 / 3.0 * steps * Second);
+    fork->LowerBound(Instant() + 2.0 / 3.0 * steps * Second);
+    fork->LowerBound(Instant() + 5.0 / 6.0 * steps * Second);
   }
 }
 

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -115,6 +115,28 @@ void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
   }
 }
 
+void BM_DiscreteTrajectoryTMin(benchmark::State& state) {
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateMotionlessTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+
+  for (auto _ : state) {
+    fork->t_min();
+  }
+}
+
+void BM_DiscreteTrajectoryTMax(benchmark::State& state) {
+  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
+      CreateMotionlessTrajectory(4);
+  not_null<DiscreteTrajectory<World>*> const fork =
+      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+
+  for (auto _ : state) {
+    fork->t_max();
+  }
+}
+
 void BM_DiscreteTrajectoryCreateDestroy(benchmark::State& state) {
   int const steps = state.range(0);
   for (auto _ : state) {
@@ -205,6 +227,8 @@ BENCHMARK(BM_DiscreteTrajectoryFront);
 BENCHMARK(BM_DiscreteTrajectoryBack);
 BENCHMARK(BM_DiscreteTrajectoryBegin);
 BENCHMARK(BM_DiscreteTrajectoryEnd);
+BENCHMARK(BM_DiscreteTrajectoryTMin);
+BENCHMARK(BM_DiscreteTrajectoryTMax);
 BENCHMARK(BM_DiscreteTrajectoryCreateDestroy)->Range(8, 1024);
 BENCHMARK(BM_DiscreteTrajectoryIterate)->Range(8, 1024);
 BENCHMARK(BM_DiscreteTrajectoryReverseIterate)->Range(8, 1024);

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -38,7 +38,7 @@ not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateMotionlessTrajectory(
     int const steps) {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
   for (Time t = 0 * Second; t < steps * Second; t += 1 * Second) {
-    trajectory->Append(Instant{} + t, {World::origin, World::unmoving});
+    trajectory->Append(Instant() + t, {World::origin, World::unmoving});
   }
   return trajectory;
 }
@@ -52,7 +52,7 @@ not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateCircularTrajectory(
     double const sin_ωt = Sin(ω * t);
     double const cos_ωt = Cos(ω * t);
     trajectory->Append(
-        Instant{} + t,
+        Instant() + t,
         {World::origin +
              Displacement<World>({cos_ωt * Metre, 0 * Metre, sin_ωt * Metre}),
          Velocity<World>({-sin_ωt * Metre / Second,

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -25,8 +25,8 @@ using quantities::si::Second;
 
 namespace {
 
-// Creates a trajectory with the given number of steps.
-not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateTrajectory(
+// Creates a motionless trajectory with the given number of steps.
+not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateMotionlessTrajectory(
     int const steps) {
   auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
   Instant t;
@@ -73,7 +73,7 @@ not_null<DiscreteTrajectory<World>*> ForkAt(DiscreteTrajectory<World>& parent,
 
 void BM_DiscreteTrajectoryFront(benchmark::State& state) {
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(4);
+      CreateMotionlessTrajectory(4);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -84,7 +84,7 @@ void BM_DiscreteTrajectoryFront(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryBack(benchmark::State& state) {
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(4);
+      CreateMotionlessTrajectory(4);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -95,7 +95,7 @@ void BM_DiscreteTrajectoryBack(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(4);
+      CreateMotionlessTrajectory(4);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -106,7 +106,7 @@ void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
 
 void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(4);
+      CreateMotionlessTrajectory(4);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -118,14 +118,14 @@ void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
 void BM_DiscreteTrajectoryCreateDestroy(benchmark::State& state) {
   int const steps = state.range(0);
   for (auto _ : state) {
-    CreateTrajectory(steps);
+    CreateMotionlessTrajectory(steps);
   }
 }
 
 void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
   int const steps = state.range(0);
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(steps);
+      CreateMotionlessTrajectory(steps);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -138,7 +138,7 @@ void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
 void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
   int const steps = state.range(0);
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(steps);
+      CreateMotionlessTrajectory(steps);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -151,7 +151,7 @@ void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
 void BM_DiscreteTrajectoryFind(benchmark::State& state) {
   int const steps = state.range(0);
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(steps);
+      CreateMotionlessTrajectory(steps);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
@@ -166,7 +166,7 @@ void BM_DiscreteTrajectoryFind(benchmark::State& state) {
 void BM_DiscreteTrajectoryLowerBound(benchmark::State& state) {
   int const steps = state.range(0);
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateTrajectory(steps);
+      CreateMotionlessTrajectory(steps);
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -151,8 +151,10 @@ void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
+  auto const begin = fork->begin();
+  auto const end = fork->end();
   for (auto _ : state) {
-    for (auto it = fork->begin(); it != fork->end(); ++it) {
+    for (auto it = begin; it != end; ++it) {
     }
   }
 }
@@ -164,8 +166,10 @@ void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
   not_null<DiscreteTrajectory<World>*> const fork =
       ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
 
+  auto const begin = fork->begin();
+  auto const end = fork->end();
   for (auto _ : state) {
-    for (auto it = fork->end(); it != fork->begin(); --it) {
+    for (auto it = end; it != begin; --it) {
     }
   }
 }

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -259,9 +259,7 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
       std::vector<DiscreteTrajectory<Frame>**> const& forks);
 
   // Returns the Hermite interpolation for the left-open, right-closed
-  // trajectory segment bounded above by |upper|, or, if |upper| is |begin()|,
-  // returns a first-degree polynomial which should be evaluated only at
-  // |t_min()|.
+  // trajectory segment bounded above by |upper|.
   Hermite3<Instant, Position<Frame>> GetInterpolation(
       Iterator const& upper) const;
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -46,12 +46,12 @@ class DiscreteTrajectoryIterator
                               DiscreteTrajectoryTraits<Frame>> {
  public:
   struct reference {
-    explicit reference(
-        typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it);
-
     Instant const& time;
     DegreesOfFreedom<Frame> const& degrees_of_freedom;
   };
+
+  static reference MakeReference(
+      typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it);
 
   reference operator*() const;
   std::optional<reference> operator->() const;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -46,12 +46,12 @@ class DiscreteTrajectoryIterator
                               DiscreteTrajectoryTraits<Frame>> {
  public:
   struct reference {
+    explicit reference(
+        typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it);
+
     Instant const& time;
     DegreesOfFreedom<Frame> const& degrees_of_freedom;
   };
-
-  static reference MakeReference(
-      typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it);
 
   reference operator*() const;
   std::optional<reference> operator->() const;

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -46,6 +46,9 @@ class DiscreteTrajectoryIterator
                               DiscreteTrajectoryTraits<Frame>> {
  public:
   struct reference {
+    explicit reference(
+        typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it);
+
     Instant const& time;
     DegreesOfFreedom<Frame> const& degrees_of_freedom;
   };
@@ -256,11 +259,11 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
       std::vector<DiscreteTrajectory<Frame>**> const& forks);
 
   // Returns the Hermite interpolation for the left-open, right-closed
-  // trajectory segment containing the given |time|, or, if |time| is |t_min()|,
+  // trajectory segment bounded above by |upper|, or, if |upper| is |begin()|,
   // returns a first-degree polynomial which should be evaluated only at
   // |t_min()|.
   Hermite3<Instant, Position<Frame>> GetInterpolation(
-      Instant const& time) const;
+      Iterator const& upper) const;
 
   Timeline timeline_;
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -322,8 +322,8 @@ Position<Frame> DiscreteTrajectory<Frame>::EvaluatePosition(
   if (iter->time == time) {
     return iter->degrees_of_freedom.position();
   }
-  CHECK_LE(t_min(), time);
-  CHECK_GE(t_max(), time);
+  CHECK_LT(t_min(), time);
+  CHECK_GT(t_max(), time);
   return GetInterpolation(iter).Evaluate(time);
 }
 
@@ -334,8 +334,8 @@ Velocity<Frame> DiscreteTrajectory<Frame>::EvaluateVelocity(
   if (iter->time == time) {
     return iter->degrees_of_freedom.velocity();
   }
-  CHECK_LE(t_min(), time);
-  CHECK_GE(t_max(), time);
+  CHECK_LT(t_min(), time);
+  CHECK_GT(t_max(), time);
   return GetInterpolation(iter).EvaluateDerivative(time);
 }
 
@@ -346,8 +346,8 @@ DegreesOfFreedom<Frame> DiscreteTrajectory<Frame>::EvaluateDegreesOfFreedom(
   if (iter->time == time) {
     return iter->degrees_of_freedom;
   }
-  CHECK_LE(t_min(), time);
-  CHECK_GE(t_max(), time);
+  CHECK_LT(t_min(), time);
+  CHECK_GT(t_max(), time);
   auto const interpolation = GetInterpolation(iter);
   return {interpolation.Evaluate(time), interpolation.EvaluateDerivative(time)};
 }
@@ -664,7 +664,8 @@ void DiscreteTrajectory<Frame>::FillSubTreeFromMessage(
 template<typename Frame>
 Hermite3<Instant, Position<Frame>> DiscreteTrajectory<Frame>::GetInterpolation(
     Iterator const& upper) const {
-  auto const lower = upper == this->begin() ? upper : --Iterator{upper};
+  CHECK(upper != this->begin());
+  auto const lower = --Iterator{upper};
   return Hermite3<Instant, Position<Frame>>{
       {lower->time, upper->time},
       {lower->degrees_of_freedom.position(),

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -1,4 +1,4 @@
-
+﻿
 #pragma once
 
 #include "physics/discrete_trajectory.hpp"
@@ -32,17 +32,22 @@ Instant const& DiscreteTrajectoryTraits<Frame>::time(
 }
 
 template<typename Frame>
+DiscreteTrajectoryIterator<Frame>::reference::reference(
+    typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it)
+    : time(it->first), degrees_of_freedom(it->second) {}
+
+template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference
 DiscreteTrajectoryIterator<Frame>::operator*() const {
   auto const& it = this->current();
-  return {it->first, it->second};
+  return reference(it);
 }
 
 template<typename Frame>
 std::optional<typename DiscreteTrajectoryIterator<Frame>::reference>
     DiscreteTrajectoryIterator<Frame>::operator->() const {
   auto const& it = this->current();
-  return std::make_optional<reference>({it->first, it->second});
+  return std::make_optional<reference>(it);
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -32,24 +32,22 @@ Instant const& DiscreteTrajectoryTraits<Frame>::time(
 }
 
 template<typename Frame>
-typename DiscreteTrajectoryIterator<Frame>::reference
-DiscreteTrajectoryIterator<Frame>::MakeReference(
-    typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it) {
-  return {it->first, it->second};
-}
+DiscreteTrajectoryIterator<Frame>::reference::reference(
+    typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it)
+    : time(it->first), degrees_of_freedom(it->second) {}
 
 template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference
 DiscreteTrajectoryIterator<Frame>::operator*() const {
   auto const& it = this->current();
-  return MakeReference(it);
+  return reference(it);
 }
 
 template<typename Frame>
 std::optional<typename DiscreteTrajectoryIterator<Frame>::reference>
     DiscreteTrajectoryIterator<Frame>::operator->() const {
   auto const& it = this->current();
-  return std::make_optional<reference>(MakeReference(it));
+  return std::make_optional<reference>(it);
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -32,22 +32,23 @@ Instant const& DiscreteTrajectoryTraits<Frame>::time(
 }
 
 template<typename Frame>
-DiscreteTrajectoryIterator<Frame>::reference::reference(
+typename DiscreteTrajectoryIterator<Frame>::reference DiscreteTrajectoryIterator<Frame>::MakeReference(
     typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it)
-    : time(it->first), degrees_of_freedom(it->second) {}
+    { return {it->first, it->second};
+    }
 
 template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference
 DiscreteTrajectoryIterator<Frame>::operator*() const {
   auto const& it = this->current();
-  return reference(it);
+  return MakeReference(it);
 }
 
 template<typename Frame>
 std::optional<typename DiscreteTrajectoryIterator<Frame>::reference>
     DiscreteTrajectoryIterator<Frame>::operator->() const {
   auto const& it = this->current();
-  return std::make_optional<reference>(it);
+  return std::make_optional<reference>(MakeReference(it));
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -32,10 +32,11 @@ Instant const& DiscreteTrajectoryTraits<Frame>::time(
 }
 
 template<typename Frame>
-typename DiscreteTrajectoryIterator<Frame>::reference DiscreteTrajectoryIterator<Frame>::MakeReference(
-    typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it)
-    { return {it->first, it->second};
-    }
+typename DiscreteTrajectoryIterator<Frame>::reference
+DiscreteTrajectoryIterator<Frame>::MakeReference(
+    typename DiscreteTrajectoryTraits<Frame>::TimelineConstIterator it) {
+  return {it->first, it->second};
+}
 
 template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -39,6 +39,10 @@ using geometry::Instant;
 // TimelineConstIterator must be an STL-like iterator in the timeline of
 // Tr4jectory.  |time()| must return the corresponding time.  Iterators must be
 // STL-like and *must*not* be invalidated when the trajectory changes.
+//
+// The It3rator class must export declarations similar to the following:
+//   using reference = ...;
+//   static reference MakeReference(Traits::TimelineConstIterator it);
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 class Forkable;

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -42,7 +42,7 @@ using geometry::Instant;
 //
 // The It3rator class must export declarations similar to the following:
 //   using reference = ...;
-//   static reference MakeReference(Traits::TimelineConstIterator it);
+// where reference can be constructed from a TimelineConstIterator.
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 class Forkable;

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -202,7 +202,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
 template<typename Tr4jectory, typename It3rator, typename Traits>
 typename It3rator::reference
 Forkable<Tr4jectory, It3rator, Traits>::front() const {
-  return It3rator::MakeReference(root()->timeline_begin());
+  return typename It3rator::reference(root()->timeline_begin());
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -210,7 +210,7 @@ typename It3rator::reference Forkable<Tr4jectory, It3rator, Traits>::
 back() const {
   // Handle case where back is in our timeline.
   if (!timeline_empty()) {
-    return It3rator::MakeReference(--timeline_end());
+    return typename It3rator::reference(--timeline_end());
   }
 
   // Handle case where back is in the first nonempty parent timeline.
@@ -220,7 +220,7 @@ back() const {
          trajectory->parent()->timeline_end()) {
     trajectory = trajectory->parent();
   }
-  return It3rator::MakeReference(*trajectory->position_in_parent_timeline_);
+  return typename It3rator::reference(*trajectory->position_in_parent_timeline_);
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -213,7 +213,7 @@ back() const {
     return It3rator::MakeReference(--timeline_end());
   }
 
-  // Handle case where back is in some parent timeline.
+  // Handle case where back is in the first nonempty parent timeline.
   CHECK_NOTNULL(parent_);
   not_null<Tr4jectory const*> trajectory = that();
   while (trajectory->position_in_parent_timeline_ ==

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -202,7 +202,7 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
 template<typename Tr4jectory, typename It3rator, typename Traits>
 typename It3rator::reference
 Forkable<Tr4jectory, It3rator, Traits>::front() const {
-  return typename It3rator::reference(root()->timeline_begin());
+  return It3rator::MakeReference(root()->timeline_begin());
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -210,7 +210,7 @@ typename It3rator::reference Forkable<Tr4jectory, It3rator, Traits>::
 back() const {
   // Handle case where back is in our timeline.
   if (!timeline_empty()) {
-    return typename It3rator::reference(--timeline_end());
+    return It3rator::MakeReference(--timeline_end());
   }
 
   // Handle case where back is in some parent timeline.
@@ -220,7 +220,7 @@ back() const {
          trajectory->parent()->timeline_end()) {
     trajectory = trajectory->parent();
   }
-  return typename It3rator::reference(*trajectory->position_in_parent_timeline_);
+  return It3rator::MakeReference(*trajectory->position_in_parent_timeline_);
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -220,7 +220,8 @@ back() const {
          trajectory->parent()->timeline_end()) {
     trajectory = trajectory->parent();
   }
-  return typename It3rator::reference(*trajectory->position_in_parent_timeline_);
+  return
+      typename It3rator::reference(*trajectory->position_in_parent_timeline_);
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -177,8 +177,16 @@ not_null<Tr4jectory*> Forkable<Tr4jectory, It3rator, Traits>::parent() {
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 It3rator Forkable<Tr4jectory, It3rator, Traits>::begin() const {
-  not_null<Tr4jectory const*> ancestor = root();
-  return Wrap(ancestor, ancestor->timeline_begin());
+  It3rator iterator;
+  not_null<Tr4jectory const*> ancestor = that();
+  iterator.ancestry_.push_back(ancestor);
+  while (ancestor->parent_ != nullptr) {
+    ancestor = ancestor->parent();
+    iterator.ancestry_.push_back(ancestor);
+  }
+  iterator.current_ = ancestor->timeline_begin();
+
+  return iterator;
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -194,15 +202,25 @@ It3rator Forkable<Tr4jectory, It3rator, Traits>::end() const {
 template<typename Tr4jectory, typename It3rator, typename Traits>
 typename It3rator::reference
 Forkable<Tr4jectory, It3rator, Traits>::front() const {
-  // TODO(phl): This can be implemented more efficiently.
-  return *begin();
+  return typename It3rator::reference(root()->timeline_begin());
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
 typename It3rator::reference Forkable<Tr4jectory, It3rator, Traits>::
 back() const {
-  // TODO(phl): This can be implemented more efficiently.
-  return *--end();
+  // Handle case where back is in our timeline.
+  if (!timeline_empty()) {
+    return typename It3rator::reference(--timeline_end());
+  }
+
+  // Handle case where back is in some parent timeline.
+  CHECK_NOTNULL(parent_);
+  not_null<Tr4jectory const*> trajectory = that();
+  while (trajectory->position_in_parent_timeline_ ==
+         trajectory->parent()->timeline_end()) {
+    trajectory = trajectory->parent();
+  }
+  return typename It3rator::reference(*trajectory->position_in_parent_timeline_);
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>

--- a/physics/forkable_test.cpp
+++ b/physics/forkable_test.cpp
@@ -36,6 +36,9 @@ class FakeTrajectoryIterator : public ForkableIterator<FakeTrajectory,
                          FakeTrajectoryTraits>::current;
   using reference = Instant const&;
 
+  static reference MakeReference(
+      FakeTrajectoryTraits::TimelineConstIterator it);
+
   reference operator*() const;
 
  protected:
@@ -89,6 +92,11 @@ class FakeTrajectory : public Forkable<FakeTrajectory,
 };
 
 Instant const& FakeTrajectoryTraits::time(TimelineConstIterator const it) {
+  return *it;
+}
+
+FakeTrajectoryIterator::reference FakeTrajectoryIterator::MakeReference(
+    FakeTrajectoryTraits::TimelineConstIterator it) {
   return *it;
 }
 


### PR DESCRIPTION
In particular,
* `DiscreteTrajectory::EvaluatePosition` and friends now only compute the interpolation when necessary (as suggested by @pleroy in #2961).
* `Forkable::{begin, front, back}` have been made more efficient.

Accordingly, DiscreteTrajectory benchmarks for `t_max`, `t_min`, and `EvaluateDegreesOfFreedom` have been added. Additionally, some unrelated DiscreteTrajectory benchmarks have been improved:
* The `find` and `lower_bound` benchmarks now correctly adapt to trajectory size.
* The iteration benchmarks now cache `begin` and `end`.

Here are the relevant benchmark diffs from fc81d60 to f52362a:
```
Benchmark                                                                   Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                               -0.8568         -0.8565            23             3            23             3
BM_DiscreteTrajectoryBack                                                -0.6674         -0.6678            17             6            17             6
BM_DiscreteTrajectoryBegin                                               -0.2585         -0.2590            23            17            23            17
BM_DiscreteTrajectoryEnd                                                 +0.0118         +0.0112             5             5             5             5
BM_DiscreteTrajectoryTMin                                                -0.7728         -0.7728            27             6            27             6
BM_DiscreteTrajectoryTMax                                                -0.5384         -0.5391            19             9            19             9
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact                       -0.7189         -0.7188            95            27            95            27
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated                -0.1196         -0.1186            93            82            93            82
```