### PR TITLE
Use static styles to prevent Unity leaks

### DIFF
--- a/ksp_plugin_adapter/style.cs
+++ b/ksp_plugin_adapter/style.cs
@@ -2,6 +2,15 @@
 namespace ksp_plugin_adapter {
 
 internal static class Style {
+  static Style() {
+    horizontal_line_style_ =
+        new UnityEngine.GUIStyle(UnityEngine.GUI.skin.horizontalSlider);
+    horizontal_line_style_.fixedHeight /= 5;
+    horizontal_line_style_.normal.background = ultra_cool_grey_texture;
+    line_spacing_style_ = new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label);
+    line_spacing_style_.fixedHeight /= 5;
+  }
+
   public static UnityEngine.Color Tangent { get; } = XKCDColors.NeonYellow;
   public static UnityEngine.Color Normal { get; } = XKCDColors.AquaBlue;
   public static UnityEngine.Color Binormal { get; } = XKCDColors.PurplePink;
@@ -61,18 +70,11 @@ internal static class Style {
   }
 
   public static void HorizontalLine() {
-    var horizontal_line_style =
-        new UnityEngine.GUIStyle(UnityEngine.GUI.skin.horizontalSlider);
-    horizontal_line_style.fixedHeight /= 5;
-    horizontal_line_style.normal.background = ultra_cool_grey_texture;
-    UnityEngine.GUILayout.Label("", horizontal_line_style);
+    UnityEngine.GUILayout.Label("", horizontal_line_style_);
   }
 
   public static void LineSpacing() {
-    var horizontal_line_style =
-        new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label);
-    horizontal_line_style.fixedHeight /= 5;
-    UnityEngine.GUILayout.Label("", horizontal_line_style);
+    UnityEngine.GUILayout.Label("", line_spacing_style_);
   }
 
   private static UnityEngine.Texture2D ultra_cool_grey_texture {
@@ -90,6 +92,12 @@ internal static class Style {
   // Close to XKCD "cool grey", but hue-neutral
   private static readonly UnityEngine.Color ultra_cool_grey_ =
       new UnityEngine.Color(0.64f, 0.64f, 0.64f);
+
+  // It is very important to use *static* styles for these elements.  If we use
+  // local variables at the place of use, the stupid Unity ends up burning 9 kiB
+  // for each horizontal line we display.  See #3064.
+  private static readonly UnityEngine.GUIStyle horizontal_line_style_;
+  private static readonly UnityEngine.GUIStyle line_spacing_style_;
 }
 
 }  // namespace ksp_plugin_adapter


### PR DESCRIPTION
Before this PR, the save given in #3064 burns about 120 MiB/minute when the flight planner UI is visible.  After this PR, it uses about 10 MiB/minute.  Note that we do expect some memory growth due to Principia as the trajectories of the celestials and vessels are extended.

Fix #3064.