### PR TITLE
Mirror the overloads of Localizer.Format in LRUCache.Get and L10n.CacheFormat

### DIFF
--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -134,6 +134,15 @@ internal static class L10N {
                                 FormatOrNull(template, names));
   }
 
+  public static string CacheFormat(string name) {
+    return lru_cache_.Get(name, () => Localizer.Format(name));
+  }
+
+  public static string CacheFormat(string name, params string[] args) {
+    return lru_cache_.Get(name, args,
+                          () => Localizer.Format(name, args));
+  }
+
   public static string CacheFormat(string name, params object[] args) {
     return lru_cache_.Get(name, args,
                           () => Localizer.Format(name, args));

--- a/ksp_plugin_adapter/lru_cache.cs
+++ b/ksp_plugin_adapter/lru_cache.cs
@@ -8,7 +8,15 @@ namespace principia {
 namespace ksp_plugin_adapter {
 
 class LRUCache {
+  public string Get(string name, Func<string> compute_value) {
+    return Get(name, new string[]{}, compute_value);
+  }
+
   public string Get(string name, object[] args, Func<string> compute_value) {
+    return Get(name, (from arg in args select arg.ToString()).ToArray(), compute_value);
+  }
+
+  public string Get(string name, string[] args, Func<string> compute_value) {
     string key = MakeKey(name, args);
     Entry entry;
     if (cache_.TryGetValue(key, out entry)) {
@@ -30,10 +38,9 @@ class LRUCache {
     return entry.value;
   }
 
-  public string MakeKey(string name, object[] args) {
+  public string MakeKey(string name, string[] args) {
     string unit_separator = "\x1F";
-    return name + unit_separator +
-        string.Join(unit_separator, from arg in args select arg.ToString());
+    return name + unit_separator + string.Join(unit_separator, args);
   }
 
   private class Entry {

--- a/ksp_plugin_adapter/lru_cache.cs
+++ b/ksp_plugin_adapter/lru_cache.cs
@@ -12,10 +12,6 @@ class LRUCache {
     return Get(name, new string[]{}, compute_value);
   }
 
-  public string Get(string name, object[] args, Func<string> compute_value) {
-    return Get(name, (from arg in args select arg.ToString()).ToArray(), compute_value);
-  }
-
   public string Get(string name, string[] args, Func<string> compute_value) {
     string key = MakeKey(name, args);
     Entry entry;
@@ -36,6 +32,10 @@ class LRUCache {
     }
     cache_by_time_.Add(entry);
     return entry.value;
+  }
+
+  public string Get(string name, object[] args, Func<string> compute_value) {
+    return Get(name, (from arg in args select arg.ToString()).ToArray(), compute_value);
   }
 
   public string MakeKey(string name, string[] args) {


### PR DESCRIPTION
Fix #3226.

This allows for null strings (but not null objects, which `Localization.Format` does not support).