### PR TITLE
Use UTF-16 for filenames on Windows only

### DIFF
--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -106,8 +106,8 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
     }
   }
   mathematica::Logger logger(
-      SOLUTION_DIR / "mathematica" / u"лидов_古在.generated.wl",
-                             /*make_unique=*/false);
+      SOLUTION_DIR / "mathematica" / PATH_ENCODING("лидов_古在.generated.wl"),
+      /*make_unique=*/false);
 
   DiscreteTrajectory<MercuryCentredInertial> mercury_centred_trajectory;
   for (auto const& [t, dof] : icrs_trajectory) {

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -106,7 +106,8 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
     }
   }
   mathematica::Logger logger(
-      SOLUTION_DIR / "mathematica" / PATH_ENCODING("лидов_古在.generated.wl"),
+      SOLUTION_DIR / "mathematica" /
+          PRINCIPIA_PATH_ENCODING("лидов_古在.generated.wl"),
       /*make_unique=*/false);
 
   DiscreteTrajectory<MercuryCentredInertial> mercury_centred_trajectory;

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -241,5 +241,11 @@ template_and_result declared_name parameters;              \
 }                                                          \
 using internal_##package_name::declared_name
 
+#if OS_WIN
+#define PATH_ENCODING(string) u##string
+#else
+#define PATH_ENCODING(string) u8##string
+#endif
+
 }  // namespace base
 }  // namespace principia

--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -242,9 +242,9 @@ template_and_result declared_name parameters;              \
 using internal_##package_name::declared_name
 
 #if OS_WIN
-#define PATH_ENCODING(string) u##string
+#define PRINCIPIA_PATH_ENCODING(string) u##string
 #else
-#define PATH_ENCODING(string) u8##string
+#define PRINCIPIA_PATH_ENCODING(string) u8##string
 #endif
 
 }  // namespace base


### PR DESCRIPTION
This should fix the mac build, where our compatibility `path` is lacking a `char16_t const*` constructor.