### PR TITLE
Update zh-cn localization and add strings for the new frame selector

### DIFF
--- a/ksp_plugin_adapter/localization/celestial_strings.cfg
+++ b/ksp_plugin_adapter/localization/celestial_strings.cfg
@@ -78,6 +78,6 @@
     #Principia_ReferenceFrameSelector_Name_BodySurface(Earth).zh-cn = 地心地固
     #Principia_ReferenceFrameSelector_Name_BodySurface(Moon).zh-cn = 月心月固
     #Principia_ReferenceFrameSelector_Name_BodyCentredParentDirection(Earth,Sun).zh-cn = 地心太阳黄道
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = The centre of <<1>> is fixed.\n黄道 (the plane of its orbit around <<2>>) is horizontal.\nThe reference frame rotates with the orbit, fixing the direction of <<2>>.
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = 固定<<1>>的质心。\n以黄道（<<1>>绕<<2>>的轨道面）为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
   }
 }

--- a/ksp_plugin_adapter/localization/celestial_strings.cfg
+++ b/ksp_plugin_adapter/localization/celestial_strings.cfg
@@ -78,6 +78,6 @@
     #Principia_ReferenceFrameSelector_Name_BodySurface(Earth).zh-cn = 地心地固
     #Principia_ReferenceFrameSelector_Name_BodySurface(Moon).zh-cn = 月心月固
     #Principia_ReferenceFrameSelector_Name_BodyCentredParentDirection(Earth,Sun).zh-cn = 地心太阳黄道
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = <<1>>的质心已固定，\n水平面为黄道（<<1>>绕<<2>>的轨道面）。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = <<1>>的质心已固定，\n水平面为黄道（<<1>>绕<<2>>的轨道面）。\n这个参考系跟随轨道旋转，面向着<<2>>的方位不变。
   }
 }

--- a/ksp_plugin_adapter/localization/celestial_strings.cfg
+++ b/ksp_plugin_adapter/localization/celestial_strings.cfg
@@ -78,6 +78,6 @@
     #Principia_ReferenceFrameSelector_Name_BodySurface(Earth).zh-cn = 地心地固
     #Principia_ReferenceFrameSelector_Name_BodySurface(Moon).zh-cn = 月心月固
     #Principia_ReferenceFrameSelector_Name_BodyCentredParentDirection(Earth,Sun).zh-cn = 地心太阳黄道
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = 固定<<1>>的质心。\n以黄道（<<1>>绕<<2>>的轨道面）为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection(Earth,Sun).zh-cn = <<1>>的质心已固定，\n水平面为黄道（<<1>>绕<<2>>的轨道面）。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
   }
 }

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -71,6 +71,7 @@ Localization {
     #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>> reference frame: for flybys of <<2>>, transfers to or from it.
     #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>> reference frame: for intercepts or rendez-vous with the target vessel.
     #Principia_ReferenceFrameSelector_Target = Target: <<1>>
+    #Principia_ReferenceFrameSelector_Pin = Pin
 
 
     // OrbitAnalyser

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -54,10 +54,10 @@ Localization {
     #Principia_ReferenceFrameSelector_Description_Heading = <<1>>参考系：
     // <<1>> and <<2>> are the names of the relevant bodies, with articles if appropriate, <<2>> being the parent of <<1>>.
     // For the target frame, <<1>> is the name of the target vessel.
-    #Principia_ReferenceFrameSelector_Description_Target = 固定目标载具，<<1>>。\n以它绕<<2>>的轨道为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
-    #Principia_ReferenceFrameSelector_Description_BodyCentredNonRotating = 固定<<1>>的质心。\n以它的赤道为水平面。\n这个参考系不旋转。
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = 固定<<1>>的质心。\n以它绕<<2>>的轨道为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
-    #Principia_ReferenceFrameSelector_Description_BodySurface = 固定<<1>>。\n以它的赤道为水平面。\n这个参考系与<<1>>共同旋转。  // <<1>>centred body name
+    #Principia_ReferenceFrameSelector_Description_Target = 目标载具<<1>>已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredNonRotating = <<1>>的质心已固定，\n水平面为它的赤道。\n这个参考系不旋转。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = <<1>>的质心已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodySurface = <<1>>已固定，\n水平面为它的赤道。\n这个参考系与<<1>>共同旋转。  // <<1>>centred body name
     #Principia_ReferenceFrameSelector_ReferencePlane_Centred = <<1>>的赤道  // <<1>> centred body
     #Principia_ReferenceFrameSelector_ReferencePlane_Secondary_Target = 目标
     #Principia_ReferenceFrameSelector_ReferencePlane = <<1>>绕<<2>>的轨道  // <<1>> secondary body <<2>> centred body

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -3,25 +3,25 @@ Localization {
     #Principia_GrammaticalForm_Standalone = <<C:1>>
 
     // MainWindow
-    #Principia_MainWindow_PluginNotStarted = Principia没有正确启动
+    #Principia_MainWindow_PluginNotStarted = Principia没有启动
     // <<1>> next_release_lunation_number <<2>> next release name
-    #Principia_MainWindow_NewMoonAnnouncementWithKspDeprecation = 注意：最新的Principia版本 <<1>> 已经发布；请下载最新的Principia-<<2>>，并将KSP更新至<<3>>，当前已支持<<3>>的RO/RSSRO/RSS。
-    #Principia_MainWindow_NewMoonAnnouncement = 注意：最新的Principia版本 <<1>> 已经发布；请下载最新的Principia-<<2>>。
+    #Principia_MainWindow_NewMoonAnnouncementWithKspDeprecation = 提示：以Meeus《天文算法》定义的第<<1>>个新月已经来临；请更新KSP至<<3>>并下载最新的Principia版本：<<2>>。请注意RealismOverhaul和RealSolarSystem现已支持KSP<<3>>。
+    #Principia_MainWindow_NewMoonAnnouncement = 提示：以Meeus《天文算法》定义的第<<1>>个新月已经来临；请下载最新的Principia版本：<<2>>。
     #Principia_MainWindow_TargetVessel_Select = 选择目标载具...
     #Principia_MainWindow_TargetVessel_Name = 当前目标：<<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = 清除
     #Principia_MainWindow_TargetVessel_SwitchTo = 切换至目标
     #Principia_MainWindow_PredictionSettings = 轨道预测选项
-    #Principia_MainWindow_KspFeatures = KSP本体功能
+    #Principia_MainWindow_KspFeatures = KSP功能
     #Principia_MainWindow_LoggingSettings = 日志选项
-    #Principia_MainWindow_KspFeature_DisplayPatchedConics = 启用原版轨道显示（不可用于轨道规划!）
+    #Principia_MainWindow_KspFeature_DisplayPatchedConics = 显示圆锥曲线拼接轨道（不可用于轨道规划!）
     #Principia_MainWindow_TargetCelestial_Select = 选择目标天体...
     #Principia_MainWindow_TargetCelestial_Name = 当前目标：<<1>>
     #Principia_MainWindow_TargetCelestial_Clear = 清除
     #Principia_MainWindow_LoggingSettings_VerboseLevel = 详细级别：
-    #Principia_MainWindow_LoggingSettings_LogOption = 日志选项
-    #Principia_MainWindow_LoggingSettings_StderrOption = 错误选项
-    #Principia_MainWindow_LoggingSettings_FlushOption = 忽略选项
+    #Principia_MainWindow_LoggingSettings_LogOption = 日志
+    #Principia_MainWindow_LoggingSettings_StderrOption = 错误
+    #Principia_MainWindow_LoggingSettings_FlushOption = 忽略
     #Principia_MainWindow_LoggingSettings_RecordJournal = 记录日志（重启生效）
     #Principia_MainWindow_LoggingSettings_RecordJournalResult = 日志记录已 <<1>>  // <<1>> ON/OFF
     #Principia_MainWindow_LoggingSettings_JournalingStatus_ON = 打开
@@ -41,7 +41,6 @@ Localization {
     #Principia_SpeedDisplayText = <<1>> m/s  // <<1>>: active_vessel_velocity.magnitude.ToString("F1").
 
     // ReferenceFrameSelector
-    // TODO(egg): translations.
     #Principia_ReferenceFrameSelector_Name_Target = 目标<<1>>轨道
     #Principia_ReferenceFrameSelector_Name_BodyCentredNonRotating = <<1>>质心惯性
     // The code will replace the U+200B (ZWSP) with a hyphen if both celestials have non-CJK names.
@@ -51,35 +50,38 @@ Localization {
     #Principia_ReferenceFrameSelector_SelectorText_BodyCentredNonRotating = 惯性系
     #Principia_ReferenceFrameSelector_SelectorText_BodyCentredParentDirection = 轨道系
     #Principia_ReferenceFrameSelector_SelectorText_BodySurface = 体固系
+    // <<1>> is the full name of the reference frame, <<2>> is its abbreviation.
     #Principia_ReferenceFrameSelector_Description_Heading = <<1>>参考系：
-    #Principia_ReferenceFrameSelector_Description_Target = The target vessel, <<1>>, is fixed.\nThe plane of its orbit around <<2>> is horizontal.\nThe reference frame rotates with the orbit, fixing the direction of <<2>>.
-    #Principia_ReferenceFrameSelector_Description_BodyCentredNonRotating = The centre of <<1>> is fixed.\nIts equator is horizontal.\nThe reference frame does not rotate.
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = The centre of <<1>> is fixed.\nThe plane of its orbit around <<2>> is horizontal.\nThe reference frame rotates with the orbit, fixing the direction of <<2>>.
-    #Principia_ReferenceFrameSelector_Description_BodySurface = <<1>> is fixed.\nIts equator is horizontal.\nThe reference frame rotates with <<1>>.  // <<1>>centred body name
-    #Principia_ReferenceFrameSelector_ReferencePlane_Centred = （<<1>>）的赤道面  // <<1>> centred body
-    #Principia_ReferenceFrameSelector_ReferencePlane_Secondary_Target = 选中的目标
-    #Principia_ReferenceFrameSelector_ReferencePlane = （<<1>>）的轨道环绕于<<2>>  // <<1>> secondary body <<2>> centred body
+    // <<1>> and <<2>> are the names of the relevant bodies, with articles if appropriate, <<2>> being the parent of <<1>>.
+    // For the target frame, <<1>> is the name of the target vessel.
+    #Principia_ReferenceFrameSelector_Description_Target = 固定目标载具，<<1>>。\n以它绕<<2>>的轨道为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredNonRotating = 固定<<1>>的质心。\n以它的赤道为水平面。\n这个参考系不旋转。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = 固定<<1>>的质心。\n以它绕<<2>>的轨道为水平面。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodySurface = 固定<<1>>。\n以它的赤道为水平面。\n这个参考系与<<1>>共同旋转。  // <<1>>centred body name
+    #Principia_ReferenceFrameSelector_ReferencePlane_Centred = <<1>>的赤道  // <<1>> centred body
+    #Principia_ReferenceFrameSelector_ReferencePlane_Secondary_Target = 目标
+    #Principia_ReferenceFrameSelector_ReferencePlane = <<1>>绕<<2>>的轨道  // <<1>> secondary body <<2>> centred body
     #Principia_ReferenceFrameSelector_ToggleButton = <<1>>选择器（<<2>>）...  // <<1>> plotting <<2>> selected frame
     #Principia_ReferenceFrameSelector_Title = <<1>>选择器（<<2>>）  // <<1>>plotting <<2>> selected frame
     // TODO(egg): translations.
-    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredNonRotating = <<1>>参考系： for perturbed Keplerian trajectories around <<2>>.
-    #Principia_ReferenceFrameSelector_Tooltip_BodySurface = <<1>>参考系： for operations involving the surface of <<2>>: landings, remote sensing, imaging, ground communications, etc.
-    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>>参考系： for flybys of <<2>>, transfers to or from it.
-    #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>>参考系： for intercepts or rendez-vous with the target vessel.
+    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredNonRotating = <<1>>参考系：用于绕<<2>>的被摄动的Kepler轨道。
+    #Principia_ReferenceFrameSelector_Tooltip_BodySurface = <<1>>参考系：用于与<<2>>表面有关的活动：着陆、遥感、观测、通讯等等。
+    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>>参考系：用于飞略<<2>>和以它为起点或终点的轨道转移。
+    #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>>参考系：用于交会或拦截目标载具。
     #Principia_ReferenceFrameSelector_Target = 目标：<<1>>
-    #Principia_ReferenceFrameSelector_TargetFrameSelected = 在导航求上以选中的目标为参考定义速度\n\n<<1>>  // <<1>> describe when target selected
+    #Principia_ReferenceFrameSelector_Pin = 固定
 
 
     // OrbitAnalyser
     #Principia_OrbitAnalyser_Precesses = （进动）
     #Principia_OrbitAnalyser_Title = 轨道分析器
-    #Principia_OrbitAnalyser_Duration_GroundTrackCycles = （<<1>>地面周期）  // <<1>> ground_track_cycles.FormatN(0)
+    #Principia_OrbitAnalyser_Duration_GroundTrackCycles = （<<1>>个地面周期）  // <<1>> ground_track_cycles.FormatN(0)
     // See below for the sources for the terms for the various kinds of periods.
-    #Principia_OrbitAnalyser_Duration_Revolutions = <<1>>恒星周期\n<<2>>交点周期<<3>>\n<<4>>近点周期  // <<3>> duration_in_ground_track_cycles
-    #Principia_OrbitAnalyser_Warning_NoElements1 = 无法确定轨道根数；任务持续时间可能小于一次周期，或者轨迹不在重力影响范围。 // TODO(phl): Garbled by removing <<1>>.
-    #Principia_OrbitAnalyser_Warning_NoElements2 = 无法确定轨道根数；任务持续时间可能小于一次周期，或者轨迹不在<<1>>重力影响范围。 // <<1>> primary.NameWithArticle()
-    #Principia_OrbitAnalyser_Warning_NoPrimary = <<1>> 不在重力影响范围 <<2>>  // <<2>> mission_duration.FormatDuration <<1>> vessel name
-    #Principia_OrbitAnalyser_AnalysisDescription = <<1>>的轨道相对于<<2>>在<<3>>：\n<<4>>  // <<1>> vesselname <<2>> centre body <<3>> time <<4>> result
+    #Principia_OrbitAnalyser_Duration_Revolutions = <<1>>个恒星周期\n<<2>>个交点周期<<3>>\n<<4>>个近点周期  // <<3>> duration_in_ground_track_cycles
+    #Principia_OrbitAnalyser_Warning_NoElements1 = 无法确定轨道根数；任务持续时间可能小于一个周期，或者轨迹不被引力束缚。
+    #Principia_OrbitAnalyser_Warning_NoElements2 = 无法确定轨道根数；任务持续时间可能小于一个周期，或者轨迹不被<<1>>的引力束缚。 // <<1>> primary.NameWithArticle()
+    #Principia_OrbitAnalyser_Warning_NoPrimary = <<1>>在<<2>>之内不被引力束缚  // <<2>> mission_duration.FormatDuration <<1>> vessel name
+    #Principia_OrbitAnalyser_AnalysisDescription = <<1>>在<<3>>之内相对于<<2>>的轨道：\n<<4>>  // <<1>> vesselname <<2>> centre body <<3>> time <<4>> result
     #Principia_OrbitAnalyser_OrbitDescription_Circular = 圆形
     #Principia_OrbitAnalyser_OrbitDescription_HighlyElliptical = 大椭圆
     #Principia_OrbitAnalyser_OrbitDescription_Equatorial = 赤道
@@ -158,7 +160,7 @@ Localization {
     #Principia_OrbitAnalyser_MissionDuration = 分析长度
     #Principia_CurrentOrbitAnalyser_ToggleButton = 轨道分析...
     #Principia_CurrentOrbitAnalyser_ToggleButtonWithDescription = 分析：<<1>>...  // <<1>> orbit_description
-    #Principia_CurrentOrbitAnalyser_Analysing = 轨道分析 <<1>>...  // <<1>> vessel name
+    #Principia_CurrentOrbitAnalyser_Analysing = 正在分析<<1>>的轨道...  // <<1>> vessel name
     #Principia_PlannedOrbitAnalyser_ToggleButton = 分析最终轨迹...
     #Principia_PlannedOrbitAnalyser_ToggleButtonWithDescription = 最终轨道分析：<<1>>...  // <<1>> orbit_description
     #Principia_PlannedOrbitAnalyser_Analysing = 最终计划轨道分析 <<1>>...  // <<1>> predicted_vessel.vesselName
@@ -186,7 +188,7 @@ Localization {
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = 在<<1>>之后  // <<1>> Timeout
-    #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器已达到最大步数<<1>>  // <<1>> Timeout
+    #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器已<<1>>达到最大步数  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSegment = 请增加“最大迭代步长”或避免与天体碰撞
     #Principia_FlightPlan_StatusMessage_Singularity = 积分器遇到奇点（可能是天体的中心）<<1>>  // <<1>> timeout
     #Principia_FlightPlan_StatusMessage_AvoidingCollision = 请避免与天体的碰撞
@@ -195,7 +197,7 @@ Localization {
     #Principia_FlightPlan_StatusMessage_OutRange1 = 第<<1>>次轨道机动 与 <<2>> 重叠 或者 <<3>>  // TODO(phl): Added <<3>> at a random place.
     #Principia_FlightPlan_StatusMessage_OutRange2 = 轨道规划的开始
     #Principia_FlightPlan_StatusMessage_OutRange3 = 第<<1>>次轨道机动
-    #Principia_FlightPlan_StatusMessage_OutRange4 = 轨道规划的最终
+    #Principia_FlightPlan_StatusMessage_OutRange4 = 轨道规划的结尾
     #Principia_FlightPlan_StatusMessage_OutRange5 = 第<<1>>次轨道机动
     #Principia_FlightPlan_StatusMessage_OutRange6 = <<1>>调整第<<2>>次轨道机动的初始时间或者持续时间
     #Principia_FlightPlan_StatusMessage_OutRange7 = 延长轨道规划时间或
@@ -217,16 +219,16 @@ Localization {
     #Principia_BurnEditor_MinimizedHeader = <<1>>（<<2>> m/s）  // <<1>>: header, <<2>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Info_InconsistentFrames = 当前轨道机动参考系与绘制参考系不同
     #Principia_BurnEditor_Delete = 删除
-    #Principia_BurnEditor_ActiveEngines = 模拟引擎推力
-    #Principia_BurnEditor_ActiveRCS = 模拟RCS推力
-    #Principia_BurnEditor_InstantImpulse = 模拟瞬间冲量
+    #Principia_BurnEditor_ActiveEngines = 引擎推力
+    #Principia_BurnEditor_ActiveRCS = RCS推力
+    #Principia_BurnEditor_InstantImpulse = 瞬间冲量
     #Principia_BurnEditor_InertiallyFixed = 固定方向（自旋稳定）
     #Principia_BurnEditor_TimeBase_StartOfFlightPlan = 计时起点：轨道规划开始
     #Principia_BurnEditor_TimeBase_EndOfManœuvre = 计时起点：第<<1>>次轨道机动结束时刻  // <<1>> index
     #Principia_BurnEditor_Δv = 轨道机动Δv：<<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = 持续时间：<<1>> s  // <<1>>: duration_.ToString("0.0").
-    #Principia_BurnEditor_Warning_NoActiveEngines = 没用启用的引擎，自动切换为RCS模拟模式。
-    #Principia_BurnEditor_Warning_NoActiveRCS = 没有启用的RCS，自动切换为瞬间冲量模拟模式。
+    #Principia_BurnEditor_Warning_NoActiveEngines = 没用启用的引擎，自动切换为RCS模式。
+    #Principia_BurnEditor_Warning_NoActiveRCS = 没有启用的RCS，自动切换为瞬间冲量模式。
 
     // Log
     #Principia_Logging_Info = 信息
@@ -235,8 +237,8 @@ Localization {
     #Principia_Logging_Fatal = 严重
 
     // MapNodePool
-    #Principia_MapNode_Planned = 已计划
-    #Principia_MapNode_Predicted = 已预测
+    #Principia_MapNode_Planned = 计划的
+    #Principia_MapNode_Predicted = 预测的
     // For the apsides, <<1>> is the name of the celestial.
     #Principia_MapNode_Periapsis = <<1>>近拱点
     #Principia_MapNode_Apoapsis = <<1>>远拱点

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -54,9 +54,9 @@ Localization {
     #Principia_ReferenceFrameSelector_Description_Heading = <<1>>参考系：
     // <<1>> and <<2>> are the names of the relevant bodies, with articles if appropriate, <<2>> being the parent of <<1>>.
     // For the target frame, <<1>> is the name of the target vessel.
-    #Principia_ReferenceFrameSelector_Description_Target = 目标载具<<1>>已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_Target = 目标载具<<1>>已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，面向着<<2>>的方位不变。
     #Principia_ReferenceFrameSelector_Description_BodyCentredNonRotating = <<1>>的质心已固定，\n水平面为它的赤道。\n这个参考系不旋转。
-    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = <<1>>的质心已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，以保持<<2>>的方向不变。
+    #Principia_ReferenceFrameSelector_Description_BodyCentredParentDirection = <<1>>的质心已固定，\n水平面为绕着<<2>>的轨道。\n这个参考系跟随轨道旋转，面向着<<2>>的方位不变。
     #Principia_ReferenceFrameSelector_Description_BodySurface = <<1>>已固定，\n水平面为它的赤道。\n这个参考系与<<1>>共同旋转。  // <<1>>centred body name
     #Principia_ReferenceFrameSelector_ReferencePlane_Centred = <<1>>的赤道  // <<1>> centred body
     #Principia_ReferenceFrameSelector_ReferencePlane_Secondary_Target = 目标
@@ -64,9 +64,9 @@ Localization {
     #Principia_ReferenceFrameSelector_ToggleButton = <<1>>选择器（<<2>>）...  // <<1>> plotting <<2>> selected frame
     #Principia_ReferenceFrameSelector_Title = <<1>>选择器（<<2>>）  // <<1>>plotting <<2>> selected frame
     // TODO(egg): translations.
-    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredNonRotating = <<1>>参考系：用于绕<<2>>的被摄动的Kepler轨道。
-    #Principia_ReferenceFrameSelector_Tooltip_BodySurface = <<1>>参考系：用于与<<2>>表面有关的活动：着陆、遥感、观测、通讯等等。
-    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>>参考系：用于飞略<<2>>和以它为起点或终点的轨道转移。
+    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredNonRotating = <<1>>参考系：<<2>>为中心，轨迹画成有摄动的Kepler轨道。
+    #Principia_ReferenceFrameSelector_Tooltip_BodySurface = <<1>>参考系：用于有关<<2>>表面的活动：着陆、遥感、观测、通讯等等。
+    #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>>参考系：用于飞略<<2>>和<<2>>为起讫点的轨道转移。
     #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>>参考系：用于交会或拦截目标载具。
     #Principia_ReferenceFrameSelector_Target = 目标：<<1>>
     #Principia_ReferenceFrameSelector_Pin = 固定
@@ -187,10 +187,10 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = 新建轨道机动
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
-    #Principia_FlightPlan_StatusMessage_TimeOut = 在<<1>>之后  // <<1>> Timeout
-    #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器已<<1>>达到最大步数  // <<1>> Timeout
+    #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
+    #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSegment = 请增加“最大迭代步长”或避免与天体碰撞
-    #Principia_FlightPlan_StatusMessage_Singularity = 积分器遇到奇点（可能是天体的中心）<<1>>  // <<1>> timeout
+    #Principia_FlightPlan_StatusMessage_Singularity = 积分器在算 + <<1>> 时刻时遇到了奇点  // <<1>> timeout
     #Principia_FlightPlan_StatusMessage_AvoidingCollision = 请避免与天体的碰撞
     #Principia_FlightPlan_StatusMessage_Infinite = 第<<1>>次轨道机动 会产生无限或不确定的速度  // <<1>> Error Manœuvre
     #Principia_FlightPlan_StatusMessage_Adjust = 调整第<<1>>次轨道机动的持续时间  // <<1>> Error Manœuvre

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -190,7 +190,7 @@ Localization {
     #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSegment = 请增加“最大迭代步长”或避免与天体碰撞
-    #Principia_FlightPlan_StatusMessage_Singularity = 积分器在算 + <<1>> 时刻时遇到了奇点  // <<1>> timeout
+    #Principia_FlightPlan_StatusMessage_Singularity = 积分器在算 + <<1>> 时刻时遇到了奇点（可能是天体的中心）  // <<1>> timeout
     #Principia_FlightPlan_StatusMessage_AvoidingCollision = 请避免与天体的碰撞
     #Principia_FlightPlan_StatusMessage_Infinite = 第<<1>>次轨道机动 会产生无限或不确定的速度  // <<1>> Error Manœuvre
     #Principia_FlightPlan_StatusMessage_Adjust = 调整第<<1>>次轨道机动的持续时间  // <<1>> Error Manœuvre

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -502,7 +502,8 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
           L10N.Standalone(celestial.NameWithoutArticle()));
       UnityEngine.GUILayout.FlexibleSpace();
       if (celestial.is_root()) {
-        UnityEngine.GUILayout.Label("Pin");
+        UnityEngine.GUILayout.Label(
+            Localizer.Format("#Principia_ReferenceFrameSelector_Pin"));
       } else if (UnityEngine.GUILayout.Toggle(pinned_[celestial], "") !=
                  pinned_[celestial]) {
         pinned_[celestial] = !pinned_[celestial];


### PR DESCRIPTION
Notable changes:

* Added localized strings for the new plotting frame selector.
* Localized the word 'Pin'.
* Rewrote the update reminders to be more faithful to the en-us version. It now mentions lunation numbers, but uses a written-out explanation ("The \<n\>th new moon, as defined by Meeus's _Astronomical Algorithms_, has arrived...") as the concept does not appear to exist in Chinese.
* Corrected the patched conics toggle to actually use the term 'patched conics'. The original instead used 'original orbit plotting,' in the sense of being in the unmodded game.
* Changed a number of flight analyser error messages so that they no longer refer to the craft not being inside an SoI. (_N.B._ the term Egg originally suggested for 'gravitationally bound' was '重力束缚‘. However, this term is not attested on CNKI (other than one usage in an odd philosophical context), so I chose the more commonly attested (in the context of globular clusters and black holes) '引力束缚‘ instead.)
* Removed the term 'simulate' (模拟) from the three burn mode (engine/RCS/instant impulse) selectors.
* Changed 'predicted/planned' from '已预测/已计划' to '预测的/计划的'. I parse the former as '\<unspecified subject\> has predicted/planned,' which seems awkward. The new translation is the adjectival form.
* Removed a number of (IMHO) extraneous parentheses around body names.
* Made various smaller edits where the wording felt extraneous/awkward/inaccurate to me.

These should be correct to the best of my knowledge. However, my Chinese is somewhat rusty and I do not have much formal mathematics/physics education in Chinese. Thus, a second pair of eyes might be advisable.