### PR TITLE
Fix some bugs related to forgetting

### DIFF
--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -289,7 +289,9 @@ void DiscreteTraject0ry<Frame>::ForgetAfter(Instant const& t) {
 
 template<typename Frame>
 void DiscreteTraject0ry<Frame>::ForgetAfter(iterator const it) {
-  ForgetAfter(it->time);
+  if (it != end()) {
+    ForgetAfter(it->time);
+  }
 }
 
 template<typename Frame>
@@ -326,7 +328,11 @@ void DiscreteTraject0ry<Frame>::ForgetBefore(Instant const& t) {
 
 template<typename Frame>
 void DiscreteTraject0ry<Frame>::ForgetBefore(iterator const it) {
-  ForgetBefore(it->time);
+  if (it == end()) {
+    clear();
+  } else {
+    ForgetBefore(it->time);
+  }
 }
 
 template<typename Frame>

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -269,9 +269,14 @@ void DiscreteTraject0ry<Frame>::ForgetAfter(Instant const& t) {
   // Here |sit| designates a segment starting at or after |t|.  If |t| is
   // exactly at the beginning of the segment,
   // |DiscreteTrajectorySegment::ForgetAfter| will leave it empty.  In that
-  // case we drop the segment entirely.
+  // case we drop the segment entirely, unless it is the only one in the
+  // trajectory.
   if (sit->empty()) {
-    segments_->erase(sit, segments_->end());
+    if (sit == segments_->begin()) {
+      segments_->erase(std::next(sit), segments_->end());
+    } else {
+      segments_->erase(sit, segments_->end());
+    }
     segment_by_left_endpoint_.erase(leit, segment_by_left_endpoint_.end());
   } else {
     segments_->erase(std::next(sit), segments_->end());
@@ -576,7 +581,7 @@ absl::Status DiscreteTraject0ry<Frame>::ConsistencyStatus() const {
       }
     }
   }
-  {
+  if (!segments_->empty()) {
     int i = 0;
     for (auto sit = segments_->cbegin();
          sit != std::prev(segments_->cend());

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -482,8 +482,9 @@ TEST_F(DiscreteTraject0ryTest, ForgetAfter) {
   EXPECT_EQ(t0_, trajectory.begin()->time);
   EXPECT_EQ(t0_ + 4 * Second, trajectory.rbegin()->time);
 
-  trajectory.ForgetAfter(t0_ - 99 * Second);
+  trajectory.ForgetAfter(t0_);
   EXPECT_TRUE(trajectory.empty());
+  EXPECT_EQ(1, trajectory.segments().size());
 }
 
 TEST_F(DiscreteTraject0ryTest, ForgetBefore) {

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -467,6 +467,9 @@ TEST_F(DiscreteTraject0ryTest, DeleteSegments) {
 TEST_F(DiscreteTraject0ryTest, ForgetAfter) {
   auto trajectory = MakeTrajectory();
 
+  trajectory.ForgetAfter(trajectory.end());
+  EXPECT_EQ(3, trajectory.segments().size());
+
   trajectory.ForgetAfter(t0_ + 12 * Second);
   EXPECT_EQ(3, trajectory.segments().size());
   EXPECT_EQ(t0_, trajectory.begin()->time);
@@ -535,6 +538,9 @@ TEST_F(DiscreteTraject0ryTest, ForgetBefore) {
   }
 
   trajectory.ForgetBefore(t0_ + 99 * Second);
+  EXPECT_TRUE(trajectory.empty());
+
+  trajectory.ForgetBefore(trajectory.end());
   EXPECT_TRUE(trajectory.empty());
 }
 


### PR DESCRIPTION
1. `ForgetAfter` should not delete all the segments, it should at least keep one empty segment.
2. Forgetting by iterator should support the past-the-end iterator.

#3136.