### PR TITLE
Benchmark for DiscreteTrajectory

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\numerics\fast_sin_cos_2π.cpp" />
     <ClCompile Include="..\physics\protector.cpp" />
     <ClCompile Include="apsides.cpp" />
+    <ClCompile Include="discrete_trajectory.cpp" />
     <ClCompile Include="dynamic_frame.cpp" />
     <ClCompile Include="elliptic_integrals_benchmark.cpp" />
     <ClCompile Include="elliptic_functions_benchmark.cpp" />

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClCompile Include="..\geometry\instant_output.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="discrete_trajectory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp">

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -3,6 +3,8 @@
 
 #include "physics/discrete_trajectory.hpp"
 
+#include <vector>
+
 #include "astronomy/epoch.hpp"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -1,21 +1,27 @@
-
+﻿
 // .\Release\x64\benchmarks.exe --benchmark_filter=DiscreteTrajectory
 
 #include "physics/discrete_trajectory.hpp"
 
+#include "astronomy/epoch.hpp"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
+#include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
 #include "ksp_plugin/frames.hpp"
+#include "physics/discrete_trajectory_types.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
+#include "testing_utilities/discrete_trajectory_factories.hpp"
 
 namespace principia {
 namespace physics {
 
+using astronomy::InfiniteFuture;
 using base::make_not_null_unique;
 using base::not_null;
+using geometry::Barycentre;
 using geometry::Displacement;
 using geometry::Frame;
 using geometry::Handedness;
@@ -23,6 +29,7 @@ using geometry::Inertial;
 using geometry::Instant;
 using geometry::Velocity;
 using ksp_plugin::World;
+using physics::internal_discrete_trajectory_types::Timeline;
 using quantities::AngularFrequency;
 using quantities::Cos;
 using quantities::Sin;
@@ -30,136 +37,154 @@ using quantities::Time;
 using quantities::si::Metre;
 using quantities::si::Radian;
 using quantities::si::Second;
+using testing_utilities::NewCircularTrajectoryTimeline;
+using testing_utilities::NewMotionlessTrajectoryTimeline;
 
 namespace {
 
-// Creates a motionless trajectory with the given number of steps.
-not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateMotionlessTrajectory(
-    int const steps) {
-  auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
-  for (Time t = 0 * Second; t < steps * Second; t += 1 * Second) {
-    trajectory->Append(Instant() + t, {World::origin, World::unmoving});
+// Constructs a trajectory by assigning the points in |timeline| to segments
+// defined by |splits|, which must be doubles in [0, 1].
+DiscreteTrajectory<World> MakeTrajectory(Timeline<World> const& timeline,
+                                         std::vector<double> const& splits) {
+  DiscreteTrajectory<World> trajectory;
+  Instant const t_min = timeline.begin()->time;
+  Instant const t_max = timeline.rbegin()->time;
+  auto it_split = splits.begin();
+  std::optional<Instant> t_split;
+  for (auto const& [t, degrees_of_freedom] : timeline) {
+    // The computation of |t_split| is complicated enough that we want to do it
+    // at a single place.
+    if (!t_split.has_value()) {
+      if (it_split == splits.end()) {
+        t_split = InfiniteFuture;
+      } else {
+        double const split = *it_split;
+        CHECK_LE(0, split);
+        CHECK_LE(split, 1);
+        t_split = Barycentre<Instant, double>({t_min, t_max},
+                                              {1 - split, split});
+      }
+    }
+    if (t >= t_split) {
+      ++it_split;
+      t_split = std::nullopt;
+      trajectory.NewSegment();
+    }
+    trajectory.Append(t, degrees_of_freedom);
   }
   return trajectory;
-}
-
-// Creates a circular trajectory with the given number of steps in the XZ plane.
-not_null<std::unique_ptr<DiscreteTrajectory<World>>> CreateCircularTrajectory(
-    int const steps) {
-  auto trajectory = make_not_null_unique<DiscreteTrajectory<World>>();
-  constexpr AngularFrequency ω = 1 * Radian / Second;
-  for (Time t = 0 * Second; t < steps * Second; t += 1 * Second) {
-    double const sin_ωt = Sin(ω * t);
-    double const cos_ωt = Cos(ω * t);
-    trajectory->Append(
-        Instant() + t,
-        {World::origin +
-             Displacement<World>({cos_ωt * Metre, 0 * Metre, sin_ωt * Metre}),
-         Velocity<World>({-sin_ωt * Metre / Second,
-                          0 * Metre / Second,
-                          cos_ωt * Metre / Second})});
-  }
-  return trajectory;
-}
-
-// Forks |parent| at a position |pos| of the way through.
-// |parent| should be nonempty.
-// |pos| should be in [0, 1].
-not_null<DiscreteTrajectory<World>*> ForkAt(DiscreteTrajectory<World>& parent,
-                                            double const pos) {
-  CHECK(!parent.Empty());
-  CHECK_GE(pos, 0);
-  CHECK_LE(pos, 1);
-  Instant const desired_fork_time =
-      parent.t_min() + (parent.t_max() - parent.t_min()) * pos;
-  auto const fork_it = parent.LowerBound(desired_fork_time);
-  return parent.NewForkWithCopy(fork_it->time);
 }
 
 }  // namespace
 
 void BM_DiscreteTrajectoryFront(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->front();
+    segment.front();
   }
 }
-
 void BM_DiscreteTrajectoryBack(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->back();
+    segment.back();
   }
 }
 
 void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->begin();
+    segment.begin();
   }
 }
 
 void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->end();
+    segment.end();
   }
 }
 
 void BM_DiscreteTrajectoryTMin(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->t_min();
+    segment.t_min();
   }
 }
 
 void BM_DiscreteTrajectoryTMax(benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(4);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    fork->t_max();
+    segment.t_max();
   }
 }
 
 void BM_DiscreteTrajectoryCreateDestroy(benchmark::State& state) {
+  Instant const t0;
   int const steps = state.range(0);
+  auto const timeline =
+      NewMotionlessTrajectoryTimeline(World::origin,
+                                      /*Δt=*/1 * Second,
+                                      /*t1=*/t0,
+                                      /*t2=*/t0 + steps * Second);
   for (auto _ : state) {
-    CreateMotionlessTrajectory(steps);
+    MakeTrajectory(timeline, {0.5, 0.75});
   }
 }
 
 void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
+  Instant const t0;
   int const steps = state.range(0);
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  auto const timeline =
+      NewMotionlessTrajectoryTimeline(World::origin,
+                                      /*Δt=*/1 * Second,
+                                      /*t1=*/t0,
+                                      /*t2=*/t0 + steps * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
 
-  auto const begin = fork->begin();
-  auto const end = fork->end();
+  auto const begin = trajectory.begin();
+  auto const end = trajectory.end();
   for (auto _ : state) {
     for (auto it = begin; it != end; ++it) {
     }
@@ -167,14 +192,17 @@ void BM_DiscreteTrajectoryIterate(benchmark::State& state) {
 }
 
 void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
+  Instant const t0;
   int const steps = state.range(0);
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  auto const timeline =
+      NewMotionlessTrajectoryTimeline(World::origin,
+                                      /*Δt=*/1 * Second,
+                                      /*t1=*/t0,
+                                      /*t2=*/t0 + steps * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
 
-  auto const begin = fork->begin();
-  auto const end = fork->end();
+  auto const begin = trajectory.begin();
+  auto const end = trajectory.end();
   for (auto _ : state) {
     for (auto it = end; it != begin; --it) {
     }
@@ -182,55 +210,72 @@ void BM_DiscreteTrajectoryReverseIterate(benchmark::State& state) {
 }
 
 void BM_DiscreteTrajectoryFind(benchmark::State& state) {
+  Instant const t0;
   int const steps = state.range(0);
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  auto const timeline =
+      NewMotionlessTrajectoryTimeline(World::origin,
+                                      /*Δt=*/1 * Second,
+                                      /*t1=*/t0,
+                                      /*t2=*/t0 + steps * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
 
   for (auto _ : state) {
-    // These times are in different segments of the fork.
-    fork->Find(Instant() + 1.0 / 3.0 * steps * Second);
-    fork->Find(Instant() + 2.0 / 3.0 * steps * Second);
-    fork->Find(Instant() + 5.0 / 6.0 * steps * Second);
+    // These times are in different segments of the trajectory.
+    trajectory.find(Instant() + 1.0 / 3.0 * steps * Second);
+    trajectory.find(Instant() + 2.0 / 3.0 * steps * Second);
+    trajectory.find(Instant() + 5.0 / 6.0 * steps * Second);
   }
 }
 
 void BM_DiscreteTrajectoryLowerBound(benchmark::State& state) {
+  Instant const t0;
   int const steps = state.range(0);
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateMotionlessTrajectory(steps);
-  not_null<DiscreteTrajectory<World>*> const fork =
-      ForkAt(*ForkAt(*trajectory, 0.5), 0.75);
+  auto const timeline =
+      NewMotionlessTrajectoryTimeline(World::origin,
+                                      /*Δt=*/1 * Second,
+                                      /*t1=*/t0,
+                                      /*t2=*/t0 + steps * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
 
   for (auto _ : state) {
-    // These times are in different segments of the fork.
-    fork->LowerBound(Instant() + 1.0 / 3.0 * steps * Second);
-    fork->LowerBound(Instant() + 2.0 / 3.0 * steps * Second);
-    fork->LowerBound(Instant() + 5.0 / 6.0 * steps * Second);
+    // These times are in different segments of the trajectory.
+    trajectory.lower_bound(Instant() + 1.0 / 3.0 * steps * Second);
+    trajectory.lower_bound(Instant() + 2.0 / 3.0 * steps * Second);
+    trajectory.lower_bound(Instant() + 5.0 / 6.0 * steps * Second);
   }
 }
 
 void BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact(
     benchmark::State& state) {
-  int const steps = state.range(0);
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateCircularTrajectory(4);
+  Instant const t0;
+  auto const timeline =
+      NewCircularTrajectoryTimeline<World>(/*ω=*/1 * Radian / Second,
+                                           /*r=*/1 * Metre,
+                                           /*Δt=*/1 * Second,
+                                           /*t1=*/t0,
+                                           /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {});
 
   Instant const t = Instant() + 1 * Second;
   for (auto _ : state) {
-    trajectory->EvaluateDegreesOfFreedom(t);
+    trajectory.EvaluateDegreesOfFreedom(t);
   }
 }
 
 void BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated(
     benchmark::State& state) {
-  not_null<std::unique_ptr<DiscreteTrajectory<World>>> const trajectory =
-      CreateCircularTrajectory(4);
+  Instant const t0;
+  auto const timeline =
+      NewCircularTrajectoryTimeline<World>(/*ω=*/1 * Radian / Second,
+                                           /*r=*/1 * Metre,
+                                           /*Δt=*/1 * Second,
+                                           /*t1=*/t0,
+                                           /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {});
 
   Instant const t = Instant() + 1.5 * Second;
   for (auto _ : state) {
-    trajectory->EvaluateDegreesOfFreedom(t);
+    trajectory.EvaluateDegreesOfFreedom(t);
   }
 }
 

--- a/testing_utilities/discrete_trajectory_factories.hpp
+++ b/testing_utilities/discrete_trajectory_factories.hpp
@@ -18,6 +18,7 @@ namespace internal_discrete_trajectory_factories {
 
 using base::not_null;
 using geometry::Instant;
+using geometry::Position;
 using geometry::Velocity;
 using physics::DegreesOfFreedom;
 using physics::DiscreteTrajectory;
@@ -36,6 +37,14 @@ class DiscreteTrajectoryFactoriesFriend {
                              DegreesOfFreedom<Frame> const& degrees_of_freedom,
                              DiscreteTrajectorySegment<Frame>& segment);
 };
+
+// A motionless trajectory at the given position.
+template<typename Frame>
+Timeline<Frame>
+NewMotionlessTrajectoryTimeline(Position<Frame> const& position,
+                                Time const& Δt,
+                                Instant const& t1,
+                                Instant const& t2);
 
 // A linear trajectory with constant velocity, going through
 // |degrees_of_freedom.position()| at t = t0.  The first point is at time |t1|,
@@ -99,6 +108,7 @@ void AppendTrajectoryTimeline(
 using internal_discrete_trajectory_factories::AppendTrajectoryTimeline;
 using internal_discrete_trajectory_factories::NewCircularTrajectoryTimeline;
 using internal_discrete_trajectory_factories::NewLinearTrajectoryTimeline;
+using internal_discrete_trajectory_factories::NewMotionlessTrajectoryTimeline;
 
 }  // namespace testing_utilities
 }  // namespace principia

--- a/testing_utilities/discrete_trajectory_factories_body.hpp
+++ b/testing_utilities/discrete_trajectory_factories_body.hpp
@@ -33,6 +33,15 @@ absl::Status DiscreteTrajectoryFactoriesFriend<Frame>::Append(
 }
 
 template<typename Frame>
+Timeline<Frame> NewMotionlessTrajectoryTimeline(Position<Frame> const& position,
+                                                Time const& Δt,
+                                                Instant const& t1,
+                                                Instant const& t2) {
+  return NewLinearTrajectoryTimeline(
+      DegreesOfFreedom<Frame>(position, Velocity<Frame>()), Δt, t1, t2);
+}
+
+template<typename Frame>
 Timeline<Frame>
 NewLinearTrajectoryTimeline(DegreesOfFreedom<Frame> const& degrees_of_freedom,
                             Time const& Δt,

--- a/testing_utilities/discrete_trajectory_factories_test.cpp
+++ b/testing_utilities/discrete_trajectory_factories_test.cpp
@@ -39,6 +39,30 @@ class DiscreteTrajectoryFactoriesTest : public ::testing::Test {
                       serialization::Frame::TEST>;
 };
 
+TEST_F(DiscreteTrajectoryFactoriesTest, NewMotionlessTrajectoryTimeline) {
+  auto const timeline = NewMotionlessTrajectoryTimeline<World>(
+      /*position=*/
+      World::origin + Displacement<World>({30 * Metre, 40 * Metre, 50 * Metre}),
+      /*Δt=*/0.1 * Second,
+      /*t1=*/Instant() + 4 * Second,
+      /*t2=*/Instant() + 42 * Second);
+
+  for (auto const& [time, degrees_of_freedom] : timeline) {
+    Position<World> const& position = degrees_of_freedom.position();
+    Velocity<World> const& velocity = degrees_of_freedom.velocity();
+
+    EXPECT_THAT((position - World::origin).Norm(),
+                AlmostEquals(Sqrt(5000) * Metre, 0));
+    EXPECT_THAT(velocity.Norm(),
+                AlmostEquals(0 * Metre / Second, 0));
+  }
+  EXPECT_THAT(timeline.begin()->time,
+              AlmostEquals(Instant() + 4 * Second, 0));
+  EXPECT_THAT(timeline.rbegin()->time,
+              AlmostEquals(Instant() + 41.9 * Second, 46));
+  EXPECT_EQ(380, timeline.size());
+}
+
 TEST_F(DiscreteTrajectoryFactoriesTest, NewLinearTrajectoryTimeline) {
   auto const timeline = NewLinearTrajectoryTimeline<World>(
       /*degrees_of_freedom=*/


### PR DESCRIPTION
It turns out that this file was never added to our project (see #2776), so I didn't convert it.

Note that it's sometimes a bit hard to decide how to do the conversion: the old benchmark was doing fancy things with forks that may or may not have an equivalent with segments.

The numbers are not so nice, apparently because `operator++` and `operator--` on `DiscreteTrajectoryIterator` are costly.

Before:
```
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                      9.06 ns         8.97 ns     74785845
BM_DiscreteTrajectoryBack                                       13.4 ns         13.5 ns     49857230
BM_DiscreteTrajectoryBegin                                      40.0 ns         40.0 ns     17948603
BM_DiscreteTrajectoryEnd                                        21.2 ns         20.9 ns     32051077
BM_DiscreteTrajectoryTMin                                       12.8 ns         12.8 ns     56089384
BM_DiscreteTrajectoryTMax                                       17.4 ns         17.2 ns     40792279
BM_DiscreteTrajectoryCreateDestroy/8                             755 ns          765 ns       897430
BM_DiscreteTrajectoryCreateDestroy/64                           6041 ns         5980 ns       112179
BM_DiscreteTrajectoryCreateDestroy/512                         52671 ns        53040 ns        10000
BM_DiscreteTrajectoryCreateDestroy/1024                       107548 ns       107083 ns         6410
BM_DiscreteTrajectoryIterate/8                                   158 ns          156 ns      4487151
BM_DiscreteTrajectoryIterate/64                                 1389 ns         1283 ns       498572
BM_DiscreteTrajectoryIterate/512                               11160 ns        10951 ns        64102
BM_DiscreteTrajectoryIterate/1024                              22941 ns        21903 ns        29914
BM_DiscreteTrajectoryReverseIterate/8                            136 ns          131 ns      5608938
BM_DiscreteTrajectoryReverseIterate/64                          1033 ns         1046 ns       641022
BM_DiscreteTrajectoryReverseIterate/512                         8445 ns         8344 ns        74786
BM_DiscreteTrajectoryReverseIterate/1024                       16967 ns        17209 ns        40792
BM_DiscreteTrajectoryFind/8                                      167 ns          167 ns      4487151
BM_DiscreteTrajectoryFind/64                                     147 ns          146 ns      4487151
BM_DiscreteTrajectoryFind/512                                    153 ns          153 ns      4487151
BM_DiscreteTrajectoryFind/1024                                   154 ns          153 ns      4487151
BM_DiscreteTrajectoryLowerBound/8                                227 ns          224 ns      2991434
BM_DiscreteTrajectoryLowerBound/64                               196 ns          199 ns      3451654
BM_DiscreteTrajectoryLowerBound/512                              221 ns          224 ns      3205108
BM_DiscreteTrajectoryLowerBound/1024                             192 ns          190 ns      3451654
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              44.2 ns         43.4 ns     15472934
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated        137 ns          138 ns      4985723
```

After:
```
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                      13.9 ns         13.8 ns     49857230
BM_DiscreteTrajectoryBack                                       73.1 ns         73.7 ns     11217877
BM_DiscreteTrajectoryBegin                                      11.6 ns         11.7 ns     64102153
BM_DiscreteTrajectoryEnd                                        33.4 ns         32.9 ns     20396140
BM_DiscreteTrajectoryTMin                                       2.89 ns         2.88 ns    249286151
BM_DiscreteTrajectoryTMax                                       13.9 ns         13.8 ns     49857230
BM_DiscreteTrajectoryCreateDestroy/8                            1947 ns         1961 ns       373929
BM_DiscreteTrajectoryCreateDestroy/64                           8555 ns         8518 ns        89743
BM_DiscreteTrajectoryCreateDestroy/512                         62091 ns        61188 ns        11218
BM_DiscreteTrajectoryCreateDestroy/1024                       123657 ns       122376 ns         5609
BM_DiscreteTrajectoryIterate/8                                   219 ns          221 ns      3451654
BM_DiscreteTrajectoryIterate/64                                 1487 ns         1502 ns       498572
BM_DiscreteTrajectoryIterate/512                               11029 ns        10951 ns        64102
BM_DiscreteTrajectoryIterate/1024                              21925 ns        21903 ns        32051
BM_DiscreteTrajectoryReverseIterate/8                            175 ns          177 ns      4487151
BM_DiscreteTrajectoryReverseIterate/64                          1031 ns         1022 ns       641022
BM_DiscreteTrajectoryReverseIterate/512                         8117 ns         8170 ns        89743
BM_DiscreteTrajectoryReverseIterate/1024                       16110 ns        16062 ns        40792
BM_DiscreteTrajectoryFind/8                                      597 ns          598 ns      1121788
BM_DiscreteTrajectoryFind/64                                     692 ns          695 ns      1121788
BM_DiscreteTrajectoryFind/512                                    771 ns          765 ns       897430
BM_DiscreteTrajectoryFind/1024                                   770 ns          765 ns       897430
BM_DiscreteTrajectoryLowerBound/8                                382 ns          384 ns      1869646
BM_DiscreteTrajectoryLowerBound/64                               452 ns          454 ns      1547293
BM_DiscreteTrajectoryLowerBound/512                              524 ns          501 ns      1121788
BM_DiscreteTrajectoryLowerBound/1024                             527 ns          530 ns      1000000
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              73.9 ns         73.0 ns      8974301
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated        112 ns          112 ns      6410215
```