### PR TITLE
Track the backstory when checkpointing

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -656,11 +656,12 @@ Checkpointer<serialization::Vessel>::Writer Vessel::MakeCheckpointerWriter() {
     lock_.AssertReaderHeld();
     // The extremities of the |backstory_| are implicitly exact.  Note that
     // |backstory_->end()| might cause serialization of a 1-point psychohistory
-    // or prediction (at the last time of the backstory).
+    // or prediction (at the last time of the backstory).  To figure things out
+    // when reading we must track the |backstory_|.
     trajectory_.WriteToMessage(message->mutable_non_collapsible_segment(),
                                backstory_->begin(),
                                backstory_->end(),
-                               /*tracked=*/{},
+                               /*tracked=*/{backstory_},
                                /*exact=*/{});
 
     // Here the containing pile-up is the one for the collapsible segment.


### PR DESCRIPTION
We'll need it when reanimating to know what segment to use.

#2400.