### PR TITLE
Remove the sun lens flare toggle

### DIFF
--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -16,7 +16,6 @@ Localization {
     #Principia_MainWindow_KspFeatures = KSP Features
     #Principia_MainWindow_LoggingSettings = Logging Settings
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = Display patched conics (do not use for flight planning!)
-    #Principia_MainWindow_KspFeature_SunFlare = Enable Sun lens flare
     #Principia_MainWindow_TargetCelestial_Select = Select target celestial...
     #Principia_MainWindow_TargetCelestial_Name = Target: <<1>>  // <<1>> celestial name
     #Principia_MainWindow_TargetCelestial_Clear = Clear

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -15,7 +15,6 @@ Localization {
     #Principia_MainWindow_KspFeatures = KSP本体功能
     #Principia_MainWindow_LoggingSettings = 日志选项
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = 启用原版轨道显示（不可用于轨道规划!）
-    #Principia_MainWindow_KspFeature_SunFlare = 太阳耀斑选项
     #Principia_MainWindow_TargetCelestial_Select = 选择目标天体...
     #Principia_MainWindow_TargetCelestial_Name = 当前目标：<<1>>
     #Principia_MainWindow_TargetCelestial_Clear = 清除

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -245,9 +245,6 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
         value : display_patched_conics,
         text  : Localizer.Format(
             "#Principia_MainWindow_KspFeature_DisplayPatchedConics"));
-    Sun.Instance.sunFlare.enabled = UnityEngine.GUILayout.Toggle(
-        value : Sun.Instance.sunFlare.enabled,
-        text  : Localizer.Format("#Principia_MainWindow_KspFeature_SunFlare"));
     if (MapView.MapIsEnabled &&
         FlightGlobals.ActiveVessel?.orbitTargeter != null) {
       using (new UnityEngine.GUILayout.HorizontalScope()) {


### PR DESCRIPTION
It appears that KSP has it off-by-default, it doesn’t really work anyway, and it certainly doesn’t work in the presence of Scatterer, which one should have in order to observe eclipses in RSS.