### PR TITLE
Remove custom optional implementation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,6 @@ endif
 ifeq ($(UNAME_S),Darwin)
     INCLUDES += \
 			-I$(DEP_DIR)compatibility/filesystem \
-			-I$(DEP_DIR)compatibility/optional \
-			-I$(DEP_DIR)Optional \
 			-include "base/macos_allocator_replacement.hpp"
     LIBS += -framework CoreFoundation
     SHARED_ARGS += -mmacosx-version-min=10.14 -arch x86_64 -D_LIBCPP_STD_VER=16

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -74,12 +74,4 @@ for repo in protobuf glog googletest gipfeli abseil-cpp compatibility benchmark 
   popd
 done
 
-if [ ! -d "Optional" ]; then
-  mkdir Optional
-fi
-pushd Optional
-curl "https://raw.githubusercontent.com/llvm-mirror/libcxx/52f9ca28a39aa02a2e78fa0eb5aa927ad046487f/include/optional" > principia_optional_impl
-touch __undef_macros
-popd
-
 popd


### PR DESCRIPTION
It is no longer needed as of #3279.