### PR TITLE
Added time units to benchmarks

### DIFF
--- a/benchmark_automation/benchmark_automation.cs
+++ b/benchmark_automation/benchmark_automation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -84,7 +84,8 @@ class BenchmarkAutomation {
                 CommaSeparatedAppend(ref csv_means, μ.ToString());
               } else if (!has_repetitions) {
                 string benchmark_name = words[0];
-                double μ = double.Parse(words[1]);
+                double μ = double.Parse(words[1]) *
+                    TimeConversionFactor(words[2]);
                 CommaSeparatedAppend(
                     ref csv_benchmark_names,
                     "\"" + benchmark_name.Replace("\"", "\"\"") + "\"");

--- a/benchmark_automation/benchmark_automation.cs
+++ b/benchmark_automation/benchmark_automation.cs
@@ -108,7 +108,8 @@ class BenchmarkAutomation {
                   mathematica_stream.Write(", ");
                 }
                 mathematica_stream.Write(
-                    double.Parse(words[1]).ToString().Replace("e", "*^"));
+                    double.Parse(words[1] * TimeConversionFactor(words[2]))
+                        .ToString().Replace("e", "*^"));
               }
             }
           }

--- a/benchmark_automation/benchmark_automation.cs
+++ b/benchmark_automation/benchmark_automation.cs
@@ -108,7 +108,7 @@ class BenchmarkAutomation {
                   mathematica_stream.Write(", ");
                 }
                 mathematica_stream.Write(
-                    double.Parse(words[1] * TimeConversionFactor(words[2]))
+                    (double.Parse(words[1]) * TimeConversionFactor(words[2]))
                         .ToString().Replace("e", "*^"));
               }
             }

--- a/benchmark_automation/benchmark_automation.cs
+++ b/benchmark_automation/benchmark_automation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -75,7 +75,8 @@ class BenchmarkAutomation {
                     words[0].Substring(
                         startIndex : 0,
                         length     : words[0].Length - mean_suffix.Length);
-                double μ = double.Parse(words[1]);
+                double μ = double.Parse(words[1]) *
+                    TimeConversionFactor(words[2]);
                 Console.WriteLine(benchmark_name + ": μ = " + μ + " ns");
                 CommaSeparatedAppend(
                     ref csv_benchmark_names,
@@ -127,6 +128,20 @@ class BenchmarkAutomation {
       csv = value;
     } else {
       csv = csv + ", " + value;
+    }
+  }
+
+  private static double TimeConversionFactor(string unit) {
+    if (unit == "ns") {
+      return 1e0;
+    } else if (unit == "us") {
+      return 1e3;
+    } else if (unit == "ms") {
+      return 1e6;
+    } else if (unit == "s") {
+      return 1e9;
+    } else {
+      throw new ArgumentException("Invalid unit: " + unit);
     }
   }
 }

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -223,8 +223,12 @@ void BM_BarycentricRotatingDynamicFrame(benchmark::State& state) {
 
 int const iterations = (1000 << 10) + 1;
 
-BENCHMARK(BM_BodyCentredNonRotatingDynamicFrame)->Arg(iterations);
-BENCHMARK(BM_BarycentricRotatingDynamicFrame)->Arg(iterations);
+BENCHMARK(BM_BodyCentredNonRotatingDynamicFrame)
+    ->Arg(iterations)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_BarycentricRotatingDynamicFrame)
+    ->Arg(iterations)
+    ->Unit(benchmark::kMillisecond);
 
 }  // namespace physics
 }  // namespace principia

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -124,7 +124,7 @@ ApplyDynamicFrame(
 
 void BM_BodyCentredNonRotatingDynamicFrame(benchmark::State& state) {
   Time const Δt = 5 * Minute;
-  int const steps = state.range_x();
+  int const steps = state.range(0);
 
   SolarSystem<Barycentric> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
@@ -173,7 +173,7 @@ void BM_BodyCentredNonRotatingDynamicFrame(benchmark::State& state) {
 
 void BM_BarycentricRotatingDynamicFrame(benchmark::State& state) {
   Time const Δt = 5 * Minute;
-  int const steps = state.range_x();
+  int const steps = state.range(0);
 
   SolarSystem<Barycentric> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -163,7 +163,7 @@ void BM_BodyCentredNonRotatingDynamicFrame(benchmark::State& state) {
 
   BodyCentredNonRotatingDynamicFrame<Barycentric, Rendering>
       dynamic_frame(ephemeris.get(), earth);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
                                probe_trajectory.begin(),
@@ -213,7 +213,7 @@ void BM_BarycentricRotatingDynamicFrame(benchmark::State& state) {
 
   BarycentricRotatingDynamicFrame<Barycentric, Rendering>
       dynamic_frame(ephemeris.get(), earth, venus);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto v = ApplyDynamicFrame(&probe,
                                &dynamic_frame,
                                probe_trajectory.begin(),

--- a/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
@@ -236,11 +236,13 @@ void BM_EmbeddedExplicitRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D(
 
 BENCHMARK_TEMPLATE2(
     BM_EmbeddedExplicitRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::DormandالمكاوىPrince1986RKN434FM, Length);
+    methods::DormandالمكاوىPrince1986RKN434FM, Length)
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_TEMPLATE2(
     BM_EmbeddedExplicitRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::DormandالمكاوىPrince1986RKN434FM, Position<World>);
+    methods::DormandالمكاوىPrince1986RKN434FM, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 
 }  // namespace integrators
 }  // namespace principia

--- a/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
@@ -203,7 +203,7 @@ void BM_EmbeddedExplicitRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D(
     benchmark::State& state) {
   Length q_error;
   Speed v_error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     SolveHarmonicOscillatorAndComputeError1D(
         state,
         q_error,
@@ -220,7 +220,7 @@ void BM_EmbeddedExplicitRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D(
     benchmark::State& state) {
   Length q_error;
   Speed v_error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     SolveHarmonicOscillatorAndComputeError3D(
         state,
         q_error,

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -586,97 +586,122 @@ BENCHMARK(BM_EphemerisMultithreadingBenchmark)
     ->ArgPair(3, 2)
     ->ArgPair(3, 3)
     ->ArgPair(3, 4)
-    ->ArgPair(3, 5);
-BENCHMARK(BM_EphemerisKSPSystem)->Arg(-3);
+    ->ArgPair(3, 5)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_EphemerisKSPSystem)->Arg(-3)->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisSolarSystem,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithFixedStepSRKN)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithFixedStepSRKN)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithAdaptiveStep)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisLEOProbe,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithFixedStepSRKN)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisTranslunarSpaceProbe,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisTranslunarSpaceProbe,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisTranslunarSpaceProbe,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe1Year,
                    SolarSystemFactory::Accuracy::MajorBodiesOnly,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe1Year,
                    SolarSystemFactory::Accuracy::MinorAndMajorBodies,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 BENCHMARK_TEMPLATE(BM_EphemerisL4Probe1Year,
                    SolarSystemFactory::Accuracy::AllBodiesAndDampedOblateness,
                    &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(-3);
+    ->Arg(-3)
+    ->Unit(benchmark::kSecond);
 
 BENCHMARK_TEMPLATE(BM_EphemerisFittingTolerance, &FlowEphemerisWithAdaptiveStep)
-    ->DenseRange(-4, 4);
+    ->DenseRange(-4, 4)
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_TEMPLATE(BM_EphemerisStartup, &FlowEphemerisWithFixedStepSLMS)
-    ->Arg(3);
+    ->Arg(3)
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE(BM_EphemerisStartup, &FlowEphemerisWithFixedStepSRKN)
-    ->Arg(3);
+    ->Arg(3)
+    ->Unit(benchmark::kMicrosecond);
 
 }  // namespace physics
 }  // namespace principia

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -116,7 +116,7 @@ not_null<std::unique_ptr<SolarSystem<Barycentric>>> SolarSystemAtСпутник1
 
 void BM_EphemerisKSPSystem(benchmark::State& state) {
   Length error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
 
     auto at_origin = make_not_null_unique<SolarSystem<Barycentric>>(
@@ -153,7 +153,7 @@ void BM_EphemerisKSPSystem(benchmark::State& state) {
 template<SolarSystemFactory::Accuracy accuracy>
 void BM_EphemerisSolarSystem(benchmark::State& state) {
   Length error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
 
     auto const at_спутник_1_launch = SolarSystemAtСпутник1Launch(accuracy);
@@ -200,7 +200,7 @@ void BM_EphemerisLEOProbe(benchmark::State& state) {
 
   CHECK_OK(ephemeris->Prolong(final_time));
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
     // A probe in low earth orbit.
     MasslessBody probe;
@@ -269,7 +269,7 @@ void BM_EphemerisTranslunarSpaceProbe(benchmark::State& state) {
 
   CHECK_OK(ephemeris->Prolong(final_time));
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
     // A probe orbiting the Earth beyond the orbit of the Moon.
     MasslessBody probe;
@@ -360,7 +360,7 @@ void BM_EphemerisMultithreadingBenchmark(benchmark::State& state) {
   static constexpr Frequency refresh_frequency = 50 * Hertz;
   static constexpr Time step = warp_factor / refresh_frequency;
   Instant final_time = epoch;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
     std::vector<not_null<std::unique_ptr<Integrator<Ephemeris<
         Barycentric>::NewtonianMotionEquation>::Instance>>>
@@ -473,7 +473,7 @@ void EphemerisL4ProbeBenchmark(Time const integration_duration,
     total_degree += ephemeris->trajectory(body)->average_degree();
   }
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     not_null<std::unique_ptr<DiscreteTrajectory<Barycentric>>> trajectory =
         make_l4_probe_trajectory();
     state.PauseTiming();

--- a/benchmarks/fast_sin_cos_2π_benchmark.cpp
+++ b/benchmarks/fast_sin_cos_2π_benchmark.cpp
@@ -83,9 +83,9 @@ void BM_FastSinCos2πThroughput(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_FastSinCos2πPoorlyPredictedLatency);
-BENCHMARK(BM_FastSinCos2πWellPredictedLatency);
-BENCHMARK(BM_FastSinCos2πThroughput);
+BENCHMARK(BM_FastSinCos2πPoorlyPredictedLatency)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_FastSinCos2πWellPredictedLatency)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_FastSinCos2πThroughput)->Unit(benchmark::kMicrosecond);
 
 }  // namespace numerics
 }  // namespace principia

--- a/benchmarks/fast_sin_cos_2π_benchmark.cpp
+++ b/benchmarks/fast_sin_cos_2π_benchmark.cpp
@@ -45,7 +45,7 @@ double PoorlyMixTrigonometricLines(double cos_2πx, double sin_2πx) {
 }  // namespace
 
 void BM_FastSinCos2πPoorlyPredictedLatency(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     double sin = π;
     double cos = 0.0;
     for (int i = 0; i < 1e3; ++i) {
@@ -55,7 +55,7 @@ void BM_FastSinCos2πPoorlyPredictedLatency(benchmark::State& state) {
 }
 
 void BM_FastSinCos2πWellPredictedLatency(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     double sin = π;
     double cos = 0.0;
     for (int i = 0; i < 1e3; ++i) {
@@ -72,7 +72,7 @@ void BM_FastSinCos2πThroughput(benchmark::State& state) {
     input.push_back(distribution(random));
   }
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     double sin;
     double cos;
     for (double const x : input) {

--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -248,12 +248,23 @@ void BM_ComputeGeopotentialF90(benchmark::State& state) {
 
 #undef PRINCIPIA_CASE_COMPUTE_GEOPOTENTIAL_F90
 
-BENCHMARK(BM_ComputeGeopotentialCpp)->Arg(2)->Arg(3)->Arg(5)->Arg(10);
-BENCHMARK(BM_ComputeGeopotentialF90)->Arg(2)->Arg(3)->Arg(5)->Arg(10);
+BENCHMARK(BM_ComputeGeopotentialCpp)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(5)
+    ->Arg(10)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ComputeGeopotentialF90)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(5)
+    ->Arg(10)
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_ComputeGeopotentialDistance)
-    ->Arg(150'000)     // C₂₂, S₂₂, J₂.
-    ->Arg(500'000)     // J₂.
-    ->Arg(5'000'000);  // Central
+    ->Arg(150'000)    // C₂₂, S₂₂, J₂.
+    ->Arg(500'000)    // J₂.
+    ->Arg(5'000'000)  // Central
+    ->Unit(benchmark::kMicrosecond);
 
 }  // namespace physics
 }  // namespace principia

--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -138,7 +138,7 @@ void BM_ComputeGeopotentialCpp(benchmark::State& state) {
                             distribution(random) * Metre})));
   }
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Vector<Exponentiation<Length, -2>, ICRS> acceleration;
     for (auto const& displacement : displacements) {
       acceleration = GeneralSphericalHarmonicsAccelerationCpp(
@@ -178,7 +178,7 @@ void BM_ComputeGeopotentialDistance(benchmark::State& state) {
     }
   }
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Vector<Exponentiation<Length, -2>, ICRS> acceleration;
     for (auto const& displacement : displacements) {
       acceleration = GeneralSphericalHarmonicsAccelerationCpp(
@@ -198,7 +198,7 @@ void BM_ComputeGeopotentialDistance(benchmark::State& state) {
         snm[n][m] = earth.sin()[n][m] * LegendreNormalizationFactor[n][m]; \
       }                                                                    \
     }                                                                      \
-    while (state.KeepRunning()) {                                          \
+    for (auto _ : state) {                                          \
       Vector<Exponentiation<Length, -2>, ICRS> acceleration;               \
       for (auto const& displacement : displacements) {                     \
         acceleration =                                                     \

--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -35,7 +35,7 @@ template<typename Result,
                            Instant const& t_max,
                            double& error_estimate)>
 void BM_NewhallApproximationDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<double> p;
   std::vector<Variation<double>> v;
@@ -65,7 +65,7 @@ template<typename Result,
                            Instant const& t_max,
                            Displacement<ICRS>& error_estimate)>
 void BM_NewhallApproximationDisplacement(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<Displacement<ICRS>> p;
   std::vector<Variation<Displacement<ICRS>>> v;

--- a/benchmarks/newhall.cpp
+++ b/benchmarks/newhall.cpp
@@ -44,7 +44,7 @@ void BM_NewhallApproximationDouble(benchmark::State& state) {
   Instant const t_max = t_min + static_cast<double>(random()) * Second;
 
   double error_estimate;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
     p.clear();
     v.clear();
@@ -74,7 +74,7 @@ void BM_NewhallApproximationDisplacement(benchmark::State& state) {
   Instant const t_max = t_min + static_cast<double>(random()) * Second;
 
   Displacement<ICRS> error_estimate;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     state.PauseTiming();
     p.clear();
     v.clear();

--- a/benchmarks/perspective.cpp
+++ b/benchmarks/perspective.cpp
@@ -49,7 +49,7 @@ void RandomSegmentsBenchmark(
   Sphere<World> const sphere(World::origin,
                              /*radius=*/1 * Metre);
 
-  int const count = state.range_x();
+  int const count = state.range(0);
   std::mt19937_64 random(42);
   std::vector<Segment<World>> segments;
   for (int i = 0; i < count; ++i) {
@@ -100,7 +100,7 @@ void BM_VisibleSegmentsOrbit(benchmark::State& state) {
                              /*radius=*/1 * Metre);
 
   // A circular orbit in the x-y plane.
-  int const count = state.range_x();
+  int const count = state.range(0);
   std::vector<Segment<World>> segments;
   for (int i = 0; i < count; ++i) {
     Angle θ1 = 2 * π * i * Radian / static_cast<double>(count);
@@ -154,7 +154,7 @@ void BM_VisibleSegmentsOrbitMultipleSpheres(benchmark::State& state) {
   // A bunch of other spheres scattered around.
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> distribution(-10.0, 10.0);
-  for (int i = 0; i < state.range_y(); ++i) {
+  for (int i = 0; i < state.range(1); ++i) {
     spheres.emplace_back(
         World::origin + Displacement<World>({distribution(random) * Metre,
                                              distribution(random) * Metre,
@@ -163,7 +163,7 @@ void BM_VisibleSegmentsOrbitMultipleSpheres(benchmark::State& state) {
   }
 
   // A circular orbit in the x-y plane.
-  int const count = state.range_x();
+  int const count = state.range(0);
   std::vector<Segment<World>> segments;
   for (int i = 0; i < count; ++i) {
     Angle θ1 = 2 * π * i * Radian / static_cast<double>(count);

--- a/benchmarks/perspective.cpp
+++ b/benchmarks/perspective.cpp
@@ -68,7 +68,7 @@ void RandomSegmentsBenchmark(
 
   int visible_segments_count = 0;
   int visible_segments_size = 0;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (auto const& segment : segments) {
       auto const visible_segments =
           perspective.VisibleSegments(segment, sphere);
@@ -120,7 +120,7 @@ void BM_VisibleSegmentsOrbit(benchmark::State& state) {
 
   int visible_segments_count = 0;
   int visible_segments_size = 0;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (auto const& segment : segments) {
       auto const visible_segments =
           perspective.VisibleSegments(segment, sphere);
@@ -183,7 +183,7 @@ void BM_VisibleSegmentsOrbitMultipleSpheres(benchmark::State& state) {
 
   int visible_segments_count = 0;
   int visible_segments_size = 0;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (auto const& segment : segments) {
       auto const visible_segments =
           perspective.VisibleSegments(segment, spheres);

--- a/benchmarks/planetarium_plot_methods.cpp
+++ b/benchmarks/planetarium_plot_methods.cpp
@@ -215,7 +215,7 @@ void RunBenchmark(benchmark::State& state,
   int iterations = 0;
   // This is the time of a lunar eclipse in January 2000.
   constexpr Instant now = "2000-01-21T04:41:30,5"_TT;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     lines = planetarium.PlotMethod2(satellites.goes_8_trajectory(),
                                     satellites.goes_8_trajectory().begin(),
                                     satellites.goes_8_trajectory().end(),

--- a/benchmarks/planetarium_plot_methods.cpp
+++ b/benchmarks/planetarium_plot_methods.cpp
@@ -262,10 +262,14 @@ void BM_PlanetariumPlotMethod2FarEquatorialPerspective(
   RunBenchmark(state, EquatorialPerspective(far));
 }
 
-BENCHMARK(BM_PlanetariumPlotMethod2NearPolarPerspective);
-BENCHMARK(BM_PlanetariumPlotMethod2FarPolarPerspective);
-BENCHMARK(BM_PlanetariumPlotMethod2NearEquatorialPerspective);
-BENCHMARK(BM_PlanetariumPlotMethod2FarEquatorialPerspective);
+BENCHMARK(BM_PlanetariumPlotMethod2NearPolarPerspective)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PlanetariumPlotMethod2FarPolarPerspective)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PlanetariumPlotMethod2NearEquatorialPerspective)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PlanetariumPlotMethod2FarEquatorialPerspective)
+    ->Unit(benchmark::kMillisecond);
 
 }  // namespace geometry
 }  // namespace principia

--- a/benchmarks/polynomial.cpp
+++ b/benchmarks/polynomial.cpp
@@ -107,7 +107,7 @@ void EvaluatePolynomialInMonomialBasis(benchmark::State& state) {
 
 template<template<typename, typename, int> class Evaluator>
 void BM_EvaluatePolynomialInMonomialBasisDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   switch (degree) {
     case 4:
       EvaluatePolynomialInMonomialBasis<double, Time, 4, Evaluator>(state);
@@ -129,7 +129,7 @@ void BM_EvaluatePolynomialInMonomialBasisDouble(benchmark::State& state) {
 
 template<template<typename, typename, int> class Evaluator>
 void BM_EvaluatePolynomialInMonomialBasisQuantity(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   switch (degree) {
     case 4:
       EvaluatePolynomialInMonomialBasis<Length, Time, 4, Evaluator>(state);
@@ -151,7 +151,7 @@ void BM_EvaluatePolynomialInMonomialBasisQuantity(benchmark::State& state) {
 
 template<template<typename, typename, int> class Evaluator>
 void BM_EvaluatePolynomialInMonomialBasisVectorDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   switch (degree) {
     case 4:
       EvaluatePolynomialInMonomialBasis<Multivector<double, ICRS, 1>,
@@ -185,7 +185,7 @@ void BM_EvaluatePolynomialInMonomialBasisVectorDouble(benchmark::State& state) {
 
 template<template<typename, typename, int> class Evaluator>
 void BM_EvaluatePolynomialInMonomialBasisDisplacement(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   switch (degree) {
     case 4:
       EvaluatePolynomialInMonomialBasis<Displacement<ICRS>,

--- a/benchmarks/polynomial.cpp
+++ b/benchmarks/polynomial.cpp
@@ -91,7 +91,7 @@ void EvaluatePolynomialInMonomialBasis(benchmark::State& state) {
   auto const Δargument = (max - min) * 1e-9;
   auto result = Value{};
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += p(argument);
       argument += Δargument;

--- a/benchmarks/polynomial.cpp
+++ b/benchmarks/polynomial.cpp
@@ -219,28 +219,28 @@ void BM_EvaluatePolynomialInMonomialBasisDisplacement(benchmark::State& state) {
 
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisDouble,
                     EstrinEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisQuantity,
                     EstrinEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisVectorDouble,
                     EstrinEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisDisplacement,
                     EstrinEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisDouble,
                     HornerEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisQuantity,
                     HornerEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisVectorDouble,
                     HornerEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_EvaluatePolynomialInMonomialBasisDisplacement,
                     HornerEvaluator)
-    ->Arg(4)->Arg(8)->Arg(12)->Arg(16);
+    ->Arg(4)->Arg(8)->Arg(12)->Arg(16)->Unit(benchmark::kMicrosecond);
 
 }  // namespace numerics
 }  // namespace principia

--- a/benchmarks/quantities.cpp
+++ b/benchmarks/quantities.cpp
@@ -11,7 +11,7 @@ namespace quantities {
 
 void BM_DimensionfulDiscreteCosineTransform(benchmark::State& state) {
   std::vector<Momentum> output;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     DimensionfulDiscreteCosineTransform(output);
   }
 }
@@ -19,7 +19,7 @@ BENCHMARK(BM_DimensionfulDiscreteCosineTransform);
 
 void BM_DoubleDiscreteCosineTransform(benchmark::State& state) {
   std::vector<double> output;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     DoubleDiscreteCosineTransform(output);
   }
 }

--- a/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
@@ -205,53 +205,69 @@ void BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D(
 
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::McLachlanAtela1992Order4Optimal, Length);
+    methods::McLachlanAtela1992Order4Optimal, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::McLachlan1995SB3A4, Length);
+    methods::McLachlan1995SB3A4, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::McLachlan1995SB3A5, Length);
+    methods::McLachlan1995SB3A5, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::BlanesMoan2002SRKN6B, Length);
+    methods::BlanesMoan2002SRKN6B, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::McLachlanAtela1992Order5Optimal, Length);
+    methods::McLachlanAtela1992Order5Optimal, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::OkunborSkeel1994Order6Method13, Length);
+    methods::OkunborSkeel1994Order6Method13, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::BlanesMoan2002SRKN11B, Length);
+    methods::BlanesMoan2002SRKN11B, Length)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D,
-    methods::BlanesMoan2002SRKN14A, Length);
+    methods::BlanesMoan2002SRKN14A, Length)
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::McLachlanAtela1992Order4Optimal, Position<World>);
+    methods::McLachlanAtela1992Order4Optimal, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::McLachlan1995SB3A4, Position<World>);
+    methods::McLachlan1995SB3A4, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::McLachlan1995SB3A5, Position<World>);
+    methods::McLachlan1995SB3A5, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::BlanesMoan2002SRKN6B, Position<World>);
+    methods::BlanesMoan2002SRKN6B, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::McLachlanAtela1992Order5Optimal, Position<World>);
+    methods::McLachlanAtela1992Order5Optimal, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::OkunborSkeel1994Order6Method13, Position<World>);
+    methods::OkunborSkeel1994Order6Method13, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::BlanesMoan2002SRKN11B, Position<World>);
+    methods::BlanesMoan2002SRKN11B, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE2(
     BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D,
-    methods::BlanesMoan2002SRKN14A, Position<World>);
+    methods::BlanesMoan2002SRKN14A, Position<World>)
+    ->Unit(benchmark::kMillisecond);
 
 }  // namespace integrators
 }  // namespace principia

--- a/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/symplectic_runge_kutta_nyström_integrator.cpp
@@ -174,7 +174,7 @@ void BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator1D(
     benchmark::State& state) {
   Length q_error;
   Speed v_error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     SolveHarmonicOscillatorAndComputeError1D(
         state,
         q_error,
@@ -191,7 +191,7 @@ void BM_SymplecticRungeKuttaNyströmIntegratorSolveHarmonicOscillator3D(
     benchmark::State& state) {
   Length q_error;
   Speed v_error;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     SolveHarmonicOscillatorAndComputeError3D(
         state,
         q_error,

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -105,7 +105,8 @@ BENCHMARK(BM_ThreadPoolNoLock)
     ->Arg(5)
     ->Arg(6)
     ->Arg(7)
-    ->Arg(8);
+    ->Arg(8)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_ThreadPoolSharedLock)
     ->Arg(1)
     ->Arg(2)
@@ -114,7 +115,8 @@ BENCHMARK(BM_ThreadPoolSharedLock)
     ->Arg(5)
     ->Arg(6)
     ->Arg(7)
-    ->Arg(8);
+    ->Arg(8)
+    ->Unit(benchmark::kMillisecond);
 BENCHMARK(BM_ThreadPoolExclusiveLock)
     ->Arg(1)
     ->Arg(2)
@@ -123,7 +125,8 @@ BENCHMARK(BM_ThreadPoolExclusiveLock)
     ->Arg(5)
     ->Arg(6)
     ->Arg(7)
-    ->Arg(8);
+    ->Arg(8)
+    ->Unit(benchmark::kMillisecond);
 
 }  // namespace base
 }  // namespace principia

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -47,7 +47,7 @@ double ComsumeCpuExclusiveLock(std::int64_t const n) {
 }
 
 void BM_ThreadPoolNoLock(benchmark::State& state) {
-  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  ThreadPool<void> pool(/*pool_size=*/state.range(0));
   std::vector<std::int64_t> results;
   for (auto _ : state) {
     std::vector<std::future<void>> futures;
@@ -64,7 +64,7 @@ void BM_ThreadPoolNoLock(benchmark::State& state) {
 }
 
 void BM_ThreadPoolSharedLock(benchmark::State& state) {
-  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  ThreadPool<void> pool(/*pool_size=*/state.range(0));
   std::vector<std::int64_t> results;
   for (auto _ : state) {
     std::vector<std::future<void>> futures;
@@ -81,7 +81,7 @@ void BM_ThreadPoolSharedLock(benchmark::State& state) {
 }
 
 void BM_ThreadPoolExclusiveLock(benchmark::State& state) {
-  ThreadPool<void> pool(/*pool_size=*/state.range_x());
+  ThreadPool<void> pool(/*pool_size=*/state.range(0));
   std::vector<std::int64_t> results;
   for (auto _ : state) {
     std::vector<std::future<void>> futures;

--- a/benchmarks/thread_pool.cpp
+++ b/benchmarks/thread_pool.cpp
@@ -49,7 +49,7 @@ double ComsumeCpuExclusiveLock(std::int64_t const n) {
 void BM_ThreadPoolNoLock(benchmark::State& state) {
   ThreadPool<void> pool(/*pool_size=*/state.range_x());
   std::vector<std::int64_t> results;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     std::vector<std::future<void>> futures;
     for (int i = 0; i < 1000; ++i) {
       futures.push_back(pool.Add([]() {
@@ -66,7 +66,7 @@ void BM_ThreadPoolNoLock(benchmark::State& state) {
 void BM_ThreadPoolSharedLock(benchmark::State& state) {
   ThreadPool<void> pool(/*pool_size=*/state.range_x());
   std::vector<std::int64_t> results;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     std::vector<std::future<void>> futures;
     for (int i = 0; i < 1000; ++i) {
       futures.push_back(pool.Add([]() {
@@ -83,7 +83,7 @@ void BM_ThreadPoolSharedLock(benchmark::State& state) {
 void BM_ThreadPoolExclusiveLock(benchmark::State& state) {
   ThreadPool<void> pool(/*pool_size=*/state.range_x());
   std::vector<std::int64_t> results;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     std::vector<std::future<void>> futures;
     for (int i = 0; i < 1000; ++i) {
       futures.push_back(pool.Add([]() {

--- a/benchmarks/чебышёв_series.cpp
+++ b/benchmarks/чебышёв_series.cpp
@@ -205,16 +205,51 @@ void BM_EvaluateDisplacement(benchmark::State& state) {
   state.SetLabel(ss.str().substr(0, 0));
 }
 
-BENCHMARK(BM_EvaluateDouble)->
-    Arg(4)->Arg(8)->Arg(15)->Arg(16)->Arg(17)->Arg(18)->Arg(19);
-BENCHMARK(BM_EvaluateQuantity)->
-    Arg(4)->Arg(8)->Arg(15)->Arg(16)->Arg(17)->Arg(18)->Arg(19);
-BENCHMARK(BM_EvaluateR3ElementDouble)->
-    Arg(4)->Arg(8)->Arg(15)->Arg(16)->Arg(17)->Arg(18)->Arg(19);
-BENCHMARK(BM_EvaluateVectorDouble)->
-    Arg(4)->Arg(8)->Arg(15)->Arg(16)->Arg(17)->Arg(18)->Arg(19);
-BENCHMARK(BM_EvaluateDisplacement)->
-    Arg(4)->Arg(8)->Arg(15)->Arg(16)->Arg(17)->Arg(18)->Arg(19);
+BENCHMARK(BM_EvaluateDouble)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(15)
+    ->Arg(16)
+    ->Arg(17)
+    ->Arg(18)
+    ->Arg(19)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_EvaluateQuantity)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(15)
+    ->Arg(16)
+    ->Arg(17)
+    ->Arg(18)
+    ->Arg(19)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_EvaluateR3ElementDouble)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(15)
+    ->Arg(16)
+    ->Arg(17)
+    ->Arg(18)
+    ->Arg(19)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_EvaluateVectorDouble)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(15)
+    ->Arg(16)
+    ->Arg(17)
+    ->Arg(18)
+    ->Arg(19)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_EvaluateDisplacement)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(15)
+    ->Arg(16)
+    ->Arg(17)
+    ->Arg(18)
+    ->Arg(19)
+    ->Unit(benchmark::kMicrosecond);
 
 }  // namespace numerics
 }  // namespace principia

--- a/benchmarks/чебышёв_series.cpp
+++ b/benchmarks/чебышёв_series.cpp
@@ -64,7 +64,7 @@ void BM_EvaluateDouble(benchmark::State& state) {
   Time const Δt = (t_max - t_min) * 1e-9;
   double result = 0.0;
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += series.Evaluate(t);
       t += Δt;
@@ -92,7 +92,7 @@ void BM_EvaluateQuantity(benchmark::State& state) {
   Time const Δt = (t_max - t_min) * 1e-9;
   Length result = 0.0 * Metre;
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += series.Evaluate(t);
       t += Δt;
@@ -124,7 +124,7 @@ void BM_EvaluateR3ElementDouble(benchmark::State& state) {
   Time const Δt = (t_max - t_min) * 1e-9;
   R3Element<double> result{0.0, 0.0, 0.0};
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += series.Evaluate(t);
       t += Δt;
@@ -158,7 +158,7 @@ void BM_EvaluateVectorDouble(benchmark::State& state) {
   Time const Δt = (t_max - t_min) * 1e-9;
   Multivector<double, ICRS, 1> result{};
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += series.Evaluate(t);
       t += Δt;
@@ -191,7 +191,7 @@ void BM_EvaluateDisplacement(benchmark::State& state) {
   Time const Δt = (t_max - t_min) * 1e-9;
   Displacement<ICRS> result{};
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (int i = 0; i < evaluations_per_iteration; ++i) {
       result += series.Evaluate(t);
       t += Δt;

--- a/benchmarks/чебышёв_series.cpp
+++ b/benchmarks/чебышёв_series.cpp
@@ -49,7 +49,7 @@ constexpr int evaluations_per_iteration = 1000;
 }  // namespace
 
 void BM_EvaluateDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<double> coefficients;
   for (int i = 0; i <= degree; ++i) {
@@ -77,7 +77,7 @@ void BM_EvaluateDouble(benchmark::State& state) {
 }
 
 void BM_EvaluateQuantity(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<Length> coefficients;
   for (int i = 0; i <= degree; ++i) {
@@ -107,7 +107,7 @@ void BM_EvaluateQuantity(benchmark::State& state) {
 }
 
 void BM_EvaluateR3ElementDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<R3Element<double>> coefficients;
   for (int i = 0; i <= degree; ++i) {
@@ -139,7 +139,7 @@ void BM_EvaluateR3ElementDouble(benchmark::State& state) {
 }
 
 void BM_EvaluateVectorDouble(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<Multivector<double, ICRS, 1>> coefficients;
   for (int i = 0; i <= degree; ++i) {
@@ -173,7 +173,7 @@ void BM_EvaluateVectorDouble(benchmark::State& state) {
 }
 
 void BM_EvaluateDisplacement(benchmark::State& state) {
-  int const degree = state.range_x();
+  int const degree = state.range(0);
   std::mt19937_64 random(42);
   std::vector<Displacement<ICRS>> coefficients;
   for (int i = 0; i <= degree; ++i) {

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -22,7 +22,7 @@ namespace journal {
 using namespace std::chrono_literals;
 
 void BM_PlayForReal(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Player player(
         R"(P:\Public Mockingbird\Principia\Journals\JOURNAL.20180311-192733)");
     int count = 0;

--- a/ksp_plugin_test/benchmark.cpp
+++ b/ksp_plugin_test/benchmark.cpp
@@ -115,9 +115,9 @@ void BM_PluginDeserializationBenchmark(benchmark::State& state) {
   state.SetBytesProcessed(bytes_processed);
 }
 
-BENCHMARK(BM_PluginSerializationBenchmark);
-BENCHMARK(BM_PluginDeserializationBenchmark);
-BENCHMARK(BM_PluginIntegrationBenchmark);
+BENCHMARK(BM_PluginSerializationBenchmark)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PluginDeserializationBenchmark)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PluginIntegrationBenchmark)->Unit(benchmark::kMillisecond);
 
 // .\Release\x64\ksp_plugin_test_tests.exe --gtest_filter=PluginBenchmark.DISABLED_All --gtest_also_run_disabled_tests  // NOLINT
 TEST(PluginBenchmark, DISABLED_All) {


### PR DESCRIPTION
Because I don't need to know a multi-second benchmark to nanosecond precision.
For example, `BM_EphemerisKSPSystem` goes from `16353847667  ns` to `16.3 s`
Microseconds, milliseconds, and seconds are used where appropriate.
Also replaced `while (state.KeepRunning())` with the updated form `for (auto _ : state)`, and updated `state.range_x()`and `state.range_y()` to `state.range(0)` and `state.range(1)`.
New benchmark output is here: [bench.txt](https://github.com/mockingbirdnest/Principia/files/7991189/bench.txt).
