### PR TITLE
Merge was not processing the segments of the target after the end of the source

### DIFF
--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -431,8 +431,15 @@ void DiscreteTrajectory<Frame>::Merge(DiscreteTrajectory<Frame> trajectory) {
                           /*to=*/*this,
                           /*to_segments_begin=*/end_before_splice);
       break;
+    } else if (sit_t != segments_->end()) {
+      // No more segments in the source.  Make sure that we restore the time-to-
+      // segment map for the segments that follows the last one in the source.
+      if (!sit_t->empty()) {
+        segment_by_left_endpoint_.insert_or_assign(sit_t->front().time, sit_t);
+      }
+      ++sit_t;
     } else {
-      // No more segments in the source, or both lists done.
+      // Both lists done.
       break;
     }
   }

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -639,6 +639,20 @@ TEST_F(DiscreteTrajectoryTest, Merge) {
 
     trajectory2.Merge(std::move(trajectory1));
   }
+  {
+    // This used to fail a consistency check because the segments of the target
+    // that follow the end of the source were not processed, and the time-to-
+    // segment map was left inconsistent.
+    auto trajectory1 = MakeTrajectory();
+    auto trajectory2 = MakeTrajectory();
+
+    trajectory1.ForgetBefore(t0_ + 4 * Second);
+    auto sit = std::next(trajectory1.segments().begin());
+    trajectory1.DeleteSegments(sit);
+    trajectory2.ForgetBefore(t0_ + 4 * Second);
+
+    trajectory2.Merge(std::move(trajectory1));
+  }
 }
 
 TEST_F(DiscreteTrajectoryTest, TMinTMaxEvaluate) {


### PR DESCRIPTION
This led to an inconsistent time-to-segment map (reference to a 1-point segment that was not the most recent).

#3136.