### PR TITLE
Zermelo

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -477,14 +477,13 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
   bool const is_pre_chasles = message.has_prediction();
   bool const is_pre_陈景润 = !message.history().has_downsampling();
   // TODO(phl): Decide in which version it goes.
-  bool const is_pre_grothendieck_haar =
-      !message.history().has_tracked_position();
-  LOG_IF(WARNING, is_pre_grothendieck_haar)
+  bool const is_pre_zermelo = !message.history().has_tracked_position();
+  LOG_IF(WARNING, is_pre_zermelo)
       << "Reading pre-"
       << (is_pre_cesàro    ? u8"Cesàro"
           : is_pre_chasles ? "Chasles"
           : is_pre_陈景润   ? u8"陈景润"
-                           : "Grothendieck/Haar")
+                           : "Zermelo")
       << " Vessel";
 
   // NOTE(egg): for now we do not read the |MasslessBody| as it can contain no
@@ -540,7 +539,7 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
         /*tracked=*/{&vessel->psychohistory_});
     vessel->backstory_ = vessel->psychohistory_->parent();
     vessel->prediction_ = vessel->psychohistory_->NewForkAtLast();
-  } else if (is_pre_grothendieck_haar) {
+  } else if (is_pre_zermelo) {
     vessel->history_ = DiscreteTrajectory<Barycentric>::ReadFromMessage(
         message.history(),
         /*tracked=*/{&vessel->psychohistory_,

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -272,7 +272,7 @@ class Vessel {
   not_null<Celestial const*> parent_;
   not_null<Ephemeris<Barycentric>*> const ephemeris_;
 
-  // When reading a pre-Grothendieck/Haar save, the existing history must be
+  // When reading a pre-Zermelo save, the existing history must be
   // non-collapsible as we don't know anything about it.
   bool is_collapsible_ = false;
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -528,9 +528,9 @@ typename DiscreteTrajectory<Frame>::Downsampling
 DiscreteTrajectory<Frame>::Downsampling::ReadFromMessage(
     serialization::DiscreteTrajectory::Downsampling const& message,
     DiscreteTrajectory const& trajectory) {
-  bool const is_pre_grothendieck_haar = message.has_start_of_dense_timeline();
-  LOG_IF(WARNING, is_pre_grothendieck_haar)
-      << "Reading pre-Grothendieck/Haar Downsampling";
+  bool const is_pre_zermelo = message.has_start_of_dense_timeline();
+  LOG_IF(WARNING, is_pre_zermelo)
+      << "Reading pre-Zermelo Downsampling";
   Downsampling downsampling(message.max_dense_intervals(),
                             Length::ReadFromMessage(message.tolerance()),
                             [&trajectory](Instant const& t){
@@ -538,7 +538,7 @@ DiscreteTrajectory<Frame>::Downsampling::ReadFromMessage(
                               CHECK(it != trajectory.end());
                               return it.current();
                             });
-  if (is_pre_grothendieck_haar) {
+  if (is_pre_zermelo) {
     // No support for forks in legacy saves, so |find| will succeed and ++ is
     // safe.
     auto it = trajectory.timeline_.find(

--- a/physics/forkable.hpp
+++ b/physics/forkable.hpp
@@ -207,7 +207,7 @@ class Forkable {
   // serialized.  The forks in |tracked| will be retrieved in the same order
   // when reading.  The pointers in |excluded| are removed, the pointers in
   // |tracked| are nulled-out as they are used.
-  // Note that prior to Grothendieck/Haar all forks that were not tracked were
+  // Note that prior to Zermelo all forks that were not tracked were
   // implicitly excluded (so the serialized-but-not-tracked case didn't happen).
   // Returns false if this trajectory is excluded.
   bool WriteSubTreeToMessage(

--- a/physics/forkable_body.hpp
+++ b/physics/forkable_body.hpp
@@ -525,11 +525,11 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
     serialization::DiscreteTrajectory const& message,
     std::vector<Tr4jectory**> const& tracked,
     Timeline const& exact) {
-  bool const is_pre_grothendieck_haar = !message.has_tracked_position();
-  LOG_IF(WARNING, is_pre_grothendieck_haar)
-      << "Reading pre-Grothendieck/Haar Forkable";
+  bool const is_pre_zermelo = !message.has_tracked_position();
+  LOG_IF(WARNING, is_pre_zermelo)
+      << "Reading pre-Zermelo Forkable";
 
-  if (!is_pre_grothendieck_haar) {
+  if (!is_pre_zermelo) {
     std::int32_t const tracked_position = message.tracked_position();
     if (tracked_position !=
         serialization::DiscreteTrajectory::MISSING_TRACKED_POSITION) {
@@ -540,7 +540,7 @@ void Forkable<Tr4jectory, It3rator, Traits>::FillSubTreeFromMessage(
   // There were no fork positions prior to Буняковский, but we don't maintain
   // compatibility that far back.
   bool const has_fork_position = message.fork_position_size() > 0;
-  CHECK(is_pre_grothendieck_haar || !has_fork_position)
+  CHECK(is_pre_zermelo || !has_fork_position)
       << message.DebugString();
 
   std::int32_t index = 0;

--- a/serialization/ksp_plugin.proto
+++ b/serialization/ksp_plugin.proto
@@ -176,7 +176,7 @@ message Vessel {
   optional bool psychohistory_is_authoritative = 17;  // Pre-Cesàro.
   optional DiscreteTrajectory prediction = 18;  // Pre-Chasles.
   optional FlightPlan flight_plan = 4;
-  repeated Checkpoint checkpoint = 21;  // Added in Grothendieck/Haar.
+  repeated Checkpoint checkpoint = 21;  // Added in Zermelo.
 
   // Pre-Буняковский.
   reserved 2, 3, 5;
@@ -190,7 +190,7 @@ message Vessel {
            "prediction_fork_time";
   // Pre-Cesàro.
   reserved "psychohistory";
-  // Grothendieck/Haar failed attempt.
+  // Zermelo failed attempt.
   reserved 20;
   reserved "prehistory";
 }

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -104,7 +104,7 @@ message DiscreteTrajectory {
   }
   repeated Brood children = 1;
   repeated InstantaneousDegreesOfFreedom timeline = 2;
-  // Pre Zermelo.
+  // Pre-Zermelo.
   repeated int32 fork_position = 3;
   // Added in Zermelo.
   optional int32 tracked_position = 7;  // Required.

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -80,7 +80,7 @@ message ContinuousTrajectory {
 
 message DiscreteTrajectory {
   // A marker to indicate that a fork doesn't have its position tracked.
-  // Added in Grothendieck/Haar.
+  // Added in Zermelo.
   enum TrackedPosition {
     MISSING_TRACKED_POSITION = -1;
   }
@@ -88,9 +88,9 @@ message DiscreteTrajectory {
     required int64 max_dense_intervals = 2;
     required Quantity tolerance = 3;
     // The instant of the iterator; absent if it is the end of the timeline.
-    // Pre Grothendieck/Haar.
+    // Pre Zermelo.
     optional Point start_of_dense_timeline = 1;
-    // Added in Grothendieck/Haar.
+    // Added in Zermelo.
     repeated Point dense_timeline = 4;
   }
   message InstantaneousDegreesOfFreedom {
@@ -104,9 +104,9 @@ message DiscreteTrajectory {
   }
   repeated Brood children = 1;
   repeated InstantaneousDegreesOfFreedom timeline = 2;
-  // Pre Grothendieck/Haar.
+  // Pre Zermelo.
   repeated int32 fork_position = 3;
-  // Added in Grothendieck/Haar.
+  // Added in Zermelo.
   optional int32 tracked_position = 7;  // Required.
   // Added in 陈景润.
   optional Downsampling downsampling = 4;


### PR DESCRIPTION
Having Grothendieck/Haar as a marker for the changes done in `Entwurf` is getting annoying now that it's clear that it's not going in either Grothendieck or Haar, but some other changes do go in Grothendieck and/or Haar.  I am using Zermelo as a marker for the changes in `Entwurf`.

#2400 always takes longer than you expect.