### PR TITLE
No FMA with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,6 @@ INCLUDES      := -I. -I$(DEP_DIR)glog/src \
 	-I$(DEP_DIR)zfp/include
 SHARED_ARGS   := \
 	-std=c++1z -stdlib=libc++ -O3 -g                              \
-	-mfma                                                         \
 	-fPIC -fexceptions -ferror-limit=1000 -fno-omit-frame-pointer \
 	-Wall -Wpedantic                                              \
 	-Wno-char-subscripts                                          \

--- a/numerics/fma.hpp
+++ b/numerics/fma.hpp
@@ -11,10 +11,18 @@ namespace internal_fma {
 
 using base::CPUFeatureFlags;
 
+// With clang, using FMA requires VEX-encoding everything; see #3019.
+#if PRINCIPIA_COMPILER_MSVC
+constexpr bool CanEmitFMAInstructions = true;
+#else
+constexpr bool CanEmitFMAInstructions = false;
+#endif
+
 // The functions in this file unconditionally wrap the appropriate intrinsics.
 // The caller may only use them if |UseHardwareFMA| is true.
 #if PRINCIPIA_USE_FMA_IF_AVAILABLE
-inline bool const UseHardwareFMA = HasCPUFeatures(CPUFeatureFlags::FMA);
+inline bool const UseHardwareFMA =
+    CanEmitFMAInstructions && HasCPUFeatures(CPUFeatureFlags::FMA);
 #else
 inline bool const UseHardwareFMA = false;
 #endif
@@ -33,6 +41,7 @@ inline double FusedNegatedMultiplySubtract(double a, double b, double c);
 
 }  // namespace internal_fma
 
+using internal_fma::CanEmitFMAInstructions;
 using internal_fma::FusedMultiplyAdd;
 using internal_fma::FusedMultiplySubtract;
 using internal_fma::FusedNegatedMultiplyAdd;

--- a/numerics/fma_body.hpp
+++ b/numerics/fma_body.hpp
@@ -2,33 +2,51 @@
 
 #include "numerics/fma.hpp"
 
+#include "glog/logging.h"
+
 namespace principia {
 namespace numerics {
 namespace internal_fma {
 
 inline double FusedMultiplyAdd(double const a, double const b, double const c) {
-  return _mm_cvtsd_f64(
-      _mm_fmadd_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  if constexpr (CanEmitFMAInstructions) {
+    return _mm_cvtsd_f64(
+        _mm_fmadd_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  } else {
+    LOG(FATAL) << "Clang cannot use FMA without VEX-encoding everything";
+  }
 }
 
 inline double FusedMultiplySubtract(double const a,
                                     double const b,
                                     double const c) {
-  return _mm_cvtsd_f64(
-      _mm_fmsub_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  if constexpr (CanEmitFMAInstructions) {
+    return _mm_cvtsd_f64(
+        _mm_fmsub_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  } else {
+    LOG(FATAL) << "Clang cannot use FMA without VEX-encoding everything";
+  }
 }
 inline double FusedNegatedMultiplyAdd(double const a,
                                       double const b,
                                       double const c) {
-  return _mm_cvtsd_f64(
-      _mm_fnmadd_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  if constexpr (CanEmitFMAInstructions) {
+    return _mm_cvtsd_f64(
+        _mm_fnmadd_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  } else {
+    LOG(FATAL) << "Clang cannot use FMA without VEX-encoding everything";
+  }
 }
 
 inline double FusedNegatedMultiplySubtract(double const a,
                                            double const b,
                                            double const c) {
-  return _mm_cvtsd_f64(
-      _mm_fnmsub_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  if constexpr (CanEmitFMAInstructions) {
+    return _mm_cvtsd_f64(
+        _mm_fnmsub_sd(_mm_set_sd(a), _mm_set_sd(b), _mm_set_sd(c)));
+  } else {
+    LOG(FATAL) << "Clang cannot use FMA without VEX-encoding everything";
+  }
 }
 
 }  // namespace internal_fma

--- a/numerics/fma_test.cpp
+++ b/numerics/fma_test.cpp
@@ -17,7 +17,7 @@ class FMATest : public testing::Test {};
 
 TEST_F(FMATest, FMA) {
   // Note that we test even if |UseHardwareFMA| is false, i.e., even in debug.
-  if (!HasCPUFeatures(CPUFeatureFlags::FMA)) {
+  if (!CanEmitFMAInstructions || !HasCPUFeatures(CPUFeatureFlags::FMA)) {
     LOG(ERROR) << "Cannot test FMA on a machine without FMA";
     return;
   }


### PR DESCRIPTION
See the comments on #3010.

To be revisited once #3019 is addressed (the SSE2 build will never have FMA, and the AVX build will be VEX-encoded).