### PR TITLE
Properly downsample very flat trajectories

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -502,6 +502,27 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     vessel->flight_plan_ = FlightPlan::ReadFromMessage(message.flight_plan(),
                                                        ephemeris);
   }
+
+  LOG(ERROR) << "Vessel: " << vessel->name() << " " << message.ByteSizeLong()
+             << " bytes"
+             << "\n  Hist: " << vessel->history_->size() << " points from "
+             << vessel->history_->front().time << " to "
+             << vessel->history_->back().time
+             << "\n  Psy: " << vessel->psychohistory_->size() << " points from "
+             << vessel->psychohistory_->front().time << " to "
+             << vessel->psychohistory_->back().time
+             << "\n  Pred: " << vessel->prediction_->size() << " points from "
+             << vessel->prediction_->front().time << " to "
+             << vessel->prediction_->back().time;
+
+  if (vessel->name() == "0255 neptune 5") {
+    auto history = message.history();
+    for (auto& s : *history.mutable_segment()) {
+      s.clear_zfp();
+    }
+    LOG(ERROR) << history.DebugString();
+  }
+
   return vessel;
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -504,26 +504,6 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
                                                        ephemeris);
   }
 
-  LOG(ERROR) << "Vessel: " << vessel->name() << " " << message.ByteSizeLong()
-             << " bytes"
-             << "\n  Hist: " << vessel->history_->size() << " points from "
-             << vessel->history_->front().time << " to "
-             << vessel->history_->back().time
-             << "\n  Psy: " << vessel->psychohistory_->size() << " points from "
-             << vessel->psychohistory_->front().time << " to "
-             << vessel->psychohistory_->back().time
-             << "\n  Pred: " << vessel->prediction_->size() << " points from "
-             << vessel->prediction_->front().time << " to "
-             << vessel->prediction_->back().time;
-
-  if (vessel->name() == "0255 neptune 5") {
-    auto history = message.history();
-    for (auto& s : *history.mutable_segment()) {
-      s.clear_zfp();
-    }
-    LOG(ERROR) << history.DebugString();
-  }
-
   return vessel;
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -503,7 +503,6 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     vessel->flight_plan_ = FlightPlan::ReadFromMessage(message.flight_plan(),
                                                        ephemeris);
   }
-
   return vessel;
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -416,7 +416,8 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
     std::function<void(PartId)> const& deletion_callback) {
   bool const is_pre_cesàro = message.has_psychohistory_is_authoritative();
   bool const is_pre_chasles = message.has_prediction();
-  bool const is_pre_陈景润 = !message.history().has_downsampling();
+  bool const is_pre_陈景润 = !message.history().has_downsampling() &&
+                             message.history().segment_size() == 0;
   bool const is_pre_ζήνων = message.history().segment_size() == 0;
   LOG_IF(WARNING, is_pre_ζήνων)
       << "Reading pre-"

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -412,7 +412,7 @@ TEST_F(PluginCompatibilityTest, DISABLED_Egg) {
 
 // Use for debugging saves given by users.
 TEST_F(PluginCompatibilityTest, DISABLED_SECULAR_Debug) {
-   not_null<std::unique_ptr<Plugin const>> plugin = ReadPluginFromFile(
+  not_null<std::unique_ptr<Plugin const>> plugin = ReadPluginFromFile(
       R"(P:\Public Mockingbird\Principia\Saves\3203\wip.proto.b64)",
       /*compressor=*/"gipfeli",
       /*decoder=*/"base64");

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -412,13 +412,7 @@ TEST_F(PluginCompatibilityTest, DISABLED_Egg) {
 
 // Use for debugging saves given by users.
 TEST_F(PluginCompatibilityTest, DISABLED_SECULAR_Debug) {
-#if 0
-   not_null<std::unique_ptr<Plugin const>> plugin1 = ReadPluginFromFile(
-      R"(P:\Public Mockingbird\Principia\Saves\3203\0 - 1961.proto.b64)",
-      /*compressor=*/"gipfeli",
-      /*decoder=*/"base64");
-#endif
-   not_null<std::unique_ptr<Plugin const>> plugin2 = ReadPluginFromFile(
+   not_null<std::unique_ptr<Plugin const>> plugin = ReadPluginFromFile(
       R"(P:\Public Mockingbird\Principia\Saves\3203\wip.proto.b64)",
       /*compressor=*/"gipfeli",
       /*decoder=*/"base64");

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -412,8 +412,14 @@ TEST_F(PluginCompatibilityTest, DISABLED_Egg) {
 
 // Use for debugging saves given by users.
 TEST_F(PluginCompatibilityTest, DISABLED_SECULAR_Debug) {
-  CheckSaveCompatibility(
-      R"(P:\Public Mockingbird\Principia\Saves\2685\five-minute-scene-change-neptune.txt)",
+#if 0
+   not_null<std::unique_ptr<Plugin const>> plugin1 = ReadPluginFromFile(
+      R"(P:\Public Mockingbird\Principia\Saves\3203\0 - 1961.proto.b64)",
+      /*compressor=*/"gipfeli",
+      /*decoder=*/"base64");
+#endif
+   not_null<std::unique_ptr<Plugin const>> plugin2 = ReadPluginFromFile(
+      R"(P:\Public Mockingbird\Principia\Saves\3203\wip.proto.b64)",
       /*compressor=*/"gipfeli",
       /*decoder=*/"base64");
 }

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -434,8 +434,7 @@ absl::Status DiscreteTrajectorySegment<Frame>::DownsampleIfNeeded() {
     }
 
     if (right_endpoints->empty()) {
-      number_of_dense_points_ = timeline_.empty() ? 0 : 1;
-      return absl::OkStatus();
+      right_endpoints->push_back(std::prev(dense_iterators.end()));
     }
 
     // Obtain the times for the right endpoints.  This is necessary because we

--- a/physics/discrete_trajectory_segment_test.cpp
+++ b/physics/discrete_trajectory_segment_test.cpp
@@ -29,6 +29,7 @@ using geometry::Frame;
 using geometry::Handedness;
 using geometry::Inertial;
 using geometry::Instant;
+using geometry::Velocity;
 using quantities::Abs;
 using quantities::AngularFrequency;
 using quantities::Length;
@@ -45,6 +46,7 @@ using testing_utilities::AppendTrajectoryTimeline;
 using testing_utilities::EqualsProto;
 using testing_utilities::IsNear;
 using testing_utilities::NewCircularTrajectoryTimeline;
+using testing_utilities::NewLinearTrajectoryTimeline;
 using testing_utilities::operator""_⑴;
 using ::testing::Eq;
 using ::testing::Le;
@@ -237,7 +239,7 @@ TEST_F(DiscreteTrajectorySegmentTest, Evaluate) {
               IsNear(10.4_⑴ * Nano(Metre / Second)));
 }
 
-TEST_F(DiscreteTrajectorySegmentTest, Downsampling) {
+TEST_F(DiscreteTrajectorySegmentTest, DownsamplingCircle) {
   auto const circle_segments = MakeSegments(1);
   auto const downsampled_circle_segments = MakeSegments(1);
   auto& circle = *circle_segments->begin();
@@ -272,6 +274,45 @@ TEST_F(DiscreteTrajectorySegmentTest, Downsampling) {
               IsNear(0.98_⑴ * Milli(Metre)));
   EXPECT_THAT(*std::max_element(velocity_errors.begin(), velocity_errors.end()),
               IsNear(14_⑴ * Milli(Metre / Second)));
+}
+
+TEST_F(DiscreteTrajectorySegmentTest, DownsamplingStraightLine) {
+  auto const line_segments = MakeSegments(1);
+  auto const downsampled_line_segments = MakeSegments(1);
+  auto& line = *line_segments->begin();
+  auto& downsampled_line = *downsampled_line_segments->begin();
+  downsampled_line.SetDownsampling(
+      {.max_dense_intervals = 50, .tolerance = 1 * Milli(Metre)});
+  auto const v = Velocity<World>({1 * Metre / Second,
+                                  2 * Metre / Second,
+                                  3 * Metre / Second});
+  Time const Δt = 10 * Milli(Second);
+  Instant const t1 = t0_;
+  Instant const t2 = t0_ + 10 * Second;
+  AppendTrajectoryTimeline(
+      NewLinearTrajectoryTimeline<World>(v, Δt, t1, t2),
+      /*to=*/line);
+  AppendTrajectoryTimeline(
+      NewLinearTrajectoryTimeline<World>(v, Δt, t1, t2),
+      /*to=*/downsampled_line);
+
+  EXPECT_THAT(line.size(), Eq(1001));
+  // In the test3200 release this used to have 1001 points, see #3203.
+  EXPECT_THAT(downsampled_line.size(), Eq(21));
+  std::vector<Length> position_errors;
+  std::vector<Speed> velocity_errors;
+  for (auto const& [time, degrees_of_freedom] : line) {
+    position_errors.push_back(
+        (downsampled_line.EvaluatePosition(time) -
+         degrees_of_freedom.position()).Norm());
+    velocity_errors.push_back(
+        (downsampled_line.EvaluateVelocity(time) -
+         degrees_of_freedom.velocity()).Norm());
+  }
+  EXPECT_THAT(*std::max_element(position_errors.begin(), position_errors.end()),
+              IsNear(3.6e-15_⑴ * Metre));
+  EXPECT_THAT(*std::max_element(velocity_errors.begin(), velocity_errors.end()),
+              IsNear(1.1e-14_⑴ * Metre / Second));
 }
 
 TEST_F(DiscreteTrajectorySegmentTest, DownsamplingForgetAfter) {

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -687,17 +687,17 @@ TEST_F(DiscreteTraject0ryTest, SerializationExactEndpoints) {
   EXPECT_THAT(
       (deserialized_degrees_of_freedom1.position() - World::origin).Norm(),
       AbsoluteErrorFrom((degrees_of_freedom1.position() - World::origin).Norm(),
-                        IsNear(0.27_⑴*Milli(Metre))));
+                        IsNear(0.022_⑴*Milli(Metre))));
   EXPECT_THAT(deserialized_degrees_of_freedom1.velocity().Norm(),
               AbsoluteErrorFrom(degrees_of_freedom1.velocity().Norm(),
-                                IsNear(82_⑴ * Milli(Metre) / Second)));
+                                IsNear(5.8_⑴ * Milli(Metre) / Second)));
   EXPECT_THAT(
       (deserialized_degrees_of_freedom2.position() - World::origin).Norm(),
       AbsoluteErrorFrom((degrees_of_freedom2.position() - World::origin).Norm(),
-                        IsNear(0.19_⑴*Milli(Metre))));
+                        IsNear(0.47_⑴*Milli(Metre))));
   EXPECT_THAT(deserialized_degrees_of_freedom2.velocity().Norm(),
               AbsoluteErrorFrom(degrees_of_freedom2.velocity().Norm(),
-                                IsNear(0.36_⑴ * Metre / Second)));
+                                IsNear(1.5_⑴ * Milli(Metre) / Second)));
 }
 
 TEST_F(DiscreteTraject0ryTest, SerializationRange) {


### PR DESCRIPTION
Also a small bug in pre-陈景润 compatibility that would cause us to clobber the downsampling parameters in some cases.

Fix #3203.