### PR TITLE
Bypass stock aerodynamics outside the atmosphere

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1627,6 +1627,9 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       foreach (Vessel vessel in FlightGlobals.Vessels.Where(
           v => is_manageable(v) && !v.packed)) {
         foreach (Part part in vessel.parts) {
+          if (part.atmDensity <= 0) {
+            continue;
+          }
           Part physical_parent = closest_physical_parent(part);
           if (part.bodyLiftLocalVector != UnityEngine.Vector3.zero ||
               part.dragVector != UnityEngine.Vector3.zero) {


### PR DESCRIPTION
They produce tiny forces (micronewtons or less) there.
We never noticed that because most of the pile-up testing was done with FAR, and little forces are of little consequence prior to the advent of checkpointing for #2400.