### PR TITLE
Allow tracking the root trajectory (not only forks) during serialization

### DIFF
--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -173,8 +173,8 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
   // The points denoted by |exact| are written and re-read exactly and are not
   // affected by any errors introduced by zfp compression.
   void WriteToMessage(not_null<serialization::DiscreteTrajectory*> message,
-                      std::set<DiscreteTrajectory*> const& excluded,
-                      std::vector<DiscreteTrajectory*> const& tracked,
+                      std::set<DiscreteTrajectory const*> const& excluded,
+                      std::vector<DiscreteTrajectory const*> const& tracked,
                       std::vector<Iterator> const& exact) const;
 
   // |forks| must have a size appropriate for the |message| being deserialized
@@ -270,11 +270,12 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
     std::vector<TimelineConstIterator> dense_iterators_;
   };
 
-  // This trajectory need not be a root.
-  void WriteSubTreeToMessage(
+  // This trajectory need not be a root.  Returnst false if this trajectory is
+  // excluded.
+  bool WriteSubTreeToMessage(
       not_null<serialization::DiscreteTrajectory*> message,
-      std::set<DiscreteTrajectory*>& excluded,
-      std::vector<DiscreteTrajectory*>& tracked) const;
+      std::set<DiscreteTrajectory const*>& excluded,
+      std::vector<DiscreteTrajectory const*>& tracked) const;
 
   void FillSubTreeFromMessage(
       serialization::DiscreteTrajectory const& message,

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -270,7 +270,7 @@ class DiscreteTrajectory : public Forkable<DiscreteTrajectory<Frame>,
     std::vector<TimelineConstIterator> dense_iterators_;
   };
 
-  // This trajectory need not be a root.  Returnst false if this trajectory is
+  // This trajectory need not be a root.  Returns false if this trajectory is
   // excluded.
   bool WriteSubTreeToMessage(
       not_null<serialization::DiscreteTrajectory*> message,

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -736,31 +736,37 @@ TEST_F(DiscreteTrajectoryTest, TrajectorySerializationSuccess) {
   serialization::DiscreteTrajectory reference_message;
 
   // Don't serialize |fork0|.
-  massive_trajectory_->WriteToMessage(&message,
-                                      /*excluded=*/{fork0},
-                                      /*tracked=*/{fork1, fork3, fork2},
-                                      /*exact=*/{});
-  massive_trajectory_->WriteToMessage(&reference_message,
-                                      /*excluded=*/{fork0},
-                                      /*tracked=*/{fork1, fork3, fork2},
-                                      /*exact=*/{});
+  massive_trajectory_->WriteToMessage(
+      &message,
+      /*excluded=*/{fork0},
+      /*tracked=*/{massive_trajectory_.get(), fork1, fork3, fork2},
+      /*exact=*/{});
+  massive_trajectory_->WriteToMessage(
+      &reference_message,
+      /*excluded=*/{fork0},
+      /*tracked=*/{massive_trajectory_.get(), fork1, fork3, fork2},
+      /*exact=*/{});
 
+  DiscreteTrajectory<World>* deserialized_root = nullptr;
   DiscreteTrajectory<World>* deserialized_fork1 = nullptr;
   DiscreteTrajectory<World>* deserialized_fork2 = nullptr;
   DiscreteTrajectory<World>* deserialized_fork3 = nullptr;
   not_null<std::unique_ptr<DiscreteTrajectory<World>>> const
       deserialized_trajectory =
           DiscreteTrajectory<World>::ReadFromMessage(message,
-                                                     {&deserialized_fork1,
+                                                     {&deserialized_root,
+                                                      &deserialized_fork1,
                                                       &deserialized_fork3,
                                                       &deserialized_fork2});
+  EXPECT_EQ(deserialized_trajectory.get(), deserialized_root);
   EXPECT_EQ(t2_, deserialized_fork1->Fork()->time);
   EXPECT_EQ(t2_, deserialized_fork2->Fork()->time);
   EXPECT_EQ(t3_, deserialized_fork3->Fork()->time);
   message.Clear();
   deserialized_trajectory->WriteToMessage(&message,
                                           /*excluded=*/{},
-                                          /*tracked=*/{deserialized_fork1,
+                                          /*tracked=*/{deserialized_root,
+                                                       deserialized_fork1,
                                                        deserialized_fork3,
                                                        deserialized_fork2},
                                           /*exact=*/{});

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -1071,7 +1071,7 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
                              /*excluded=*/{}, /*tracked=*/{}, /*exact=*/{});
   std::string uncompressed;
   message.SerializePartialToString(&uncompressed);
-  EXPECT_EQ(24'394, uncompressed.size());
+  EXPECT_EQ(24'405, uncompressed.size());
 
   std::string compressed;
   auto compressor = google::compression::NewGipfeliCompressor();
@@ -1079,8 +1079,8 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
 
   // We want a change detector, but the actual compressed size varies depending
   // on the exact numerical values, and therefore on the mathematical library.
-  EXPECT_LE(18'825, compressed.size());
-  EXPECT_GE(18'825, compressed.size());
+  EXPECT_LE(18'836, compressed.size());
+  EXPECT_GE(18'836, compressed.size());
 
   auto const trajectory2 =
       DiscreteTrajectory<ICRS>::ReadFromMessage(message, /*tracked=*/{});

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -209,10 +209,11 @@ class Forkable {
   // |tracked| are nulled-out as they are used.
   // Note that prior to Grothendieck/Haar all forks that were not tracked were
   // implicitly excluded (so the serialized-but-not-tracked case didn't happen).
-  void WriteSubTreeToMessage(
+  // Returns false if this trajectory is excluded.
+  bool WriteSubTreeToMessage(
       not_null<serialization::DiscreteTrajectory*> message,
-      std::set<Tr4jectory*>& excluded,
-      std::vector<Tr4jectory*>& tracked) const;
+      std::set<Tr4jectory const*>& excluded,
+      std::vector<Tr4jectory const*>& tracked) const;
 
   void FillSubTreeFromMessage(serialization::DiscreteTrajectory const& message,
                               std::vector<Tr4jectory**> const& tracked,

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -500,12 +500,12 @@ bool Forkable<Tr4jectory, It3rator, Traits>::WriteSubTreeToMessage(
   std::optional<Instant> last_instant;
   serialization::DiscreteTrajectory::Child* serialized_child = nullptr;
   for (auto const& [fork_time, child] : children_) {
-
     // We don't know if this child needs to be included in the serialization, so
     // we write it to a temporary object and swap if appropriate.
     serialization::DiscreteTrajectory candidate_trajectory;
     bool const included = child->WriteSubTreeToMessage(
         &candidate_trajectory, excluded, tracked);
+
     if (included) {
       // If this is the first included child at this fork time, create the
       // |Child| message.

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -498,7 +498,7 @@ bool Forkable<Tr4jectory, It3rator, Traits>::WriteSubTreeToMessage(
   }
 
   std::optional<Instant> last_instant;
-  serialization::DiscreteTrajectory::Child* serialized_child = nullptr;
+  serialization::DiscreteTrajectory::Brood* brood = nullptr;
   for (auto const& [fork_time, child] : children_) {
     // We don't know if this child needs to be included in the serialization, so
     // we write it to a temporary object and swap if appropriate.
@@ -508,13 +508,13 @@ bool Forkable<Tr4jectory, It3rator, Traits>::WriteSubTreeToMessage(
 
     if (included) {
       // If this is the first included child at this fork time, create the
-      // |Child| message.
+      // |Brood| message.
       if (!last_instant || fork_time != last_instant) {
         last_instant = fork_time;
-        serialized_child = message->add_children();
-        fork_time.WriteToMessage(serialized_child->mutable_fork_time());
+        brood = message->add_children();
+        fork_time.WriteToMessage(brood->mutable_fork_time());
       }
-      candidate_trajectory.Swap(serialized_child->add_trajectories());
+      candidate_trajectory.Swap(brood->add_trajectories());
     }
   }
   return true;
@@ -544,11 +544,11 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
       << message.DebugString();
 
   std::int32_t index = 0;
-  for (serialization::DiscreteTrajectory::Child const& child :
+  for (serialization::DiscreteTrajectory::Brood const& brood :
            message.children()) {
-    Instant const fork_time = Instant::ReadFromMessage(child.fork_time());
+    Instant const fork_time = Instant::ReadFromMessage(brood.fork_time());
     for (serialization::DiscreteTrajectory const& child :
-             child.trajectories()) {
+             brood.trajectories()) {
       not_null<Tr4jectory*> fork = NewFork(timeline_find(fork_time));
       fork->FillSubTreeFromMessage(child, tracked, exact);
       if (has_fork_position) {

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -471,44 +471,51 @@ CheckNoForksBefore(Instant const& time) {
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
-void Forkable<Tr4jectory, It3rator, Traits>::WriteSubTreeToMessage(
+bool Forkable<Tr4jectory, It3rator, Traits>::WriteSubTreeToMessage(
     not_null<serialization::DiscreteTrajectory*> const message,
-    std::set<Tr4jectory*>& excluded,
-    std::vector<Tr4jectory*>& tracked) const {
+    std::set<Tr4jectory const*>& excluded,
+    std::vector<Tr4jectory const*>& tracked) const {
+  // Determine if this object needs to be serialized.
+  auto const it_excluded = excluded.find(&*that());
+  if (it_excluded == excluded.end()) {
+    // Apologies for the O(N) search.
+    auto const it_tracked = std::find(tracked.begin(), tracked.end(), &*that());
+    if (it_tracked == tracked.end()) {
+      // The caller wants to serialize this object but doesn't want to track it,
+      // let's record this fact.
+      message->set_tracked_position(
+          serialization::DiscreteTrajectory::MISSING_TRACKED_POSITION);
+    } else {
+      // The caller wants to serialize this object and track it, let's record
+      // its position in the vector.
+      message->set_tracked_position(it_tracked - tracked.begin());
+      *it_tracked = nullptr;
+    }
+  } else {
+    // The caller doesn't want to serialize this object.  Don't traverse it.
+    excluded.erase(it_excluded);
+    return false;
+  }
+
   std::optional<Instant> last_instant;
   serialization::DiscreteTrajectory::Child* serialized_child = nullptr;
   for (auto const& [fork_time, child] : children_) {
-    // Determine if this |child| needs to be serialized.
-    auto const it_excluded = excluded.find(child.get());
-    if (it_excluded == excluded.end()) {
-      // Apologies for the O(N) search.
-      auto const it_tracked =
-          std::find(tracked.begin(), tracked.end(), child.get());
-      if (it_tracked == tracked.end()) {
-        // The caller wants to serialize this fork but doesn't want to track it,
-        // let's record this fact.
-        message->add_fork_position(
-            serialization::DiscreteTrajectory::MISSING_FORK_POSITION);
-      } else {
-        // The caller wants to serialize this fork and track it, let's record
-        // its position in the vector.
-        message->add_fork_position(it_tracked - tracked.begin());
-        *it_tracked = nullptr;
-      }
-    } else {
-      // The caller doesn't want to serialize this fork.  Don't traverse it.
-      excluded.erase(it_excluded);
-      continue;
-    }
-
     if (!last_instant || fork_time != last_instant) {
       last_instant = fork_time;
       serialized_child = message->add_children();
       fork_time.WriteToMessage(serialized_child->mutable_fork_time());
     }
-    child->WriteSubTreeToMessage(serialized_child->add_trajectories(),
-                                 excluded, tracked);
+
+    // We don't know if this child need to be included in the serialization, so
+    // we write it to a temporary object and swap if needed.
+    serialization::DiscreteTrajectory candidate_trajectory;
+    bool const included = child->WriteSubTreeToMessage(
+        &candidate_trajectory, excluded, tracked);
+    if (included) {
+      candidate_trajectory.Swap(serialized_child->add_trajectories());
+    }
   }
+  return true;
 }
 
 template<typename Tr4jectory, typename It3rator, typename Traits>
@@ -516,8 +523,24 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
     serialization::DiscreteTrajectory const& message,
     std::vector<Tr4jectory**> const& tracked,
     Timeline const& exact) {
-  // There were no fork positions prior to Буняковский.
+  bool const is_pre_grothendieck_haar = !message.has_tracked_position();
+  LOG_IF(WARNING, is_pre_grothendieck_haar)
+      << "Reading pre-Grothendieck/Haar Forkable";
+
+  if (!is_pre_grothendieck_haar) {
+    std::int32_t const tracked_position = message.tracked_position();
+    if (tracked_position !=
+        serialization::DiscreteTrajectory::MISSING_TRACKED_POSITION) {
+      *tracked[tracked_position] = &*that();
+    }
+  }
+
+  // There were no fork positions prior to Буняковский, but we don't maintain
+  // compatibility that far back.
   bool const has_fork_position = message.fork_position_size() > 0;
+  CHECK(is_pre_grothendieck_haar || !has_fork_position)
+      << message.DebugString();
+
   std::int32_t index = 0;
   for (serialization::DiscreteTrajectory::Child const& child :
            message.children()) {
@@ -530,7 +553,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
         CHECK_LT(index, message.fork_position_size());
         std::int32_t const fork_position = message.fork_position(index);
         if (fork_position !=
-            serialization::DiscreteTrajectory::MISSING_FORK_POSITION) {
+            serialization::DiscreteTrajectory::MISSING_TRACKED_POSITION) {
           *tracked[fork_position] = fork;
         }
       }

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -97,11 +97,12 @@ message DiscreteTrajectory {
     required Point instant = 1;
     required Pair degrees_of_freedom = 2;
   }
-  message Child {
+  // All the trajectories forked at a given time.
+  message Brood {
     required Point fork_time = 1;
     repeated DiscreteTrajectory trajectories = 2;
   }
-  repeated Child children = 1;
+  repeated Brood children = 1;
   repeated InstantaneousDegreesOfFreedom timeline = 2;
   // Pre Grothendieck/Haar.
   repeated int32 fork_position = 3;

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -81,8 +81,8 @@ message ContinuousTrajectory {
 message DiscreteTrajectory {
   // A marker to indicate that a fork doesn't have its position tracked.
   // Added in Grothendieck/Haar.
-  enum ForkPosition {
-    MISSING_FORK_POSITION = -1;
+  enum TrackedPosition {
+    MISSING_TRACKED_POSITION = -1;
   }
   message Downsampling {
     required int64 max_dense_intervals = 2;
@@ -103,7 +103,10 @@ message DiscreteTrajectory {
   }
   repeated Child children = 1;
   repeated InstantaneousDegreesOfFreedom timeline = 2;
+  // Pre Grothendieck/Haar.
   repeated int32 fork_position = 3;
+  // Added in Grothendieck/Haar.
+  optional int32 tracked_position = 7;  // Required.
   // Added in 陈景润.
   optional Downsampling downsampling = 4;
   // Added in Haar.

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -97,11 +97,11 @@ message DiscreteTrajectory {
     required Point instant = 1;
     required Pair degrees_of_freedom = 2;
   }
-  message Litter {
+  message Child {
     required Point fork_time = 1;
     repeated DiscreteTrajectory trajectories = 2;
   }
-  repeated Litter children = 1;
+  repeated Child children = 1;
   repeated InstantaneousDegreesOfFreedom timeline = 2;
   repeated int32 fork_position = 3;
   // Added in 陈景润.


### PR DESCRIPTION
This makes it possible to track a pointer that may denote either the root or some fork.

You guessed it, #2400.