### PR TITLE
Ungarble unsupported languages somewhat

### DIFF
--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -1,5 +1,6 @@
 Localization {
   en-us {
+    #Principia_UILanguage = en-us
     // Placeholder-only strings for extracting specific forms.
     #Principia_GrammaticalForm_Standalone = <<C:1>>
 

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -1,5 +1,6 @@
 Localization {
   fr-fr {
+    #Principia_UILanguage = fr-fr
     // Placeholder-only strings for extracting specific forms.
     #Principia_GrammaticalForm_Standalone = <<C:1>>
 

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -1,5 +1,6 @@
 Localization {
   zh-cn {
+    #Principia_UILanguage = zh-cn
     #Principia_GrammaticalForm_Standalone = <<C:1>>
 
     // MainWindow

--- a/ksp_plugin_adapter/localization_extensions.cs
+++ b/ksp_plugin_adapter/localization_extensions.cs
@@ -170,8 +170,11 @@ internal static class L10N {
     // These escapes are handled by KSP *after* formatting, contrary to
     // the \u ones and the ｢｣ for {}, which are handled when the Localizer
     // loads the tags.
-    return Lingoona.Grammar.useGrammar(template, resolved_args)
+    Lingoona.Grammar.setLanguage(UILanguage());
+    var result = Lingoona.Grammar.useGrammar(template, resolved_args)
         .Replace(@"\n", "\n").Replace(@"\""", "\"").Replace(@"\t", "\t");
+    Lingoona.Grammar.setLanguage(Localizer.CurrentLanguage);
+    return result;
   }
 
   public static string CacheFormat(string name, params object[] args) {


### PR DESCRIPTION
The result is not great (in particular in stock we end up with translated celestial names inside untranslated message templates, with any hope of sensible grammar long lost), but at least it is not saying `_Selector_` on every button in the reference frame selector.
Fix #3245.
![image](https://user-images.githubusercontent.com/2284290/147390187-5bde06c4-3a25-4d6b-b505-f6a5c7fcbb87.png)
