### PR TITLE
Orient the camera in CelestialSphere, not World

### DIFF
--- a/ksp_plugin/renderer.cpp
+++ b/ksp_plugin/renderer.cpp
@@ -278,17 +278,17 @@ RigidTransformation<World, Navigation> Renderer::WorldToPlotting(
          WorldToBarycentric(time, sun_world_position, planetarium_rotation);
 }
 
-Rotation<CameraReference, World> Renderer::CameraReferenceRotation(
+Rotation<CameraReference, CelestialSphere> Renderer::CameraReferenceRotation(
     Instant const& time,
     Rotation<Barycentric, AliceSun> const& planetarium_rotation) const {
-  Permutation<CameraReference, Navigation> const celestial_mirror(
+  Permutation<Barycentric, CelestialSphere> const celestial_mirror(
+      OddPermutation::XZY);
+  Permutation<CameraReference, Navigation> const camera_mirror(
       OddPermutation::XZY);
   auto const result =
-      OrthogonalMap<WorldSun, World>::Identity() *
-      sun_looking_glass.Inverse().Forget<OrthogonalMap>() *
-      planetarium_rotation.Forget<OrthogonalMap>() *
+      celestial_mirror.Forget<OrthogonalMap>() *
       GetPlottingFrame()->FromThisFrameAtTime(time).orthogonal_map() *
-      celestial_mirror.Forget<OrthogonalMap>();
+      camera_mirror.Forget<OrthogonalMap>();
   return result.AsRotation();
 }
 

--- a/ksp_plugin/renderer.hpp
+++ b/ksp_plugin/renderer.hpp
@@ -159,7 +159,7 @@ class Renderer {
       Position<World> const& sun_world_position,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
 
-  virtual Rotation<CameraReference, World> CameraReferenceRotation(
+  virtual Rotation<CameraReference, CelestialSphere> CameraReferenceRotation(
       Instant const& time,
       Rotation<Barycentric, AliceSun> const& planetarium_rotation) const;
 


### PR DESCRIPTION
Fix #3235.

The reference rotation is used here:
https://github.com/mockingbirdnest/Principia/blob/0aa17d4d67902cfeffc54aeb8d1fc7324e0599f0/ksp_plugin_adapter/planetarium_camera_adjuster.cs#L64-L76

The rotation of the pivot *is* with respect to `World`. However, the game compensates for the planetarium rotation, and we only adjust the orientation maintained by the game, we do not maintain an authoritative camera orientation, so that we should not compensate for the planetarium rotation ourselves.