### PR TITLE
Oveflow in constexpr arithmetic with clang 8, continued

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -162,13 +162,17 @@ inline void noreturn() { std::exit(0); }
 #define CONSTEXPR_CHECK(condition) CHECK(condition)
 #define CONSTEXPR_DCHECK(condition) DCHECK(condition)
 
-// Clang for some reason doesn't like FP arithmetic that yields infinities in
-// constexpr code (MSVC and GCC are fine with that).  This will be fixed in
-// Clang 9.0.0, all hail zygoloid.
-#if PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL
-#  define CONSTEXPR_INFINITY const
-#else
+// Clang for some reason doesn't like FP arithmetic that yields infinities by
+// overflow (as opposed to division by zero, which the standard explicitly
+// prohibits) in constexpr code (MSVC and GCC are fine with that).  This will be
+// fixed in Clang 9.0.0, all hail zygoloid.
+#define PRINCIPIA_MAY_SIGNAL_OVERFLOW_IN_CONSTEXPR_ARITHMETIC    \
+  !((PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL) && \
+    __clang_major__ >= 9)
+#if PRINCIPIA_MAY_SIGNAL_OVERFLOW_IN_CONSTEXPR_ARITHMETIC
 #  define CONSTEXPR_INFINITY constexpr
+#else
+#  define CONSTEXPR_INFINITY const
 #endif
 
 #if PRINCIPIA_COMPILER_MSVC

--- a/numerics/next_body.hpp
+++ b/numerics/next_body.hpp
@@ -24,7 +24,6 @@ constexpr SourceFormat NextUp(SourceFormat const x) {
     return std::numeric_limits<SourceFormat>::denorm_min();
   }
   if (x == std::numeric_limits<SourceFormat>::infinity()) {
-    // TODO(egg): Should we be signalling the overflow exception?
     return std::numeric_limits<SourceFormat>::infinity();
   }
   if (x == -std::numeric_limits<SourceFormat>::infinity()) {
@@ -50,6 +49,15 @@ constexpr SourceFormat NextUp(SourceFormat const x) {
   if (signed_significand == -1) {
     return x + ulp / std::numeric_limits<SourceFormat>::radix;
   }
+#if !PRINCIPIA_MAY_SIGNAL_OVERFLOW_IN_CONSTEXPR_ARITHMETIC
+  // When |x| is the largest finite number in |SourceFormat|, the operation
+  // |x + ulp| below results in positive infinity and signals the overflow
+  // exception.  On compilers that think overflow is non-constexpr, explicitly
+  // return an infinity.
+  if (x == -std::numeric_limits<SourceFormat>::max()) {
+    return std::numeric_limits<SourceFormat>::infinity();
+  }
+#endif
   return x + ulp;
 }
 


### PR DESCRIPTION
Previously: #1117, #2513.