### PR TITLE
Optimizations for DiscreteTrajectory

### DIFF
--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -63,8 +63,8 @@ DiscreteTrajectory<World> MakeTrajectory(Timeline<World> const& timeline,
         double const split = *it_split;
         CHECK_LE(0, split);
         CHECK_LE(split, 1);
-        t_split =
-            Barycentre<Instant, double>({t_min, t_max}, {1 - split, split});
+        t_split = Barycentre<Instant, double>({t_min, t_max},
+                                              {1 - split, split});
       }
     }
     if (t >= t_split) {
@@ -79,7 +79,7 @@ DiscreteTrajectory<World> MakeTrajectory(Timeline<World> const& timeline,
 
 // Constructs a trajectory beginning with many empty segments.
 DiscreteTrajectory<World> MakeTrajectoryWithEmptySegments(
-    int num_empty_segments) {
+    int const num_empty_segments) {
   DiscreteTrajectory<World> trajectory;
   for (int i = 0; i < num_empty_segments; i++) {
     trajectory.NewSegment();

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -79,9 +79,9 @@ DiscreteTrajectory<World> MakeTrajectory(Timeline<World> const& timeline,
 
 // Constructs a trajectory beginning with many empty segments.
 DiscreteTrajectory<World> MakeTrajectoryWithEmptySegments(
-    int const num_empty_segments) {
+    int const number_of_empty_segments) {
   DiscreteTrajectory<World> trajectory;
-  for (int i = 0; i < num_empty_segments; i++) {
+  for (int i = 0; i < number_of_empty_segments; i++) {
     trajectory.NewSegment();
   }
   CHECK_OK(trajectory.Append(

--- a/benchmarks/discrete_trajectory.cpp
+++ b/benchmarks/discrete_trajectory.cpp
@@ -86,10 +86,9 @@ void BM_DiscreteTrajectoryFront(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(segment.front());
+    benchmark::DoNotOptimize(trajectory.front());
   }
 }
 void BM_DiscreteTrajectoryBack(benchmark::State& state) {
@@ -99,10 +98,9 @@ void BM_DiscreteTrajectoryBack(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(segment.back());
+    benchmark::DoNotOptimize(trajectory.back());
   }
 }
 
@@ -113,10 +111,9 @@ void BM_DiscreteTrajectoryBegin(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(segment.begin());
+    benchmark::DoNotOptimize(trajectory.begin());
   }
 }
 
@@ -127,10 +124,9 @@ void BM_DiscreteTrajectoryEnd(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.end();
+    benchmark::DoNotOptimize(trajectory.end());
   }
 }
 
@@ -141,10 +137,9 @@ void BM_DiscreteTrajectoryTMin(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.t_min();
+    benchmark::DoNotOptimize(trajectory.t_min());
   }
 }
 
@@ -155,10 +150,93 @@ void BM_DiscreteTrajectoryTMax(benchmark::State& state) {
                                                         /*t1=*/t0,
                                                         /*t2=*/t0 + 4 * Second);
   auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
-  auto const& segment = trajectory.segments().back();
 
   for (auto _ : state) {
-    segment.t_max();
+    benchmark::DoNotOptimize(trajectory.t_max());
+  }
+}
+
+
+void BM_DiscreteTrajectorySegmentFront(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.front());
+  }
+}
+void BM_DiscreteTrajectorySegmentBack(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.back());
+  }
+}
+
+void BM_DiscreteTrajectorySegmentBegin(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.begin());
+  }
+}
+
+void BM_DiscreteTrajectorySegmentEnd(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.end());
+  }
+}
+
+void BM_DiscreteTrajectorySegmentTMin(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.t_min());
+  }
+}
+
+void BM_DiscreteTrajectorySegmentTMax(benchmark::State& state) {
+  Instant const t0;
+  auto const timeline = NewMotionlessTrajectoryTimeline(World::origin,
+                                                        /*Δt=*/1 * Second,
+                                                        /*t1=*/t0,
+                                                        /*t2=*/t0 + 4 * Second);
+  auto const trajectory = MakeTrajectory(timeline, {0.5, 0.75});
+  auto const& segment = trajectory.segments().front();
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(segment.t_max());
   }
 }
 
@@ -287,6 +365,12 @@ BENCHMARK(BM_DiscreteTrajectoryBegin);
 BENCHMARK(BM_DiscreteTrajectoryEnd);
 BENCHMARK(BM_DiscreteTrajectoryTMin);
 BENCHMARK(BM_DiscreteTrajectoryTMax);
+BENCHMARK(BM_DiscreteTrajectorySegmentFront);
+BENCHMARK(BM_DiscreteTrajectorySegmentBack);
+BENCHMARK(BM_DiscreteTrajectorySegmentBegin);
+BENCHMARK(BM_DiscreteTrajectorySegmentEnd);
+BENCHMARK(BM_DiscreteTrajectorySegmentTMin);
+BENCHMARK(BM_DiscreteTrajectorySegmentTMax);
 BENCHMARK(BM_DiscreteTrajectoryCreateDestroy)->Range(8, 1024);
 BENCHMARK(BM_DiscreteTrajectoryIterate)->Range(8, 1024);
 BENCHMARK(BM_DiscreteTrajectoryReverseIterate)->Range(8, 1024);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -33,7 +33,7 @@ DiscreteTrajectory<Frame>::DiscreteTrajectory()
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::reference
 DiscreteTrajectory<Frame>::front() const {
-  return segments_->front().front();
+  return *segment_by_left_endpoint_.begin()->second->timeline_.begin();
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -45,7 +45,7 @@ DiscreteTrajectory<Frame>::back() const {
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::iterator
 DiscreteTrajectory<Frame>::begin() const {
-  return segments_->front().begin();
+  return segment_by_left_endpoint_.begin()->second->begin();
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -103,12 +103,8 @@ DiscreteTrajectory<Frame>::find(Instant const& t) const {
   if (leit == segment_by_left_endpoint_.cend()) {
     return end();
   }
-  auto const sit = leit->second;
-  auto const it = sit->find(t);
-  if (it == sit->end()) {
-    return end();
-  }
-  return it;
+  auto const it = leit->second->FindImpl(t);
+  return it.has_value() ? *it : end();
 }
 
 template<typename Frame>
@@ -119,12 +115,8 @@ DiscreteTrajectory<Frame>::lower_bound(Instant const& t) const {
     // This includes an empty trajectory.
     return begin();
   }
-  auto const sit = leit->second;
-  auto const it = sit->lower_bound(t);
-  if (it == sit->end()) {
-    return end();
-  }
-  return it;
+  auto const it = leit->second->LowerBoundImpl(t);
+  return it.has_value() ? *it : end();
 }
 
 template<typename Frame>
@@ -135,12 +127,8 @@ DiscreteTrajectory<Frame>::upper_bound(Instant const& t) const {
     // This includes an empty trajectory.
     return begin();
   }
-  auto const sit = leit->second;
-  auto const it = sit->upper_bound(t);
-  if (it == sit->end()) {
-    return end();
-  }
-  return it;
+  auto const it = leit->second->UpperBoundImpl(t);
+  return it.has_value() ? *it : end();
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -33,7 +33,8 @@ DiscreteTrajectory<Frame>::DiscreteTrajectory()
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::reference
 DiscreteTrajectory<Frame>::front() const {
-  return *segment_by_left_endpoint_.begin()->second->timeline_.begin();
+  auto const sit = segment_by_left_endpoint_.begin()->second;
+  return *sit->timeline_.begin();
 }
 
 template<typename Frame>
@@ -42,17 +43,22 @@ DiscreteTrajectory<Frame>::back() const {
   return *rbegin();
 }
 
-template<typename Frame>
-typename DiscreteTrajectory<Frame>::iterator
-DiscreteTrajectory<Frame>::begin() const {
-  return empty() ? end() : segment_by_left_endpoint_.begin()->second->begin();
+template <typename Frame>
+typename DiscreteTrajectory<Frame>::iterator DiscreteTrajectory<Frame>::begin()
+    const {
+  if (empty()) {
+    return end();
+  } else {
+    auto const sit = segment_by_left_endpoint_.begin()->second;
+    return sit->begin();
+  }
 }
 
-template<typename Frame>
-typename DiscreteTrajectory<Frame>::iterator
-DiscreteTrajectory<Frame>::end() const {
-  return iterator(SegmentIterator(segments_.get(), segments_->end()),
-                  std::nullopt);
+template <typename Frame>
+typename DiscreteTrajectory<Frame>::iterator DiscreteTrajectory<Frame>::end()
+    const {
+  return iterator::EndOfLastSegment(
+      SegmentIterator(segments_.get(), segments_->end()));
 }
 
 template<typename Frame>
@@ -103,7 +109,8 @@ DiscreteTrajectory<Frame>::find(Instant const& t) const {
   if (leit == segment_by_left_endpoint_.cend()) {
     return end();
   }
-  auto const it = leit->second->FindImpl(t);
+  auto const sit = leit->second;
+  auto const it = sit->FindOrNullopt(t);
   return it.has_value() ? *it : end();
 }
 
@@ -115,7 +122,8 @@ DiscreteTrajectory<Frame>::lower_bound(Instant const& t) const {
     // This includes an empty trajectory.
     return begin();
   }
-  auto const it = leit->second->LowerBoundImpl(t);
+  auto const sit = leit->second;
+  auto const it = sit->LowerBoundOrNullopt(t);
   return it.has_value() ? *it : end();
 }
 
@@ -127,7 +135,8 @@ DiscreteTrajectory<Frame>::upper_bound(Instant const& t) const {
     // This includes an empty trajectory.
     return begin();
   }
-  auto const it = leit->second->UpperBoundImpl(t);
+  auto const sit = leit->second;
+  auto const it = sit->UpperBoundOrNullopt(t);
   return it.has_value() ? *it : end();
 }
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -45,7 +45,7 @@ DiscreteTrajectory<Frame>::back() const {
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::iterator
 DiscreteTrajectory<Frame>::begin() const {
-  return segment_by_left_endpoint_.begin()->second->begin();
+  return empty() ? end() : segment_by_left_endpoint_.begin()->second->begin();
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -33,7 +33,7 @@ DiscreteTrajectory<Frame>::DiscreteTrajectory()
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::reference
 DiscreteTrajectory<Frame>::front() const {
-  return *begin();
+  return segments_->front().front();
 }
 
 template<typename Frame>
@@ -51,7 +51,8 @@ DiscreteTrajectory<Frame>::begin() const {
 template<typename Frame>
 typename DiscreteTrajectory<Frame>::iterator
 DiscreteTrajectory<Frame>::end() const {
-  return segments_->back().end();
+  return iterator(SegmentIterator(segments_.get(), segments_->end()),
+                  std::nullopt);
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -84,6 +84,8 @@ class DiscreteTrajectoryIterator {
   OptionalTimelineConstIterator point_;
 
   template<typename F>
+  friend class physics::DiscreteTrajectory;
+  template<typename F>
   friend class physics::DiscreteTrajectorySegment;
   friend class physics::DiscreteTrajectoryIteratorTest;
 };

--- a/physics/discrete_trajectory_iterator.hpp
+++ b/physics/discrete_trajectory_iterator.hpp
@@ -65,6 +65,10 @@ class DiscreteTrajectoryIterator {
   using OptionalTimelineConstIterator =
       std::optional<typename Timeline::const_iterator>;
 
+  // Constructs an `end()` iterator.
+  static DiscreteTrajectoryIterator EndOfLastSegment(
+      DiscreteTrajectorySegmentIterator<Frame> segment);
+
   DiscreteTrajectoryIterator(DiscreteTrajectorySegmentIterator<Frame> segment,
                              OptionalTimelineConstIterator point);
 

--- a/physics/discrete_trajectory_iterator_body.hpp
+++ b/physics/discrete_trajectory_iterator_body.hpp
@@ -249,6 +249,14 @@ bool DiscreteTrajectoryIterator<Frame>::operator>=(
   return !operator<(other);
 }
 
+template <typename Frame>
+DiscreteTrajectoryIterator<Frame>
+DiscreteTrajectoryIterator<Frame>::EndOfLastSegment(
+    DiscreteTrajectorySegmentIterator<Frame> const segment) {
+  DCHECK(segment.is_end());
+  return DiscreteTrajectoryIterator<Frame>(segment, std::nullopt);
+}
+
 template<typename Frame>
 DiscreteTrajectoryIterator<Frame>::DiscreteTrajectoryIterator(
     DiscreteTrajectorySegmentIterator<Frame> const segment,

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -136,6 +136,12 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
       DiscreteTrajectorySegmentIterator<Frame> self);
 
  private:
+  // Versions of find, lower_bound, and upper_bound that use optionals to
+  // indicate absense. Useful for bypassing expensive end() call.
+  std::optional<iterator> FindImpl(Instant const& t) const;
+  std::optional<iterator> LowerBoundImpl(Instant const& t) const;
+  std::optional<iterator> UpperBoundImpl(Instant const& t) const;
+
   // Changes the |self_| iterator.  Only for use when attaching/detaching
   // segments.
   void SetSelf(DiscreteTrajectorySegmentIterator<Frame> self);

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -138,9 +138,9 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
  private:
   // Versions of find, lower_bound, and upper_bound that use optionals to
   // indicate absense. Useful for bypassing expensive end() call.
-  std::optional<iterator> FindImpl(Instant const& t) const;
-  std::optional<iterator> LowerBoundImpl(Instant const& t) const;
-  std::optional<iterator> UpperBoundImpl(Instant const& t) const;
+  std::optional<iterator> FindOrNullopt(Instant const& t) const;
+  std::optional<iterator> LowerBoundOrNullopt(Instant const& t) const;
+  std::optional<iterator> UpperBoundOrNullopt(Instant const& t) const;
 
   // Changes the |self_| iterator.  Only for use when attaching/detaching
   // segments.

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -45,7 +45,7 @@ void DiscreteTrajectorySegment<Frame>::SetDownsamplingUnconditionally(
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::reference
 DiscreteTrajectorySegment<Frame>::front() const {
-  return *timeline_.begin();
+  return *begin();
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -107,9 +107,16 @@ void DiscreteTrajectorySegment<Frame>::clear() {
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::find(Instant const& t) const {
+  auto const it = FindImpl(t);
+  return it.has_value() ? *it : end();
+}
+
+template <typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::FindImpl(Instant const& t) const {
   auto const it = timeline_.find(t);
   if (it == timeline_.end()) {
-    return end();
+    return std::nullopt;
   } else {
     return iterator(self_, it);
   }
@@ -118,9 +125,16 @@ DiscreteTrajectorySegment<Frame>::find(Instant const& t) const {
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::lower_bound(Instant const& t) const {
+  auto const it = LowerBoundImpl(t);
+  return it.has_value() ? *it : end();
+}
+
+template<typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::LowerBoundImpl(Instant const& t) const {
   auto const it = timeline_.lower_bound(t);
   if (it == timeline_.end()) {
-    return end();
+    return std::nullopt;
   } else {
     return iterator(self_, it);
   }
@@ -129,9 +143,16 @@ DiscreteTrajectorySegment<Frame>::lower_bound(Instant const& t) const {
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::upper_bound(Instant const& t) const {
+  auto const it = UpperBoundImpl(t);
+  return it.has_value() ? *it : end();
+}
+
+template<typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::UpperBoundImpl(Instant const& t) const {
   auto const it = timeline_.upper_bound(t);
   if (it == timeline_.end()) {
-    return end();
+    return std::nullopt;
   } else {
     return iterator(self_, it);
   }

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -107,55 +107,22 @@ void DiscreteTrajectorySegment<Frame>::clear() {
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::find(Instant const& t) const {
-  auto const it = FindImpl(t);
+  auto const it = FindOrNullopt(t);
   return it.has_value() ? *it : end();
-}
-
-template <typename Frame>
-std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
-DiscreteTrajectorySegment<Frame>::FindImpl(Instant const& t) const {
-  auto const it = timeline_.find(t);
-  if (it == timeline_.end()) {
-    return std::nullopt;
-  } else {
-    return iterator(self_, it);
-  }
 }
 
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::lower_bound(Instant const& t) const {
-  auto const it = LowerBoundImpl(t);
+  auto const it = LowerBoundOrNullopt(t);
   return it.has_value() ? *it : end();
-}
-
-template<typename Frame>
-std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
-DiscreteTrajectorySegment<Frame>::LowerBoundImpl(Instant const& t) const {
-  auto const it = timeline_.lower_bound(t);
-  if (it == timeline_.end()) {
-    return std::nullopt;
-  } else {
-    return iterator(self_, it);
-  }
 }
 
 template<typename Frame>
 typename DiscreteTrajectorySegment<Frame>::iterator
 DiscreteTrajectorySegment<Frame>::upper_bound(Instant const& t) const {
-  auto const it = UpperBoundImpl(t);
+  auto const it = UpperBoundOrNullopt(t);
   return it.has_value() ? *it : end();
-}
-
-template<typename Frame>
-std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
-DiscreteTrajectorySegment<Frame>::UpperBoundImpl(Instant const& t) const {
-  auto const it = timeline_.upper_bound(t);
-  if (it == timeline_.end()) {
-    return std::nullopt;
-  } else {
-    return iterator(self_, it);
-  }
 }
 
 template<typename Frame>
@@ -345,6 +312,39 @@ DiscreteTrajectorySegment<Frame>::ReadFromMessage(
   }
 
   return segment;
+}
+
+template <typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::FindOrNullopt(Instant const& t) const {
+  auto const it = timeline_.find(t);
+  if (it == timeline_.end()) {
+    return std::nullopt;
+  } else {
+    return iterator(self_, it);
+  }
+}
+
+template<typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::LowerBoundOrNullopt(Instant const& t) const {
+  auto const it = timeline_.lower_bound(t);
+  if (it == timeline_.end()) {
+    return std::nullopt;
+  } else {
+    return iterator(self_, it);
+  }
+}
+
+template<typename Frame>
+std::optional<typename DiscreteTrajectorySegment<Frame>::iterator>
+DiscreteTrajectorySegment<Frame>::UpperBoundOrNullopt(Instant const& t) const {
+  auto const it = timeline_.upper_bound(t);
+  if (it == timeline_.end()) {
+    return std::nullopt;
+  } else {
+    return iterator(self_, it);
+  }
 }
 
 template<typename Frame>

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -205,8 +205,10 @@ TEST_F(DiscreteTrajectoryTest, IterateBackward) {
 TEST_F(DiscreteTrajectoryTest, Empty) {
   DiscreteTrajectory<World> trajectory;
   EXPECT_TRUE(trajectory.empty());
+  EXPECT_EQ(trajectory.begin(), trajectory.end());
   trajectory = MakeTrajectory();
   EXPECT_FALSE(trajectory.empty());
+  EXPECT_NE(trajectory.begin(), trajectory.end());
 }
 
 TEST_F(DiscreteTrajectoryTest, Size) {

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -139,24 +139,19 @@ TEST_F(DiscreteTrajectoryTest, BackFront) {
 
 TEST_F(DiscreteTrajectoryTest, FrontEmpty) {
   // Construct a non-empty trajectory with an empty front segment.
-  DegreesOfFreedom<World> const dof(
-      World::origin, Velocity<World>({1 * Metre / Second, 0 * Metre / Second,
-                                      0 * Metre / Second}));
   DiscreteTrajectory<World> trajectory;
-  ASSERT_TRUE(trajectory.Append(t0_, dof).ok());
-  trajectory.AttachSegments(MakeTrajectory(t0_, dof));
-
-  Instant const t1 = t0_ + 1 * Second;
-  trajectory.ForgetBefore(t1);
+  trajectory.NewSegment();
+  EXPECT_OK(trajectory.Append(
+      t0_, DegreesOfFreedom<World>(World::origin, Velocity<World>())));
   ASSERT_FALSE(trajectory.empty());
   ASSERT_TRUE(trajectory.segments().front().empty());
 
   // Verify that begin() and front() behave as expected.
-  EXPECT_EQ(trajectory.front().time, t1);
-  EXPECT_EQ(trajectory.begin()->time, t1);
+  EXPECT_EQ(trajectory.front().time, t0_);
+  EXPECT_EQ(trajectory.begin()->time, t0_);
 
-  EXPECT_EQ(trajectory.segments().front().front().time, t1);
-  EXPECT_EQ(trajectory.segments().front().begin()->time, t1);
+  EXPECT_EQ(trajectory.segments().front().front().time, t0_);
+  EXPECT_EQ(trajectory.segments().front().begin()->time, t0_);
 }
 
 TEST_F(DiscreteTrajectoryTest, IterateForward) {

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -137,6 +137,28 @@ TEST_F(DiscreteTrajectoryTest, BackFront) {
   EXPECT_EQ(t0_ + 14 * Second, trajectory.back().time);
 }
 
+TEST_F(DiscreteTrajectoryTest, FrontEmpty) {
+  // Construct a non-empty trajectory with an empty front segment.
+  DegreesOfFreedom<World> const dof(
+      World::origin, Velocity<World>({1 * Metre / Second, 0 * Metre / Second,
+                                      0 * Metre / Second}));
+  DiscreteTrajectory<World> trajectory;
+  ASSERT_TRUE(trajectory.Append(t0_, dof).ok());
+  trajectory.AttachSegments(MakeTrajectory(t0_, dof));
+
+  Instant const t1 = t0_ + 1 * Second;
+  trajectory.ForgetBefore(t1);
+  ASSERT_FALSE(trajectory.empty());
+  ASSERT_TRUE(trajectory.segments().front().empty());
+
+  // Verify that begin() and front() behave as expected.
+  EXPECT_EQ(trajectory.front().time, t1);
+  EXPECT_EQ(trajectory.begin()->time, t1);
+
+  EXPECT_EQ(trajectory.segments().front().front().time, t1);
+  EXPECT_EQ(trajectory.segments().front().begin()->time, t1);
+}
+
 TEST_F(DiscreteTrajectoryTest, IterateForward) {
   auto const trajectory = MakeTrajectory();
   std::vector<Instant> times;


### PR DESCRIPTION
To `front` and `end`.
Also, renamed the existing Front/Back/etc benchmarks as BM_DiscreteTrajectorySegmentFoo (because they measure the performance of segment functions), and created new benchmarks that measure the corresponding functions on the entire trajectory.

Before optimizations, but including benchmark reconfiguration (#5b6df36):
```
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                      2.06 ns         2.06 ns    335252253
BM_DiscreteTrajectoryBack                                       18.5 ns         18.5 ns     37876943
BM_DiscreteTrajectoryBegin                                      1.22 ns         1.22 ns    572222676
BM_DiscreteTrajectoryEnd                                        7.84 ns         7.83 ns     89294826
BM_DiscreteTrajectoryTMin                                       2.34 ns         2.34 ns    298857936
BM_DiscreteTrajectoryTMax                                       4.41 ns         4.41 ns    158582724
BM_DiscreteTrajectorySegmentFront                              0.316 ns        0.316 ns   1000000000
BM_DiscreteTrajectorySegmentBack                               0.590 ns        0.590 ns   1000000000
BM_DiscreteTrajectorySegmentBegin                              0.789 ns        0.789 ns    884765600
BM_DiscreteTrajectorySegmentEnd                                 6.32 ns         6.31 ns    110878794
BM_DiscreteTrajectorySegmentTMin                                1.90 ns         1.90 ns    369151584
BM_DiscreteTrajectorySegmentTMax                                4.42 ns         4.42 ns    158637350
BM_DiscreteTrajectoryCreateDestroy/8                            1323 ns         1322 ns       528753
BM_DiscreteTrajectoryCreateDestroy/64                           4301 ns         4299 ns       163910
BM_DiscreteTrajectoryCreateDestroy/512                         27396 ns        27381 ns        25575
BM_DiscreteTrajectoryCreateDestroy/1024                        54314 ns        54277 ns        12885
BM_DiscreteTrajectoryIterate/8                                  21.6 ns         21.5 ns     32600900
BM_DiscreteTrajectoryIterate/64                                  152 ns          151 ns      4615801
BM_DiscreteTrajectoryIterate/512                                1180 ns         1179 ns       592934
BM_DiscreteTrajectoryIterate/1024                               2326 ns         2325 ns       299891
BM_DiscreteTrajectoryReverseIterate/8                           19.5 ns         19.5 ns     35863412
BM_DiscreteTrajectoryReverseIterate/64                           181 ns          181 ns      3881320
BM_DiscreteTrajectoryReverseIterate/512                         1490 ns         1489 ns       469358
BM_DiscreteTrajectoryReverseIterate/1024                        2940 ns         2939 ns       238825
BM_DiscreteTrajectoryFind/8                                     95.5 ns         95.4 ns      7303535
BM_DiscreteTrajectoryFind/64                                     121 ns          121 ns      5787994
BM_DiscreteTrajectoryFind/512                                    139 ns          139 ns      4949515
BM_DiscreteTrajectoryFind/1024                                   145 ns          144 ns      4830318
BM_DiscreteTrajectoryLowerBound/8                               58.5 ns         58.4 ns     11962540
BM_DiscreteTrajectoryLowerBound/64                              73.3 ns         73.2 ns      9503122
BM_DiscreteTrajectoryLowerBound/512                             90.3 ns         90.3 ns      7786256
BM_DiscreteTrajectoryLowerBound/1024                            94.1 ns         94.0 ns      7421386
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              8.51 ns         8.51 ns     82096992
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated       20.6 ns         20.6 ns     34142844
```

After optimizations (#dc232bd):
```
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                     0.448 ns        0.448 ns   1000000000
BM_DiscreteTrajectoryBack                                       3.67 ns         3.67 ns    190162100
BM_DiscreteTrajectoryBegin                                      1.30 ns         1.30 ns    575232147
BM_DiscreteTrajectoryEnd                                       0.631 ns        0.631 ns   1000000000
BM_DiscreteTrajectoryTMin                                       2.39 ns         2.39 ns    297638030
BM_DiscreteTrajectoryTMax                                       2.63 ns         2.63 ns    269664306
BM_DiscreteTrajectorySegmentFront                              0.316 ns        0.316 ns   1000000000
BM_DiscreteTrajectorySegmentBack                               0.589 ns        0.589 ns   1000000000
BM_DiscreteTrajectorySegmentBegin                              0.789 ns        0.788 ns    886019872
BM_DiscreteTrajectorySegmentEnd                                 6.32 ns         6.32 ns    110255320
BM_DiscreteTrajectorySegmentTMin                                1.89 ns         1.89 ns    368419114
BM_DiscreteTrajectorySegmentTMax                                2.22 ns         2.22 ns    316769315
BM_DiscreteTrajectoryCreateDestroy/8                            1280 ns         1279 ns       537403
BM_DiscreteTrajectoryCreateDestroy/64                           4220 ns         4217 ns       167352
BM_DiscreteTrajectoryCreateDestroy/512                         26729 ns        26713 ns        25983
BM_DiscreteTrajectoryCreateDestroy/1024                        53650 ns        53619 ns        13030
BM_DiscreteTrajectoryIterate/8                                  20.8 ns         20.8 ns     33638159
BM_DiscreteTrajectoryIterate/64                                  143 ns          143 ns      4878627
BM_DiscreteTrajectoryIterate/512                                1201 ns         1201 ns       579005
BM_DiscreteTrajectoryIterate/1024                               2398 ns         2397 ns       291498
BM_DiscreteTrajectoryReverseIterate/8                           19.2 ns         19.2 ns     36514055
BM_DiscreteTrajectoryReverseIterate/64                           181 ns          181 ns      3841763
BM_DiscreteTrajectoryReverseIterate/512                         1492 ns         1491 ns       468751
BM_DiscreteTrajectoryReverseIterate/1024                        2943 ns         2941 ns       238100
BM_DiscreteTrajectoryFind/8                                     79.3 ns         79.2 ns      8869629
BM_DiscreteTrajectoryFind/64                                    96.3 ns         96.3 ns      7271443
BM_DiscreteTrajectoryFind/512                                    117 ns          117 ns      5980912
BM_DiscreteTrajectoryFind/1024                                   118 ns          118 ns      5954660
BM_DiscreteTrajectoryLowerBound/8                               58.9 ns         58.8 ns     11972566
BM_DiscreteTrajectoryLowerBound/64                              73.2 ns         73.1 ns      9578151
BM_DiscreteTrajectoryLowerBound/512                             87.3 ns         87.3 ns      7903889
BM_DiscreteTrajectoryLowerBound/1024                            93.8 ns         93.8 ns      7445066
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact              8.56 ns         8.56 ns     82251337
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated       18.4 ns         18.4 ns     38056715
```

Diff:
```
Benchmark                                                                   Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------
BM_DiscreteTrajectoryFront                                               -0.7831         -0.7831             2             0             2             0
BM_DiscreteTrajectoryBack                                                -0.8015         -0.8015            19             4            19             4
BM_DiscreteTrajectoryBegin                                               +0.0697         +0.0695             1             1             1             1
BM_DiscreteTrajectoryEnd                                                 -0.9195         -0.9195             8             1             8             1
BM_DiscreteTrajectoryTMin                                                +0.0219         +0.0219             2             2             2             2
BM_DiscreteTrajectoryTMax                                                -0.4038         -0.4037             4             3             4             3
BM_DiscreteTrajectorySegmentFront                                        -0.0001         -0.0003             0             0             0             0
BM_DiscreteTrajectorySegmentBack                                         -0.0022         -0.0022             1             1             1             1
BM_DiscreteTrajectorySegmentBegin                                        -0.0009         -0.0011             1             1             1             1
BM_DiscreteTrajectorySegmentEnd                                          +0.0008         +0.0009             6             6             6             6
BM_DiscreteTrajectorySegmentTMin                                         -0.0022         -0.0024             2             2             2             2
BM_DiscreteTrajectorySegmentTMax                                         -0.4973         -0.4974             4             2             4             2
BM_DiscreteTrajectoryCreateDestroy/8                                     -0.0326         -0.0327          1323          1280          1322          1279
BM_DiscreteTrajectoryCreateDestroy/64                                    -0.0188         -0.0189          4301          4220          4299          4217
BM_DiscreteTrajectoryCreateDestroy/512                                   -0.0243         -0.0244         27396         26729         27381         26713
BM_DiscreteTrajectoryCreateDestroy/1024                                  -0.0122         -0.0121         54314         53650         54277         53619
BM_DiscreteTrajectoryIterate/8                                           -0.0338         -0.0335            22            21            22            21
BM_DiscreteTrajectoryIterate/64                                          -0.0559         -0.0558           152           143           151           143
BM_DiscreteTrajectoryIterate/512                                         +0.0183         +0.0182          1180          1201          1179          1201
BM_DiscreteTrajectoryIterate/1024                                        +0.0312         +0.0310          2326          2398          2325          2397
BM_DiscreteTrajectoryReverseIterate/8                                    -0.0144         -0.0145            20            19            20            19
BM_DiscreteTrajectoryReverseIterate/64                                   -0.0006         -0.0008           181           181           181           181
BM_DiscreteTrajectoryReverseIterate/512                                  +0.0009         +0.0009          1490          1492          1489          1491
BM_DiscreteTrajectoryReverseIterate/1024                                 +0.0009         +0.0007          2940          2943          2939          2941
BM_DiscreteTrajectoryFind/8                                              -0.1697         -0.1698            95            79            95            79
BM_DiscreteTrajectoryFind/64                                             -0.2051         -0.2050           121            96           121            96
BM_DiscreteTrajectoryFind/512                                            -0.1617         -0.1618           139           117           139           117
BM_DiscreteTrajectoryFind/1024                                           -0.1836         -0.1838           145           118           144           118
BM_DiscreteTrajectoryLowerBound/8                                        +0.0070         +0.0070            58            59            58            59
BM_DiscreteTrajectoryLowerBound/64                                       -0.0015         -0.0016            73            73            73            73
BM_DiscreteTrajectoryLowerBound/512                                      -0.0333         -0.0332            90            87            90            87
BM_DiscreteTrajectoryLowerBound/1024                                     -0.0028         -0.0029            94            94            94            94
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomExact                       +0.0060         +0.0059             9             9             9             9
BM_DiscreteTrajectoryEvaluateDegreesOfFreedomInterpolated                -0.1061         -0.1062            21            18            21            18
```

Note that the TMax benchmarks appear to be noisy (TMax is not affected by this change).