### PR TITLE
Some support for nested placeholders

### DIFF
--- a/documentation/Setup.md
+++ b/documentation/Setup.md
@@ -12,7 +12,7 @@ tool for our own use, so if you use a different edition, just do
 and test the mod.
 
 These instructions use the git Powershell provided by [GitHub for Windows](https://windows.github.com/).
-We assume a working installation of Kerbal Space Program version 1.8.1 is found in `<KSP directory>`.
+We assume a working installation of Kerbal Space Program version 1.12.2 is found in `<KSP directory>`.
 
 The repository is found at https://github.com/mockingbirdnest/Principia.git.
 Pick a directory `<root>` in which you will install Principia and its
@@ -23,7 +23,7 @@ This directory should not contain any of the following subfolders:
 - `Google`.
 
 This project depends upon:
-- the KSP assembly `Assembly-CSharp.dll`, found in `<KSP directory>\KSP_x64_Data\Managed`;
+- the KSP assemblies `Assembly-CSharp.dll` and `Assembly-CSharp-firstpass.dll`, found in `<KSP directory>\KSP_x64_Data\Managed`;
 - the Unity assemblies `UnityEngine.CoreModule.dll`, `UnityEngine.dll`, `UnityEngine.ImageConversionModule.dll`, `UnityEngine.IMGUIMode.dll`, `UnityEngine.InputLegacyModule.dll`, `UnityEngine.PhysicsModule.dll`, `UnityEngine.TextRenderingModule.dll` and `UnityEngine.UI.dll`, found in
   `<KSP directory>\KSP_x64_Data\Managed`;
 - our [fork](https://github.com/mockingbirdnest/glog) of the Google glog
@@ -47,7 +47,7 @@ In `<root>`, run `git clone https://github.com/mockingbirdnest/Principia.git`.
 
 ### KSP and Unity assemblies
 
-In order to build for KSP 1.8.1, copy the corresponding KSP 1.8.1 assemblies to `<root>\KSP Assemblies\1.8.1`
+In order to build for KSP 1.12.2, copy the corresponding KSP 1.12.2 assemblies to `<root>\KSP Assemblies\1.12.2`
 
 ### Building
 

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -195,7 +195,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\KSP Assemblies\1.12.2\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -68,6 +68,9 @@
       <HintPath>..\..\KSP Assemblies\1.12.2\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\KSP Assemblies\1.12.2\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
       <HintPath>..\..\KSP Assemblies\1.12.2\UnityEngine.dll</HintPath>
@@ -194,11 +197,6 @@
     <None Include="localization\zh-cn.cfg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\KSP Assemblies\1.12.2\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -161,8 +161,11 @@ internal static class L10N {
           for (int n = 1; n <= resolved_args.Count; ++n) {
             template.Replace($"<<X:{n}>>", resolved_args[n - 1]);
           }
+          // These escapes are handled by KSP *after* formatting, contrary to
+          // the \u ones and the ｢｣ for {}, which are handled when the Localizer
+          // loads the tags.
           return Lingoona.Grammar.useGrammar(template, resolved_args)
-              .Replace("\\n", "\n").Replace("\\\"", "\"").Replace("\\t", "\t");
+              .Replace(@"\n", "\n").Replace(@"\""", "\"").Replace(@"\t", "\t");
         });
   }
 

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -142,9 +142,10 @@ internal static class L10N {
     // Nested <<>> rules don’t work prior to Lingoona 1.7.0 (2021-07-07).
     // We need them for some of the more advanced grammatical constructs.
     // We manually replace <<X:n>> placeholders and leave the result to
-    // Lingoona, which allows placeholders inside <<>> rules, and is enough for
-    // our purposes.  <<X:n>> placeholders are substituted untransformed, so the
-    // behaviour is consistent with what Lingoona 1.7.0 or later would do.
+    // Lingoona. This allows for some substitution inside <<>> rules, and is
+    // enough for our purposes.  <<X:n>> placeholders are substituted
+    // untransformed, so the behaviour is consistent with what Lingoona 1.7.0 or
+    // later would do.
     return lru_cache_.Get(
         name, args,
         () => {

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -139,13 +139,35 @@ internal static class L10N {
   }
 
   public static string CacheFormat(string name, params string[] args) {
-    return lru_cache_.Get(name, args,
-                          () => Localizer.Format(name, args));
+    // Nested <<>> rules don’t work prior to Lingoona 1.7.0 (2021-07-07).
+    // We need them for some of the more advanced grammatical constructs.
+    // We manually replace <<X:n>> placeholders and leave the result to
+    // Lingoona, which allows placeholders inside <<>> rules, and is enough for
+    // our purposes.  <<X:n>> placeholders are substituted untransformed, so the
+    // behaviour is consistent with what Lingoona 1.7.0 or later would do.
+    return lru_cache_.Get(
+        name, args,
+        () => {
+          string template = Localizer.GetStringByTag(name);
+          // KSP substitutes arguments that are themselves localization keys,
+          // e.g., the names of the default vessels.
+          var resolved_args = new List<string>();
+          foreach (var arg in args) {
+            // KSP treats nulls as empty strings here (but not in the overload
+            // that takes objects).
+            resolved_args.Add(
+                arg == null ? "" : (Localizer.Tags.GetValueOrNull(arg) ?? arg));
+          }
+          for (int n = 1; n <= resolved_args.Count; ++n) {
+            template.Replace($"<<X:{n}>>", resolved_args[n - 1]);
+          }
+          return Lingoona.Grammar.useGrammar(template, resolved_args)
+              .Replace("\\n", "\n").Replace("\\\"", "\"").Replace("\\t", "\t");
+        });
   }
 
   public static string CacheFormat(string name, params object[] args) {
-    return lru_cache_.Get(name, args,
-                          () => Localizer.Format(name, args));
+    return CacheFormat(name, (from arg in args select arg.ToString()).ToArray());
   }
 
   private static LRUCache lru_cache_ = new LRUCache();


### PR DESCRIPTION
Lingoona 1.7.0 can do some fairly fancy things:
https://lingoona.com/cgi-bin/grammar#l=ru&t=%3C%3CC%3A%3C%3C1%3E%3E+%D0%BF%D0%B5%D1%80%D0%B8%D1%86%D0%B5%D0%BD%D1%82%D1%80%5Em%3E%3E.+%3C%3CC%3A%3C%3C1%3E%3E+%D0%BF%D1%80%D0%B8%D0%B1%D0%BB%D0%B8%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5%5En%3E%3E.&v1=%D0%BF%D0%BB%D0%B0%D0%BD%D0%B8%D1%80%D1%83%D0%B5%D0%BC%D1%8B%D0%B9&oh=1
We are stuck with a version that cannot, but we can hack in some limited support.