### PR TITLE
Do not ship Assembly-CSharp-firstpass

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.csproj
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.csproj
@@ -70,6 +70,7 @@
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\..\KSP Assemblies\1.12.2\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">


### PR DESCRIPTION
This reference, added in #3238, was set up to be copied to the output directory. We don’t want that.