### PR TITLE
Fixes for some clang warnings.

### DIFF
--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -428,7 +428,7 @@ TEST_P(KSPSystemConvergenceTest, DISABLED_Convergence) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AllKSPSystemConvergenceTests,
     KSPSystemConvergenceTest,
     ::testing::Values(

--- a/astronomy/lunar_orbit_test.cpp
+++ b/astronomy/lunar_orbit_test.cpp
@@ -269,7 +269,7 @@ constexpr std::array<GeopotentialTruncation, 4> geopotential_truncations = {
      }},
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     DISABLED_TruncatedSelenopotentials,
     LunarOrbitTest,
     ::testing::ValuesIn(geopotential_truncations));

--- a/astronomy/solar_system_dynamics_test.cpp
+++ b/astronomy/solar_system_dynamics_test.cpp
@@ -706,7 +706,7 @@ TEST_P(SolarSystemDynamicsConvergenceTest, DISABLED_Convergence) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AllSolarSystemDynamicsConvergenceTests,
     SolarSystemDynamicsConvergenceTest,
     ::testing::Values(

--- a/astronomy/standard_product_3_test.cpp
+++ b/astronomy/standard_product_3_test.cpp
@@ -293,7 +293,7 @@ class StandardProduct3DynamicsTest
   BodySurfaceDynamicFrame<ICRS, ITRS> itrs_;
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AllVersionsAndDialects,
     StandardProduct3DynamicsTest,
     ValuesIn(std::vector<StandardProduct3Args>{

--- a/benchmarks/dynamic_frame.cpp
+++ b/benchmarks/dynamic_frame.cpp
@@ -61,10 +61,6 @@ namespace si = quantities::si;
 
 namespace physics {
 
-namespace {
-const Length tolerance = 0.01 * Metre;
-}  // namespace
-
 using Rendering = Frame<enum class RenderingTag>;
 
 template<typename F, template<typename> class T>

--- a/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
+++ b/benchmarks/embedded_explicit_runge_kutta_nyström_integrator.cpp
@@ -151,7 +151,6 @@ void SolveHarmonicOscillatorAndComputeError3D(
   Velocity<World> const v_initial;
   Instant const t_initial;
   Instant const t_final = t_initial + 1000 * Second;
-  Time const step = 3.0e-4 * Second;
   Length const length_tolerance = 1e-6 * Metre;
   Speed const speed_tolerance = 1e-6 * Metre / Second;
 

--- a/benchmarks/ephemeris.cpp
+++ b/benchmarks/ephemeris.cpp
@@ -419,7 +419,7 @@ void EphemerisL4ProbeBenchmark(Time const integration_duration,
 
   CHECK_OK(ephemeris->Prolong(final_time));
 
-  auto make_l4_probe_trajectory = [&ephemeris, &at_спутник_1_launch]() {
+  auto make_l4_probe_trajectory = [&at_спутник_1_launch]() {
     // A probe near the L4 point of the Sun-Earth system.
     Identity<ICRS, Barycentric> to_barycentric;
     Identity<Barycentric, ICRS> from_barycentric;

--- a/integrators/symmetric_linear_multistep_integrator_test.cpp
+++ b/integrators/symmetric_linear_multistep_integrator_test.cpp
@@ -186,7 +186,7 @@ class SymmetricLinearMultistepIntegratorTest
   }
 };
 
-INSTANTIATE_TEST_CASE_P(SymmetricLinearMultistepIntegratorTests,
+INSTANTIATE_TEST_SUITE_P(SymmetricLinearMultistepIntegratorTests,
                         SymmetricLinearMultistepIntegratorTest,
                         ValuesIn(Instances()));
 

--- a/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_test.cpp
@@ -535,7 +535,7 @@ class SymplecticRungeKuttaNyströmIntegratorTest
   }
 };
 
-INSTANTIATE_TEST_CASE_P(SymplecticRungeKuttaNyströmIntegratorTests,
+INSTANTIATE_TEST_SUITE_P(SymplecticRungeKuttaNyströmIntegratorTests,
                         SymplecticRungeKuttaNyströmIntegratorTest,
                         ValuesIn(Instances()));
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -80,14 +80,15 @@ Vessel::Vessel(
             return Reanimate(desired_t_min);
           },
           20ms),  // 50 Hz.
+      backstory_(trajectory_.segments().begin()),
+      psychohistory_(trajectory_.segments().end()),
+      prediction_(trajectory_.segments().end()),
       prognosticator_(
           [this](PrognosticatorParameters const& parameters) {
             return FlowPrognostication(parameters);
           },
-          20ms),  // 50 Hz.
-      backstory_(trajectory_.segments().begin()),
-      psychohistory_(trajectory_.segments().end()),
-      prediction_(trajectory_.segments().end()) {}
+          20ms)  // 50 Hz.
+{}
 
 Vessel::~Vessel() {
   LOG(INFO) << "Destroying vessel " << ShortDebugString();
@@ -794,10 +795,10 @@ Vessel::Vessel()
       prediction_adaptive_step_parameters_(DefaultPredictionParameters()),
       parent_(testing_utilities::make_not_null<Celestial const*>()),
       ephemeris_(testing_utilities::make_not_null<Ephemeris<Barycentric>*>()),
-      reanimator_(/*action=*/nullptr, 0ms),
       checkpointer_(make_not_null_unique<Checkpointer<serialization::Vessel>>(
           /*reader=*/nullptr,
           /*writer=*/nullptr)),
+      reanimator_(/*action=*/nullptr, 0ms),
       backstory_(trajectory_.segments().begin()),
       psychohistory_(trajectory_.segments().end()),
       prediction_(trajectory_.segments().end()),

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -169,23 +169,6 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
           SLMS_INTEGRATOR(QuinlanTremaine1990Order14)};
 }
 
-// Those methods which have converged to the limits of double-precision floating
-// point error on the circular Kepler problem tested by
-// |GenerateKeplerProblemWorkErrorGraphs| with less than 8e4 evaluations.
-std::vector<SimpleHarmonicMotionPlottedIntegrator> ReferenceMethods() {
-  return {// Order 5
-          SRKN_INTEGRATOR(McLachlanAtela1992Order5Optimal),
-          // Order 6
-          SPRK_INTEGRATOR(McLachlan1995SS9, BAB),
-          SPRK_INTEGRATOR(BlanesMoan2002S10, BAB),
-          SRKN_INTEGRATOR(OkunborSkeel1994Order6Method13),
-          SRKN_INTEGRATOR(BlanesMoan2002SRKN11B),
-          SRKN_INTEGRATOR(BlanesMoan2002SRKN14A),
-          // Order 8
-          SPRK_INTEGRATOR(McLachlan1995SS15, BAB),
-          SPRK_INTEGRATOR(McLachlan1995SS17, BAB)};
-}
-
 }  // namespace
 
 // Templatized to allow for problems where specific energy is more convenient

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -1074,6 +1074,7 @@ Ephemeris<Frame>::AppendMassiveBodiesStateToTrajectories(
     typename NewtonianMotionEquation::SystemState const& state,
     std::vector<not_null<ContinuousTrajectoryPtr>> const& trajectories) {
   std::vector<absl::Status> statuses;
+  statuses.reserve(trajectories.size());
   Instant const time = state.time.value;
   int index = 0;
   for (auto& trajectory : trajectories) {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -1166,7 +1166,7 @@ TEST(EphemerisTestNoFixture, Reanimator) {
 }
 #endif
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AllEphemerisTests,
     EphemerisTest,
     ::testing::Values(


### PR DESCRIPTION
Deprecated macros, unused declarations, etc.
Also added a missing `reserve` call to `AppendMassiveBodiesStateToTrajectories`.