### PR TITLE
Make not_null<foo*> trivially copyable.

### DIFF
--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 #include "base/macros.hpp"
 #include "base/not_constructible.hpp"
@@ -94,14 +95,14 @@ struct remove_not_null<not_null<Pointer>> {
 };
 
 // Wrapper struct for pointers with move assigment compatible with not_null.
-template<typename Pointer, typename=void>
+template <typename Pointer, typename = void>
 struct NotNullStorage;
 
 // Case: move assignment is equvalent to copy (raw pointer).
 template <typename P>
 struct NotNullStorage<
     P, std::enable_if_t<std::is_trivially_move_assignable_v<P>>> {
-  NotNullStorage(P&& pointer) : pointer(std::move(pointer)) {}
+  explicit NotNullStorage(P&& pointer) : pointer(std::move(pointer)) {}
   NotNullStorage(NotNullStorage const&) = default;
   NotNullStorage(NotNullStorage&&) = default;
   NotNullStorage& operator=(NotNullStorage const&) = default;
@@ -114,7 +115,7 @@ struct NotNullStorage<
 template <typename P>
 struct NotNullStorage<
     P, std::enable_if_t<!std::is_trivially_move_assignable_v<P>>> {
-  NotNullStorage(P&& pointer) : pointer(std::move(pointer)) {}
+  explicit NotNullStorage(P&& pointer) : pointer(std::move(pointer)) {}
   NotNullStorage(NotNullStorage const&) = default;
   NotNullStorage(NotNullStorage&&) = default;
   NotNullStorage& operator=(NotNullStorage const&) = default;
@@ -215,8 +216,8 @@ class not_null final {
                std::is_convertible<OtherPointer, pointer>::value>::type>
   not_null& operator=(not_null<OtherPointer>&& other);
 
-  // Returns |storage_.pointer|, by const reference to avoid a copy if |pointer| is
-  // |unique_ptr|.
+  // Returns |storage_.pointer|, by const reference to avoid a copy if |pointer|
+  // is |unique_ptr|.
   // If this were to return by |const&|, ambiguities would arise where an rvalue
   // of type |not_null<pointer>| is given as an argument to a function that has
   // overloads for both |pointer const&| and |pointer&&|.

--- a/base/not_null.hpp
+++ b/base/not_null.hpp
@@ -1,6 +1,7 @@
 ﻿
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <type_traits>
 #include <utility>

--- a/base/not_null_test.cpp
+++ b/base/not_null_test.cpp
@@ -270,22 +270,22 @@ TEST_F(NotNullTest, RValue) {
 
 TEST_F(NotNullTest, TypeTraits) {
   // not_null<foo*> is trivially copyable.
-  EXPECT_TRUE(std::is_trivially_copyable_v<not_null<int*>>);
-  EXPECT_TRUE(std::is_trivially_copy_constructible_v<not_null<int*>>);
-  EXPECT_TRUE(std::is_trivially_copy_assignable_v<not_null<int*>>);
-  EXPECT_TRUE(std::is_trivially_move_constructible_v<not_null<int*>>);
-  EXPECT_TRUE(std::is_trivially_move_assignable_v<not_null<int*>>);
+  static_assert(std::is_trivially_copyable_v<not_null<int*>>);
+  static_assert(std::is_trivially_copy_constructible_v<not_null<int*>>);
+  static_assert(std::is_trivially_copy_assignable_v<not_null<int*>>);
+  static_assert(std::is_trivially_move_constructible_v<not_null<int*>>);
+  static_assert(std::is_trivially_move_assignable_v<not_null<int*>>);
 
   // not_null<std::unique_ptr<foo>> is not.
-  EXPECT_FALSE(std::is_trivially_copyable_v<not_null<std::unique_ptr<int>>>);
-  EXPECT_FALSE(
-      std::is_trivially_copy_constructible_v<not_null<std::unique_ptr<int>>>);
-  EXPECT_FALSE(
-      std::is_trivially_copy_assignable_v<not_null<std::unique_ptr<int>>>);
-  EXPECT_FALSE(
-      std::is_trivially_move_constructible_v<not_null<std::unique_ptr<int>>>);
-  EXPECT_FALSE(
-      std::is_trivially_move_assignable_v<not_null<std::unique_ptr<int>>>);
+  static_assert(!std::is_trivially_copyable_v<not_null<std::unique_ptr<int>>>);
+  static_assert(
+      !std::is_trivially_copy_constructible_v<not_null<std::unique_ptr<int>>>);
+  static_assert(
+      !std::is_trivially_copy_assignable_v<not_null<std::unique_ptr<int>>>);
+  static_assert(
+      !std::is_trivially_move_constructible_v<not_null<std::unique_ptr<int>>>);
+  static_assert(
+      !std::is_trivially_move_assignable_v<not_null<std::unique_ptr<int>>>);
 }
 
 }  // namespace base

--- a/base/not_null_test.cpp
+++ b/base/not_null_test.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <utility>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "base/macros.hpp"
@@ -176,6 +177,11 @@ TEST_F(NotNullTest, CheckArguments) {
 #endif
 }
 
+TEST_F(NotNullTest, ExplicitCast) {
+  int* pointer_to_int = new int();
+  not_null<std::unique_ptr<int>>(check_not_null(pointer_to_int));
+}
+
 TEST_F(NotNullTest, DynamicCast) {
   class Base {
    public:
@@ -260,6 +266,26 @@ TEST_F(NotNullTest, RValue) {
   std::unique_ptr<int const> owner_const_int = make_not_null_unique<int>(5);
 #endif
   EXPECT_EQ(5, *owner_const_int);
+}
+
+TEST_F(NotNullTest, TypeTraits) {
+  // not_null<foo*> is trivially copyable.
+  EXPECT_TRUE(std::is_trivially_copyable_v<not_null<int*>>);
+  EXPECT_TRUE(std::is_trivially_copy_constructible_v<not_null<int*>>);
+  EXPECT_TRUE(std::is_trivially_copy_assignable_v<not_null<int*>>);
+  EXPECT_TRUE(std::is_trivially_move_constructible_v<not_null<int*>>);
+  EXPECT_TRUE(std::is_trivially_move_assignable_v<not_null<int*>>);
+
+  // not_null<std::unique_ptr<foo>> is not.
+  EXPECT_FALSE(std::is_trivially_copyable_v<not_null<std::unique_ptr<int>>>);
+  EXPECT_FALSE(
+      std::is_trivially_copy_constructible_v<not_null<std::unique_ptr<int>>>);
+  EXPECT_FALSE(
+      std::is_trivially_copy_assignable_v<not_null<std::unique_ptr<int>>>);
+  EXPECT_FALSE(
+      std::is_trivially_move_constructible_v<not_null<std::unique_ptr<int>>>);
+  EXPECT_FALSE(
+      std::is_trivially_move_assignable_v<not_null<std::unique_ptr<int>>>);
 }
 
 }  // namespace base


### PR DESCRIPTION
This fixes an annoying -Wrange-loop-construct clang warning.

Done by creating a wrapper struct that uses the default move assignment operator for trivially move assignable pointers and the custom swap-based move assignment operator for others.