### PR TITLE
Don’t plot all celestials all the time

### DIFF
--- a/geometry/perspective.hpp
+++ b/geometry/perspective.hpp
@@ -20,6 +20,7 @@ namespace internal_perspective {
 
 using base::BoundedArray;
 using quantities::Length;
+using quantities::Square;
 
 template<typename Frame>
 using Segment = std::pair<Position<Frame>, Position<Frame>>;
@@ -57,6 +58,8 @@ class Perspective final {
   // as seen from the camera.
   double Tan²AngularDistance(Position<FromFrame> const& p1,
                              Position<FromFrame> const& p2) const;
+
+  Square<Length> SquaredDistanceFromCamera(Position<FromFrame> const& p) const;
 
   // Returns true iff the |point| is hidden by the |sphere| in this perspective.
   bool IsHiddenBySphere(Position<FromFrame> const& point,

--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -99,6 +99,12 @@ double Perspective<FromFrame, ToFrame>::Tan²AngularDistance(
 }
 
 template<typename FromFrame, typename ToFrame>
+Square<Length> Perspective<FromFrame, ToFrame>::SquaredDistanceFromCamera(
+    Position<FromFrame> const& p) const {
+  return (p - camera_).Norm²();
+}
+
+template<typename FromFrame, typename ToFrame>
 bool Perspective<FromFrame, ToFrame>::IsHiddenBySphere(
     Position<FromFrame> const& point,
     Sphere<FromFrame> const& sphere) const {

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -2,6 +2,7 @@
 #include "ksp_plugin/interface.hpp"
 
 #include <algorithm>
+#include <limits>
 
 #include "geometry/affine_map.hpp"
 #include "geometry/grassmann.hpp"

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -207,6 +207,7 @@ Iterator* __cdecl principia__PlanetariumPlotCelestialTrajectoryForPsychohistory(
 
   // Do not plot the past when there is a target vessel as it is misleading.
   if (plugin->renderer().HasTargetVessel()) {
+    *minimal_distance_from_camera = std::numeric_limits<double>::infinity();
     return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
   } else {
     auto const& celestial_trajectory =
@@ -253,6 +254,7 @@ principia__PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
 
   // Do not plot the past when there is a target vessel as it is misleading.
   if (plugin->renderer().HasTargetVessel()) {
+    *minimal_distance_from_camera = std::numeric_limits<double>::infinity();
     return m.Return(new TypedIterator<RP2Lines<Length, Camera>>({}));
   } else {
     auto const& vessel = *plugin->GetVessel(vessel_guid);

--- a/ksp_plugin/planetarium.cpp
+++ b/ksp_plugin/planetarium.cpp
@@ -158,7 +158,7 @@ RP2Lines<Length, Camera> Planetarium::PlotMethod2(
     Instant const& last_time,
     Instant const& now,
     bool const reverse,
-    Length* minimal_distance) const {
+    Length* const minimal_distance) const {
   RP2Lines<Length, Camera> lines;
   auto const plottable_spheres = ComputePlottableSpheres(now);
   double const tan²_angular_resolution =

--- a/ksp_plugin/planetarium.hpp
+++ b/ksp_plugin/planetarium.hpp
@@ -101,7 +101,8 @@ class Planetarium {
       Instant const& first_time,
       Instant const& last_time,
       Instant const& now,
-      bool reverse) const;
+      bool reverse,
+      Length* minimal_distance = nullptr) const;
 
  private:
   // Computes the coordinates of the spheres that represent the |ephemeris_|

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2255,18 +2255,13 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       min_distance_from_camera =
           (root.position - camera_world_position).magnitude;
     } else {
-      // TODO(egg): Figure that out while plotting instead of taking the current
-      // distance.
-      var camera_world_position = ScaledSpace.ScaledToLocalSpace(
-          PlanetariumCamera.fetch.transform.position);
-      min_distance_from_camera =
-          (root.position - camera_world_position).magnitude;
       using (DisposableIterator rp2_lines_iterator =
              planetarium.PlanetariumPlotCelestialTrajectoryForPsychohistory(
                  plugin_,
                  root.flightGlobalsIndex,
                  main_vessel_guid,
-                 main_window_.history_length)) {
+                 main_window_.history_length,
+                 out min_distance_from_camera)) {
         GLLines.PlotRP2Lines(rp2_lines_iterator, colour, GLLines.Style.Faded);
       }
       if (main_vessel_guid != null) {
@@ -2275,12 +2270,17 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                 PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan(
                     plugin_,
                     root.flightGlobalsIndex,
-                    main_vessel_guid)) {
+                    main_vessel_guid,
+                    out double min_distance_for_flight_plan)) {
+          min_distance_from_camera =
+              Math.Min(min_distance_from_camera, min_distance_for_flight_plan);
           GLLines.PlotRP2Lines(rp2_lines_iterator, colour, GLLines.Style.Solid);
         }
       }
     }
-    // TODO(egg): Get that from the planetarium.
+    // TODO(egg): Consider getting that from the planetarium (though it may make
+    // more sense to compute it in C# based on the screen resolution, and to use
+    // that in the planetarium).
     const double degree = Math.PI / 180;
     const double arcminute = degree / 60;
     double tan_angular_resolution = Math.Tan(0.4 * arcminute);

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2239,12 +2239,16 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
 
   private void PlotCelestialTrajectories(DisposablePlanetarium planetarium,
                                          string main_vessel_guid) {
-    // TODO(egg): use that angular resolution in the planetarium too.
     const double degree = Math.PI / 180;
     UnityEngine.Camera camera = PlanetariumCamera.Camera;
+    float vertical_fov = camera.fieldOfView;
+    float horizontal_fov =
+        UnityEngine.Camera.VerticalToHorizontalFieldOfView(
+            vertical_fov, camera.aspect);
     // The angle subtended by the pixel closest to the centre of the viewport.
-    double tan_angular_resolution =
-        Math.Tan(camera.fieldOfView * degree / 2) / (camera.pixelHeight / 2);
+    double tan_angular_resolution = Math.Min(
+            Math.Tan(vertical_fov * degree / 2) / (camera.pixelHeight / 2),
+            Math.Tan(horizontal_fov * degree / 2) / (camera.pixelWidth / 2));
     PlotSubtreeTrajectories(planetarium, main_vessel_guid,
                             Planetarium.fetch.Sun,
                             tan_angular_resolution);
@@ -2255,7 +2259,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                                        CelestialBody root,
                                        double tan_angular_resolution) {
     var colour = root.orbitDriver?.Renderer?.orbitColor ??
-                  XKCDColors.SunshineYellow;
+        XKCDColors.SunshineYellow;
     var camera_world_position = ScaledSpace.ScaledToLocalSpace(
         PlanetariumCamera.fetch.transform.position);
     double min_distance_from_camera =

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1819,12 +1819,16 @@ message PlanetariumPlotCelestialTrajectoryForPsychohistory {
     optional string vessel_guid = 4;
     required double max_history_length = 5;
   }
+  message Out {
+    required double minimal_distance_from_camera = 1;
+  }
   message Return {
     required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",
                                     (disposable) = "DisposableIterator",
                                     (is_produced) = true];
   }
   optional In in = 1;
+  optional Out out = 2;
   optional Return return = 3;
 }
 
@@ -1840,12 +1844,16 @@ message PlanetariumPlotCelestialTrajectoryForPredictionOrFlightPlan {
     required int32 celestial_index = 3;
     required string vessel_guid = 4;
   }
+  message Out {
+    required double minimal_distance_from_camera = 1;
+  }
   message Return {
     required fixed64 rp2_lines = 1 [(pointer_to) = "Iterator",
                                     (disposable) = "DisposableIterator",
                                     (is_produced) = true];
   }
   optional In in = 1;
+  optional Out out = 2;
   optional Return return = 3;
 }
 


### PR DESCRIPTION
Related to #3035.
This uses the hierarchical Keplerian structure of celestials to only plot those that could be visibly separated from their primary at some point along the plotted trajectory.

On a sample 50ish-year trajectory flying by Jupiter and Neptune, looking at the Neptune flyby in Neptune-Sun-Orbit, the framerate goes from 2 to 8 FPS; looking at the Jupiter flyby in Jupiter-Sun-Orbit, from 2 to 4 FPS.

The following table lists the bodies plotted in various situations in RSS, with multi-year trajectories:
| Reference frame & camera position | Bodies plotted |
|---|---|
| ECEF or ECI, near the Earth | Sun, Mercury, Venus,<br>(Earth), Moon,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, Ganymede, Callisto,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| HCI above the ecliptic,<br>FoV ≈ orbit of Earth | (Sun), Mercury, Venus,<br>Earth, Moon,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, Ganymede, Callisto,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| HCI above the ecliptic,<br>FoV ≈ orbit of Mars | (Sun), Mercury, Venus,<br>Earth, ~~Moon~~,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, Ganymede, Callisto,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| HCI above the ecliptic,<br>FoV ≈ orbit of Jupiter | (Sun), Mercury, Venus,<br>Earth, ~~Moon~~,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, ~~Ganymede~~, Callisto,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| HCI above the ecliptic,<br>FoV ≈ orbit of Saturn | (Sun), Mercury, Venus,<br>Earth, ~~Moon~~,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, ~~Ganymede~~, ~~Callisto~~,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| HCI above the ecliptic,<br>FoV ≈ orbit of Uranus | (Sun), Mercury, Venus,<br>Earth, ~~Moon~~,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, ~~Ganymede~~, ~~Callisto~~,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, ~~Iapetus~~,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>Neptune, ~~Triton~~,<br>Pluto, ~~Charon~~
| Neptune-Sun-Orbit, near Neptune | Sun, Mercury, Venus,<br>Earth, ~~Moon~~,<br>Mars, ~~Phobos~~, ~~Deimos~~,<br>Vesta, Ceres,<br>Jupiter, ~~Io~~, ~~Europa~~, ~~Ganymede~~, ~~Callisto~~,<br>Saturn, ~~Mimas~~, ~~Enceladus~~, ~~Tethys~~, ~~Dione~~, ~~Rhea~~, ~~Titan~~, Iapetus,<br>Uranus, ~~Miranda~~, ~~Ariel~~, ~~Umbriel~~, ~~Titania~~, ~~Oberon~~,<br>(Neptune), Triton,<br>Pluto, ~~Charon~~