### PR TITLE
Make DiscreteTrajectoryIterator a LegacyRandomAccessIterator

### DIFF
--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -42,12 +42,6 @@ class DiscreteTrajectoryIterator {
 
   DiscreteTrajectoryIterator& operator+=(difference_type n);
   DiscreteTrajectoryIterator& operator-=(difference_type n);
-  friend DiscreteTrajectoryIterator operator+(DiscreteTrajectoryIterator it,
-                                              difference_type n);
-  friend DiscreteTrajectoryIterator operator+(difference_type n,
-                                              DiscreteTrajectoryIterator it);
-  friend DiscreteTrajectoryIterator operator-(DiscreteTrajectoryIterator it,
-                                              difference_type n);
   reference operator[](difference_type n) const;
 
   bool operator==(DiscreteTrajectoryIterator other) const;
@@ -81,6 +75,19 @@ class DiscreteTrajectoryIterator {
   // single point to clients.
   DiscreteTrajectorySegmentIterator<Frame> segment_;
   OptionalTimelineConstIterator point_;
+
+  template<typename F>
+  friend DiscreteTrajectoryIterator<F> operator+(
+      DiscreteTrajectoryIterator<F> it,
+      typename DiscreteTrajectoryIterator<F>::difference_type n);
+  template<typename F>
+  friend DiscreteTrajectoryIterator<F> operator+(
+      typename DiscreteTrajectoryIterator<F>::difference_type n,
+      DiscreteTrajectoryIterator<F> it);
+  template<typename F>
+  friend DiscreteTrajectoryIterator<F> operator-(
+      DiscreteTrajectoryIterator<F> it,
+      typename DiscreteTrajectoryIterator<F>::difference_type n);
 
   template<typename F>
   friend class physics::DiscreteTrajectorySegment;

--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -44,6 +44,11 @@ class DiscreteTrajectoryIterator {
   DiscreteTrajectoryIterator& operator-=(difference_type n);
   reference operator[](difference_type n) const;
 
+  // The operator+ are outside of this class because one of them cannot be a
+  // member.
+  DiscreteTrajectoryIterator operator-(difference_type n) const;
+  difference_type operator-(DiscreteTrajectoryIterator right) const;
+
   bool operator==(DiscreteTrajectoryIterator other) const;
   bool operator!=(DiscreteTrajectoryIterator other) const;
   bool operator<(DiscreteTrajectoryIterator other) const;
@@ -77,19 +82,6 @@ class DiscreteTrajectoryIterator {
   OptionalTimelineConstIterator point_;
 
   template<typename F>
-  friend DiscreteTrajectoryIterator<F> operator+(
-      DiscreteTrajectoryIterator<F> it,
-      typename DiscreteTrajectoryIterator<F>::difference_type n);
-  template<typename F>
-  friend DiscreteTrajectoryIterator<F> operator+(
-      typename DiscreteTrajectoryIterator<F>::difference_type n,
-      DiscreteTrajectoryIterator<F> it);
-  template<typename F>
-  friend DiscreteTrajectoryIterator<F> operator-(
-      DiscreteTrajectoryIterator<F> it,
-      typename DiscreteTrajectoryIterator<F>::difference_type n);
-
-  template<typename F>
   friend class physics::DiscreteTrajectorySegment;
   friend class physics::DiscreteTrajectoryIteratorTest;
 };
@@ -102,10 +94,6 @@ template<typename Frame>
 DiscreteTrajectoryIterator<Frame> operator+(
     typename DiscreteTrajectoryIterator<Frame>::difference_type n,
     DiscreteTrajectoryIterator<Frame> it);
-template<typename Frame>
-DiscreteTrajectoryIterator<Frame> operator-(
-    DiscreteTrajectoryIterator<Frame> it,
-    typename DiscreteTrajectoryIterator<Frame>::difference_type n);
 
 }  // namespace internal_discrete_trajectory_iterator
 

--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -40,8 +40,22 @@ class DiscreteTrajectoryIterator {
   reference operator*() const;
   pointer operator->() const;
 
-  bool operator==(DiscreteTrajectoryIterator const& other) const;
-  bool operator!=(DiscreteTrajectoryIterator const& other) const;
+  DiscreteTrajectoryIterator& operator+=(difference_type n);
+  DiscreteTrajectoryIterator& operator-=(difference_type n);
+  friend DiscreteTrajectoryIterator operator+(DiscreteTrajectoryIterator it,
+                                              difference_type n);
+  friend DiscreteTrajectoryIterator operator+(difference_type n,
+                                              DiscreteTrajectoryIterator it);
+  friend DiscreteTrajectoryIterator operator-(DiscreteTrajectoryIterator it,
+                                              difference_type n);
+  reference operator[](difference_type n) const;
+
+  bool operator==(DiscreteTrajectoryIterator other) const;
+  bool operator!=(DiscreteTrajectoryIterator other) const;
+  bool operator<(DiscreteTrajectoryIterator other) const;
+  bool operator>(DiscreteTrajectoryIterator other) const;
+  bool operator<=(DiscreteTrajectoryIterator other) const;
+  bool operator>=(DiscreteTrajectoryIterator other) const;
 
  private:
   using Timeline = internal_discrete_trajectory_types::Timeline<Frame>;

--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -87,6 +87,19 @@ class DiscreteTrajectoryIterator {
   friend class physics::DiscreteTrajectoryIteratorTest;
 };
 
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator+(
+    DiscreteTrajectoryIterator<Frame> it,
+    typename DiscreteTrajectoryIterator<Frame>::difference_type n);
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator+(
+    typename DiscreteTrajectoryIterator<Frame>::difference_type n,
+    DiscreteTrajectoryIterator<Frame> it);
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator-(
+    DiscreteTrajectoryIterator<Frame> it,
+    typename DiscreteTrajectoryIterator<Frame>::difference_type n);
+
 }  // namespace internal_discrete_trajectory_iterator
 
 using internal_discrete_trajectory_iterator::DiscreteTrajectoryIterator;

--- a/physics/discrete_trajectory_iterator_body.hpp
+++ b/physics/discrete_trajectory_iterator_body.hpp
@@ -224,7 +224,7 @@ bool DiscreteTrajectoryIterator<Frame>::operator<(
   } else if (is_at_end(other.point_)) {
     return true;
   } else {
-    return point_->time < other.point_->time;
+    return iterator(point_)->time < iterator(other.point_)->time;
   }
 }
 
@@ -236,7 +236,7 @@ bool DiscreteTrajectoryIterator<Frame>::operator>(
   } else if (is_at_end(point_)) {
     return true;
   } else {
-    return point_->time > other.point_->time;
+    return iterator(point_)->time > iterator(other.point_)->time;
   }
 }
 

--- a/physics/discrete_trajectory_iterator_body.hpp
+++ b/physics/discrete_trajectory_iterator_body.hpp
@@ -159,7 +159,7 @@ DiscreteTrajectoryIterator<Frame>::operator-=(difference_type const n) {
 
 template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference
- DiscreteTrajectoryIterator<Frame>::operator[](difference_type const n) const {
+DiscreteTrajectoryIterator<Frame>::operator[](difference_type const n) const {
   return *(*this + n);
 }
 

--- a/physics/discrete_trajectory_iterator_body.hpp
+++ b/physics/discrete_trajectory_iterator_body.hpp
@@ -150,7 +150,7 @@ DiscreteTrajectoryIterator<Frame>::operator-=(difference_type const n) {
 template<typename Frame>
 typename DiscreteTrajectoryIterator<Frame>::reference
  DiscreteTrajectoryIterator<Frame>::operator[](difference_type const n) const {
-  return reference();
+  return *(*this + n);
 }
 
 template<typename Frame>
@@ -174,25 +174,37 @@ bool DiscreteTrajectoryIterator<Frame>::operator!=(
 template<typename Frame>
 bool DiscreteTrajectoryIterator<Frame>::operator<(
     DiscreteTrajectoryIterator const other) const {
-  return false;
+  if (is_at_end(point_)) {
+    return false;
+  } else if (is_at_end(other.point_)) {
+    return true;
+  } else {
+    return point_->time < other.point_->time;
+  }
 }
 
 template<typename Frame>
 bool DiscreteTrajectoryIterator<Frame>::operator>(
     DiscreteTrajectoryIterator const other) const {
-  return false;
+  if (is_at_end(other.point_)) {
+    return false;
+  } else if (is_at_end(point_)) {
+    return true;
+  } else {
+    return point_->time > other.point_->time;
+  }
 }
 
 template<typename Frame>
 bool DiscreteTrajectoryIterator<Frame>::operator<=(
     DiscreteTrajectoryIterator const other) const {
-  return false;
+  return !operator>(other);
 }
 
 template<typename Frame>
 bool DiscreteTrajectoryIterator<Frame>::operator>=(
     DiscreteTrajectoryIterator const other) const {
-  return false;
+  return !operator<(other);
 }
 
 template<typename Frame>
@@ -233,6 +245,30 @@ DiscreteTrajectoryIterator<Frame>::iterator(
     OptionalTimelineConstIterator const& point) {
   DCHECK(point.has_value());
   return point.value();
+}
+
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator+(
+    DiscreteTrajectoryIterator<Frame> const it,
+    typename DiscreteTrajectoryIterator<Frame>::difference_type const n) {
+  auto mutable_it = it;
+  return mutable_it += n;
+}
+
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator+(
+    typename DiscreteTrajectoryIterator<Frame>::difference_type const n,
+    DiscreteTrajectoryIterator<Frame> const it) {
+  auto mutable_it = it;
+  return mutable_it += n;
+}
+
+template<typename Frame>
+DiscreteTrajectoryIterator<Frame> operator-(
+    DiscreteTrajectoryIterator<Frame> const it,
+    typename DiscreteTrajectoryIterator<Frame>::difference_type const n) {
+  auto mutable_it = it;
+  return mutable_it -= n;
 }
 
 }  // namespace internal_discrete_trajectory_iterator

--- a/physics/discrete_trajectory_iterator_test.cpp
+++ b/physics/discrete_trajectory_iterator_test.cpp
@@ -248,6 +248,20 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(2, iterator3 - iterator2);
     EXPECT_EQ(8, iterator3 - iterator1);
   }
+  {
+    EXPECT_LT(begin + 3, begin + 4);
+    EXPECT_LT(begin + 4, end);
+    EXPECT_LE(begin + 4, begin + 4);
+    EXPECT_LE(begin + 3, begin + 4);
+    EXPECT_LE(begin + 4, end);
+    EXPECT_LE(end, end);
+    EXPECT_GE(begin + 4, begin + 4);
+    EXPECT_GE(begin + 4, begin + 3);
+    EXPECT_GE(end, begin + 4);
+    EXPECT_GE(end, end);
+    EXPECT_GT(begin + 4, begin + 3);
+    EXPECT_GT(end, begin + 4);
+  }
 }
 
 // Empty segments may exist in a transient manner, we must be able to iterate

--- a/physics/discrete_trajectory_iterator_test.cpp
+++ b/physics/discrete_trajectory_iterator_test.cpp
@@ -171,9 +171,10 @@ TEST_F(DiscreteTrajectoryIteratorTest, Equality) {
 }
 
 TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
+  auto const begin = MakeBegin(segments_->begin());
+  auto const end = MakeEnd(--segments_->end());
   {
-    auto segment = segments_->begin();
-    auto iterator = MakeBegin(segment);
+    auto iterator = begin;
     iterator += 4;
     EXPECT_EQ(t0_ + 11 * Second, iterator->time);
     iterator += 3;
@@ -182,10 +183,11 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(t0_ + 13 * Second, iterator->time);
     iterator += 0;
     EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+    iterator += 4;
+    EXPECT_TRUE(iterator == end);
   }
   {
-    auto segment = segments_->begin();
-    auto iterator = MakeBegin(segment);
+    auto iterator = begin;
     ++iterator;
     iterator += 0;
     EXPECT_EQ(t0_ + 3 * Second, iterator->time);
@@ -195,6 +197,8 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(t0_ + 5 * Second, iterator->time);
     iterator += 3;
     EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+    iterator += 4;
+    EXPECT_TRUE(iterator == end);
   }
   {
     auto iterator = MakeEnd(--segments_->end());
@@ -206,6 +210,8 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(t0_ + 17 * Second, iterator->time);
     iterator -= 0;
     EXPECT_EQ(t0_ + 17 * Second, iterator->time);
+    iterator -= 6;
+    EXPECT_TRUE(iterator == begin);
   }
   {
     auto iterator = MakeEnd(--segments_->end());
@@ -219,10 +225,11 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(t0_ + 17 * Second, iterator->time);
     iterator -= 1;
     EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+    iterator -= 5;
+    EXPECT_TRUE(iterator == begin);
   }
   {
-    auto segment = segments_->begin();
-    auto iterator = MakeBegin(segment);
+    auto iterator = begin;
     ++iterator;
     ++iterator;
     EXPECT_EQ(t0_ + 3 * Second, (iterator - 1)->time);
@@ -230,6 +237,16 @@ TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
     EXPECT_EQ(t0_ + 13 * Second, (3 + iterator)->time);
     EXPECT_EQ(t0_ + 7 * Second, iterator[1].time);
     EXPECT_EQ(t0_ + 2 * Second, iterator[-2].time);
+  }
+  {
+    auto iterator1 = begin;
+    ++iterator1;
+    auto const iterator2 = iterator1 + 6;
+    EXPECT_EQ(6, iterator2 - iterator1);
+    EXPECT_EQ(0, iterator2 - iterator2);
+    auto const iterator3 = end;
+    EXPECT_EQ(2, iterator3 - iterator2);
+    EXPECT_EQ(8, iterator3 - iterator1);
   }
 }
 

--- a/physics/discrete_trajectory_iterator_test.cpp
+++ b/physics/discrete_trajectory_iterator_test.cpp
@@ -170,6 +170,69 @@ TEST_F(DiscreteTrajectoryIteratorTest, Equality) {
   EXPECT_NE(MakeBegin(segments_->begin()), MakeEnd(--segments_->end()));
 }
 
+TEST_F(DiscreteTrajectoryIteratorTest, RandomAccess) {
+  {
+    auto segment = segments_->begin();
+    auto iterator = MakeBegin(segment);
+    iterator += 4;
+    EXPECT_EQ(t0_ + 11 * Second, iterator->time);
+    iterator += 3;
+    EXPECT_EQ(t0_ + 19 * Second, iterator->time);
+    iterator += -2;
+    EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+    iterator += 0;
+    EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+  }
+  {
+    auto segment = segments_->begin();
+    auto iterator = MakeBegin(segment);
+    ++iterator;
+    iterator += 0;
+    EXPECT_EQ(t0_ + 3 * Second, iterator->time);
+    iterator += 6;
+    EXPECT_EQ(t0_ + 19 * Second, iterator->time);
+    iterator += -5;
+    EXPECT_EQ(t0_ + 5 * Second, iterator->time);
+    iterator += 3;
+    EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+  }
+  {
+    auto iterator = MakeEnd(--segments_->end());
+    iterator -= 4;
+    EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+    iterator -= -3;
+    EXPECT_EQ(t0_ + 23 * Second, iterator->time);
+    iterator -= 2;
+    EXPECT_EQ(t0_ + 17 * Second, iterator->time);
+    iterator -= 0;
+    EXPECT_EQ(t0_ + 17 * Second, iterator->time);
+  }
+  {
+    auto iterator = MakeEnd(--segments_->end());
+    --iterator;
+    --iterator;
+    iterator -= 0;
+    EXPECT_EQ(t0_ + 19 * Second, iterator->time);
+    iterator -= 6;
+    EXPECT_EQ(t0_ + 3 * Second, iterator->time);
+    iterator -= -5;
+    EXPECT_EQ(t0_ + 17 * Second, iterator->time);
+    iterator -= 1;
+    EXPECT_EQ(t0_ + 13 * Second, iterator->time);
+  }
+  {
+    auto segment = segments_->begin();
+    auto iterator = MakeBegin(segment);
+    ++iterator;
+    ++iterator;
+    EXPECT_EQ(t0_ + 3 * Second, (iterator - 1)->time);
+    EXPECT_EQ(t0_ + 19 * Second, (iterator + 5)->time);
+    EXPECT_EQ(t0_ + 13 * Second, (3 + iterator)->time);
+    EXPECT_EQ(t0_ + 7 * Second, iterator[1].time);
+    EXPECT_EQ(t0_ + 2 * Second, iterator[-2].time);
+  }
+}
+
 // Empty segments may exist in a transient manner, we must be able to iterate
 // over them.
 TEST_F(DiscreteTrajectoryIteratorTest, EmptySegment) {

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -177,6 +177,7 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   typename Timeline::const_iterator timeline_begin() const;
   typename Timeline::const_iterator timeline_end() const;
   bool timeline_empty() const;
+  std::int64_t timeline_size() const;
 
   // Implementation of serialization.  The caller is expected to pass consistent
   // parameters.  |timeline_begin| and |timeline_end| define the range to write.

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -16,7 +16,6 @@
 #include "numerics/fit_hermite_spline.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
-#include "discrete_trajectory_segment.hpp"
 
 namespace principia {
 namespace physics {

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -16,6 +16,7 @@
 #include "numerics/fit_hermite_spline.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
+#include "discrete_trajectory_segment.hpp"
 
 namespace principia {
 namespace physics {
@@ -491,6 +492,11 @@ DiscreteTrajectorySegment<Frame>::timeline_end() const {
 template<typename Frame>
 bool DiscreteTrajectorySegment<Frame>::timeline_empty() const {
   return timeline_.empty();
+}
+
+template<typename Frame>
+std::int64_t DiscreteTrajectorySegment<Frame>::timeline_size() const {
+  return timeline_.size();
 }
 
 template<typename Frame>


### PR DESCRIPTION
This makes it possible to efficiently skip entire segments of the trajectory.

#3136.