### PR TITLE
Change FindSegment to avoid failing when given a time before the beginning of the trajectory

### DIFF
--- a/physics/discrete_traject0ry.hpp
+++ b/physics/discrete_traject0ry.hpp
@@ -73,6 +73,9 @@ class DiscreteTraject0ry : public Trajectory<Frame> {
   bool empty() const;
   std::int64_t size() const;
 
+  // Doesn't invalidate iterators to the first segment.
+  void clear();
+
   iterator find(Instant const& t) const;
 
   iterator lower_bound(Instant const& t) const;
@@ -134,8 +137,8 @@ class DiscreteTraject0ry : public Trajectory<Frame> {
   // t ∈ [t1, t2[.  For the last segment, t2 is assumed to be +∞.  A 1-point
   // segment is never returned, unless it is the last one (because its upper
   // bound is assumed to be +∞).  Returns segment_by_left_endpoint_->end() iff
-  // the trajectory is empty().  Fails if t is before the first time of the
-  // trajectory.
+  // t is before the first time of the trajectory or if the trajectory is
+  // empty().
   typename SegmentByLeftEndpoint::iterator FindSegment(Instant const& t);
   typename SegmentByLeftEndpoint::const_iterator
   FindSegment(Instant const& t) const;

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -79,6 +79,13 @@ std::int64_t DiscreteTraject0ry<Frame>::size() const {
 }
 
 template<typename Frame>
+void DiscreteTraject0ry<Frame>::clear() {
+  segments_->erase(std::next(segments_->begin()), segments_->end());
+  segments_->front().clear();
+  segment_by_left_endpoint_.clear();
+}
+
+template<typename Frame>
 typename DiscreteTraject0ry<Frame>::iterator
 DiscreteTraject0ry<Frame>::find(Instant const& t) const {
   auto const leit = FindSegment(t);
@@ -98,7 +105,8 @@ typename DiscreteTraject0ry<Frame>::iterator
 DiscreteTraject0ry<Frame>::lower_bound(Instant const& t) const {
   auto const leit = FindSegment(t);
   if (leit == segment_by_left_endpoint_.cend()) {
-    return end();
+    // This includes an empty trajectory.
+    return begin();
   }
   auto const sit = leit->second;
   auto const it = sit->lower_bound(t);
@@ -113,7 +121,8 @@ typename DiscreteTraject0ry<Frame>::iterator
 DiscreteTraject0ry<Frame>::upper_bound(Instant const& t) const {
   auto const leit = FindSegment(t);
   if (leit == segment_by_left_endpoint_.cend()) {
-    return end();
+    // This includes an empty trajectory.
+    return begin();
   }
   auto const sit = leit->second;
   auto const it = sit->upper_bound(t);
@@ -252,6 +261,7 @@ template<typename Frame>
 void DiscreteTraject0ry<Frame>::ForgetAfter(Instant const& t) {
   auto const leit = FindSegment(t);
   if (leit == segment_by_left_endpoint_.end()) {
+    clear();
     return;
   }
   auto const sit = leit->second;
@@ -284,7 +294,8 @@ void DiscreteTraject0ry<Frame>::ForgetBefore(Instant const& t) {
     return;
   }
   auto const sit = leit->second;
-  // This call never makes the segment |*sit| empty.
+  // This call may make the segment |*sit| empty if |t| is after the end of
+  // |*sit|.
   sit->ForgetBefore(t);
   for (auto s = segments_->begin(); s != sit; ++s) {
     // This call may either make the segment |*s| empty or leave it with a
@@ -297,10 +308,13 @@ void DiscreteTraject0ry<Frame>::ForgetBefore(Instant const& t) {
   // just have truncated.
   segment_by_left_endpoint_.erase(segment_by_left_endpoint_.begin(),
                                   std::next(leit));
-  // Recreate an entry for |sit| with its new left endpoint.
-  segment_by_left_endpoint_.insert_or_assign(segment_by_left_endpoint_.begin(),
-                                             sit->front().time,
-                                             sit);
+  // It |*sit| is not empty, recreate an entry with its new left endpoint.
+  if (!sit->empty()) {
+    segment_by_left_endpoint_.insert_or_assign(
+        segment_by_left_endpoint_.begin(),
+        sit->front().time,
+        sit);
+  }
 
   DCHECK_OK(ConsistencyStatus());
 }
@@ -314,15 +328,18 @@ template<typename Frame>
 void DiscreteTraject0ry<Frame>::Append(
     Instant const& t,
     DegreesOfFreedom<Frame> const& degrees_of_freedom) {
-  auto leit = FindSegment(t);
   typename Segments::iterator sit;
-  if (leit == segment_by_left_endpoint_.end()) {
+  if (segment_by_left_endpoint_.empty()) {
     // If this is the first point appended to this trajectory, insert it in the
     // time-to-segment map.
     sit = --segments_->end();
-    leit = segment_by_left_endpoint_.insert_or_assign(
+    segment_by_left_endpoint_.insert_or_assign(
         segment_by_left_endpoint_.end(), t, sit);
   } else {
+    auto const leit = FindSegment(t);
+    CHECK(leit != segment_by_left_endpoint_.end())
+        << "Append at " << t << " before the beginning of the trajectory at "
+        << front().time;
     // The segment is expected to always have a point copied from its
     // predecessor.
     sit = leit->second;
@@ -482,24 +499,26 @@ template<typename Frame>
 typename DiscreteTraject0ry<Frame>::SegmentByLeftEndpoint::iterator
 DiscreteTraject0ry<Frame>::FindSegment(
     Instant const& t) {
-  if (segment_by_left_endpoint_.empty()) {
-    return segment_by_left_endpoint_.end();
-  }
   auto it = segment_by_left_endpoint_.upper_bound(t);
-  CHECK(it != segment_by_left_endpoint_.begin()) << "No segment covering " << t;
-  return --it;
+  if (it == segment_by_left_endpoint_.begin()) {
+    // This includes an empty trajectory.
+    return segment_by_left_endpoint_.end();
+  } else {
+    return --it;
+  }
 }
 
 template<typename Frame>
 typename DiscreteTraject0ry<Frame>::SegmentByLeftEndpoint::const_iterator
 DiscreteTraject0ry<Frame>::FindSegment(
     Instant const& t) const {
-  if (segment_by_left_endpoint_.empty()) {
-    return segment_by_left_endpoint_.cend();
-  }
   auto it = segment_by_left_endpoint_.upper_bound(t);
-  CHECK(it != segment_by_left_endpoint_.begin()) << "No segment covering " << t;
-  return --it;
+  if (it == segment_by_left_endpoint_.begin()) {
+    // This includes an empty trajectory.
+    return segment_by_left_endpoint_.cend();
+  } else {
+    return --it;
+  }
 }
 
 template<typename Frame>

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -266,6 +266,11 @@ TEST_F(DiscreteTraject0ryTest, LowerBound) {
     auto const it = trajectory.lower_bound(t0_ + 14.2 * Second);
     EXPECT_TRUE(it == trajectory.end());
   }
+  {
+    auto const it = trajectory.lower_bound(t0_ - 99 * Second);
+    auto const& [t, _] = *it;
+    EXPECT_EQ(t, t0_);
+  }
 }
 
 TEST_F(DiscreteTraject0ryTest, UpperBound) {
@@ -309,6 +314,11 @@ TEST_F(DiscreteTraject0ryTest, UpperBound) {
   {
     auto const it = trajectory.upper_bound(t0_ + 14.2 * Second);
     EXPECT_TRUE(it == trajectory.end());
+  }
+  {
+    auto const it = trajectory.upper_bound(t0_ - 99 * Second);
+    auto const& [t, _] = *it;
+    EXPECT_EQ(t, t0_);
   }
 }
 
@@ -471,6 +481,9 @@ TEST_F(DiscreteTraject0ryTest, ForgetAfter) {
   EXPECT_EQ(1, trajectory.segments().size());
   EXPECT_EQ(t0_, trajectory.begin()->time);
   EXPECT_EQ(t0_ + 4 * Second, trajectory.rbegin()->time);
+
+  trajectory.ForgetAfter(t0_ - 99 * Second);
+  EXPECT_TRUE(trajectory.empty());
 }
 
 TEST_F(DiscreteTraject0ryTest, ForgetBefore) {
@@ -519,6 +532,9 @@ TEST_F(DiscreteTraject0ryTest, ForgetBefore) {
                             t0_ + 10 * Second,
                             t0_ + 9 * Second));
   }
+
+  trajectory.ForgetBefore(t0_ + 99 * Second);
+  EXPECT_TRUE(trajectory.empty());
 }
 
 TEST_F(DiscreteTraject0ryTest, TMinTMaxEvaluate) {

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -86,6 +86,8 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   bool empty() const;
   std::int64_t size() const;
 
+  void clear();
+
   iterator find(Instant const& t) const;
 
   iterator lower_bound(Instant const& t) const;

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -92,6 +92,13 @@ std::int64_t DiscreteTrajectorySegment<Frame>::size() const {
 }
 
 template<typename Frame>
+void DiscreteTrajectorySegment<Frame>::clear() {
+  downsampling_parameters_.reset();
+  number_of_dense_points_ = 0;
+  timeline_.clear();
+}
+
+template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::find(Instant const& t) const {
   auto const it = timeline_.find(t);


### PR DESCRIPTION
1. Fix the methods for which this change is necessary because a time far in the past makes sense: `lower_bound`, `upper_bound`, forgetting, etc.
2. Add a `clear` method to bring back a trajectory to its state at construction without iterator invalidation.

#3136.