### PR TITLE
Log the compatibility paths

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -241,5 +241,21 @@ template_and_result declared_name parameters;              \
 }                                                          \
 using internal_##package_name::declared_name
 
+#define LOG_IF_EVERY(severity, Δt, condition)                                \
+  static std::optional<std::chrono::steady_clock::time_point>                \
+      LOG_EVERY_N_VARNAME(last_log_time, __LINE__);                          \
+  bool const LOG_EVERY_N_VARNAME(Δt_elapsed, __LINE__) =                     \
+      !LOG_EVERY_N_VARNAME(last_log_time, __LINE__).has_value() ||           \
+      std::chrono::steady_clock::now() -                                     \
+              *LOG_EVERY_N_VARNAME(last_log_time, __LINE__) >=               \
+          (Δt);                                                              \
+  LOG_IF(severity, (condition) && LOG_EVERY_N_VARNAME(Δt_elapsed, __LINE__)) \
+      << (LOG_EVERY_N_VARNAME(last_log_time, __LINE__) =                     \
+              std::chrono::steady_clock::now(),                              \
+          "")
+
+#define LOG_IF_EVERY_SECOND(severity, condition) \
+  LOG_IF_EVERY(severity, std::chrono::seconds(1), (condition))
+
 }  // namespace base
 }  // namespace principia

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -246,9 +246,8 @@ using internal_##package_name::declared_name
       LOG_EVERY_N_VARNAME(last_log_time, __LINE__);                          \
   bool const LOG_EVERY_N_VARNAME(Δt_elapsed, __LINE__) =                     \
       !LOG_EVERY_N_VARNAME(last_log_time, __LINE__).has_value() ||           \
-      std::chrono::steady_clock::now() -                                     \
-              *LOG_EVERY_N_VARNAME(last_log_time, __LINE__) >=               \
-          (Δt);                                                              \
+      (std::chrono::steady_clock::now() -                                    \
+       *LOG_EVERY_N_VARNAME(last_log_time, __LINE__)) >= (Δt);               \
   LOG_IF(severity, (condition) && LOG_EVERY_N_VARNAME(Δt_elapsed, __LINE__)) \
       << (LOG_EVERY_N_VARNAME(last_log_time, __LINE__) =                     \
               std::chrono::steady_clock::now(),                              \

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -106,6 +106,7 @@ OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::ReadFromMessage(
     serialization::OrthogonalMap const& message) {
   bool const is_pre_frege = message.has_rotation();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_frege) << "Reading pre-Frege OrthogonalMap";
   return OrthogonalMap(
       is_pre_frege
           ? Quaternion::ReadFromMessage(message.rotation().quaternion())

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -106,7 +106,8 @@ OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::ReadFromMessage(
     serialization::OrthogonalMap const& message) {
   bool const is_pre_frege = message.has_rotation();
-  LOG_IF_EVERY_SECOND(WARNING, is_pre_frege) << "Reading pre-Frege OrthogonalMap";
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_frege)
+      << "Reading pre-Frege OrthogonalMap";
   return OrthogonalMap(
       is_pre_frege
           ? Quaternion::ReadFromMessage(message.rotation().quaternion())

--- a/integrators/integrators_body.hpp
+++ b/integrators/integrators_body.hpp
@@ -565,6 +565,8 @@ AdaptiveStepSizeIntegrator<ODE_>::Parameters::ReadFromMessage(
     serialization::AdaptiveStepSizeIntegratorInstance::Parameters const&
         message) {
   bool const is_pre_cartan = !message.has_last_step_is_exact();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_cartan)
+      << "Reading pre-Cartan AdaptiveStepSizeIntegrator";
   Parameters result(Time::ReadFromMessage(message.first_time_step()),
                     message.safety_factor(),
                     message.max_steps(),
@@ -636,6 +638,8 @@ AdaptiveStepSizeIntegrator<ODE_>::Instance::ReadFromMessage(
   auto const& extension = message.GetExtension(
       serialization::AdaptiveStepSizeIntegratorInstance::extension);
   bool const is_pre_cartan = !extension.has_time_step();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_cartan)
+      << "Reading pre-Cartan AdaptiveStepSizeIntegrator Instance";
 
   auto const parameters =
       Parameters::ReadFromMessage(extension.parameters());

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -264,6 +264,8 @@ std::unique_ptr<FlightPlan> FlightPlan::ReadFromMessage(
 
   bool const is_pre_erdős =
       !message.has_generalized_adaptive_step_parameters();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_erdős)
+      << u8"Reading pre-Erdős FlightPlan";
   std::unique_ptr<Ephemeris<Barycentric>::GeneralizedAdaptiveStepParameters>
       generalized_adaptive_step_parameters;
   if (is_pre_erdős) {

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -266,6 +266,12 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
       is_pre_fréchet || (message.has_pre_frenet_inertia_tensor() &&
                          !message.has_intrinsic_torque());
   bool const is_pre_galileo = !message.has_centre_of_mass();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_galileo)
+      << "Reading pre-"
+      << (is_pre_cesàro    ? u8"Cesàro"
+          : is_pre_fréchet ? u8"Fréchet"
+          : is_pre_frenet  ? "Frenet"
+                           : "Galileo") << " Part";
 
   std::unique_ptr<Part> part;
   if (is_pre_fréchet) {

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -217,6 +217,13 @@ not_null<std::unique_ptr<PileUp>> PileUp::ReadFromMessage(
                             message.apparent_part_degrees_of_freedom_size() > 0;
   bool const is_pre_frobenius = message.rigid_pile_up().empty() ||
                                 !message.has_angular_momentum();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_frobenius)
+      << "Reading pre-"
+      << (is_pre_cartan   ? "Cartan"
+          : is_pre_cesàro ? u8"Cesàro"
+          : is_pre_frege  ? "Frege"
+                          : "Frobenius") << " PileUp";
+
   std::unique_ptr<PileUp> pile_up;
   if (is_pre_cesàro) {
     if (is_pre_cartan) {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1453,6 +1453,8 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
   plugin->UpdatePlanetariumRotation();
 
   bool const is_pre_cauchy = message.has_pre_cauchy_plotting_frame();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_cauchy) << "Reading pre-Cauchy Plugin";
+
   if (is_pre_cauchy) {
     plugin->renderer_ =
         std::make_unique<Renderer>(
@@ -1577,6 +1579,9 @@ void Plugin::ReadCelestialsFromMessages(
   int index = 0;
   for (auto const& celestial_message : celestial_messages) {
     bool const is_pre_cauchy = !celestial_message.has_ephemeris_index();
+    LOG_IF_EVERY_SECOND(WARNING, is_pre_cauchy)
+        << "Reading pre-Cauchy Celestial";
+
     auto const& body = is_pre_cauchy
                            ? bodies[index++]
                            : bodies[celestial_message.ephemeris_index()];

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -403,6 +403,11 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
   bool const is_pre_cesàro = message.has_psychohistory_is_authoritative();
   bool const is_pre_chasles = message.has_prediction();
   bool const is_pre_陈景润 = !message.history().has_downsampling();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_陈景润) << "Reading pre-"
+                                              << (is_pre_cesàro    ? u8"Cesàro"
+                                                  : is_pre_chasles ? "Chasles"
+                                                                   : "陈景润")
+                                              << " Vessel";
 
   // NOTE(egg): for now we do not read the |MasslessBody| as it can contain no
   // information.

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -32,6 +32,10 @@ const char preferred_encoder[] = "base64";
 
 class PluginCompatibilityTest : public testing::Test {
  protected:
+  PluginCompatibilityTest() {
+    google::SetStderrLogging(google::WARNING);
+  }
+
   // Reads a plugin from a file containing only the "serialized_plugin = "
   // lines, with "serialized_plugin = " dropped.
   not_null<std::unique_ptr<Plugin const>> ReadPluginFromFile(

--- a/numerics/polynomial_body.hpp
+++ b/numerics/polynomial_body.hpp
@@ -557,6 +557,9 @@ ReadFromMessage(serialization::Polynomial const& message) {
 
   bool const is_pre_gröbner = extension.origin_case() ==
     serialization::PolynomialInMonomialBasis::ORIGIN_NOT_SET;
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_gröbner)
+      << u8"Reading pre-Gröbner PolynomialInMonomialBasis";
+
   Coefficients coefficients;
   TupleSerializer<Coefficients, 0>::FillFromMessage(extension, coefficients);
 

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -396,6 +396,12 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
        message.instant_polynomial_pair(0).polynomial()
            .GetExtension(serialization::PolynomialInMonomialBasis::extension)
            .coefficient(0).has_multivector());
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_gröbner)
+      << "Reading pre-"
+      << (is_pre_cohen       ? "Cohen"
+          : is_pre_fatou     ? "Fatou"
+          : is_pre_grassmann ? "Grassmann"
+                             : u8"Gröbner") << " ContinuousTrajectory";
 
   not_null<std::unique_ptr<ContinuousTrajectory<Frame>>> continuous_trajectory =
       std::make_unique<ContinuousTrajectory<Frame>>(

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -617,6 +617,8 @@ void DiscreteTrajectory<Frame>::FillSubTreeFromMessage(
     serialization::DiscreteTrajectory const& message,
     std::vector<DiscreteTrajectory<Frame>**> const& forks) {
   bool const is_pre_frobenius = !message.has_zfp();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_frobenius)
+      << "Reading pre-Frobenius PolynomialInMonomialBasis";
   if (is_pre_frobenius) {
     for (auto const& instantaneous_dof : message.timeline()) {
       Append(Instant::ReadFromMessage(instantaneous_dof.instant()),

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -790,6 +790,11 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
   bool const is_pre_ἐρατοσθένης = !message.has_accuracy_parameters();
   bool const is_pre_fatou = !message.has_checkpoint_time();
   bool const is_pre_grassmann = message.checkpoint_size() == 0;
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_grassmann)
+      << "Reading pre-"
+      << (is_pre_ἐρατοσθένης ? u8"Ἐρατοσθένης"
+          : is_pre_fatou     ? "Fatou"
+                             : "Grassmann") << " Ephemeris";
 
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies;
   for (auto const& body : message.body()) {

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -193,6 +193,7 @@ RotatingBody<Frame>::ReadFromMessage(
     MassiveBody::Parameters const& massive_body_parameters) {
   bool is_pre_del_ferro = !message.has_min_radius() &&
                           !message.has_max_radius();
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_del_ferro) << "Reading pre-del Ferro RotatingBody";
   std::optional<Parameters> parameters;
   if (is_pre_del_ferro) {
     Length const mean_radius = Length::ReadFromMessage(message.mean_radius());

--- a/physics/rotating_body_body.hpp
+++ b/physics/rotating_body_body.hpp
@@ -193,7 +193,8 @@ RotatingBody<Frame>::ReadFromMessage(
     MassiveBody::Parameters const& massive_body_parameters) {
   bool is_pre_del_ferro = !message.has_min_radius() &&
                           !message.has_max_radius();
-  LOG_IF_EVERY_SECOND(WARNING, is_pre_del_ferro) << "Reading pre-del Ferro RotatingBody";
+  LOG_IF_EVERY_SECOND(WARNING, is_pre_del_ferro)
+      << "Reading pre-del Ferro RotatingBody";
   std::optional<Parameters> parameters;
   if (is_pre_del_ferro) {
     Length const mean_radius = Length::ReadFromMessage(message.mean_radius());


### PR DESCRIPTION
Add a time-based LOG_IF_EVERY (as opposed to count-based like LOG_IF_EVERY_N) to avoid spamming about every trajectory, polynomial, vessel, part, etc..

With this change (and logging `WARNING` to stderr) the test added in #3070 prints
```
[ RUN      ] PluginCompatibilityTest.PreCohen
E0718 17:50:59.961947 24484 plugin_compatibility_test.cpp:65] Deserialization starting
W0718 17:50:59.975911 17736 ephemeris_body.hpp:793] Reading pre-Ἐρατοσθένης Ephemeris
W0718 17:50:59.976277 17736 rotating_body_body.hpp:196] Reading pre-del Ferro RotatingBody
W0718 17:50:59.976506 17736 continuous_trajectory_body.hpp:399] Reading pre-Cohen ContinuousTrajectory
W0718 17:50:59.984709 17736 vessel.cpp:406] Reading pre-Cesàro Vessel
W0718 17:50:59.985708 17736 part.cpp:269] Reading pre-Cesàro Part
W0718 17:50:59.986559 17736 discrete_trajectory_body.hpp:620] Reading pre-Frobenius PolynomialInMonomialBasis
W0718 17:50:59.986711 17736 plugin.cpp:1456] Reading pre-Cauchy Plugin
W0718 17:50:59.987212 17736 pile_up.cpp:220] Reading pre-Cesàro PileUp
E0718 17:50:59.987573 24484 plugin_compatibility_test.cpp:78] Deserialization complete
E0718 17:50:59.988317 24484 plugin_compatibility_test.cpp:92] Serialization starting
E0718 17:51:00.008291 24484 plugin_compatibility_test.cpp:104] Serialization complete
E0718 17:51:00.054144 24484 plugin_compatibility_test.cpp:65] Deserialization starting
E0718 17:51:00.071099 24484 plugin_compatibility_test.cpp:78] Deserialization complete
[       OK ] PluginCompatibilityTest.PreCohen (191 ms)
```

It should probably be renamed in a future pull request.