### PR TITLE
Refactor the ReferenceFrameSelector API

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -220,7 +220,8 @@ class BurnEditor : ScalingRenderer {
     };
   }
 
-  public void ReferenceFrameChanged(NavigationFrameParameters parameters) {
+  public void ReferenceFrameChanged(NavigationFrameParameters? parameters,
+                                    Vessel target_vessel) {
     changed_reference_frame_ = true;
   }
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2235,7 +2235,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
   private void PlotCelestialTrajectories(DisposablePlanetarium planetarium,
                                          string main_vessel_guid) {
     foreach (CelestialBody celestial in FlightGlobals.Bodies) {
-      if (plotting_frame_selector_.FixedBodies().Contains(celestial)) {
+      if (plotting_frame_selector_.FixesBody(celestial)) {
         continue;
       }
       var colour = celestial.MapObject?.uiNode?.VisualIconData.color ??
@@ -2305,10 +2305,10 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                                    MapNodePool.NodeSource.Prediction,
                                    plotting_frame_selector_);
     } else {
-      foreach (CelestialBody celestial in
-          plotting_frame_selector_.FixedBodies()) {
+      if (plotting_frame_selector_.Centre() != null) {
+        var centre_index = plotting_frame_selector_.Centre().flightGlobalsIndex;
         plugin_.RenderedPredictionApsides(vessel_guid,
-                                          celestial.flightGlobalsIndex,
+                                          centre_index,
                                           sun_world_position,
                                           MapNodePool.MaxRenderedNodes,
                                           out DisposableIterator
@@ -2370,10 +2370,10 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                                    MapNodePool.NodeSource.FlightPlan,
                                    plotting_frame_selector_);
     } else {
-      foreach (CelestialBody celestial in
-          plotting_frame_selector_.FixedBodies()) {
+      if (plotting_frame_selector_.Centre() != null) {
+        var centre_index = plotting_frame_selector_.Centre().flightGlobalsIndex;
         plugin_.FlightPlanRenderedApsides(vessel_guid,
-                                          celestial.flightGlobalsIndex,
+                                          centre_index,
                                           sun_world_position,
                                           MapNodePool.MaxRenderedNodes,
                                           out DisposableIterator

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1868,7 +1868,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
     }
 
     var target_vessel = FlightGlobals.fetch.VesselTarget?.GetVessel();
-    if (!plugin_.HasVessel(target_vessel.id.ToString())) {
+    if (target_vessel != null && !plugin_.HasVessel(target_vessel.id.ToString())) {
       target_vessel = null;
     }
     if (plotting_frame_selector_.target != target_vessel) {
@@ -1932,8 +1932,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
         // plotting frame.
         if (FlightGlobals.speedDisplayMode !=
             FlightGlobals.SpeedDisplayModes.Target) {
-          if (plotting_frame_selector_.frame_type ==
-              ReferenceFrameSelector.FrameType.BODY_SURFACE) {
+          if (plotting_frame_selector_.IsSurfaceFrame()) {
             if (FlightGlobals.speedDisplayMode !=
                 FlightGlobals.SpeedDisplayModes.Surface) {
               FlightGlobals.SetSpeedMode(
@@ -2437,6 +2436,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           target_vessel.id.ToString(),
           target_vessel.orbit.referenceBody.flightGlobalsIndex);
     } else {
+      plugin_.ClearTargetVessel();
       plugin_.SetPlottingFrame(frame_parameters.Value);
     }
     navball_changed_ = true;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -108,8 +108,6 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
   private UnityEngine.Texture target_navball_texture_;
   private bool navball_changed_ = true;
   private FlightGlobals.SpeedDisplayModes? previous_display_mode_;
-  private ReferenceFrameSelector.FrameType last_orbital_type_ =
-      ReferenceFrameSelector.FrameType.BODY_CENTRED_NON_ROTATING;
 
   private UnityEngine.Color history_colour = XKCDColors.Lime;
   private GLLines.Style history_style = GLLines.Style.Faded;
@@ -1906,11 +1904,10 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       // frame accordingly.
       switch (FlightGlobals.speedDisplayMode) {
         case FlightGlobals.SpeedDisplayModes.Surface:
-          plotting_frame_selector_.SetFrameType(
-              ReferenceFrameSelector.FrameType.BODY_SURFACE);
+          plotting_frame_selector_.SetToSurfaceFrame();
           break;
         case FlightGlobals.SpeedDisplayModes.Orbit:
-          plotting_frame_selector_.SetFrameType(last_orbital_type_);
+          plotting_frame_selector_.SetToOrbitalFrame();
           break;
         case FlightGlobals.SpeedDisplayModes.Target:
           if (target_vessel != null) {
@@ -2441,12 +2438,6 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           target_vessel.orbit.referenceBody.flightGlobalsIndex);
     } else {
       plugin_.SetPlottingFrame(frame_parameters.Value);
-    }
-    if (target_vessel == null &&
-        (ReferenceFrameSelector.FrameType)frame_parameters.Value.extension !=
-            ReferenceFrameSelector.FrameType.BODY_SURFACE) {
-      last_orbital_type_ =
-          (ReferenceFrameSelector.FrameType)frame_parameters.Value.extension;
     }
     navball_changed_ = true;
     reset_rsas_target_ = true;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1878,8 +1878,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
          // The target is not longer manageable.
          plotting_frame_selector_.UnsetTargetFrame();
        } else if (FlightGlobals.speedDisplayMode ==
-           FlightGlobals.SpeedDisplayModes.Target &&
-           !plotting_frame_selector_.target_frame_selected) {
+                      FlightGlobals.SpeedDisplayModes.Target &&
+                  !plotting_frame_selector_.target_frame_selected) {
          // The navball was in target mode, but the target was not known to
          // Principia; now that it is, switch the reference frame accordingly.
          plotting_frame_selector_.SetTargetFrame();

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -67,15 +67,7 @@ internal class MapNodePool {
         break;
       case MapObject.ObjectType.AscendingNode:
       case MapObject.ObjectType.DescendingNode:
-        if (reference_frame.Centre() != null) {
-          // In one-body frames, the apsides are shown with the colour of the
-          // body.
-          // The nodes are with respect to the equator, rather than with respect
-          // to an orbit. We show the nodes in a different (but arbitrary)
-          // colour so that they can be distinguished easily.
-          associated_map_object = reference_frame.Centre().MapObject;
-          colour = XKCDColors.Chartreuse;
-        } else {
+        if (reference_frame.Centre() == null) {
           // In two-body frames, if apsides are shown, they are shown with the
           // colour of the secondary (or in XKCD chartreuse if the secondary is
           // a vessel).
@@ -84,8 +76,16 @@ internal class MapNodePool {
           CelestialBody primary = reference_frame.OrientingBody();
           associated_map_object = primary.MapObject;
           colour = primary.orbit == null
-                       ? XKCDColors.SunshineYellow
-                       : primary.orbitDriver.Renderer.nodeColor;
+                        ? XKCDColors.SunshineYellow
+                        : primary.orbitDriver.Renderer.nodeColor;
+        } else {
+          // In one-body frames, the apsides are shown with the colour of the
+          // body.
+          // The nodes are with respect to the equator, rather than with respect
+          // to an orbit. We show the nodes in a different (but arbitrary)
+          // colour so that they can be distinguished easily.
+          associated_map_object = reference_frame.Centre().MapObject;
+          colour = XKCDColors.Chartreuse;
         }
         break;
       default:
@@ -245,8 +245,8 @@ internal class MapNodePool {
         }
         case MapObject.ObjectType.ApproachIntersect: {
           double separation = 
-            (properties.reference_frame.target.GetWorldPos3D() -
-             properties.world_position).magnitude;
+              (properties.reference_frame.target.GetWorldPos3D() -
+               properties.world_position).magnitude;
           double speed = properties.velocity.magnitude;
           caption.Header = Localizer.Format("#Principia_MapNode_ApproachHeader",
                                             source,

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -67,10 +67,7 @@ internal class MapNodePool {
         break;
       case MapObject.ObjectType.AscendingNode:
       case MapObject.ObjectType.DescendingNode:
-        if (reference_frame.frame_type ==
-                ReferenceFrameSelector.FrameType.BODY_CENTRED_NON_ROTATING ||
-            reference_frame.frame_type ==
-                ReferenceFrameSelector.FrameType.BODY_SURFACE) {
+        if (reference_frame.FixedBodies().Length == 1) {
           // In one-body frames, the apsides are shown with the colour of the
           // body.
           // The nodes are with respect to the equator, rather than with respect
@@ -84,7 +81,7 @@ internal class MapNodePool {
           // a vessel).
           // The nodes are with respect to the orbit of the secondary around the
           // primary. We show the nodes with the colour of the primary.
-          CelestialBody primary = reference_frame.orienting_body;
+          CelestialBody primary = reference_frame.OrientingBody();
           associated_map_object = primary.MapObject;
           colour = primary.orbit == null
                        ? XKCDColors.SunshineYellow

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -55,29 +55,28 @@ internal class MapNodePool {
     switch (type) {
       case MapObject.ObjectType.Apoapsis:
       case MapObject.ObjectType.Periapsis:
-        CelestialBody fixed_body = reference_frame.selected_celestial;
+        CelestialBody fixed_body = reference_frame.FixedBodies()[0];
         associated_map_object = fixed_body.MapObject;
         colour = fixed_body.orbit == null
                      ? XKCDColors.SunshineYellow
                      : fixed_body.orbitDriver.Renderer.nodeColor;
         break;
       case MapObject.ObjectType.ApproachIntersect:
-        associated_map_object = reference_frame.target_override.mapObject;
+        associated_map_object = reference_frame.target.mapObject;
         colour = XKCDColors.Chartreuse;
         break;
       case MapObject.ObjectType.AscendingNode:
       case MapObject.ObjectType.DescendingNode:
-        if (!reference_frame.target_override &&
-            (reference_frame.frame_type ==
-             ReferenceFrameSelector.FrameType.BODY_CENTRED_NON_ROTATING ||
-             reference_frame.frame_type ==
-             ReferenceFrameSelector.FrameType.BODY_SURFACE)) {
+        if (reference_frame.frame_type ==
+                ReferenceFrameSelector.FrameType.BODY_CENTRED_NON_ROTATING ||
+            reference_frame.frame_type ==
+                ReferenceFrameSelector.FrameType.BODY_SURFACE) {
           // In one-body frames, the apsides are shown with the colour of the
           // body.
           // The nodes are with respect to the equator, rather than with respect
           // to an orbit. We show the nodes in a different (but arbitrary)
           // colour so that they can be distinguished easily.
-          associated_map_object = reference_frame.selected_celestial.MapObject;
+          associated_map_object = reference_frame.FixedBodies()[0].MapObject;
           colour = XKCDColors.Chartreuse;
         } else {
           // In two-body frames, if apsides are shown, they are shown with the
@@ -85,10 +84,7 @@ internal class MapNodePool {
           // a vessel).
           // The nodes are with respect to the orbit of the secondary around the
           // primary. We show the nodes with the colour of the primary.
-          CelestialBody primary = reference_frame.target_override
-                                      ? reference_frame.selected_celestial
-                                      : reference_frame.selected_celestial.
-                                          referenceBody;
+          CelestialBody primary = reference_frame.orienting_body;
           associated_map_object = primary.MapObject;
           colour = primary.orbit == null
                        ? XKCDColors.SunshineYellow
@@ -116,7 +112,7 @@ internal class MapNodePool {
           associated_map_object = associated_map_object,
       };
       if (type == MapObject.ObjectType.Periapsis &&
-          reference_frame.selected_celestial.GetAltitude(
+          reference_frame.FixedBodies()[0].GetAltitude(
               node_properties.world_position) < 0) {
         node_properties.object_type = MapObject.ObjectType.PatchTransition;
         node_properties.colour = XKCDColors.Orange;
@@ -220,7 +216,7 @@ internal class MapNodePool {
                   ? Localizer.Format("#Principia_MapNode_Periapsis")
                   : Localizer.Format("#Principia_MapNode_Apoapsis");
           CelestialBody celestial =
-              properties.reference_frame.selected_celestial;
+              properties.reference_frame.FixedBodies()[0];
           Vector3d position = properties.world_position;
           double speed = properties.velocity.magnitude;
           caption.Header = Localizer.Format("#Principia_MapNode_ApsisHeader",
@@ -251,9 +247,9 @@ internal class MapNodePool {
           break;
         }
         case MapObject.ObjectType.ApproachIntersect: {
-          Vessel target_vessel = properties.reference_frame.target_override;
-          double separation = (target_vessel.GetWorldPos3D() -
-                               properties.world_position).magnitude;
+          double separation = 
+            (properties.reference_frame.target.GetWorldPos3D() -
+             properties.world_position).magnitude;
           double speed = properties.velocity.magnitude;
           caption.Header = Localizer.Format("#Principia_MapNode_ApproachHeader",
                                             source,
@@ -264,8 +260,7 @@ internal class MapNodePool {
           break;
         }
         case MapObject.ObjectType.PatchTransition: {
-          CelestialBody celestial =
-              properties.reference_frame.selected_celestial;
+          CelestialBody celestial = properties.reference_frame.FixedBodies()[0];
           caption.Header = Localizer.Format("#Principia_MapNode_ImpactHeader",
                                             source,
                                             celestial.name);

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -55,7 +55,7 @@ internal class MapNodePool {
     switch (type) {
       case MapObject.ObjectType.Apoapsis:
       case MapObject.ObjectType.Periapsis:
-        CelestialBody fixed_body = reference_frame.FixedBodies()[0];
+        CelestialBody fixed_body = reference_frame.Centre();
         associated_map_object = fixed_body.MapObject;
         colour = fixed_body.orbit == null
                      ? XKCDColors.SunshineYellow
@@ -67,13 +67,13 @@ internal class MapNodePool {
         break;
       case MapObject.ObjectType.AscendingNode:
       case MapObject.ObjectType.DescendingNode:
-        if (reference_frame.FixedBodies().Length == 1) {
+        if (reference_frame.Centre() != null) {
           // In one-body frames, the apsides are shown with the colour of the
           // body.
           // The nodes are with respect to the equator, rather than with respect
           // to an orbit. We show the nodes in a different (but arbitrary)
           // colour so that they can be distinguished easily.
-          associated_map_object = reference_frame.FixedBodies()[0].MapObject;
+          associated_map_object = reference_frame.Centre().MapObject;
           colour = XKCDColors.Chartreuse;
         } else {
           // In two-body frames, if apsides are shown, they are shown with the
@@ -109,7 +109,7 @@ internal class MapNodePool {
           associated_map_object = associated_map_object,
       };
       if (type == MapObject.ObjectType.Periapsis &&
-          reference_frame.FixedBodies()[0].GetAltitude(
+          reference_frame.Centre().GetAltitude(
               node_properties.world_position) < 0) {
         node_properties.object_type = MapObject.ObjectType.PatchTransition;
         node_properties.colour = XKCDColors.Orange;
@@ -213,7 +213,7 @@ internal class MapNodePool {
                   ? Localizer.Format("#Principia_MapNode_Periapsis")
                   : Localizer.Format("#Principia_MapNode_Apoapsis");
           CelestialBody celestial =
-              properties.reference_frame.FixedBodies()[0];
+              properties.reference_frame.Centre();
           Vector3d position = properties.world_position;
           double speed = properties.velocity.magnitude;
           caption.Header = Localizer.Format("#Principia_MapNode_ApsisHeader",
@@ -257,7 +257,7 @@ internal class MapNodePool {
           break;
         }
         case MapObject.ObjectType.PatchTransition: {
-          CelestialBody celestial = properties.reference_frame.FixedBodies()[0];
+          CelestialBody celestial = properties.reference_frame.Centre();
           caption.Header = Localizer.Format("#Principia_MapNode_ImpactHeader",
                                             source,
                                             celestial.name);

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -301,17 +301,23 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     }
   }
 
-  public CelestialBody[] FixedBodies() {
+  public bool FixesBody(CelestialBody celestial) {
+    // TODO(egg): When we have the rotating-pulsating frame, this should return
+    // true for both bodies.
+    return celestial == Centre();
+  }
+
+  public CelestialBody Centre() {
     if (target_frame_selected) {
-      return new CelestialBody[]{};
+      return null;
     }
     switch (frame_type) {
       case FrameType.BODY_CENTRED_NON_ROTATING:
       case FrameType.BODY_CENTRED_PARENT_DIRECTION:
       case FrameType.BODY_SURFACE:
-        return new []{selected_celestial};
+        return selected_celestial;
       case FrameType.BARYCENTRIC_ROTATING:
-        return new CelestialBody[]{};
+        return null;
       default:
         throw Log.Fatal("Unexpected frame_type " + frame_type.ToString());
     }

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -94,7 +94,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
   }
 
   public bool IsSurfaceFrame() {
-    return frame_type == FrameType.BODY_SURFACE;
+    return !target_frame_selected && frame_type == FrameType.BODY_SURFACE;
   }
 
   public void SetToOrbitalFrame() {
@@ -296,8 +296,11 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
       case FrameType.BARYCENTRIC_ROTATING:
       case FrameType.BODY_CENTRED_PARENT_DIRECTION:
         return selected_celestial.referenceBody;
-      default:
+      case FrameType.BODY_CENTRED_NON_ROTATING:
+      case FrameType.BODY_SURFACE:
         return null;
+      default:
+        throw Log.Fatal("Unexpected frame_type " + frame_type.ToString());
     }
   }
 


### PR DESCRIPTION
Do not merge before Grothendieck.

This pull request mostly makes the API of ReferenceFrameSelector less dependent on the UI (most notably doing away with the concept of a selected celestial).

Its observable effect is to make it so that the target frame always uses the primary of the target (in the stock sense for now).

This is a preparatory step for an overhaul of the frame selection UI.