### PR TITLE
Optimize some operations of DiscreteTrajectory and friends

### DIFF
--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -89,7 +89,7 @@ void BM_DiscreteTrajectoryFront(benchmark::State& state) {
   auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.front();
+    benchmark::DoNotOptimize(segment.front());
   }
 }
 void BM_DiscreteTrajectoryBack(benchmark::State& state) {
@@ -102,7 +102,7 @@ void BM_DiscreteTrajectoryBack(benchmark::State& state) {
   auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.back();
+    benchmark::DoNotOptimize(segment.back());
   }
 }
 
@@ -116,7 +116,7 @@ void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
   auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.begin();
+    benchmark::DoNotOptimize(segment.begin());
   }
 }
 

--- a/physics/discrete_trajectory_iterator_body.hpp
+++ b/physics/discrete_trajectory_iterator_body.hpp
@@ -13,13 +13,14 @@ using astronomy::InfiniteFuture;
 using geometry::Instant;
 
 template<typename Frame>
-DiscreteTrajectoryIterator<Frame>&
+FORCE_INLINE(inline) DiscreteTrajectoryIterator<Frame>&
 DiscreteTrajectoryIterator<Frame>::operator++() {
   CHECK(!is_at_end(point_));
   auto& point = iterator(point_);
   Instant const previous_time = point->time;
   do {
-    if (point == std::prev(segment_->timeline_end())) {
+    ++point;
+    if (point == segment_->timeline_end()) {
       do {
         ++segment_;
       } while (!segment_.is_end() && segment_->timeline_empty());
@@ -30,15 +31,13 @@ DiscreteTrajectoryIterator<Frame>::operator++() {
       } else {
         point = segment_->timeline_begin();
       }
-    } else {
-      ++point;
     }
   } while (point->time == previous_time);
   return *this;
 }
 
 template<typename Frame>
-DiscreteTrajectoryIterator<Frame>&
+FORCE_INLINE(inline) DiscreteTrajectoryIterator<Frame>&
 DiscreteTrajectoryIterator<Frame>::operator--() {
   bool const point_is_at_end = is_at_end(point_);
   if (point_is_at_end) {
@@ -48,16 +47,14 @@ DiscreteTrajectoryIterator<Frame>::operator--() {
     // Now proceed with the decrement.
   }
   auto& point = iterator(point_);
-  std::optional<Instant> const previous_time =
-      point_is_at_end ? std::nullopt : std::make_optional(point->time);
+  Instant const previous_time = point_is_at_end ? InfiniteFuture : point->time;
   do {
     if (point == segment_->timeline_begin()) {
       CHECK(!segment_.is_begin());
       --segment_;
-      point = std::prev(segment_->timeline_end());
-    } else {
-      --point;
+      point = segment_->timeline_end();
     }
+    --point;
   } while (point->time == previous_time);
   return *this;
 }

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -46,13 +46,13 @@ void DiscreteTrajectorySegment<Frame>::SetDownsamplingUnconditionally(
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::reference
 DiscreteTrajectorySegment<Frame>::front() const {
-  return *begin();
+  return *timeline_.begin();
 }
 
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::reference
 DiscreteTrajectorySegment<Frame>::back() const {
-  return *rbegin();
+  return *std::prev(timeline_.end());
 }
 
 template<typename Frame>
@@ -68,7 +68,8 @@ DiscreteTrajectorySegment<Frame>::end() const {
     return iterator(self_, timeline_.end());
   } else {
     // The decrement/increment ensures that we normalize the end iterator to the
-    // next segment or to the end of the trajectory.
+    // next segment or to the end of the trajectory.  This is relatively
+    // expensive, taking 25-30 ns.
     return ++iterator(self_, --timeline_.end());
   }
 }

--- a/physics/discrete_trajectory_segment_iterator_body.hpp
+++ b/physics/discrete_trajectory_segment_iterator_body.hpp
@@ -6,10 +6,13 @@ namespace principia {
 namespace physics {
 namespace internal_discrete_trajectory_segment_iterator {
 
+// Note the use of DCHECK, not DCHECK_NOTNULL, below, because the latter does
+// not go away when compiled in non-debug mode (don't ask).
+
 template<typename Frame>
 DiscreteTrajectorySegmentIterator<Frame>&
 DiscreteTrajectorySegmentIterator<Frame>::operator++() {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   ++iterator_;
   return *this;
 }
@@ -17,7 +20,7 @@ DiscreteTrajectorySegmentIterator<Frame>::operator++() {
 template<typename Frame>
 DiscreteTrajectorySegmentIterator<Frame>&
 DiscreteTrajectorySegmentIterator<Frame>::operator--() {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   --iterator_;
   return *this;
 }
@@ -25,35 +28,35 @@ DiscreteTrajectorySegmentIterator<Frame>::operator--() {
 template<typename Frame>
 DiscreteTrajectorySegmentIterator<Frame>
 DiscreteTrajectorySegmentIterator<Frame>::operator++(int) {  // NOLINT
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return DiscreteTrajectorySegmentIterator(segments_, iterator_++);
 }
 
 template<typename Frame>
 DiscreteTrajectorySegmentIterator<Frame>
 DiscreteTrajectorySegmentIterator<Frame>::operator--(int) {  // NOLINT
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return DiscreteTrajectorySegmentIterator(segments_, iterator_--);
 }
 
 template<typename Frame>
 typename DiscreteTrajectorySegmentIterator<Frame>::reference
 DiscreteTrajectorySegmentIterator<Frame>::operator*() const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return *iterator_;
 }
 
 template<typename Frame>
 typename DiscreteTrajectorySegmentIterator<Frame>::pointer
 DiscreteTrajectorySegmentIterator<Frame>::operator->() const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return &*iterator_;
 }
 
 template<typename Frame>
 bool DiscreteTrajectorySegmentIterator<Frame>::operator==(
     DiscreteTrajectorySegmentIterator const& other) const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return segments_ == other.segments_ && iterator_ == other.iterator_;
 }
 
@@ -72,20 +75,20 @@ DiscreteTrajectorySegmentIterator<Frame>::DiscreteTrajectorySegmentIterator(
 
 template<typename Frame>
 bool DiscreteTrajectorySegmentIterator<Frame>::is_begin() const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return iterator_ == segments_->begin();
 }
 
 template<typename Frame>
 bool DiscreteTrajectorySegmentIterator<Frame>::is_end() const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return iterator_ == segments_->end();
 }
 
 template<typename Frame>
 DiscreteTrajectorySegmentRange<DiscreteTrajectorySegmentIterator<Frame>>
 DiscreteTrajectorySegmentIterator<Frame>::segments() const {
-  CHECK_NOTNULL(segments_);
+  DCHECK(segments_ != nullptr);
   return {DiscreteTrajectorySegmentIterator(segments_, segments_->begin()),
           DiscreteTrajectorySegmentIterator(segments_, segments_->end())};
 }

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -59,7 +59,7 @@ using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
-class DiscreteTraject0ryTest : public ::testing::Test {
+class DiscreteTrajectoryTest : public ::testing::Test {
  protected:
   using World = Frame<serialization::Frame::TestTag,
                       Inertial,
@@ -126,17 +126,17 @@ class DiscreteTraject0ryTest : public ::testing::Test {
   Instant const t0_;
 };
 
-TEST_F(DiscreteTraject0ryTest, Make) {
+TEST_F(DiscreteTrajectoryTest, Make) {
   auto const trajectory = MakeTrajectory();
 }
 
-TEST_F(DiscreteTraject0ryTest, BackFront) {
+TEST_F(DiscreteTrajectoryTest, BackFront) {
   auto const trajectory = MakeTrajectory();
   EXPECT_EQ(t0_, trajectory.front().time);
   EXPECT_EQ(t0_ + 14 * Second, trajectory.back().time);
 }
 
-TEST_F(DiscreteTraject0ryTest, IterateForward) {
+TEST_F(DiscreteTrajectoryTest, IterateForward) {
   auto const trajectory = MakeTrajectory();
   std::vector<Instant> times;
   for (auto const& [t, _] : trajectory) {
@@ -160,7 +160,7 @@ TEST_F(DiscreteTraject0ryTest, IterateForward) {
                           t0_ + 14 * Second));
 }
 
-TEST_F(DiscreteTraject0ryTest, IterateBackward) {
+TEST_F(DiscreteTrajectoryTest, IterateBackward) {
   auto const trajectory = MakeTrajectory();
   std::vector<Instant> times;
   for (auto it = trajectory.rbegin(); it != trajectory.rend(); ++it) {
@@ -184,21 +184,21 @@ TEST_F(DiscreteTraject0ryTest, IterateBackward) {
                           t0_));
 }
 
-TEST_F(DiscreteTraject0ryTest, Empty) {
+TEST_F(DiscreteTrajectoryTest, Empty) {
   DiscreteTrajectory<World> trajectory;
   EXPECT_TRUE(trajectory.empty());
   trajectory = MakeTrajectory();
   EXPECT_FALSE(trajectory.empty());
 }
 
-TEST_F(DiscreteTraject0ryTest, Size) {
+TEST_F(DiscreteTrajectoryTest, Size) {
   DiscreteTrajectory<World> trajectory;
   EXPECT_EQ(0, trajectory.size());
   trajectory = MakeTrajectory();
   EXPECT_EQ(15, trajectory.size());
 }
 
-TEST_F(DiscreteTraject0ryTest, Find) {
+TEST_F(DiscreteTrajectoryTest, Find) {
   auto const trajectory = MakeTrajectory();
   {
     auto const it = trajectory.find(t0_ + 3 * Second);
@@ -224,7 +224,7 @@ TEST_F(DiscreteTraject0ryTest, Find) {
   }
 }
 
-TEST_F(DiscreteTraject0ryTest, LowerBound) {
+TEST_F(DiscreteTrajectoryTest, LowerBound) {
   auto const trajectory = MakeTrajectory();
   {
     auto const it = trajectory.lower_bound(t0_ + 3.9 * Second);
@@ -273,7 +273,7 @@ TEST_F(DiscreteTraject0ryTest, LowerBound) {
   }
 }
 
-TEST_F(DiscreteTraject0ryTest, UpperBound) {
+TEST_F(DiscreteTrajectoryTest, UpperBound) {
   auto const trajectory = MakeTrajectory();
   {
     auto const it = trajectory.upper_bound(t0_ + 3.9 * Second);
@@ -322,7 +322,7 @@ TEST_F(DiscreteTraject0ryTest, UpperBound) {
   }
 }
 
-TEST_F(DiscreteTraject0ryTest, Segments) {
+TEST_F(DiscreteTrajectoryTest, Segments) {
   auto const trajectory = MakeTrajectory();
   std::vector<Instant> begin;
   std::vector<Instant> rbegin;
@@ -338,7 +338,7 @@ TEST_F(DiscreteTraject0ryTest, Segments) {
       ElementsAre(t0_ + 4 * Second, t0_ + 9 * Second, t0_ + 14 * Second));
 }
 
-TEST_F(DiscreteTraject0ryTest, RSegments) {
+TEST_F(DiscreteTrajectoryTest, RSegments) {
   auto const trajectory = MakeTrajectory();
   std::vector<Instant> begin;
   std::vector<Instant> rbegin;
@@ -354,7 +354,7 @@ TEST_F(DiscreteTraject0ryTest, RSegments) {
       ElementsAre(t0_ + 14 * Second, t0_ + 9 * Second, t0_ + 4 * Second));
 }
 
-TEST_F(DiscreteTraject0ryTest, DetachSegments) {
+TEST_F(DiscreteTrajectoryTest, DetachSegments) {
   auto trajectory1 = MakeTrajectory();
   auto const first_segment = trajectory1.segments().begin();
   auto const second_segment = std::next(first_segment);
@@ -406,7 +406,7 @@ TEST_F(DiscreteTraject0ryTest, DetachSegments) {
   }
 }
 
-TEST_F(DiscreteTraject0ryTest, AttachSegmentsMatching) {
+TEST_F(DiscreteTrajectoryTest, AttachSegmentsMatching) {
   auto trajectory1 = MakeTrajectory();
   auto trajectory2 = MakeTrajectory(
       t0_ + 14 * Second,
@@ -453,7 +453,7 @@ TEST_F(DiscreteTraject0ryTest, AttachSegmentsMatching) {
   }
 }
 
-TEST_F(DiscreteTraject0ryTest, AttachSegmentsMismatching) {
+TEST_F(DiscreteTrajectoryTest, AttachSegmentsMismatching) {
   auto trajectory1 = MakeTrajectory();
   auto trajectory2 = MakeTrajectory(
       t0_ + 15 * Second,
@@ -479,7 +479,7 @@ TEST_F(DiscreteTraject0ryTest, AttachSegmentsMismatching) {
                                                  5 * Metre}));
 }
 
-TEST_F(DiscreteTraject0ryTest, DeleteSegments) {
+TEST_F(DiscreteTrajectoryTest, DeleteSegments) {
   auto trajectory = MakeTrajectory();
   auto const first_segment = trajectory.segments().begin();
   auto second_segment = std::next(first_segment);
@@ -490,7 +490,7 @@ TEST_F(DiscreteTraject0ryTest, DeleteSegments) {
   EXPECT_TRUE(second_segment == trajectory.segments().end());
 }
 
-TEST_F(DiscreteTraject0ryTest, ForgetAfter) {
+TEST_F(DiscreteTrajectoryTest, ForgetAfter) {
   auto trajectory = MakeTrajectory();
 
   trajectory.ForgetAfter(trajectory.end());
@@ -516,7 +516,7 @@ TEST_F(DiscreteTraject0ryTest, ForgetAfter) {
   EXPECT_EQ(1, trajectory.segments().size());
 }
 
-TEST_F(DiscreteTraject0ryTest, ForgetBefore) {
+TEST_F(DiscreteTrajectoryTest, ForgetBefore) {
   auto trajectory = MakeTrajectory();
 
   trajectory.ForgetBefore(t0_ + 3 * Second);
@@ -570,7 +570,7 @@ TEST_F(DiscreteTraject0ryTest, ForgetBefore) {
   EXPECT_TRUE(trajectory.empty());
 }
 
-TEST_F(DiscreteTraject0ryTest, TMinTMaxEvaluate) {
+TEST_F(DiscreteTrajectoryTest, TMinTMaxEvaluate) {
   auto const trajectory = MakeTrajectory();
   EXPECT_EQ(t0_, trajectory.t_min());
   EXPECT_EQ(t0_ + 14 * Second, trajectory.t_max());
@@ -592,7 +592,7 @@ TEST_F(DiscreteTraject0ryTest, TMinTMaxEvaluate) {
                                         0 * Metre / Second}), 0)));
 }
 
-TEST_F(DiscreteTraject0ryTest, SerializationRoundTrip) {
+TEST_F(DiscreteTrajectoryTest, SerializationRoundTrip) {
   auto const trajectory = MakeTrajectory();
   auto const trajectory_first_segment = trajectory.segments().begin();
   auto const trajectory_second_segment = std::next(trajectory_first_segment);
@@ -641,7 +641,7 @@ TEST_F(DiscreteTraject0ryTest, SerializationRoundTrip) {
   EXPECT_THAT(message2, EqualsProto(message1));
 }
 
-TEST_F(DiscreteTraject0ryTest, SerializationExactEndpoints) {
+TEST_F(DiscreteTrajectoryTest, SerializationExactEndpoints) {
   DiscreteTrajectory<World> trajectory;
   AngularFrequency const ω = 3 * Radian / Second;
   Length const r = 2 * Metre;
@@ -700,7 +700,7 @@ TEST_F(DiscreteTraject0ryTest, SerializationExactEndpoints) {
                                 IsNear(1.5_⑴ * Milli(Metre) / Second)));
 }
 
-TEST_F(DiscreteTraject0ryTest, SerializationRange) {
+TEST_F(DiscreteTrajectoryTest, SerializationRange) {
   auto const trajectory1 = MakeTrajectory();
   auto trajectory2 = MakeTrajectory();
 
@@ -724,7 +724,7 @@ TEST_F(DiscreteTraject0ryTest, SerializationRange) {
   EXPECT_THAT(message1, EqualsProto(message2));
 }
 
-TEST_F(DiscreteTraject0ryTest, DISABLED_SerializationPreΖήνωνCompatibility) {
+TEST_F(DiscreteTrajectoryTest, DISABLED_SerializationPreΖήνωνCompatibility) {
   StringLogSink log_warning(google::WARNING);
   auto const serialized_message = ReadFromBinaryFile(
       R"(P:\Public Mockingbird\Principia\Saves\3136\trajectory_3136.proto.bin)");  // NOLINT


### PR DESCRIPTION
Also fix a 1337 identifier that I had missed.

Benchmark results (the alert reader may also want to compare with the "before" section in #3206).  Note how iteration got faster:

Before:
```
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                      13.9 ns         13.8 ns     49857230
BM_DiscreteTrajectoryBack                                       73.1 ns         73.7 ns     11217877
BM_DiscreteTrajectoryBegin                                      11.6 ns         11.7 ns     64102153
BM_DiscreteTrajectoryEnd                                        33.4 ns         32.9 ns     20396140
BM_DiscreteTrajectoryTMin                                       2.89 ns         2.88 ns    249286151
BM_DiscreteTrajectoryTMax                                       13.9 ns         13.8 ns     49857230
BM_DiscreteTrajectoryCreateDestroy/8                            1947 ns         1961 ns       373929
BM_DiscreteTrajectoryCreateDestroy/64                           8555 ns         8518 ns        89743
BM_DiscreteTrajectoryCreateDestroy/512                         62091 ns        61188 ns        11218
BM_DiscreteTrajectoryCreateDestroy/1024                       123657 ns       122376 ns         5609
BM_DiscreteTrajectoryIterate/8                                   219 ns          221 ns      3451654
BM_DiscreteTrajectoryIterate/64                                 1487 ns         1502 ns       498572
BM_DiscreteTrajectoryIterate/512                               11029 ns        10951 ns        64102
BM_DiscreteTrajectoryIterate/1024                              21925 ns        21903 ns        32051
BM_DiscreteTrajectoryReverseIterate/8                            175 ns          177 ns      4487151
BM_DiscreteTrajectoryReverseIterate/64                          1031 ns         1022 ns       641022
BM_DiscreteTrajectoryReverseIterate/512                         8117 ns         8170 ns        89743
BM_DiscreteTrajectoryReverseIterate/1024                       16110 ns        16062 ns        40792
BM_DiscreteTrajectoryFind/8                                      597 ns          598 ns      1121788
BM_DiscreteTrajectoryFind/64                                     692 ns          695 ns      1121788
BM_DiscreteTrajectoryFind/512                                    771 ns          765 ns       897430
BM_DiscreteTrajectoryFind/1024                                   770 ns          765 ns       897430
BM_DiscreteTrajectoryLowerBound/8                                382 ns          384 ns      1869646
BM_DiscreteTrajectoryLowerBound/64                               452 ns          454 ns      1547293
BM_DiscreteTrajectoryLowerBound/512                              524 ns          501 ns      1121788
BM_DiscreteTrajectoryLowerBound/1024                             527 ns          530 ns      1000000
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              73.9 ns         73.0 ns      8974301
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated        112 ns          112 ns      6410215
```
After:
```
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                      2.03 ns         2.03 ns    345165440
BM_DiscreteTrajectoryBack                                       10.3 ns         10.4 ns     74785845
BM_DiscreteTrajectoryBegin                                      12.8 ns         12.8 ns     56089384
BM_DiscreteTrajectoryEnd                                        32.8 ns         32.1 ns     21367384
BM_DiscreteTrajectoryTMin                                       2.91 ns         2.91 ns    236165828
BM_DiscreteTrajectoryTMax                                       13.9 ns         13.8 ns     49857230
BM_DiscreteTrajectoryCreateDestroy/8                            1948 ns         1961 ns       373929
BM_DiscreteTrajectoryCreateDestroy/64                           8334 ns         8344 ns        89743
BM_DiscreteTrajectoryCreateDestroy/512                         61622 ns        62578 ns        11218
BM_DiscreteTrajectoryCreateDestroy/1024                       124193 ns       121686 ns         6410
BM_DiscreteTrajectoryIterate/8                                  69.1 ns         69.5 ns     11217877
BM_DiscreteTrajectoryIterate/64                                  301 ns          292 ns      2243575
BM_DiscreteTrajectoryIterate/512                                2401 ns         2399 ns       299143
BM_DiscreteTrajectoryIterate/1024                               4763 ns         4739 ns       154729
BM_DiscreteTrajectoryReverseIterate/8                           77.4 ns         76.5 ns      8974301
BM_DiscreteTrajectoryReverseIterate/64                           370 ns          367 ns      1869646
BM_DiscreteTrajectoryReverseIterate/512                         3059 ns         3059 ns       224358
BM_DiscreteTrajectoryReverseIterate/1024                        6083 ns         6119 ns       112179
BM_DiscreteTrajectoryFind/8                                      537 ns          546 ns      1000000
BM_DiscreteTrajectoryFind/64                                     606 ns          612 ns      1121788
BM_DiscreteTrajectoryFind/512                                    692 ns          695 ns       897430
BM_DiscreteTrajectoryFind/1024                                   693 ns          695 ns       897430
BM_DiscreteTrajectoryLowerBound/8                                360 ns          352 ns      1950935
BM_DiscreteTrajectoryLowerBound/64                               415 ns          413 ns      1661908
BM_DiscreteTrajectoryLowerBound/512                              496 ns          490 ns      1402235
BM_DiscreteTrajectoryLowerBound/1024                             499 ns          501 ns      1402235
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              76.4 ns         76.5 ns      8974301
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated        115 ns          114 ns      5608938
```