### PR TITLE
Cache Localizer.Format calls

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -17,26 +17,26 @@ class BurnEditor : ScalingRenderer {
     this.index = index;
     get_burn_at_index_ = get_burn_at_index;
     Δv_tangent_ = new DifferentialSlider(
-        label            : Localizer.Format("#Principia_BurnEditor_ΔvTangent"),
-        unit             : Localizer.Format("#Principia_BurnEditor_SpeedUnit"),
+        label            : L10N.CacheFormat("#Principia_BurnEditor_ΔvTangent"),
+        unit             : L10N.CacheFormat("#Principia_BurnEditor_SpeedUnit"),
         log10_lower_rate : log10_Δv_lower_rate,
         log10_upper_rate : log10_Δv_upper_rate,
         text_colour      : Style.Tangent);
     Δv_normal_ = new DifferentialSlider(
-        label            : Localizer.Format("#Principia_BurnEditor_ΔvNormal"),
-        unit             : Localizer.Format("#Principia_BurnEditor_SpeedUnit"),
+        label            : L10N.CacheFormat("#Principia_BurnEditor_ΔvNormal"),
+        unit             : L10N.CacheFormat("#Principia_BurnEditor_SpeedUnit"),
         log10_lower_rate : log10_Δv_lower_rate,
         log10_upper_rate : log10_Δv_upper_rate,
         text_colour      : Style.Normal);
     Δv_binormal_ = new DifferentialSlider(
-        label            : Localizer.Format("#Principia_BurnEditor_ΔvBinormal"),
-        unit             : Localizer.Format("#Principia_BurnEditor_SpeedUnit"),
+        label            : L10N.CacheFormat("#Principia_BurnEditor_ΔvBinormal"),
+        unit             : L10N.CacheFormat("#Principia_BurnEditor_SpeedUnit"),
         log10_lower_rate : log10_Δv_lower_rate,
         log10_upper_rate : log10_Δv_upper_rate,
         text_colour      : Style.Binormal);
     previous_coast_duration_ = new DifferentialSlider(
         label            :
-            Localizer.Format("#Principia_BurnEditor_InitialTime"),
+            L10N.CacheFormat("#Principia_BurnEditor_InitialTime"),
         unit             : null,
         log10_lower_rate : log10_time_lower_rate,
         log10_upper_rate : log10_time_upper_rate,
@@ -52,7 +52,7 @@ class BurnEditor : ScalingRenderer {
     reference_frame_selector_ = new ReferenceFrameSelector(
         adapter_,
         ReferenceFrameChanged,
-        Localizer.Format("#Principia_BurnEditor_ManœuvringFrame"));
+        L10N.CacheFormat("#Principia_BurnEditor_ManœuvringFrame"));
     reference_frame_selector_.SetFrameParameters(
         adapter_.plotting_frame_selector_.FrameParameters());
     ComputeEngineCharacteristics();
@@ -78,7 +78,7 @@ class BurnEditor : ScalingRenderer {
         return minimized ? Event.Minimized : Event.Maximized;
       }
       UnityEngine.GUILayout.Label(
-          minimized ? Localizer.Format("#Principia_BurnEditor_MinimizedHeader",
+          minimized ? L10N.CacheFormat("#Principia_BurnEditor_MinimizedHeader",
                                        header,
                                        Δv().ToString("0.000"))
                     : header);
@@ -86,12 +86,12 @@ class BurnEditor : ScalingRenderer {
       if (!minimized &&
           !reference_frame_selector_.FrameParameters().Equals(
               adapter_.plotting_frame_selector_.FrameParameters())) {
-        info = Localizer.Format(
+        info = L10N.CacheFormat(
             "#Principia_BurnEditor_Info_InconsistentFrames");
       }
       UnityEngine.GUILayout.Label(info, Style.Info(UnityEngine.GUI.skin.label));
       if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_BurnEditor_Delete"),
+              L10N.CacheFormat("#Principia_BurnEditor_Delete"),
               GUILayoutWidth(2))) {
         return Event.Deleted;
       }
@@ -117,17 +117,17 @@ class BurnEditor : ScalingRenderer {
       } else {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_BurnEditor_ActiveEngines"))) {
+              L10N.CacheFormat("#Principia_BurnEditor_ActiveEngines"))) {
             engine_warning_ = "";
             ComputeEngineCharacteristics();
             changed = true;
           } else if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_BurnEditor_ActiveRCS"))) {
+              L10N.CacheFormat("#Principia_BurnEditor_ActiveRCS"))) {
             engine_warning_ = "";
             ComputeRCSCharacteristics();
             changed = true;
           } else if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_BurnEditor_InstantImpulse"))) {
+              L10N.CacheFormat("#Principia_BurnEditor_InstantImpulse"))) {
             engine_warning_ = "";
             UseTheForceLuke();
             changed = true;
@@ -138,7 +138,7 @@ class BurnEditor : ScalingRenderer {
       if (is_inertially_fixed_ !=
           UnityEngine.GUILayout.Toggle(
               is_inertially_fixed_,
-              Localizer.Format("#Principia_BurnEditor_InertiallyFixed"))) {
+              L10N.CacheFormat("#Principia_BurnEditor_InertiallyFixed"))) {
         changed = true;
         is_inertially_fixed_ = !is_inertially_fixed_;
       }
@@ -163,19 +163,19 @@ class BurnEditor : ScalingRenderer {
       }
       UnityEngine.GUILayout.Label(
           index == 0
-              ? Localizer.Format(
+              ? L10N.CacheFormat(
                   "#Principia_BurnEditor_TimeBase_StartOfFlightPlan")
-              : Localizer.Format("#Principia_BurnEditor_TimeBase_EndOfManœuvre",
+              : L10N.CacheFormat("#Principia_BurnEditor_TimeBase_EndOfManœuvre",
                                  index),
           style : new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
               alignment = UnityEngine.TextAnchor.UpperLeft
           });
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label(
-            Localizer.Format("#Principia_BurnEditor_Δv",
+            L10N.CacheFormat("#Principia_BurnEditor_Δv",
                              Δv().ToString("0.000")),
             GUILayoutWidth(8));
-        UnityEngine.GUILayout.Label(Localizer.Format(
+        UnityEngine.GUILayout.Label(L10N.CacheFormat(
                                         "#Principia_BurnEditor_Duration",
                                         duration_.ToString("0.0")));
       }
@@ -259,7 +259,7 @@ class BurnEditor : ScalingRenderer {
     // If there are no engines, fall back onto RCS.
     if (thrust_in_kilonewtons_ == 0) {
       engine_warning_ +=
-          Localizer.Format("#Principia_BurnEditor_Warning_NoActiveEngines");
+          L10N.CacheFormat("#Principia_BurnEditor_Warning_NoActiveEngines");
       ComputeRCSCharacteristics();
     }
   }
@@ -296,7 +296,7 @@ class BurnEditor : ScalingRenderer {
     // If RCS provides no thrust, model a virtually instant burn.
     if (thrust_in_kilonewtons_ == 0) {
       engine_warning_ +=
-          Localizer.Format("#Principia_BurnEditor_Warning_NoActiveRCS");
+          L10N.CacheFormat("#Principia_BurnEditor_Warning_NoActiveRCS");
       UseTheForceLuke();
     }
   }

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -14,7 +14,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
     adapter_ = adapter;
     predicted_vessel_ = predicted_vessel;
     final_time_ = new DifferentialSlider(
-        label            : Localizer.Format("#Principia_FlightPlan_PlanLength"),
+        label            : L10N.CacheFormat("#Principia_FlightPlan_PlanLength"),
         unit             : null,
         log10_lower_rate : log10_time_lower_rate,
         log10_upper_rate : log10_time_upper_rate,
@@ -28,7 +28,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   }
 
   public void RenderButton() {
-    RenderButton(Localizer.Format("#Principia_FlightPlan_ToggleButton"),
+    RenderButton(L10N.CacheFormat("#Principia_FlightPlan_ToggleButton"),
                  GUILayoutWidth(4));
   }
 
@@ -50,7 +50,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   }
 
   protected override string Title =>
-      Localizer.Format("#Principia_FlightPlan_Title");
+      L10N.CacheFormat("#Principia_FlightPlan_Title");
 
   protected override void RenderWindow(int window_id) {
     // We must ensure that the GUI elements don't change between Layout and
@@ -73,7 +73,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
     if (plugin.FlightPlanExists(vessel_guid)) {
       RenderFlightPlan(vessel_guid);
     } else if (UnityEngine.GUILayout.Button(
-        Localizer.Format("#Principia_FlightPlan_Create"))) {
+        L10N.CacheFormat("#Principia_FlightPlan_Create"))) {
       plugin.FlightPlanCreate(vessel_guid,
                               plugin.CurrentTime() + 3600,
                               predicted_vessel.GetTotalMass());
@@ -165,12 +165,12 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_FlightPlan_MaxSteps"),
+              L10N.CacheFormat("#Principia_FlightPlan_MaxSteps"),
               GUILayoutWidth(6));
           const int factor = 4;
           if (parameters.max_steps <= 100) {
             UnityEngine.GUILayout.Button(
-                Localizer.Format("#Principia_DiscreteSelector_Min"));
+                L10N.CacheFormat("#Principia_DiscreteSelector_Min"));
           } else if (UnityEngine.GUILayout.Button("-")) {
             parameters.max_steps /= factor;
             var status =
@@ -183,7 +183,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                                          GUILayoutWidth(3));
           if (parameters.max_steps >= long.MaxValue / factor) {
             UnityEngine.GUILayout.Button(
-                Localizer.Format("#Principia_DiscreteSelector_Max"));
+                L10N.CacheFormat("#Principia_DiscreteSelector_Max"));
           } else if (UnityEngine.GUILayout.Button("+")) {
             parameters.max_steps *= factor;
             var status =
@@ -195,11 +195,11 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
         }
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_PredictionSettings_ToleranceLabel"),
+              L10N.CacheFormat("#Principia_PredictionSettings_ToleranceLabel"),
               GUILayoutWidth(3));
           if (parameters.length_integration_tolerance <= 1e-6) {
             UnityEngine.GUILayout.Button(
-                Localizer.Format("#Principia_DiscreteSelector_Min"));
+                L10N.CacheFormat("#Principia_DiscreteSelector_Min"));
           } else if (UnityEngine.GUILayout.Button("-")) {
             parameters.length_integration_tolerance /= 2;
             parameters.speed_integration_tolerance /= 2;
@@ -210,13 +210,13 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
             UpdateStatus(status, null);
           }
           UnityEngine.GUILayout.TextArea(
-              Localizer.Format("#Principia_PredictionSettings_ToleranceText",
+              L10N.CacheFormat("#Principia_PredictionSettings_ToleranceText",
                                parameters.length_integration_tolerance.ToString(
                                    "0.0e0")),
               GUILayoutWidth(3));
           if (parameters.length_integration_tolerance >= 1e6) {
             UnityEngine.GUILayout.Button(
-                Localizer.Format("#Principia_DiscreteSelector_Max"));
+                L10N.CacheFormat("#Principia_DiscreteSelector_Max"));
           } else if (UnityEngine.GUILayout.Button("+")) {
             parameters.length_integration_tolerance *= 2;
             parameters.speed_integration_tolerance *= 2;
@@ -231,7 +231,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
       double Δv = (from burn_editor in burn_editors_
                    select burn_editor.Δv()).Sum();
-      UnityEngine.GUILayout.Label(Localizer.Format(
+      UnityEngine.GUILayout.Label(L10N.CacheFormat(
                                       "#Principia_FlightPlan_TotalΔv",
                                       Δv.ToString("0.000")));
 
@@ -254,7 +254,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
       if (burn_editors_.Count == 0 &&
           UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_FlightPlan_Delete"))) {
+              L10N.CacheFormat("#Principia_FlightPlan_Delete"))) {
         final_trajectory_analyser_.DisposeWindow();
         final_trajectory_analyser_ =
             new PlannedOrbitAnalyser(adapter_, predicted_vessel_);
@@ -264,7 +264,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
         // The state change will happen the next time we go through OnGUI.
       } else {
         if (UnityEngine.GUILayout.Button(
-            Localizer.Format("#Principia_FlightPlan_Rebase"))) {
+            L10N.CacheFormat("#Principia_FlightPlan_Rebase"))) {
           var status = plugin.FlightPlanRebase(
               vessel_guid,
               predicted_vessel.GetTotalMass());
@@ -301,7 +301,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           BurnEditor burn = burn_editors_[i];
           switch (burn.Render(
               header          :
-              Localizer.Format("#Principia_FlightPlan_ManœuvreHeader", i + 1),
+              L10N.CacheFormat("#Principia_FlightPlan_ManœuvreHeader", i + 1),
               anomalous       : i >=
                                 burn_editors_.Count -
                                 number_of_anomalous_manœuvres_,
@@ -352,10 +352,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       if (manœuvre.burn.initial_time > current_time) {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_FlightPlan_UpcomingManœuvre",
+              L10N.CacheFormat("#Principia_FlightPlan_UpcomingManœuvre",
                                first_future_manœuvre + 1));
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_FlightPlan_IgnitionCountdown",
+              L10N.CacheFormat("#Principia_FlightPlan_IgnitionCountdown",
                                FormatTimeSpan(
                                    current_time - manœuvre.burn.initial_time)),
               style : Style.RightAligned(UnityEngine.GUI.skin.label));
@@ -363,10 +363,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       } else {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_FlightPlan_OngoingManœuvre",
+              L10N.CacheFormat("#Principia_FlightPlan_OngoingManœuvre",
                                first_future_manœuvre + 1));
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_FlightPlan_CutoffCountdown",
+              L10N.CacheFormat("#Principia_FlightPlan_CutoffCountdown",
                                FormatTimeSpan(
                                    current_time - manœuvre.final_time)),
               style : Style.RightAligned(UnityEngine.GUI.skin.label));
@@ -381,9 +381,9 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           show_guidance_ = UnityEngine.GUILayout.Toggle(
               show_guidance_,
-              Localizer.Format("#Principia_FlightPlan_ShowManœuvreOnNavball"));
+              L10N.CacheFormat("#Principia_FlightPlan_ShowManœuvreOnNavball"));
           if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_FlightPlan_WarpToManœuvre"))) {
+              L10N.CacheFormat("#Principia_FlightPlan_WarpToManœuvre"))) {
             TimeWarp.fetch.WarpTo(manœuvre.burn.initial_time - 60);
           }
         }
@@ -392,7 +392,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       // Reserve some space to avoid the UI changing shape if we have
       // nothing to say.
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_FlightPlan_Warning_AllManœuvresInThePast"),
           Style.Warning(UnityEngine.GUI.skin.label));
       UnityEngine.GUILayout.Space(Width(1));
@@ -432,17 +432,17 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
             (burn_editors_[index].initial_time - start_of_coast).FormatDuration(
                 show_seconds: false);
         string coast_description = orbit_description == null
-                                       ? Localizer.Format(
+                                       ? L10N.CacheFormat(
                                            "#Principia_FlightPlan_Coast",
                                            coast_duration)
-                                       : Localizer.Format(
+                                       : L10N.CacheFormat(
                                            "#Principia_FlightPlan_CoastInOrbit",
                                            orbit_description,
                                            coast_duration);
         UnityEngine.GUILayout.Label(coast_description);
       }
       if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_FlightPlan_AddManœuvre"),
+              L10N.CacheFormat("#Principia_FlightPlan_AddManœuvre"),
               GUILayoutWidth(4))) {
         double initial_time;
         if (index == 0) {
@@ -545,89 +545,89 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       bool timed_out = actual_final_time < final_time_.value;
 
       string remedy_message =
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_FlightPlan_StatusMessage_ChangeFlightPlan");  // Preceded by "Try".
-      string status_message = Localizer.Format(
+      string status_message = L10N.CacheFormat(
           "#Principia_FlightPlan_StatusMessage_FailedError",
           status_.error,
           status_.message);
       string time_out_message =
-          timed_out ? Localizer.Format(
+          timed_out ? L10N.CacheFormat(
                           "#Principia_FlightPlan_StatusMessage_TimeOut",
                           FormatPositiveTimeSpan(
                               actual_final_time -
                               plugin.FlightPlanGetInitialTime(vessel_guid)))
                     : "";
       if (status_.is_aborted()) {
-        status_message = Localizer.Format(
+        status_message = L10N.CacheFormat(
             "#Principia_FlightPlan_StatusMessage_MaxSteps",
             time_out_message);
         remedy_message =
-            Localizer.Format("#Principia_FlightPlan_StatusMessage_MaxSegment");
+            L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_MaxSegment");
       } else if (status_.is_failed_precondition()) {
-        status_message = Localizer.Format(
+        status_message = L10N.CacheFormat(
             "#Principia_FlightPlan_StatusMessage_Singularity",
             time_out_message);
         remedy_message =
-            Localizer.Format(
+            L10N.CacheFormat(
                 "#Principia_FlightPlan_StatusMessage_AvoidingCollision");
       } else if (status_.is_invalid_argument()) {
-        status_message = Localizer.Format(
+        status_message = L10N.CacheFormat(
             "#Principia_FlightPlan_StatusMessage_Infinite",
             first_error_manœuvre_.Value + 1);
-        remedy_message = Localizer.Format(
+        remedy_message = L10N.CacheFormat(
             "#Principia_FlightPlan_StatusMessage_Adjust",
             first_error_manœuvre_.Value + 1);
       } else if (status_.is_out_of_range()) {
         if (first_error_manœuvre_.HasValue) {
-          status_message = Localizer.Format(
+          status_message = L10N.CacheFormat(
               "#Principia_FlightPlan_StatusMessage_OutRange1",
               first_error_manœuvre_.Value + 1,
               first_error_manœuvre_.Value == 0
-                  ? Localizer.Format(
+                  ? L10N.CacheFormat(
                       "#Principia_FlightPlan_StatusMessage_OutRange2")
-                  : Localizer.Format(
+                  : L10N.CacheFormat(
                       "#Principia_FlightPlan_StatusMessage_OutRange3",
                       first_error_manœuvre_.Value),
               manœuvres == 0 || first_error_manœuvre_.Value == manœuvres - 1
-                  ? Localizer.Format(
+                  ? L10N.CacheFormat(
                       "#Principia_FlightPlan_StatusMessage_OutRange4")
-                  : Localizer.Format(
+                  : L10N.CacheFormat(
                       "#Principia_FlightPlan_StatusMessage_OutRange5",
                       first_error_manœuvre_.Value + 2));
-          remedy_message =  Localizer.Format(
+          remedy_message =  L10N.CacheFormat(
               "#Principia_FlightPlan_StatusMessage_OutRange6",
               manœuvres == 0 || first_error_manœuvre_.Value == manœuvres - 1
-                  ? Localizer.Format(
+                  ? L10N.CacheFormat(
                       "#Principia_FlightPlan_StatusMessage_OutRange7")
                   : "",
               first_error_manœuvre_.Value + 1);
         } else {
           status_message =
-              Localizer.Format("#Principia_FlightPlan_StatusMessage_TooShort");
+              L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_TooShort");
           remedy_message =
-              Localizer.Format("#Principia_FlightPlan_StatusMessage_Increase");
+              L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_Increase");
         }
       } else if (status_.is_unavailable()) {
         status_message =
-            Localizer.Format("#Principia_FlightPlan_StatusMessage_CantRebase");
+            L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_CantRebase");
         remedy_message =
-            Localizer.Format("#Principia_FlightPlan_StatusMessage_WaitFinish");
+            L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_WaitFinish");
       }
 
       if (anomalous_manœuvres > 0) {
-        message = Localizer.Format(
+        message = L10N.CacheFormat(
             "#Principia_FlightPlan_StatusMessage_Last",
             anomalous_manœuvres,
             status_message ,
             remedy_message,
             (anomalous_manœuvres < manœuvres
-                 ? Localizer.Format("#Principia_FlightPlan_StatusMessage_Last2",
+                 ? L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_Last2",
                                     manœuvres - anomalous_manœuvres)
                  : ""));
       } else {
         message =
-            Localizer.Format("#Principia_FlightPlan_StatusMessage_Result",
+            L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_Result",
                              status_message,
                              remedy_message);
       }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -280,7 +280,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       bad_installation_dialog_.Hide();
     } else {
       is_bad_installation_ = true;
-      bad_installation_dialog_.message = Localizer.Format(
+      bad_installation_dialog_.message = L10N.CacheFormat(
           "#Principia_DLLFailedToLoad",
           load_error);
       bad_installation_dialog_.Show();
@@ -330,7 +330,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
     orbit_analyser_ = new CurrentOrbitAnalyser(this, PredictedVessel);
     plotting_frame_selector_ = new ReferenceFrameSelector(this,
       UpdateRenderingFrame,
-      Localizer.Format("#Principia_PlottingFrame"));
+      L10N.CacheFormat("#Principia_PlottingFrame"));
     main_window_ = new MainWindow(this,
                                   flight_planner_,
                                   orbit_analyser_,
@@ -918,7 +918,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           FlightGlobals.speedDisplayMode ==
           FlightGlobals.SpeedDisplayModes.Target) {
         KSP.UI.Screens.Flight.SpeedDisplay.Instance.textTitle.text =
-            Localizer.Format("#Principia_SpeedDisplayModeTarget");
+            L10N.CacheFormat("#Principia_SpeedDisplayModeTarget");
       }
 
       if (FlightGlobals.speedDisplayMode ==
@@ -944,7 +944,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                       new QP{q = (XYZ)active_vessel.orbit.pos,
                           p = (XYZ)active_vessel.orbit.vel},
                       active_vessel.orbit.referenceBody.flightGlobalsIndex);
-          speed_display.textSpeed.text = Localizer.Format(
+          speed_display.textSpeed.text = L10N.CacheFormat(
               "#Principia_SpeedDisplayText",
               active_vessel_velocity.magnitude.ToString("F1"));
         }

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -1,5 +1,6 @@
 ﻿using KSP.Localization;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -26,7 +27,7 @@ internal static class L10N {
   }
 
   public static string Standalone(string name) {
-    return Localizer.Format("#Principia_GrammaticalForm_Standalone", name);
+    return L10N.CacheFormat("#Principia_GrammaticalForm_Standalone", name);
   }
 
   public static string StandaloneName(this CelestialBody celestial) {
@@ -62,6 +63,9 @@ internal static class L10N {
   // Bodies that may not have an article (Saturn, Vénus) have an uppercase
   // gender tag (Saturn^N, Vénus^F).
   public static string Name(this CelestialBody body) {
+    if (names_.TryGetValue(body, out string result)) {
+      return result;
+    }
     string name = LingoonaUnqualified(body.displayName);
     string qualifiers = LingoonaQualifiers(body.displayName);
     if (qualifiers == "") {
@@ -76,23 +80,26 @@ internal static class L10N {
       // Lowercase the gender, allowing for articles.
       qualifiers = char.ToLower(qualifiers[0]) + qualifiers.Substring(1);
     }
-    return LingoonaQualify(name, qualifiers);
+    return names_[body] = LingoonaQualify(name, qualifiers);
   }
 
   private static string Initial(this CelestialBody body) {
-    return IsCJKV(LingoonaUnqualified(body.displayName))
+    if (initials_.TryGetValue(body, out string result)) {
+      return result;
+    }
+    return initials_[body] = IsCJKV(LingoonaUnqualified(body.displayName))
         ? body.displayName
         : body.Name()[0].ToString();
   }
 
-  public static string FormatOrNull(string template, params object[] args) {
+  private static string FormatOrNull(string template, params object[] args) {
     // Optional translations include the language name so that they do not fall
     // back to English.
     string qualified_template = $"{template}.{Localizer.CurrentLanguage}";
     if (!Localizer.Tags.ContainsKey(qualified_template)) {
       return null;
     }
-    return Localizer.Format(qualified_template, args);
+    return L10N.CacheFormat(qualified_template, args);
   }
 
   private static string CelestialOverride(string template,
@@ -110,8 +117,9 @@ internal static class L10N {
       (from body in bodies
        from name in new[]{body.Name(), body.Initial()}
        select name).Concat(from arg in args select arg.ToString()).ToArray();
-    return CelestialOverride(template, names, bodies) ??
-        Localizer.Format(template, names);
+    return GetCached(new StringCacheEntry(template, names),
+                     () => CelestialOverride(template, names, bodies) ??
+                           Localizer.Format(template, names));
   }
 
   public static string CelestialStringOrNull(string template,
@@ -121,9 +129,76 @@ internal static class L10N {
       (from body in bodies
        from name in new[]{body.Name(), body.Initial()}
        select name).Concat(from arg in args select arg.ToString()).ToArray();
-    return CelestialOverride(template, names, bodies) ??
-        FormatOrNull(template, names);
+    return GetCached(new StringCacheEntry(template, names),
+                     () => CelestialOverride(template, names, bodies) ??
+                           FormatOrNull(template, names));
   }
+
+  public static string CacheFormat(string name, params object[] args) {
+    return GetCached(new StringCacheEntry(name, args),
+                     () => Localizer.Format(name, args));
+  }
+
+  private static string GetCached(StringCacheEntry key_only,
+                                  Func<string> compute_value) {
+    var entry = key_only;
+    if (cache_.TryGetValue(entry, out StringCacheEntry actual)) {
+      ++cache_hit_counter;
+      entry.value = actual.value;
+      cache_.Remove(actual);
+      cache_by_time_.Remove(actual);
+    } else {
+      ++cache_miss_counter;
+      entry.value = compute_value();
+      if (cache_.Count >= max_cache_length) {
+        var evicted = cache_by_time_.First();
+        cache_.Remove(evicted);
+        cache_by_time_.Remove(evicted);
+      }
+    }
+    cache_.Add(entry);
+    cache_by_time_.Add(entry);
+    return entry.value;
+  }
+
+  public struct StringCacheEntry : IEquatable<StringCacheEntry> {
+    public StringCacheEntry(string name, object[] args) {
+      string unit_separator = "\x1F";
+      key = name + unit_separator +
+          string.Join(unit_separator, from arg in args select arg.ToString());
+      value = null;
+      timestamp = System.Diagnostics.Stopwatch.GetTimestamp();
+    }
+
+    public bool Equals(StringCacheEntry other) {
+      return key == other.key;
+    }
+
+    public override int GetHashCode() {
+      return key.GetHashCode();
+    }
+
+    public string key { get; set; }
+    public string value { get; set; }
+    public long timestamp { get; set; }
+  }
+  
+  public static ulong cache_hit_counter = 0;
+  public static ulong cache_miss_counter = 0;
+  private const int max_cache_length = 1024;
+  public static HashSet<StringCacheEntry> cache_ =
+      new HashSet<StringCacheEntry>();
+  public static SortedSet<StringCacheEntry> cache_by_time_ =
+      new SortedSet<StringCacheEntry>(Comparer<StringCacheEntry>.Create(
+          (x, y) => {
+            var time_comparison = x.timestamp.CompareTo(y.timestamp);
+            return time_comparison != 0 ? time_comparison
+                                        : x.key.CompareTo(y.key);
+          }));
+  private static Dictionary<CelestialBody, string> names_ =
+      new Dictionary<CelestialBody, string>();
+  private static Dictionary<CelestialBody, string> initials_ =
+      new Dictionary<CelestialBody, string>();
 }
 
 }

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -143,12 +143,10 @@ internal static class L10N {
                                   Func<string> compute_value) {
     var entry = key_only;
     if (cache_.TryGetValue(entry, out StringCacheEntry actual)) {
-      ++cache_hit_counter;
       entry.value = actual.value;
       cache_.Remove(actual);
       cache_by_time_.Remove(actual);
     } else {
-      ++cache_miss_counter;
       entry.value = compute_value();
       if (cache_.Count >= max_cache_length) {
         var evicted = cache_by_time_.First();
@@ -182,13 +180,11 @@ internal static class L10N {
     public string value { get; set; }
     public long timestamp { get; set; }
   }
-  
-  public static ulong cache_hit_counter = 0;
-  public static ulong cache_miss_counter = 0;
+
   private const int max_cache_length = 1024;
-  public static HashSet<StringCacheEntry> cache_ =
+  private static HashSet<StringCacheEntry> cache_ =
       new HashSet<StringCacheEntry>();
-  public static SortedSet<StringCacheEntry> cache_by_time_ =
+  private static SortedSet<StringCacheEntry> cache_by_time_ =
       new SortedSet<StringCacheEntry>(Comparer<StringCacheEntry>.Create(
           (x, y) => {
             var time_comparison = x.timestamp.CompareTo(y.timestamp);

--- a/ksp_plugin_adapter/logging.cs
+++ b/ksp_plugin_adapter/logging.cs
@@ -7,10 +7,10 @@ namespace ksp_plugin_adapter {
 
 internal static class Log {
   internal static string[] severity_names = {
-      Localizer.Format("#Principia_Logging_Info"),
-      Localizer.Format("#Principia_Logging_Warning"),
-      Localizer.Format("#Principia_Logging_Error"),
-      Localizer.Format("#Principia_Logging_Fatal")
+      L10N.CacheFormat("#Principia_Logging_Info"),
+      L10N.CacheFormat("#Principia_Logging_Warning"),
+      L10N.CacheFormat("#Principia_Logging_Error"),
+      L10N.CacheFormat("#Principia_Logging_Fatal")
   };
 
   internal static void InitGoogleLogging() {

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using KSP.Localization;
 
 namespace principia {
@@ -145,13 +146,13 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     using (new UnityEngine.GUILayout.VerticalScope()) {
       if (!adapter_.PluginRunning()) {
         UnityEngine.GUILayout.Label(
-            text : Localizer.Format("#Principia_MainWindow_PluginNotStarted"),
+            text : L10N.CacheFormat("#Principia_MainWindow_PluginNotStarted"),
             style : Style.Warning(UnityEngine.GUI.skin.label));
       }
       if (DateTimeOffset.Now > next_release_date_) {
         if (Versioning.version_minor <= 7) {
           UnityEngine.GUILayout.TextArea(
-              Localizer.Format(
+              L10N.CacheFormat(
                   "#Principia_MainWindow_NewMoonAnnouncementWithKspDeprecation",
                   next_release_lunation_number,
                   next_release_name,
@@ -159,7 +160,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
               style : Style.Multiline(UnityEngine.GUI.skin.textArea));
         } else {
           UnityEngine.GUILayout.TextArea(
-              Localizer.Format("#Principia_MainWindow_NewMoonAnnouncement",
+              L10N.CacheFormat("#Principia_MainWindow_NewMoonAnnouncement",
                                next_release_lunation_number,
                                next_release_name ),
               style: Style.Multiline(UnityEngine.GUI.skin.textArea));
@@ -177,25 +178,25 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           selecting_active_vessel_target = UnityEngine.GUILayout.Toggle(
               selecting_active_vessel_target,
-              Localizer.Format("#Principia_MainWindow_TargetVessel_Select"));
+              L10N.CacheFormat("#Principia_MainWindow_TargetVessel_Select"));
           if (selecting_active_vessel_target) {
             selecting_target_celestial_ = false;
           }
           if (FlightGlobals.fetch.VesselTarget?.GetVessel()) {
             UnityEngine.GUILayout.Label(
-                Localizer.Format("#Principia_MainWindow_TargetVessel_Name",
+                L10N.CacheFormat("#Principia_MainWindow_TargetVessel_Name",
                                  FlightGlobals.fetch.VesselTarget.GetVessel().
                                      vesselName),
                 UnityEngine.GUILayout.ExpandWidth(true));
             if (UnityEngine.GUILayout.Button(
-                    Localizer.Format(
+                    L10N.CacheFormat(
                         "#Principia_MainWindow_TargetVessel_Clear"),
                     GUILayoutWidth(2))) {
               selecting_active_vessel_target = false;
               FlightGlobals.fetch.SetVesselTarget(null);
             }
             if (UnityEngine.GUILayout.Button(
-                    Localizer.Format(
+                    L10N.CacheFormat(
                         "#Principia_MainWindow_TargetVessel_SwitchTo"))) {
               var focus_object =
                   new KSP.UI.Screens.Mapview.MapContextMenuOptions.FocusObject(
@@ -224,16 +225,16 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
         }
         RenderToggleableSection(
             name   :
-            Localizer.Format("#Principia_MainWindow_PredictionSettings"),
+            L10N.CacheFormat("#Principia_MainWindow_PredictionSettings"),
             show   : ref show_prediction_settings_,
             render : RenderPredictionSettings);
       }
       RenderToggleableSection(
-          name   : Localizer.Format("#Principia_MainWindow_KspFeatures"),
+          name   : L10N.CacheFormat("#Principia_MainWindow_KspFeatures"),
           show   : ref show_ksp_features_,
           render : RenderKSPFeatures);
       RenderToggleableSection(
-          name   : Localizer.Format("#Principia_MainWindow_LoggingSettings"),
+          name   : L10N.CacheFormat("#Principia_MainWindow_LoggingSettings"),
           show   : ref show_logging_settings_,
           render : RenderLoggingSettings);
     }
@@ -243,14 +244,14 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   private void RenderKSPFeatures() {
     display_patched_conics = UnityEngine.GUILayout.Toggle(
         value : display_patched_conics,
-        text  : Localizer.Format(
+        text  : L10N.CacheFormat(
             "#Principia_MainWindow_KspFeature_DisplayPatchedConics"));
     if (MapView.MapIsEnabled &&
         FlightGlobals.ActiveVessel?.orbitTargeter != null) {
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         selecting_target_celestial_ = UnityEngine.GUILayout.Toggle(
             selecting_target_celestial_,
-            Localizer.Format("#Principia_MainWindow_TargetCelestial_Select"));
+            L10N.CacheFormat("#Principia_MainWindow_TargetCelestial_Select"));
         if (selecting_target_celestial_) {
           selecting_active_vessel_target = false;
         }
@@ -258,11 +259,11 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
             FlightGlobals.fetch.VesselTarget as CelestialBody;
         if (target_celestial != null) {
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_MainWindow_TargetCelestial_Name",
+              L10N.CacheFormat("#Principia_MainWindow_TargetCelestial_Name",
                                target_celestial.Name()),
               UnityEngine.GUILayout.ExpandWidth(true));
           if (UnityEngine.GUILayout.Button(
-              Localizer.Format("#Principia_MainWindow_TargetCelestial_Clear"),
+              L10N.CacheFormat("#Principia_MainWindow_TargetCelestial_Clear"),
               GUILayoutWidth(2))) {
             selecting_target_celestial_ = false;
             FlightGlobals.fetch.SetVesselTarget(null);
@@ -277,7 +278,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   private void RenderLoggingSettings() {
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(
-          text : Localizer.Format(
+          text : L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_VerboseLevel"));
       if (UnityEngine.GUILayout.Button(text    : "←",
                                        options : GUILayoutWidth(2))) {
@@ -298,15 +299,15 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Space(column_width);
       UnityEngine.GUILayout.Label(
-          text    : Localizer.Format(
+          text    : L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_LogOption"),
           options : gui_layout_column_width);
       UnityEngine.GUILayout.Label(
-          text    : Localizer.Format(
+          text    : L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_StderrOption"),
           options : gui_layout_column_width);
       UnityEngine.GUILayout.Label(
-          text    : Localizer.Format(
+          text    : L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_FlushOption"),
           options : gui_layout_column_width);
     }
@@ -368,15 +369,15 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       must_record_journal_ = UnityEngine.GUILayout.Toggle(
           value   : must_record_journal_,
-          text    : Localizer.Format(
+          text    : L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_RecordJournal"));
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_MainWindow_LoggingSettings_RecordJournalResult",
               journaling_
-                  ? Localizer.Format(
+                  ? L10N.CacheFormat(
                       "#Principia_MainWindow_LoggingSettings_JournalingStatus_ON")
-                  : Localizer.Format(
+                  : L10N.CacheFormat(
                       "#Principia_MainWindow_LoggingSettings_JournalingStatus_OFF")),
           style : Style.Info(
               Style.RightAligned(
@@ -388,6 +389,8 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       journaling_ = false;
       Interface.ActivateRecorder(false);
     }
+    UnityEngine.GUILayout.Label($"L10N cache misses: {L10N.cache_miss_counter}");
+    UnityEngine.GUILayout.Label($"L10N cache size: {L10N.cache_.Count()}, {L10N.cache_by_time_.Count()}");
   }
 
   private void RenderPredictionSettings() {
@@ -418,7 +421,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     // TODO(egg): make the speed tolerance independent.
     if (RenderSelector(prediction_length_tolerances_,
                        ref prediction_length_tolerance_index_,
-                       Localizer.Format(
+                       L10N.CacheFormat(
                            "#Principia_PredictionSettings_ToleranceLabel"),
                        "{0:0.0e0} m",
                        enabled: adaptive_step_parameters.HasValue)) {
@@ -435,7 +438,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     }
     if (RenderSelector(prediction_steps_,
                        ref prediction_steps_index_,
-                       Localizer.Format("#Principia_PredictionSettings_Steps"),
+                       L10N.CacheFormat("#Principia_PredictionSettings_Steps"),
                        "{0:0.00e0}",
                        enabled: adaptive_step_parameters.HasValue)) {
       AdaptiveStepParameters new_adaptive_step_parameters =
@@ -462,7 +465,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
                                   options : GUILayoutWidth(6));
       if (UnityEngine.GUILayout.Button(
               text    : index == 0
-                            ? Localizer.Format(
+                            ? L10N.CacheFormat(
                                 "#Principia_DiscreteSelector_Min")
                             : "-",
               options : GUILayoutWidth(2)) &&
@@ -479,7 +482,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
           options : GUILayoutWidth(3));
       if (UnityEngine.GUILayout.Button(
               text    : index == array.Length - 1
-                            ? Localizer.Format(
+                            ? L10N.CacheFormat(
                                 "#Principia_DiscreteSelector_Max")
                             : "+",
               options : GUILayoutWidth(2)) &&
@@ -516,7 +519,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
 
   private DifferentialSlider history_length_ = new DifferentialSlider(
       label            :
-          Localizer.Format("#Principia_MainWindow_HistoryLength"),
+          L10N.CacheFormat("#Principia_MainWindow_HistoryLength"),
       unit             : null,
       log10_lower_rate : 0,
       log10_upper_rate : 7,

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -389,8 +389,6 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       journaling_ = false;
       Interface.ActivateRecorder(false);
     }
-    UnityEngine.GUILayout.Label($"L10N cache misses: {L10N.cache_miss_counter}");
-    UnityEngine.GUILayout.Label($"L10N cache size: {L10N.cache_.Count()}, {L10N.cache_by_time_.Count()}");
   }
 
   private void RenderPredictionSettings() {

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -197,10 +197,10 @@ internal class MapNodePool {
       string source;
       switch (properties.source) {
         case NodeSource.FlightPlan:
-          source = Localizer.Format("#Principia_MapNode_Planned");
+          source = L10N.CacheFormat("#Principia_MapNode_Planned");
           break;
         case NodeSource.Prediction:
-          source = Localizer.Format("#Principia_MapNode_Predicted");
+          source = L10N.CacheFormat("#Principia_MapNode_Predicted");
           break;
         default:
           throw Log.Fatal($"Unexpected node source {properties.source}");
@@ -219,7 +219,7 @@ internal class MapNodePool {
               source,
               celestial.GetAltitude(position).FormatN(0));
           caption.captionLine2 =
-              Localizer.Format("#Principia_MapNode_ApsisCaptionLine2",
+              L10N.CacheFormat("#Principia_MapNode_ApsisCaptionLine2",
                                speed.FormatN(0));
           break;
         }
@@ -227,14 +227,14 @@ internal class MapNodePool {
         case MapObject.ObjectType.DescendingNode: {
           string node_name =
               properties.object_type == MapObject.ObjectType.AscendingNode
-                  ? Localizer.Format("#Principia_MapNode_AscendingNode")
-                  : Localizer.Format("#Principia_MapNode_DescendingNode");
+                  ? L10N.CacheFormat("#Principia_MapNode_AscendingNode")
+                  : L10N.CacheFormat("#Principia_MapNode_DescendingNode");
           string plane = properties.reference_frame.ReferencePlaneDescription();
-          caption.Header = Localizer.Format("#Principia_MapNode_NodeHeader",
+          caption.Header = L10N.CacheFormat("#Principia_MapNode_NodeHeader",
                                             source,
                                             node_name,
                                             plane);
-          caption.captionLine2 = Localizer.Format(
+          caption.captionLine2 = L10N.CacheFormat(
               "#Principia_MapNode_NodeCaptionLine2",
               properties.velocity.z.FormatN(0));
           break;
@@ -244,17 +244,17 @@ internal class MapNodePool {
               (properties.reference_frame.target.GetWorldPos3D() -
                properties.world_position).magnitude;
           double speed = properties.velocity.magnitude;
-          caption.Header = Localizer.Format("#Principia_MapNode_ApproachHeader",
+          caption.Header = L10N.CacheFormat("#Principia_MapNode_ApproachHeader",
                                             source,
                                             separation.FormatN(0));
-          caption.captionLine2 = Localizer.Format(
+          caption.captionLine2 = L10N.CacheFormat(
               "#Principia_MapNode_ApproachCaptionLine2",
               speed.FormatN(0));
           break;
         }
         case MapObject.ObjectType.PatchTransition: {
           CelestialBody celestial = properties.reference_frame.Centre();
-          caption.Header = Localizer.Format("#Principia_MapNode_ImpactHeader",
+          caption.Header = L10N.CacheFormat("#Principia_MapNode_ImpactHeader",
                                             source,
                                             celestial.Name());
           caption.captionLine1 = "";

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -60,7 +60,7 @@ internal static class Formatters {
     double half_width = (interval.max - interval.min) / 2;
     double midpoint = interval.min + half_width;
     if (half_width > Math.PI) {
-      return Localizer.Format("#Principia_OrbitAnalyser_Precesses");
+      return L10N.CacheFormat("#Principia_OrbitAnalyser_Precesses");
     }
     const double degree = Math.PI / 180;
     int fractional_digits =
@@ -87,7 +87,7 @@ internal static class Formatters {
     CelestialBody primary) {
     double half_width_angle = (interval.max - interval.min) / 2;
     if (half_width_angle > Math.PI) {
-      return Localizer.Format("#Principia_OrbitAnalyser_Precesses");
+      return L10N.CacheFormat("#Principia_OrbitAnalyser_Precesses");
     }
     double half_width_distance = half_width_angle * primary.Radius;
     string formatted_distance = half_width_distance > 1000
@@ -185,7 +185,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
   }
 
   protected override string Title => orbit_description_ == null
-                                         ? Localizer.Format(
+                                         ? L10N.CacheFormat(
                                              "#Principia_OrbitAnalyser_Title")
                                          : orbit_description_[0].ToString().
                                                ToUpper() +
@@ -260,11 +260,11 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                                       : 0;
         string duration_in_ground_track_cycles =
             ground_track_cycles > 0
-                ?  Localizer.Format(
+                ?  L10N.CacheFormat(
                     "#Principia_OrbitAnalyser_Duration_GroundTrackCycles",
                     ground_track_cycles.FormatN(0))
                 : "";
-        duration_in_revolutions = Localizer.Format(
+        duration_in_revolutions = L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Duration_Revolutions",
             sidereal_revolutions.FormatN(0),
             nodal_revolutions.FormatN(0),
@@ -272,10 +272,10 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
             anomalistic_revolutions.FormatN(0));
       } else {
         if (primary == null) {
-          duration_in_revolutions = Localizer.Format(
+          duration_in_revolutions = L10N.CacheFormat(
               "#Principia_OrbitAnalyser_Warning_NoElements1");
         } else {
-          duration_in_revolutions = Localizer.Format(
+          duration_in_revolutions = L10N.CacheFormat(
               "#Principia_OrbitAnalyser_Warning_NoElements2",
               primary.Name());
         }
@@ -283,11 +283,11 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
       }
       string analysis_description =
           primary == null
-              ? Localizer.Format(
+              ? L10N.CacheFormat(
                   "#Principia_OrbitAnalyser_Warning_NoPrimary",
                   predicted_vessel.vesselName,
                   mission_duration.FormatDuration(show_seconds: false))
-              : Localizer.Format(
+              : L10N.CacheFormat(
                   "#Principia_OrbitAnalyser_AnalysisDescription",
                   predicted_vessel.vesselName,
                   primary.Name(),
@@ -301,11 +301,11 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
       RenderLowestAltitude(elements, primary);
       Style.HorizontalLine();
       UnityEngine.GUILayout.Label(
-          Localizer.Format("#Principia_OrbitAnalyser_Elements_MeanElements"));
+          L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_MeanElements"));
       RenderOrbitalElements(elements, primary);
       Style.HorizontalLine();
       UnityEngine.GUILayout.Label(
-          Localizer.Format("#Principia_OrbitAnalyser_GroundTrack"));
+          L10N.CacheFormat("#Principia_OrbitAnalyser_GroundTrack"));
       RenderOrbitRecurrence(recurrence, primary);
       Style.LineSpacing();
       RenderOrbitGroundTrack(ground_track, primary);
@@ -327,12 +327,12 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
     if (elements.Value.mean_eccentricity.max < 0.01) {
       circular = true;
       properties +=
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_OrbitDescription_Circular");
     } else if (elements.Value.mean_eccentricity.min > 0.5) {
       circular = true;
       properties +=
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_OrbitDescription_HighlyElliptical");
     }
     const double degree = Math.PI / 180;
@@ -340,15 +340,15 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
         elements.Value.mean_inclination.min > 175 * degree) {
       equatorial = true;
       properties +=
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_OrbitDescription_Equatorial");
     } else if (elements.Value.mean_inclination.min > 80 * degree &&
                elements.Value.mean_inclination.max < 100 * degree) {
       properties +=
-          Localizer.Format("#Principia_OrbitAnalyser_OrbitDescription_Polar");
+          L10N.CacheFormat("#Principia_OrbitAnalyser_OrbitDescription_Polar");
     } else if (elements.Value.mean_inclination.min > 90 * degree) {
       properties +=
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_OrbitDescription_Retrograde");
     }
     if (recurrence.HasValue && ground_track.HasValue) {
@@ -375,7 +375,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                 if (stationary_string != null) {
                   return stationary_string;
                 }
-                properties = Localizer.Format(
+                properties = L10N.CacheFormat(
                     "#Principia_OrbitAnalyser_OrbitDescription_Stationary");
               } else {
                 var synchronous_string = L10N.CelestialStringOrNull(
@@ -385,12 +385,12 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                 if (synchronous_string != null) {
                   return synchronous_string;
                 }
-                properties += Localizer.Format(
+                properties += L10N.CacheFormat(
                     "#Principia_OrbitAnalyser_OrbitDescription_Synchronous");
               }
               break;
             case 2:
-              properties += Localizer.Format(
+              properties += L10N.CacheFormat(
                   "#Principia_OrbitAnalyser_OrbitDescription_Semisynchronous");
               break;
             default:
@@ -408,7 +408,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                                     CelestialBody primary) {
     double? lowest_distance = elements?.radial_distance.min;
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_LowestAltitude"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_LowestAltitude"),
         (lowest_distance - primary?.Radius)?.FormatAltitude());
     double? lowest_primary_distance = primary?.ocean == true
                                           ? primary.Radius
@@ -416,12 +416,12 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
     string altitude_warning =
         lowest_distance < lowest_primary_distance
             ?
-            Localizer.Format("#Principia_OrbitAnalyser_Warning_Collision")
+            L10N.CacheFormat("#Principia_OrbitAnalyser_Warning_Collision")
             : lowest_distance < primary?.pqsController?.radiusMax
-                ? Localizer.Format(
+                ? L10N.CacheFormat(
                     "#Principia_OrbitAnalyser_Warning_CollisionRisk")
                 : lowest_distance < primary?.Radius + primary?.atmosphereDepth
-                    ? Localizer.Format(
+                    ? L10N.CacheFormat(
                         "#Principia_OrbitAnalyser_Warning_Reentry")
                     : "";
     UnityEngine.GUILayout.Label(altitude_warning,
@@ -431,29 +431,29 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
   private void RenderOrbitalElements(OrbitalElements? elements,
                                      CelestialBody primary) {
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_SiderealPeriod"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_SiderealPeriod"),
         elements?.sidereal_period.FormatDuration());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_NodalPeriod"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_NodalPeriod"),
         elements?.nodal_period.FormatDuration());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_AnomalisticPeriod"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_AnomalisticPeriod"),
         elements?.anomalistic_period.FormatDuration());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_SemimajorAxis"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_SemimajorAxis"),
         elements?.mean_semimajor_axis.FormatLengthInterval());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_Eccentricity"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_Eccentricity"),
         elements?.mean_eccentricity.FormatInterval());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_Inclination"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_Inclination"),
         elements?.mean_inclination.FormatAngleInterval());
     LabeledField(
-        Localizer.Format(
+        L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Elements_LongitudeOfAscendingNode"),
         elements?.mean_longitude_of_ascending_nodes.FormatAngleInterval());
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Elements_NodalPrecession"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Elements_NodalPrecession"),
         elements?.nodal_precession.FormatAngularFrequency());
     string periapsis = L10N.CelestialString(
         "#Principia_OrbitAnalyser_Elements_Periapsis",
@@ -462,17 +462,17 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
         "#Principia_OrbitAnalyser_Elements_Apoapsis",
         new[]{primary});
     LabeledField(
-        Localizer.Format(
+        L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Elements_ArgumentOfPeriapsis",
             periapsis),
         elements?.mean_argument_of_periapsis.FormatAngleInterval());
     LabeledField(
-        Localizer.Format(
+        L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Elements_MeanPeriapsisAltitude",
             periapsis),
         elements?.mean_periapsis_distance.FormatLengthInterval(primary.Radius));
     LabeledField(
-        Localizer.Format(
+        L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Elements_MeanApoapsisAltitude",
             apoapsis),
         elements?.mean_apoapsis_distance.FormatLengthInterval(primary.Radius));
@@ -485,18 +485,18 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
       string Dᴛₒ = recurrence?.dto.ToString("+0;-0") ?? em_dash;
       string Cᴛₒ = recurrence?.cto.ToString() ?? em_dash;
       UnityEngine.GUILayout.Label(
-          Localizer.Format("#Principia_OrbitAnalyser_Recurrence_CapderouTriple",
+          L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_CapderouTriple",
                            $"[{νₒ}; {Dᴛₒ}; {Cᴛₒ}]"),
           GUILayoutWidth(8));
       UnityEngine.GUILayout.FlexibleSpace();
       autodetect_recurrence_ = UnityEngine.GUILayout.Toggle(
           autodetect_recurrence_,
-          Localizer.Format("#Principia_OrbitAnalyser_Recurrence_AutoDetect"),
+          L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_AutoDetect"),
           UnityEngine.GUILayout.ExpandWidth(false));
     }
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(
-          Localizer.Format("#Principia_OrbitAnalyser_Recurrence_Cycle"));
+          L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_Cycle"));
       string text = UnityEngine.GUILayout.TextField(
           recurrence.HasValue || !autodetect_recurrence_
               ? $"{revolutions_per_cycle_}"
@@ -509,7 +509,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
         revolutions_per_cycle_ = revolutions_per_cycle;
       }
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_Recurrence_Cycle_RevolutionsEquals"),
           UnityEngine.GUILayout.ExpandWidth(false));
       text = UnityEngine.GUILayout.TextField(
@@ -524,19 +524,19 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
         days_per_cycle_ = days_per_cycle;
       }
       UnityEngine.GUILayout.Label(
-          Localizer.Format("#Principia_OrbitAnalyser_Recurrence_Cycle_Days"),
+          L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_Cycle_Days"),
           UnityEngine.GUILayout.ExpandWidth(false));
     }
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Recurrence_Subcycle"),
-        Localizer.Format(
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_Subcycle"),
+        L10N.CacheFormat(
             "#Principia_OrbitAnalyser_Recurrence_SubcycleLengthInDays",
             recurrence?.subcycle.FormatN(0) ?? em_dash));
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Recurrence_EquatorialShift"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_EquatorialShift"),
         recurrence?.equatorial_shift.FormatEquatorialAngle(primary));
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_Recurrence_GridInterval"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_Recurrence_GridInterval"),
         recurrence?.grid_interval.FormatEquatorialAngle(primary));
   }
 
@@ -544,14 +544,14 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                                       CelestialBody primary) {
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_GroundTrack_LongitudesOfEquatorialCrossings_Prefix"),
           UnityEngine.GUILayout.ExpandWidth(false));
       string text = UnityEngine.GUILayout.TextField(
           $"{ground_track_revolution_}",
           GUILayoutWidth(2));
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_OrbitAnalyser_GroundTrack_LongitudesOfEquatorialCrossings_Suffix"));
       if (int.TryParse(text, out int revolution)) {
         ground_track_revolution_ = revolution;
@@ -559,11 +559,11 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
     }
     var equatorial_crossings = ground_track?.equatorial_crossings;
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_GroundTrack_AscendingPass"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_GroundTrack_AscendingPass"),
         equatorial_crossings?.longitudes_reduced_to_ascending_pass.
             FormatEquatorialAngleInterval(primary));
     LabeledField(
-        Localizer.Format("#Principia_OrbitAnalyser_GroundTrack_DescendingPass"),
+        L10N.CacheFormat("#Principia_OrbitAnalyser_GroundTrack_DescendingPass"),
         equatorial_crossings?.longitudes_reduced_to_descending_pass.
             FormatEquatorialAngleInterval(primary));
   }
@@ -585,7 +585,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
   private readonly DifferentialSlider mission_duration_ =
       new DifferentialSlider(
           label            :
-              Localizer.Format("#Principia_OrbitAnalyser_MissionDuration"),
+              L10N.CacheFormat("#Principia_OrbitAnalyser_MissionDuration"),
           unit             : null,
           log10_lower_rate : 0,
           log10_upper_rate : 7,
@@ -637,15 +637,15 @@ internal class CurrentOrbitAnalyser : OrbitAnalyser {
 
   protected override string ButtonText(string orbit_description) {
     return orbit_description == null
-               ? Localizer.Format(
+               ? L10N.CacheFormat(
                    "#Principia_CurrentOrbitAnalyser_ToggleButton")
-               : Localizer.Format(
+               : L10N.CacheFormat(
                    "#Principia_CurrentOrbitAnalyser_ToggleButtonWithDescription",
                    orbit_description);
   }
 
   protected override string AnalysingText() {
-    return Localizer.Format("#Principia_CurrentOrbitAnalyser_Analysing",
+    return L10N.CacheFormat("#Principia_CurrentOrbitAnalyser_Analysing",
                             predicted_vessel.vesselName);
   }
 
@@ -676,15 +676,15 @@ internal class PlannedOrbitAnalyser : OrbitAnalyser {
 
   protected override string ButtonText(string orbit_description) {
     return orbit_description == null
-               ? Localizer.Format(
+               ? L10N.CacheFormat(
                    "#Principia_PlannedOrbitAnalyser_ToggleButton")
-               : Localizer.Format(
+               : L10N.CacheFormat(
                    "#Principia_PlannedOrbitAnalyser_ToggleButtonWithDescription",
                    orbit_description);
   }
 
   protected override string AnalysingText() {
-    return Localizer.Format("#Principia_PlannedOrbitAnalyser_Analysing",
+    return L10N.CacheFormat("#Principia_PlannedOrbitAnalyser_Analysing",
                             predicted_vessel.vesselName);
   }
 

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -175,13 +175,13 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
   }
 
   private static string TargetFrameSelectorText(Vessel target) {
-    return TargetFrameAbbreviation(target) ?? Localizer.Format(
+    return TargetFrameAbbreviation(target) ?? L10N.CacheFormat(
         "#Principia_ReferenceFrameSelector_SelectorText_Target");
   }
 
   private static string TargetFrameSelectorTooltip(Vessel target) {
     string name = TargetFrameName(target);
-    return Localizer.Format(
+    return L10N.CacheFormat(
         "#Principia_ReferenceFrameSelector_Tooltip_Target",
         name);
   }
@@ -259,15 +259,15 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     }
     switch (type) {
       case FrameType.BODY_CENTRED_NON_ROTATING:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_SelectorText_BodyCentredNonRotating");
       case FrameType.BARYCENTRIC_ROTATING:
         return "DEPRECATED";
       case FrameType.BODY_CENTRED_PARENT_DIRECTION:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_SelectorText_BodyCentredParentDirection");
       case FrameType.BODY_SURFACE:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_SelectorText_BodySurface");
       default:
         throw Log.Fatal("Unexpected type " + type.ToString());
@@ -279,19 +279,19 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     string name = Name(type, selected);
     switch (type) {
       case FrameType.BODY_CENTRED_NON_ROTATING:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_Tooltip_BodyCentredNonRotating",
             name,
             selected.Name());
       case FrameType.BARYCENTRIC_ROTATING:
         return "DEPRECATED";
       case FrameType.BODY_CENTRED_PARENT_DIRECTION:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection",
             name,
             selected.Name());
       case FrameType.BODY_SURFACE:
-        return Localizer.Format(
+        return L10N.CacheFormat(
             "#Principia_ReferenceFrameSelector_Tooltip_BodySurface",
             name,
             selected.Name());
@@ -302,7 +302,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
   }
 
   private static string TargetFrameDescription(Vessel target) {
-    return Localizer.Format(
+    return L10N.CacheFormat(
         "#Principia_ReferenceFrameSelector_Description_Target",
         target.vesselName,
         target.orbit.referenceBody.Name());
@@ -354,19 +354,19 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     if (!target_frame_selected &&
         (frame_type == FrameType.BODY_CENTRED_NON_ROTATING ||
          frame_type == FrameType.BODY_SURFACE)) {
-      return Localizer.Format(
+      return L10N.CacheFormat(
           "#Principia_ReferenceFrameSelector_ReferencePlane_Centred",
           selected_celestial.Name());
     }
     string secondary =
         target_frame_selected
-            ? Localizer.Format(
+            ? L10N.CacheFormat(
                 "#Principia_ReferenceFrameSelector_ReferencePlane_Secondary_Target")
             : selected_celestial.Name();
     string primary = target_frame_selected
                          ? selected_celestial.Name()
                          : selected_celestial.referenceBody.Name();
-    return Localizer.Format("#Principia_ReferenceFrameSelector_ReferencePlane",
+    return L10N.CacheFormat("#Principia_ReferenceFrameSelector_ReferencePlane",
                             secondary,
                             primary);
   }
@@ -443,7 +443,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
 
   public void RenderButton() {
     if (UnityEngine.GUILayout.Button(
-        Localizer.Format("#Principia_ReferenceFrameSelector_ToggleButton",
+        L10N.CacheFormat("#Principia_ReferenceFrameSelector_ToggleButton",
                          name_,
                          Name()))) {
       Toggle();
@@ -456,14 +456,14 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
   public bool target_frame_selected { get; private set; }
 
   protected override string Title =>
-      Localizer.Format("#Principia_ReferenceFrameSelector_Title",
+      L10N.CacheFormat("#Principia_ReferenceFrameSelector_Title",
                        name_,
                        Name());
 
   protected override void RenderWindow(int window_id) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
       UnityEngine.GUILayout.Label(
-          Localizer.Format(
+          L10N.CacheFormat(
               "#Principia_ReferenceFrameSelector_Description_Heading",
               Name(),
               Abbreviation()));
@@ -522,7 +522,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
       UnityEngine.GUILayout.FlexibleSpace();
       if (celestial.is_root()) {
         UnityEngine.GUILayout.Label(
-            Localizer.Format("#Principia_ReferenceFrameSelector_Pin"));
+            L10N.CacheFormat("#Principia_ReferenceFrameSelector_Pin"));
       } else if (UnityEngine.GUILayout.Toggle(pinned_[celestial], "") !=
                  pinned_[celestial]) {
         pinned_[celestial] = !pinned_[celestial];
@@ -537,7 +537,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
           UnityEngine.GUILayout.Button(
               "", UnityEngine.GUI.skin.label, GUILayoutWidth(offset));
           UnityEngine.GUILayout.Label(
-              Localizer.Format("#Principia_ReferenceFrameSelector_Target",
+              L10N.CacheFormat("#Principia_ReferenceFrameSelector_Target",
                                target.vesselName));
           UnityEngine.GUILayout.FlexibleSpace();
           if (UnityEngine.GUILayout.Toggle(target_pinned_, "") !=

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -128,7 +128,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
           id         : this.GetHashCode(),
           screenRect : rectangle_,
           func       : RenderWindowAndRecordTooltip,
-          text       : $"{Title} ({render_time_μs_:F0} μs)",
+          text       : Title,
           options    : options_);
 
       // The first time a window is shown, we have a moral duty to place it at
@@ -148,7 +148,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
                 width  : 0,
                 height : 0),
             func       : RenderWindowAndRecordTooltip,
-            text       : $"{Title} ({render_time_μs_:F0} μs)",
+            text       : Title,
             options    : options_);
         must_centre_ = false;
       }
@@ -173,7 +173,6 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   }
 
   private void RenderWindowAndRecordTooltip(int window_id) {
-    DateTime render_start = DateTime.Now;
     RenderWindow(window_id);
     if (UnityEngine.Event.current.type == UnityEngine.EventType.Repaint &&
         tooltip_ != UnityEngine.GUI.tooltip) {
@@ -189,9 +188,6 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
           (UnityEngine.Input.mousePosition.y - Width(1) / 2),
           Width(8), height);
     }
-    render_time_μs_ =
-        render_time_μs_ * (499.0 / 500) +
-        (DateTime.Now - render_start).TotalMilliseconds * 1000 / 500;
   }
 
   private void ShowTooltip() {
@@ -275,7 +271,6 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   private DateTime tooltip_begin_;
   private string tooltip_ = "";
   private UnityEngine.Rect tooltip_rectangle_;
-  private double render_time_μs_;
 }
 
 // The supervisor of a window decides when to clear input locks, when to render

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -128,7 +128,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
           id         : this.GetHashCode(),
           screenRect : rectangle_,
           func       : RenderWindowAndRecordTooltip,
-          text       : Title,
+          text       : $"{Title} ({render_time_μs_:F0} μs)",
           options    : options_);
 
       // The first time a window is shown, we have a moral duty to place it at
@@ -148,7 +148,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
                 width  : 0,
                 height : 0),
             func       : RenderWindowAndRecordTooltip,
-            text       : Title,
+            text       : $"{Title} ({render_time_μs_:F0} μs)",
             options    : options_);
         must_centre_ = false;
       }
@@ -173,6 +173,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   }
 
   private void RenderWindowAndRecordTooltip(int window_id) {
+    DateTime render_start = DateTime.Now;
     RenderWindow(window_id);
     if (UnityEngine.Event.current.type == UnityEngine.EventType.Repaint &&
         tooltip_ != UnityEngine.GUI.tooltip) {
@@ -188,6 +189,9 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
           (UnityEngine.Input.mousePosition.y - Width(1) / 2),
           Width(8), height);
     }
+    render_time_μs_ =
+        render_time_μs_ * (499.0 / 500) +
+        (DateTime.Now - render_start).TotalMilliseconds * 1000 / 500;
   }
 
   private void ShowTooltip() {
@@ -271,6 +275,7 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   private DateTime tooltip_begin_;
   private string tooltip_ = "";
   private UnityEngine.Rect tooltip_rectangle_;
+  private double render_time_μs_;
 }
 
 // The supervisor of a window decides when to clear input locks, when to render

--- a/ksp_plugin_adapter_stub/ksp_plugin_adapter_stub.cs
+++ b/ksp_plugin_adapter_stub/ksp_plugin_adapter_stub.cs
@@ -26,7 +26,7 @@ public partial class PrincipiaPluginAdapterStub : ScenarioModule,
 
   PrincipiaPluginAdapterStub() {
     dll_stub_executed_.message =
-        Localizer.Format("#Principia_DLLStubExecuted");
+        L10N.CacheFormat("#Principia_DLLStubExecuted");
     dll_stub_executed_.Show();
   }
 


### PR DESCRIPTION
Fix #3149. Note that we do not have System.Runtime.Caching, so we need to write our own cache.
The time spent in `RenderWindowAndRecordTooltip` for the reference frame selector changes as follows:
| Lines shown | Before | After |
|---|---|---|
| Sun, Kerbin, Mun, Minmus | 5.7 ms | 500 μs |
| Sun | 1.7 ms | 200 μs |
| All celestials | 22.5 ms | 2 ms |