### PR TITLE
Detect collapsibility changes and fork new segments of the history

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -642,6 +642,12 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
           ephemeris_.get());
     });
   }
+
+  // Now that the composition of the vessels is known, as well as their
+  // intrinsic forces and torques, we may detect collapsibility changes.
+  for (auto const& [_, vessel] : vessels_) {
+    vessel->DetectCollapsibilityChange();
+  }
 }
 
 void Plugin::SetPartApparentRigidMotion(

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -573,7 +573,7 @@ void Plugin::FreeVesselsAndPartsAndCollectPileUps(Time const& Δt) {
     Instant const vessel_time =
         is_loaded(vessel) ? current_time_ - Δt : current_time_;
     if (kept_vessels_.erase(vessel) > 0) {
-      vessel->PrepareHistory(vessel_time);
+      vessel->CreatePrehistoryIfNeeded(vessel_time);
       ++it;
     } else {
       loaded_vessels_.erase(vessel);

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -178,7 +178,7 @@ void Vessel::DetectCollapsibilityChange() {
   }
 }
 
-void Vessel::PrepareHistory(Instant const& t) {
+void Vessel::CreatePrehistoryIfNeeded(Instant const& t) {
   CHECK(!parts_.empty());
   if (prehistory_->Empty()) {
     LOG(INFO) << "Preparing history of vessel " << ShortDebugString()
@@ -525,7 +525,8 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     vessel->prediction_ = vessel->psychohistory_->NewForkAtLast();
   } else {
     if (is_pre_grothendieck_haar) {
-      // The history is guaranteed to be non-empty because of PrepareHistory.
+      // The history is guaranteed to be non-empty because of
+      // CreatePrehistoryIfNeeded.
       auto history = DiscreteTrajectory<Barycentric>::ReadFromMessage(
           message.history(),
           /*forks=*/{&vessel->psychohistory_, &vessel->prediction_});

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -450,8 +450,6 @@ void Vessel::WriteToMessage(not_null<serialization::Vessel*> const message,
   prehistory_->WriteToMessage(message->mutable_prehistory(),
                               /*exclude=*/{prediction_},
                               /*tracked=*/{history_, psychohistory_});
-  LOG(ERROR)<<prehistory_->Size()<<" "<<history_->Size()<<" "
-    <<psychohistory_->Size();
   if (flight_plan_ != nullptr) {
     flight_plan_->WriteToMessage(message->mutable_flight_plan());
   }
@@ -537,8 +535,6 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
           /*forks=*/{&vessel->history_,
                      &vessel->psychohistory_});
     }
-    LOG(ERROR)<<vessel->prehistory_->Size()<<" "<<vessel->history_->Size()<<" "
-      <<vessel->psychohistory_->Size();
     // After Grothendieck/Haar there is no empty prediction so we must create
     // one here.
     if (vessel->prediction_ == nullptr) {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -468,7 +468,8 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     std::function<void(PartId)> const& deletion_callback) {
   bool const is_pre_cesàro = message.has_psychohistory_is_authoritative();
   bool const is_pre_chasles = message.has_prediction();
-  bool const is_pre_陈景润 = !message.history().has_downsampling();
+  bool const is_pre_陈景润 = message.has_history() &&
+                            !message.history().has_downsampling();
   // TODO(phl): Decide in which version it goes.
   bool const is_pre_grothendieck_haar = !message.has_prehistory();
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -532,8 +532,8 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     } else {
       vessel->prehistory_ = DiscreteTrajectory<Barycentric>::ReadFromMessage(
           message.prehistory(),
-          /*forks=*/{&vessel->history_,
-                     &vessel->psychohistory_});
+          /*tracked=*/{&vessel->history_,
+                       &vessel->psychohistory_});
     }
     // After Grothendieck/Haar there is no empty prediction so we must create
     // one here.

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -100,6 +100,9 @@ class Vessel {
   // Clears the forces and torques on all parts.
   virtual void ClearAllIntrinsicForcesAndTorques();
 
+  //TODO(phl):Comment
+  virtual void DetectCollapsibilityChange();
+
   // If the history is empty, appends a single point to it, computed as the
   // barycentre of all parts.  |parts_| must not be empty.  After this call,
   // |history_| is never empty again and the psychohistory is usable.
@@ -258,11 +261,16 @@ class Vessel {
   not_null<Celestial const*> parent_;
   not_null<Ephemeris<Barycentric>*> const ephemeris_;
 
+  // TODO(phl): Is this right?
+  bool is_collapsible_ = true;
+
   std::map<PartId, not_null<std::unique_ptr<Part>>> parts_;
   std::set<PartId> kept_parts_;
 
   // See the comments in pile_up.hpp for an explanation of the terminology.
-  not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> history_;
+  //TODO(phl):comments
+  not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> prehistory_;
+  DiscreteTrajectory<Barycentric>* history_ = nullptr;
   DiscreteTrajectory<Barycentric>* psychohistory_ = nullptr;
 
   // The |prediction_| is forked off the end of the |psychohistory_|.

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -437,7 +437,6 @@ TEST_F(PluginTest, Serialization) {
   EXPECT_TRUE(message.vessel(0).vessel().has_flight_plan());
   EXPECT_TRUE(message.vessel(0).vessel().has_prehistory());
   auto const& vessel_0_prehistory = message.vessel(0).vessel().prehistory();
-  LOG(ERROR)<<vessel_0_prehistory.DebugString();
   EXPECT_EQ(1, vessel_0_prehistory.zfp().timeline_size());
   auto const& vessel_0_history_a =
       vessel_0_prehistory.children(0).trajectories(0);

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -447,6 +447,7 @@ TEST_F(PluginTest, Serialization) {
   auto const& vessel_0_psychohistory =
       vessel_0_history_b.children(0).trajectories(0);
   EXPECT_EQ(1, vessel_0_psychohistory.zfp().timeline_size());
+  EXPECT_EQ(0, vessel_0_psychohistory.children_size());
 
   EXPECT_TRUE(message.has_renderer());
   EXPECT_TRUE(message.renderer().has_plotting_frame());

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -435,9 +435,11 @@ TEST_F(PluginTest, Serialization) {
   EXPECT_EQ(1, message.vessel_size());
   EXPECT_EQ(SolarSystemFactory::Earth, message.vessel(0).parent_index());
   EXPECT_TRUE(message.vessel(0).vessel().has_flight_plan());
-  EXPECT_TRUE(message.vessel(0).vessel().has_history());
-  auto const& vessel_0_history = message.vessel(0).vessel().history();
-  EXPECT_EQ(7, vessel_0_history.zfp().timeline_size());
+  EXPECT_TRUE(message.vessel(0).vessel().has_prehistory());
+  auto const& vessel_0_prehistory = message.vessel(0).vessel().prehistory();
+  auto const& vessel_0_history =
+      vessel_0_prehistory.children(0).trajectories(0);
+  EXPECT_EQ(6, vessel_0_history.zfp().timeline_size());
   EXPECT_TRUE(message.has_renderer());
   EXPECT_TRUE(message.renderer().has_plotting_frame());
   EXPECT_TRUE(message.renderer().plotting_frame().HasExtension(

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -437,9 +437,18 @@ TEST_F(PluginTest, Serialization) {
   EXPECT_TRUE(message.vessel(0).vessel().has_flight_plan());
   EXPECT_TRUE(message.vessel(0).vessel().has_prehistory());
   auto const& vessel_0_prehistory = message.vessel(0).vessel().prehistory();
-  auto const& vessel_0_history =
+  LOG(ERROR)<<vessel_0_prehistory.DebugString();
+  EXPECT_EQ(1, vessel_0_prehistory.zfp().timeline_size());
+  auto const& vessel_0_history_a =
       vessel_0_prehistory.children(0).trajectories(0);
-  EXPECT_EQ(6, vessel_0_history.zfp().timeline_size());
+  EXPECT_EQ(0, vessel_0_history_a.zfp().timeline_size());
+  auto const& vessel_0_history_b =
+      vessel_0_history_a.children(0).trajectories(0);
+  EXPECT_EQ(6, vessel_0_history_b.zfp().timeline_size());
+  auto const& vessel_0_psychohistory =
+      vessel_0_history_b.children(0).trajectories(0);
+  EXPECT_EQ(1, vessel_0_psychohistory.zfp().timeline_size());
+
   EXPECT_TRUE(message.has_renderer());
   EXPECT_TRUE(message.renderer().has_plotting_frame());
   EXPECT_TRUE(message.renderer().plotting_frame().HasExtension(

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -171,7 +171,7 @@ TEST_F(VesselTest, PrepareHistory) {
       ephemeris_,
       FlowWithAdaptiveStep(_, _, astronomy::J2000 + 2 * Second, _, _))
       .Times(AnyNumber());
-  vessel_.PrepareHistory(astronomy::J2000 + 1 * Second);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000 + 1 * Second);
 
   EXPECT_EQ(1, vessel_.psychohistory().Size());
   EXPECT_EQ(astronomy::J2000 + 1 * Second,
@@ -200,7 +200,7 @@ TEST_F(VesselTest, AdvanceTime) {
       ephemeris_,
       FlowWithAdaptiveStep(_, _, astronomy::J2000 + 2 * Second, _, _))
       .Times(AnyNumber());
-  vessel_.PrepareHistory(astronomy::J2000);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000);
 
   p1_->AppendToHistory(
       astronomy::J2000 + 0.5 * Second,
@@ -301,7 +301,7 @@ TEST_F(VesselTest, Prediction) {
                 Return(absl::OkStatus())))
       .WillRepeatedly(Return(absl::OkStatus()));
 
-  vessel_.PrepareHistory(astronomy::J2000);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000);
   // Polling for the integration to happen.
   do {
     vessel_.RefreshPrediction(astronomy::J2000 + 1 * Second);
@@ -373,7 +373,7 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
                                                60.0 * Metre / Second,
                                                50.0 * Metre / Second}))),
                 Return(absl::OkStatus())));
-  vessel_.PrepareHistory(astronomy::J2000);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000);
   // Polling for the integration to happen.
   do {
     vessel_.RefreshPrediction();
@@ -412,7 +412,7 @@ TEST_F(VesselTest, FlightPlan) {
       .Times(AnyNumber());
   std::vector<not_null<MassiveBody const*>> const bodies;
   ON_CALL(ephemeris_, bodies()).WillByDefault(ReturnRef(bodies));
-  vessel_.PrepareHistory(astronomy::J2000);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000);
 
   EXPECT_FALSE(vessel_.has_flight_plan());
   EXPECT_CALL(
@@ -501,7 +501,7 @@ TEST_F(VesselTest, SerializationSuccess) {
       ephemeris_,
       FlowWithAdaptiveStep(_, _, astronomy::J2000 + 2 * Second, _, _))
       .Times(AnyNumber());
-  vessel_.PrepareHistory(astronomy::J2000);
+  vessel_.CreatePrehistoryIfNeeded(astronomy::J2000);
 
   EXPECT_CALL(
       ephemeris_,

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -519,7 +519,7 @@ TEST_F(VesselTest, SerializationSuccess) {
   serialization::Vessel message;
   vessel_.WriteToMessage(&message,
                          serialization_index_for_pile_up.AsStdFunction());
-  EXPECT_TRUE(message.has_history());
+  EXPECT_TRUE(message.has_prehistory());
   EXPECT_TRUE(message.has_flight_plan());
 
   EXPECT_CALL(ephemeris_, Prolong(_)).Times(2);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -620,7 +620,6 @@ void DiscreteTrajectory<Frame>::FillSubTreeFromMessage(
     }
   }
   if (message.has_downsampling()) {
-    CHECK(this->is_root());
     downsampling_.emplace(
         Downsampling::ReadFromMessage(message.downsampling(), timeline_));
   }

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -168,7 +168,8 @@ message Vessel {
       prediction_adaptive_step_parameters = 10;
   repeated Part parts = 14;
   repeated fixed32 kept_parts = 15;
-  required DiscreteTrajectory history = 16;
+  optional DiscreteTrajectory prehistory = 20;  // Added in Grothendieck/Haar.
+  optional DiscreteTrajectory history = 16;  // Pre-Grothendieck/Haar.
   optional bool psychohistory_is_authoritative = 17;  // Pre-Cesàro.
   optional DiscreteTrajectory prediction = 18;  // Pre-Chasles.
   optional FlightPlan flight_plan = 4;


### PR DESCRIPTION
A vessel now has a multi-segment history which is forked off of the (newly-added) prehistory, a trajectory with a single point.

A contribution to #2400.