### PR TITLE
Do not do multiple checkpoints at the same time

### DIFF
--- a/journal/player.cpp
+++ b/journal/player.cpp
@@ -13,7 +13,7 @@
 #include "journal/profiles.hpp"
 #include "glog/logging.h"
 
-#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 0
 
 namespace principia {
 

--- a/journal/player.cpp
+++ b/journal/player.cpp
@@ -13,7 +13,7 @@
 #include "journal/profiles.hpp"
 #include "glog/logging.h"
 
-#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 0
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
 
 namespace principia {
 

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -92,7 +92,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(\\CHILDERIC\Users\Public\Public Mockingbird\Principia\Journals\JOURNAL.20220102-152418)";  // NOLINT
+      R"(\\CHILDERIC\Users\Public\Public Mockingbird\Principia\Journals\JOURNAL.20220110-023344)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -109,13 +109,13 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   LOG(ERROR) << "Last successful method out/return: \n"
              << player.last_method_out_return().DebugString();
 
-#if 0
+#if 1
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(
         serialization::FreeVesselsAndPartsAndCollectPileUps::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(2718550096736);
+    in->set_plugin(2261214037168);
     in->set_delta_t(0.02);
   }
   serialization::Method method_out_return;

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -109,7 +109,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   LOG(ERROR) << "Last successful method out/return: \n"
              << player.last_method_out_return().DebugString();
 
-#if 1
+#if 0
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -551,11 +551,18 @@ void Vessel::WriteToMessage(not_null<serialization::Vessel*> const message,
     message->add_kept_parts(part_id);
   }
 
-  // We serialize at most the last |max_points_to_serialize| of the part of the
-  // trajectory that ends at the |backstory_|.
-  std::int64_t const backstory_size = backstory_->end() - trajectory_.begin();
+  // If the vessel is collapsible, we serialize at most the last
+  // |max_points_to_serialize| of the part of the trajectory that ends at the
+  // |backstory_|.  If it is not, however, we must serialize at least the entire
+  // |backstory_| otherwise we'd lose the beginning of a non-collapsible
+  // segment.
+  std::int64_t const history_size = backstory_->end() - trajectory_.begin();
+  std::int64_t const max_points_to_serialize_present_in_history =
+      std::min(max_points_to_serialize, history_size);
   std::int64_t const serialized_points =
-      std::min(max_points_to_serialize, backstory_size);
+      is_collapsible_ ? max_points_to_serialize_present_in_history
+                      : std::max(max_points_to_serialize_present_in_history,
+                                 backstory_->size());
 
   // Starting with Gateaux we don't save the prediction, see #2685.  Instead we
   // just save its first point and re-read as if it was the whole prediction.

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -191,9 +191,13 @@ void Vessel::DetectCollapsibilityChange() {
       // the last point of the backstory specifies the initial conditions of the
       // next (collapsible) segment.
       Instant const checkpoint = backstory_->back().time;
-      LOG(INFO) << "Writing " << ShortDebugString()
-                << " to checkpoint at: " << checkpoint;
-      checkpointer_->WriteToCheckpoint(checkpoint);
+      // This test is needed because in some cornercases we might try to create
+      // multiple checkpoints at the same time.  See #3280.
+      if (checkpointer_->newest_checkpoint() < checkpoint) {
+        LOG(INFO) << "Writing " << ShortDebugString()
+                  << " to checkpoint at: " << checkpoint;
+        checkpointer_->WriteToCheckpoint(checkpoint);
+      }
 
       // If there are no checkpoints in the current trajectory (this would
       // happen if we restored the last part of trajectory and it didn't overlap


### PR DESCRIPTION
Also properly serialize the last segment when it is non-collapsible.

Fix #3277.