### PR TITLE
Remove misleading FORCE_INLINE

### DIFF
--- a/numerics/polynomial.hpp
+++ b/numerics/polynomial.hpp
@@ -126,10 +126,9 @@ class PolynomialInMonomialBasis : public Polynomial<Value_, Argument_> {
   explicit operator PolynomialInMonomialBasis<
       Value, Argument, higher_degree_, HigherEvaluator>() const;
 
-  FORCE_INLINE(inline) Value
-  operator()(Argument const& argument) const override;
-  FORCE_INLINE(inline) Derivative<Value, Argument>
-  EvaluateDerivative(Argument const& argument) const override;
+  Value operator()(Argument const& argument) const override;
+  Derivative<Value, Argument> EvaluateDerivative(
+      Argument const& argument) const override;
 
   constexpr int degree() const override;
   bool is_zero() const override;


### PR DESCRIPTION
These functions are virtual (and overriding), and all calls to them are virtual, since we never direct calls such as
```C++
p.PolynomialInMonomialBasis<Value, Argument, degree, Evaluator>::operator()(x);
```
As a result, [they are never inlined](https://docs.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-160#example-2).
See [godbolt](https://gcc.godbolt.org/z/eoYsY1446).

This may be a good thing (inlining an evaluation of a polynomial of degree 16 may be abusive).
Perhaps we would want an inlinable (but not force-inlined) evaluation for polynomials of small known degree (e.g. in special functions), but it would have to be a separate non-virtual function.