### PR TITLE
Change WriteToMessage to be capable of writing only a range of the trajectory

### DIFF
--- a/physics/discrete_traject0ry.hpp
+++ b/physics/discrete_traject0ry.hpp
@@ -112,11 +112,15 @@ class DiscreteTraject0ry : public Trajectory<Frame> {
   DegreesOfFreedom<Frame> EvaluateDegreesOfFreedom(
       Instant const& t) const override;
 
-  //TODO(phl):comment
+  // The segments in |tracked| are restored at deserialization.  The points
+  // denoted by |exact| are written and re-read exactly and are not affected by
+  // any errors introduced by zfp compression.  The endpoints of each segment
+  // are always exact.
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectory*> message,
       std::vector<SegmentIterator> const& tracked,
       std::vector<iterator> const& exact) const;
+  // Same as above, but only the points defined by [begin, end[ are written.
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectory*> message,
       iterator begin,

--- a/physics/discrete_traject0ry.hpp
+++ b/physics/discrete_traject0ry.hpp
@@ -112,10 +112,18 @@ class DiscreteTraject0ry : public Trajectory<Frame> {
   DegreesOfFreedom<Frame> EvaluateDegreesOfFreedom(
       Instant const& t) const override;
 
+  //TODO(phl):comment
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectory*> message,
       std::vector<SegmentIterator> const& tracked,
       std::vector<iterator> const& exact) const;
+  void WriteToMessage(
+      not_null<serialization::DiscreteTrajectory*> message,
+      iterator begin,
+      iterator end,
+      std::vector<SegmentIterator> const& tracked,
+      std::vector<iterator> const& exact) const;
+
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
   static DiscreteTraject0ry ReadFromMessage(

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -470,8 +470,10 @@ void DiscreteTraject0ry<Frame>::WriteToMessage(
   // Convert to instants the iterators that define the range to write.  This is
   // necessary to do lookups in each segment to obtain segment-specific
   // iterators.
-  Instant const begin_time = begin == end() ? InfiniteFuture : begin->time;
-  Instant const end_time = end == end() ? InfiniteFuture : end->time;
+  Instant const begin_time = begin == this->end() ? InfiniteFuture
+                                                  : begin->time;
+  Instant const end_time = end == this->end() ? InfiniteFuture
+                                              : end->time;
 
   // The set of segments that intersect the range to write.
   absl::flat_hash_set<

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -2,6 +2,7 @@
 
 #include "physics/discrete_traject0ry.hpp"
 
+#include <algorithm>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -487,19 +487,16 @@ void DiscreteTraject0ry<Frame>::WriteToMessage(
        ++sit, ++segment_position) {
     // Look up in |*sit| the instants that define the range to write.  |find|
     // returns the past-the-end-of-segment iterator if the instant is not found.
-    auto const begin_time_it = sit->find(begin_time);
-    auto const end_time_it = sit->find(end_time);
+    //TODO(phl):comment
+    auto const begin_time_it = sit->lower_bound(begin_time);
+    auto const end_time_it = sit->upper_bound(end_time);
 
-    // If the |begin_time| is in |*sit|, this is the first segment to intersect
-    // the range to write.
-    if (begin_time_it != sit->end()) {
-      CHECK(!intersect_range);
-      intersect_range = true;
-    }
-
+    // If |begin_time| is in |*sit|, that segment intersects the range to write.
+    intersect_range = begit_time_it != sit->end();
     if (intersect_range) {
       intersecting_segments.insert(&*sit);
     }
+
     sit->WriteToMessage(
         message->add_segment(), begin_time_it, end_time_it, exact);
 
@@ -510,10 +507,10 @@ void DiscreteTraject0ry<Frame>::WriteToMessage(
       message->set_tracked_position(position_it->second, segment_position);
     }
 
-    // If the |end_time| is in |*sit|, this is the last segment to intersect the
+    // If |end_time| is in |*sit|, this is the last segment to intersect the
     // range to write.  Skip all the remaining segments.
-    if (end_time_it != sit->end()) {
-      CHECK(intersect_range);
+    //TODO(phl):correct?
+    if (intersect_range && end_time_it != sit->end()) {
       break;
     }
   }

--- a/physics/discrete_traject0ry_body.hpp
+++ b/physics/discrete_traject0ry_body.hpp
@@ -458,10 +458,9 @@ void DiscreteTraject0ry<Frame>::WriteToMessage(
       break;
     }
 
-    // If |*sit| contains a point at or after |begin_time|, that segment
-    // intersects the range to write.
+    // If |*sit| contains a point at or after |begin_time|, it intersects the
+    // range to write.
     intersect_range = begin_time_it != sit->end();
-
     if (intersect_range) {
       intersecting_segments.insert(&*sit);
     }

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -674,6 +674,28 @@ TEST_F(DiscreteTraject0ryTest, SerializationExactEndpoints) {
                                 IsNear(0.36_⑴ * Metre / Second)));
 }
 
+TEST_F(DiscreteTraject0ryTest, SerializationRange) {
+  auto const trajectory1 = MakeTrajectory();
+  auto trajectory2 = MakeTrajectory();
+
+  serialization::DiscreteTrajectory message1;
+  trajectory1.WriteToMessage(
+      &message1,
+      /*begin=*/trajectory1.upper_bound(t0_ + 6 * Second),
+      /*end=*/trajectory1.upper_bound(t0_ + 12 * Second),
+      /*tracked=*/{},
+      /*exact=*/{});
+
+  serialization::DiscreteTrajectory message2;
+  trajectory2.ForgetBefore(trajectory1.upper_bound(t0_ + 6 * Second));
+  trajectory2.ForgetAfter(trajectory1.upper_bound(t0_ + 12 * Second));
+  trajectory2.WriteToMessage(&message2,
+                             /*tracked=*/{},
+                             /*exact=*/{});
+
+  EXPECT_THAT(message1, EqualsProto(message2));
+}
+
 TEST_F(DiscreteTraject0ryTest, DISABLED_SerializationPreΖήνωνCompatibility) {
   StringLogSink log_warning(google::WARNING);
   auto const serialized_message = ReadFromBinaryFile(

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -687,8 +687,8 @@ TEST_F(DiscreteTraject0ryTest, SerializationRange) {
       /*exact=*/{});
 
   serialization::DiscreteTrajectory message2;
-  trajectory2.ForgetBefore(trajectory1.upper_bound(t0_ + 6 * Second));
-  trajectory2.ForgetAfter(trajectory1.upper_bound(t0_ + 12 * Second));
+  trajectory2.ForgetBefore(trajectory2.upper_bound(t0_ + 6 * Second));
+  trajectory2.ForgetAfter(trajectory2.upper_bound(t0_ + 12 * Second));
   trajectory2.WriteToMessage(&message2,
                              /*tracked=*/{},
                              /*exact=*/{});

--- a/physics/discrete_traject0ry_test.cpp
+++ b/physics/discrete_traject0ry_test.cpp
@@ -693,6 +693,8 @@ TEST_F(DiscreteTraject0ryTest, SerializationRange) {
                              /*tracked=*/{},
                              /*exact=*/{});
 
+  // Writing a range of the trajectory is equivalent to forgetting and writing
+  // the result.
   EXPECT_THAT(message1, EqualsProto(message2));
 }
 

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -116,6 +116,13 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectorySegment*> message,
       std::vector<iterator> const& exact) const;
+  //TODO(phl):comment
+  void WriteToMessage(
+      not_null<serialization::DiscreteTrajectorySegment*> message,
+      iterator begin,
+      iterator end,
+      std::vector<iterator> const& exact) const;
+
   template<typename F = Frame,
            typename = std::enable_if_t<base::is_serializable_v<F>>>
   static DiscreteTrajectorySegment ReadFromMessage(

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -116,7 +116,8 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectorySegment*> message,
       std::vector<iterator> const& exact) const;
-  //TODO(phl):comment
+  // Same as above, but only the points defined by [begin, end[ are written.
+  // The iterators must have been obtained by operations on this segment.
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectorySegment*> message,
       iterator begin,
@@ -174,12 +175,17 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   typename Timeline::const_iterator timeline_end() const;
   bool timeline_empty() const;
 
-  //TODO(phl):comment, pass the # of points dropped.
+  // Implementation of serialization.  The caller is expected to pass consistent
+  // parameters.  |timeline_begin| and |timeline_end| define the range to write.
+  // |timeline_size| is the distance from |timeline_begin| to |timeline_end|.
+  // |number_of_points_to_skip_at_end| is the distance between |timeline_end|
+  // and the true |end| of the timeline.
   void WriteToMessage(
       not_null<serialization::DiscreteTrajectorySegment*> message,
       typename Timeline::const_iterator timeline_begin,
       typename Timeline::const_iterator timeline_end,
-      std::int32_t timeline_size,
+      std::int64_t timeline_size,
+      std::int64_t number_of_points_to_skip_at_end,
       std::vector<iterator> const& exact) const;
 
   std::optional<DownsamplingParameters> downsampling_parameters_;

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -174,6 +174,14 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   typename Timeline::const_iterator timeline_end() const;
   bool timeline_empty() const;
 
+  //TODO(phl):comment, pass the # of points dropped.
+  void WriteToMessage(
+      not_null<serialization::DiscreteTrajectorySegment*> message,
+      typename Timeline::const_iterator timeline_begin,
+      typename Timeline::const_iterator timeline_end,
+      std::int32_t timeline_size,
+      std::vector<iterator> const& exact) const;
+
   std::optional<DownsamplingParameters> downsampling_parameters_;
 
   // The number of points at the end of the segment that are part of a "dense"

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -194,108 +194,16 @@ void DiscreteTrajectorySegment<Frame>::ClearDownsampling() {
   downsampling_parameters_ = std::nullopt;
 }
 
-//TODO(phl): Rewrite.
 template<typename Frame>
 void DiscreteTrajectorySegment<Frame>::WriteToMessage(
     not_null<serialization::DiscreteTrajectorySegment*> message,
     std::vector<iterator> const& exact) const {
-  if (downsampling_parameters_.has_value()) {
-    auto* const serialized_downsampling_parameters =
-        message->mutable_downsampling_parameters();
-    serialized_downsampling_parameters->set_max_dense_intervals(
-        downsampling_parameters_->max_dense_intervals);
-    downsampling_parameters_->tolerance.WriteToMessage(
-        serialized_downsampling_parameters->mutable_tolerance());
-  }
-  message->set_number_of_dense_points(number_of_dense_points_);
-
-  // Convert the |exact| vector into a set, and add the extremities.  This
-  // ensures that we don't have redundancies.  The set is sorted by time to
-  // guarantee that serialization is reproducible.
-  auto time_comparator = [](value_type const* const left,
-                            value_type const* const right) {
-    return left->time < right->time;
-  };
-  absl::btree_set<value_type const*,
-                  decltype(time_comparator)> exact_set(time_comparator);
-  for (auto const it : exact) {
-    exact_set.insert(&*it);
-  }
-  if (!timeline_.empty()) {
-    exact_set.insert(&*timeline_.cbegin());
-    exact_set.insert(&*timeline_.crbegin());
-  }
-
-  // Serialize the exact points.
-  for (auto const* ptr : exact_set) {
-    auto const& [t, degrees_of_freedom] = *ptr;
-    auto* const serialized_exact = message->add_exact();
-    t.WriteToMessage(serialized_exact->mutable_instant());
-    degrees_of_freedom.WriteToMessage(
-        serialized_exact->mutable_degrees_of_freedom());
-  }
-
-  std::int32_t const timeline_size = timeline_.size();
-  auto* const zfp = message->mutable_zfp();
-  zfp->set_timeline_size(timeline_size);
-
-  // The timeline data is made dimensionless and stored in separate arrays per
-  // coordinate.  We expect strong correlations within a coordinate over time,
-  // but not between coordinates.
-  std::vector<double> t;
-  std::vector<double> qx;
-  std::vector<double> qy;
-  std::vector<double> qz;
-  std::vector<double> px;
-  std::vector<double> py;
-  std::vector<double> pz;
-  t.reserve(timeline_size);
-  qx.reserve(timeline_size);
-  qy.reserve(timeline_size);
-  qz.reserve(timeline_size);
-  px.reserve(timeline_size);
-  py.reserve(timeline_size);
-  pz.reserve(timeline_size);
-  std::optional<Instant> previous_instant;
-  Time max_Δt;
-  std::string* const zfp_timeline = zfp->mutable_timeline();
-  for (auto const& [instant, degrees_of_freedom] : timeline_) {
-    auto const q = degrees_of_freedom.position() - Frame::origin;
-    auto const p = degrees_of_freedom.velocity();
-    t.push_back((instant - Instant{}) / Second);
-    qx.push_back(q.coordinates().x / Metre);
-    qy.push_back(q.coordinates().y / Metre);
-    qz.push_back(q.coordinates().z / Metre);
-    px.push_back(p.coordinates().x / (Metre / Second));
-    py.push_back(p.coordinates().y / (Metre / Second));
-    pz.push_back(p.coordinates().z / (Metre / Second));
-    if (previous_instant.has_value()) {
-      max_Δt = std::max(max_Δt, instant - *previous_instant);
-    }
-    previous_instant = instant;
-  }
-
-  // Times are exact.
-  ZfpCompressor time_compressor(0);
-  // Lengths are approximated to the downsampling tolerance if downsampling is
-  // enabled, otherwise they are exact.
-  Length const length_tolerance = downsampling_parameters_.has_value()
-                                      ? downsampling_parameters_->tolerance
-                                      : Length();
-  ZfpCompressor length_compressor(length_tolerance / Metre);
-  // Speeds are approximated based on the length tolerance and the maximum
-  // step in the timeline.
-  ZfpCompressor const speed_compressor((length_tolerance / max_Δt) /
-                                        (Metre / Second));
-
-  ZfpCompressor::WriteVersion(message);
-  time_compressor.WriteToMessageMultidimensional<2>(t, zfp_timeline);
-  length_compressor.WriteToMessageMultidimensional<2>(qx, zfp_timeline);
-  length_compressor.WriteToMessageMultidimensional<2>(qy, zfp_timeline);
-  length_compressor.WriteToMessageMultidimensional<2>(qz, zfp_timeline);
-  speed_compressor.WriteToMessageMultidimensional<2>(px, zfp_timeline);
-  speed_compressor.WriteToMessageMultidimensional<2>(py, zfp_timeline);
-  speed_compressor.WriteToMessageMultidimensional<2>(pz, zfp_timeline);
+  WriteToMessage(message,
+                 timeline_.begin(),
+                 timeline_.end(),
+                 timeline_.size(),
+                 /*number_of_points_to_skip_at_end*/ 0,
+                 exact);
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -298,6 +298,25 @@ void DiscreteTrajectorySegment<Frame>::WriteToMessage(
 }
 
 template<typename Frame>
+void DiscreteTrajectorySegment<Frame>::WriteToMessage(
+    not_null<serialization::DiscreteTrajectorySegment*> message,
+    iterator const begin,
+    iterator const end,
+    std::vector<iterator> const& exact) const {
+  typename Timeline::const_iterator const timeline_begin =
+      begin == end() ? timeline_.cend()
+                     : DiscreteTrajectoryIterator::iterator(begin.iterator_);
+  typename Timeline::const_iterator const timeline_end =
+      end == end() ? timeline_.cend()
+                   : DiscreteTrajectoryIterator::iterator(end.iterator_);
+  std::int32_t const timeline_size =
+      timeline_begin == timeline_.cbegin() && timeline_end == timeline_.cend()
+          ? timeline_.size()
+          : std::distance(timeline_begin, timeline_end);
+  WriteToMessage(message, timeline_begin, timeline_end, timeline_size, exact);
+}
+
+template<typename Frame>
 template<typename F, typename>
 DiscreteTrajectorySegment<Frame>
 DiscreteTrajectorySegment<Frame>::ReadFromMessage(
@@ -545,6 +564,112 @@ DiscreteTrajectorySegment<Frame>::timeline_end() const {
 template<typename Frame>
 bool DiscreteTrajectorySegment<Frame>::timeline_empty() const {
   return timeline_.empty();
+}
+
+template<typename Frame>
+void DiscreteTrajectorySegment<Frame>::WriteToMessage(
+    not_null<serialization::DiscreteTrajectorySegment*> message,
+    typename Timeline::const_iterator const timeline_begin,
+    typename Timeline::const_iterator const timeline_end,
+    std::int32_t const timeline_size,
+    std::vector<iterator> const& exact) const {
+  if (downsampling_parameters_.has_value()) {
+    auto* const serialized_downsampling_parameters =
+        message->mutable_downsampling_parameters();
+    serialized_downsampling_parameters->set_max_dense_intervals(
+        downsampling_parameters_->max_dense_intervals);
+    downsampling_parameters_->tolerance.WriteToMessage(
+        serialized_downsampling_parameters->mutable_tolerance());
+  }
+  message->set_number_of_dense_points(number_of_dense_points_);
+
+  // Convert the |exact| vector into a set, and add the extremities.  This
+  // ensures that we don't have redundancies.  The set is sorted by time to
+  // guarantee that serialization is reproducible.
+  auto time_comparator = [](value_type const* const left,
+                            value_type const* const right) {
+    return left->time < right->time;
+  };
+  absl::btree_set<value_type const*,
+                  decltype(time_comparator)> exact_set(time_comparator);
+  for (auto const it : exact) {
+    exact_set.insert(&*it);
+  }
+  if (timeline_size > 0) {
+    exact_set.insert(&*timeline_begin);
+    exact_set.insert(&*std::prev(timeline_end));
+  }
+
+  // Serialize the exact points.
+  for (auto const* ptr : exact_set) {
+    auto const& [t, degrees_of_freedom] = *ptr;
+    auto* const serialized_exact = message->add_exact();
+    t.WriteToMessage(serialized_exact->mutable_instant());
+    degrees_of_freedom.WriteToMessage(
+        serialized_exact->mutable_degrees_of_freedom());
+  }
+
+  auto* const zfp = message->mutable_zfp();
+  zfp->set_timeline_size(timeline_size);
+
+  // The timeline data is made dimensionless and stored in separate arrays per
+  // coordinate.  We expect strong correlations within a coordinate over time,
+  // but not between coordinates.
+  std::vector<double> t;
+  std::vector<double> qx;
+  std::vector<double> qy;
+  std::vector<double> qz;
+  std::vector<double> px;
+  std::vector<double> py;
+  std::vector<double> pz;
+  t.reserve(timeline_size);
+  qx.reserve(timeline_size);
+  qy.reserve(timeline_size);
+  qz.reserve(timeline_size);
+  px.reserve(timeline_size);
+  py.reserve(timeline_size);
+  pz.reserve(timeline_size);
+  std::optional<Instant> previous_instant;
+  Time max_Δt;
+  std::string* const zfp_timeline = zfp->mutable_timeline();
+  for (auto it = timeline_begin; it != timeline_end; ++it) {
+    auto const& [instant, degrees_of_freedom] = *it;
+    auto const q = degrees_of_freedom.position() - Frame::origin;
+    auto const p = degrees_of_freedom.velocity();
+    t.push_back((instant - Instant{}) / Second);
+    qx.push_back(q.coordinates().x / Metre);
+    qy.push_back(q.coordinates().y / Metre);
+    qz.push_back(q.coordinates().z / Metre);
+    px.push_back(p.coordinates().x / (Metre / Second));
+    py.push_back(p.coordinates().y / (Metre / Second));
+    pz.push_back(p.coordinates().z / (Metre / Second));
+    if (previous_instant.has_value()) {
+      max_Δt = std::max(max_Δt, instant - *previous_instant);
+    }
+    previous_instant = instant;
+  }
+
+  // Times are exact.
+  ZfpCompressor time_compressor(0);
+  // Lengths are approximated to the downsampling tolerance if downsampling is
+  // enabled, otherwise they are exact.
+  Length const length_tolerance = downsampling_parameters_.has_value()
+                                      ? downsampling_parameters_->tolerance
+                                      : Length();
+  ZfpCompressor length_compressor(length_tolerance / Metre);
+  // Speeds are approximated based on the length tolerance and the maximum
+  // step in the timeline.
+  ZfpCompressor const speed_compressor((length_tolerance / max_Δt) /
+                                        (Metre / Second));
+
+  ZfpCompressor::WriteVersion(message);
+  time_compressor.WriteToMessageMultidimensional<2>(t, zfp_timeline);
+  length_compressor.WriteToMessageMultidimensional<2>(qx, zfp_timeline);
+  length_compressor.WriteToMessageMultidimensional<2>(qy, zfp_timeline);
+  length_compressor.WriteToMessageMultidimensional<2>(qz, zfp_timeline);
+  speed_compressor.WriteToMessageMultidimensional<2>(px, zfp_timeline);
+  speed_compressor.WriteToMessageMultidimensional<2>(py, zfp_timeline);
+  speed_compressor.WriteToMessageMultidimensional<2>(pz, zfp_timeline);
 }
 
 }  // namespace internal_discrete_trajectory_segment

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -194,6 +194,7 @@ void DiscreteTrajectorySegment<Frame>::ClearDownsampling() {
   downsampling_parameters_ = std::nullopt;
 }
 
+//TODO(phl): Rewrite.
 template<typename Frame>
 void DiscreteTrajectorySegment<Frame>::WriteToMessage(
     not_null<serialization::DiscreteTrajectorySegment*> message,


### PR DESCRIPTION
This will be handy for `Entwurf`, if we ever resurrect it.  It will also be handy for using `DiscreteTraject0ry` in class `Vessel`, which is a more pressing concern.

#3136.