### PR TITLE
Emit a message with the compiler version at compile time

### DIFF
--- a/base/version.hpp
+++ b/base/version.hpp
@@ -1,11 +1,15 @@
 
 #pragma once
 
+#include "base/macros.hpp"
+
 namespace principia {
 namespace base {
 
 extern char const BuildDate[];
 extern char const Version[];
+
+#pragma message("Compiler version: " STRINGIFY_EXPANSION(_MSC_FULL_VER))
 
 }  // namespace base
 }  // namespace principia

--- a/base/version.hpp
+++ b/base/version.hpp
@@ -9,7 +9,9 @@ namespace base {
 extern char const BuildDate[];
 extern char const Version[];
 
+#if OS_WIN
 #pragma message("Compiler version: " STRINGIFY_EXPANSION(_MSC_FULL_VER))
+#endif
 
 }  // namespace base
 }  // namespace principia


### PR DESCRIPTION
This will help maintaining the Windows pipeline.