### PR TITLE
Improve the parsing of time spans

### DIFF
--- a/Principia.sln
+++ b/Principia.sln
@@ -61,7 +61,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Legal", "Legal", "{4B25658F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ksp_plugin_adapter", "ksp_plugin_adapter\ksp_plugin_adapter.csproj", "{E75B3F05-D64F-4AFE-9493-2F94A9B37510}"
 	ProjectSection(ProjectDependencies) = postProject
-		{873680B3-2406-4A30-9EE7-569E9B9DA661} = {873680B3-2406-4A30-9EE7-569E9B9DA661}
+		{A3F94607-2666-408F-AF98-0E47D61C98BB} = {A3F94607-2666-408F-AF98-0E47D61C98BB}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ksp_plugin", "ksp_plugin\ksp_plugin.vcxproj", "{A3F94607-2666-408F-AF98-0E47D61C98BB}"

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -325,7 +325,6 @@ class BurnEditor : ScalingRenderer {
   internal bool TryParsePreviousCoastDuration(string text, out double value) {
     value = 0;
     if (!PrincipiaTimeSpan.TryParse(text,
-                                    with_seconds: true,
                                     out PrincipiaTimeSpan ts)) {
       return false;
     }

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -63,8 +63,10 @@ internal class DifferentialSlider : ScalingRenderer {
     set {
       if (!value_.HasValue || value_ != value) {
         value_ = value;
-        formatted_value_ = formatter_(value_.Value);
       }
+      // Reformat systematically, even if the value has not changed numerically,
+      // as it may have been edited all the same (e.g., remove zeroes).
+      formatted_value_ = formatter_(value_.Value);
     }
   }
 

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -61,9 +61,7 @@ internal class DifferentialSlider : ScalingRenderer {
   public double value {
     get => value_ ?? 0.0;
     set {
-      if (!value_.HasValue || value_ != value) {
-        value_ = value;
-      }
+      value_ = value;
       // Reformat systematically, even if the value has not changed numerically,
       // as it may have been edited all the same (e.g., remove zeroes).
       formatted_value_ = formatter_(value_.Value);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -506,7 +506,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   internal bool TryParsePlanLength(string text, out double value) {
     value = 0;
     if (!PrincipiaTimeSpan.TryParse(text,
-                                    with_seconds: true,
                                     out PrincipiaTimeSpan ts)) {
       return false;
     }

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -126,7 +126,6 @@ internal static class Formatters {
   public static bool TryParseMissionDuration(string str, out double seconds) {
     seconds = 0;
     if (PrincipiaTimeSpan.TryParse(str,
-                                   with_seconds: false,
                                    out PrincipiaTimeSpan ts)) {
       seconds = ts.total_seconds;
       return true;

--- a/ksp_plugin_adapter/time_span.cs
+++ b/ksp_plugin_adapter/time_span.cs
@@ -93,22 +93,23 @@ class PrincipiaTimeSpan {
                               out PrincipiaTimeSpan time_span) {
     time_span = new PrincipiaTimeSpan(double.NaN);
     // Using a technology that is customarily used to parse HTML.
-    string pattern = @"^[+]?\s*(?<days>\d+)\s*" +
+    string pattern = @"^[+]?\s*(?:(?<days>\d+)\s*" +
                      day_symbol +
-                     @"\s*" +
-                     @"(?:(?<hours>\d+)\s*h\s*" +
-                     @"(?:(?<minutes>\d+)\s*min\s*"+
-                     @"(?:(?<seconds>[0-9.,']+)\s*s)?)?)?$";
+                     @"\s*)?" +
+                     @"(?:(?<hours>\d+)\s*h\s*)?" +
+                     @"(?:(?<minutes>\d+)\s*min\s*)?" +
+                     @"(?:(?<seconds>[0-9.,']+)\s*s\s*)?$";
     var regex = new Regex(pattern);
     var match = regex.Match(text);
     if (!match.Success) {
       return false;
     }
 
-    string days = match.Groups["days"].Value;
+    var days_group = match.Groups["days"];
     var hours_group = match.Groups["hours"];
     var minutes_group = match.Groups["minutes"];
     var seconds_group = match.Groups["seconds"];
+    string days = days_group.Success ? days_group.Value : "0";
     string hours = hours_group.Success ? hours_group.Value : "0";
     string minutes = minutes_group.Success ? minutes_group.Value : "0";
     string seconds = seconds_group.Success ? seconds_group.Value : "0";

--- a/ksp_plugin_adapter/time_span.cs
+++ b/ksp_plugin_adapter/time_span.cs
@@ -90,30 +90,28 @@ class PrincipiaTimeSpan {
   public double total_seconds => seconds_;
 
   public static bool TryParse(string text,
-                              bool with_seconds,
                               out PrincipiaTimeSpan time_span) {
     time_span = new PrincipiaTimeSpan(double.NaN);
     // Using a technology that is customarily used to parse HTML.
-    string pattern = @"^[+]?\s*(\d+)\s*" +
+    string pattern = @"^[+]?\s*(?<days>\d+)\s*" +
                      day_symbol +
-                     @"\s*(\d+)\s*h\s*(\d+)\s*min";
-    if (with_seconds) {
-      pattern += @"\s*([0-9.,']+)\s*s$";
-    } else {
-      pattern += @"$";
-    }
+                     @"\s*" +
+                     @"(?:(?<hours>\d+)\s*h\s*" +
+                     @"(?:(?<minutes>\d+)\s*min\s*"+
+                     @"(?:(?<seconds>[0-9.,']+)\s*s)?)?)?$";
     var regex = new Regex(pattern);
     var match = regex.Match(text);
     if (!match.Success) {
       return false;
     }
-    string days = match.Groups[1].Value;
-    string hours = match.Groups[2].Value;
-    string minutes = match.Groups[3].Value;
-    string seconds = "0";
-    if (with_seconds) {
-      seconds = match.Groups[4].Value;
-    }
+
+    string days = match.Groups["days"].Value;
+    var hours_group = match.Groups["hours"];
+    var minutes_group = match.Groups["minutes"];
+    var seconds_group = match.Groups["seconds"];
+    string hours = hours_group.Success ? hours_group.Value : "0";
+    string minutes = minutes_group.Success ? minutes_group.Value : "0";
+    string seconds = seconds_group.Success ? seconds_group.Value : "0";
     if (!int.TryParse(days, out int d) ||
         !int.TryParse(hours, out int h) ||
         !int.TryParse(minutes, out int min) ||


### PR DESCRIPTION
We now accept formats like:
```
7d
7d 6h
7d 6h 5min
7d 6h 5min 4s
```
With `d` replaced by `d6` as appropriate.

Example [here](http://regexstorm.net/tester?p=%5e%5b%2b%5d%3f%5cs*%28%3f%3cdays%3e%5cd%2b%29%5cs*d6%5cs*%28%3f%3a%28%3f%3chours%3e%5cd%2b%29%5cs*h%5cs*%28%3f%3a%28%3f%3cminutes%3e%5cd%2b%29%5cs*min%5cs*%28%3f%3a%28%3f%3cseconds%3e%5b0-9.%2c%27%5d%2b%29%5cs*s%29%3f%29%3f%29%3f&i=7d6+6h+5min+).

Fix #2984.