### PR TITLE
Cleanup and simplify the array APIs

### DIFF
--- a/astronomy/fortran_astrodynamics_toolkit_body.hpp
+++ b/astronomy/fortran_astrodynamics_toolkit_body.hpp
@@ -32,7 +32,7 @@ R3Element<double> ComputeGravityAccelerationLear(
   int nm1, nm2;
 
   for (int n = 2; n <= nmodel; ++n) {
-    pnm[n - 1][n] = 0.0;
+    pnm(n - 1, n) = 0.0;
   }
 
   e1 = rgr.x * rgr.x + rgr.y * rgr.y;
@@ -56,12 +56,12 @@ R3Element<double> ComputeGravityAccelerationLear(
   pn[2] = (3.0 * sphi * sphi - 1.0) / 2.0;
   ppn[1] = 1.0;
   ppn[2] = 3.0 * sphi;
-  pnm[1][1] = 1.0;
-  pnm[2][2] = 3.0 * cphi;
-  pnm[2][1] = ppn[2];
-  ppnm[1][1] = -sphi;
-  ppnm[2][2] = -6.0 * sphi * cphi;
-  ppnm[2][1] = 3.0 - 6.0 * sphi * sphi;
+  pnm(1, 1) = 1.0;
+  pnm(2, 2) = 3.0 * cphi;
+  pnm(2, 1) = ppn[2];
+  ppnm(1, 1) = -sphi;
+  ppnm(2, 2) = -6.0 * sphi * cphi;
+  ppnm(2, 1) = 3.0 - 6.0 * sphi * sphi;
   if (nmodel >= 3) {
     for (int n = 3; n <= nmodel; ++n) {
       nm1 = n - 1;
@@ -72,19 +72,19 @@ R3Element<double> ComputeGravityAccelerationLear(
       e1 = 2 * n - 1;
       pn[n] = (e1 * sphi * pn[nm1] - nm1 * pn[nm2]) / n;
       ppn[n] = sphi * ppn[nm1] + n * pn[nm1];
-      pnm[n][n] = e1 * cphi * pnm[nm1][nm1];
-      ppnm[n][n] = -n * sphi * pnm[n][n];
+      pnm(n, n) = e1 * cphi * pnm(nm1, nm1);
+      ppnm(n, n) = -n * sphi * pnm(n, n);
     }
     for (int n = 3; n <= nmodel; ++n) {
       nm1 = n - 1;
       e1 = (2 * n - 1) * sphi;
       e2 = -n * sphi;
       for (int m = 1; m <= nm1; ++m) {
-        e3 = pnm[nm1][m];
+        e3 = pnm(nm1, m);
         e4 = n + m;
-        e5 = (e1 * e3 - (e4 - 1.0) * pnm[n - 2][m]) / (n - m);
-        pnm[n][m] = e5;
-        ppnm[n][m] = e2 * e5 + e4 * e3;
+        e5 = (e1 * e3 - (e4 - 1.0) * pnm(n - 2, m)) / (n - m);
+        pnm(n, m) = e5;
+        ppnm(n, m) = e2 * e5 + e4 * e3;
       }
     }
   }
@@ -93,7 +93,7 @@ R3Element<double> ComputeGravityAccelerationLear(
   asph.z = 0.0;
 
   for (int n = 2; n <= nmodel; ++n) {
-    e1 = cnm[n][0] * rb[n];
+    e1 = cnm(n, 0) * rb[n];
     asph.x = asph.x - (n + 1) * e1 * pn[n];
     asph.z = asph.z + e1 * ppn[n];
   }
@@ -107,15 +107,15 @@ R3Element<double> ComputeGravityAccelerationLear(
     e2 = 0.0;
     e3 = 0.0;
     for (int m = 1; m <= std::min(n, mmodel); ++m) {
-      tsnm = snm[n][m];
-      tcnm = cnm[n][m];
+      tsnm = snm(n, m);
+      tcnm = cnm(n, m);
       tsm = sm[m];
       tcm = cm[m];
-      tpnm = pnm[n][m];
+      tpnm = pnm(n, m);
       e4 = tsnm * tsm + tcnm * tcm;
       e1 = e1 + e4 * tpnm;
       e2 = e2 + m * (tsnm * tcm - tcnm * tsm) * tpnm;
-      e3 = e3 + e4 * ppnm[n][m];
+      e3 = e3 + e4 * ppnm(n, m);
     }
     t1 = t1 + (n + 1) * rb[n] * e1;
     asph.y = asph.y + rb[n] * e2;

--- a/benchmarks/geopotential.cpp
+++ b/benchmarks/geopotential.cpp
@@ -194,8 +194,8 @@ void BM_ComputeGeopotentialDistance(benchmark::State& state) {
     numerics::FixedMatrix<double, (d) + 1, (d) + 1> snm;                   \
     for (int n = 0; n <= (d); ++n) {                                       \
       for (int m = 0; m <= n; ++m) {                                       \
-        cnm[n][m] = earth.cos()[n][m] * LegendreNormalizationFactor[n][m]; \
-        snm[n][m] = earth.sin()[n][m] * LegendreNormalizationFactor[n][m]; \
+        cnm(n, m) = earth.cos()(n, m) * LegendreNormalizationFactor(n, m); \
+        snm(n, m) = earth.sin()(n, m) * LegendreNormalizationFactor(n, m); \
       }                                                                    \
     }                                                                      \
     while (state.KeepRunning()) {                                          \

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -36,7 +36,7 @@ EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator() {
     CHECK_EQ(1.0, c_[stages_ - 1]);
     CHECK_EQ(0.0, b̂_[stages_ - 1]);
     for (int j = 0; j < stages_ - 1; ++j) {
-      CHECK_EQ(b̂_[j], a_[stages_ - 1][j]);
+      CHECK_EQ(b̂_[j], a_(stages_ - 1, j));
     }
   }
 }
@@ -187,8 +187,8 @@ absl::Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
           Acceleration Σj_a_ij_g_jk{};
           Acceleration Σj_aʹ_ij_g_jk{};
           for (int j = 0; j < i; ++j) {
-            Σj_a_ij_g_jk  += a[i][j] * g[j][k];
-            Σj_aʹ_ij_g_jk += aʹ[i][j] * g[j][k];
+            Σj_a_ij_g_jk  += a(i, j) * g[j][k];
+            Σj_aʹ_ij_g_jk += aʹ(i, j) * g[j][k];
           }
           q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σj_a_ij_g_jk;
           v_stage[k] = v̂[k].value + h * Σj_aʹ_ij_g_jk;

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -36,7 +36,7 @@ EmbeddedExplicitRungeKuttaNyströmIntegrator() {
     CHECK_EQ(1.0, c_[stages_ - 1]);
     CHECK_EQ(0.0, b̂_[stages_ - 1]);
     for (int j = 0; j < stages_ - 1; ++j) {
-      CHECK_EQ(b̂_[j], a_[stages_ - 1][j]);
+      CHECK_EQ(b̂_[j], a_(stages_ - 1, j));
     }
   }
 }
@@ -183,7 +183,7 @@ Instance::Solve(Instant const& t_final) {
         for (int k = 0; k < dimension; ++k) {
           Acceleration Σj_a_ij_g_jk{};
           for (int j = 0; j < i; ++j) {
-            Σj_a_ij_g_jk += a[i][j] * g[j][k];
+            Σj_a_ij_g_jk += a(i, j) * g[j][k];
           }
           q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σj_a_ij_g_jk;
         }

--- a/ksp_plugin/interface_external.cpp
+++ b/ksp_plugin/interface_external.cpp
@@ -195,8 +195,8 @@ Status* __cdecl principia__ExternalGeopotentialGetCoefficient(
     *coefficient = {0, 0};
     return m.Return(OK());
   }
-  *coefficient = {oblate_body.cos()[degree][order],
-                  oblate_body.sin()[degree][order]};
+  *coefficient = {oblate_body.cos()(degree, order),
+                  oblate_body.sin()(degree, order)};
   return m.Return(OK());
 }
 

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -421,7 +421,7 @@ std::string ToMathematica(UnboundedLowerTriangularMatrix<Scalar> const& matrix,
     std::vector<std::string> row;
     row.reserve(matrix.rows());
     for (int j = 0; j <= i; ++j) {
-      row.push_back(ToMathematica(matrix[i][j], express_in));
+      row.push_back(ToMathematica(matrix(i, j), express_in));
     }
     for (int j = i + 1; j < matrix.rows(); ++j) {
       row.push_back(ToMathematica(Scalar{}, express_in));
@@ -443,7 +443,7 @@ std::string ToMathematica(UnboundedUpperTriangularMatrix<Scalar> const& matrix,
       row.push_back(ToMathematica(Scalar{}, express_in));
     }
     for (int j = i; j < matrix.columns(); ++j) {
-      row.push_back(ToMathematica(matrix[i][j], express_in));
+      row.push_back(ToMathematica(matrix(i, j), express_in));
     }
     rows.push_back(Apply("List", row));
   }

--- a/numerics/finite_difference_body.hpp
+++ b/numerics/finite_difference_body.hpp
@@ -13,7 +13,7 @@ Derivative<Value, Argument> FiniteDifference(
     std::array<Value, n> const& values,
     Argument const& step,
     int const offset) {
-  double const* const numerators = std::get<n - 1>(Numerators)[offset];
+  auto const& numerators = std::get<n - 1>(Numerators);
   constexpr double denominator = Denominators[n - 1];
   Difference<Value> sum{};
   if (n % 2 == 1 && offset == (n - 1) / 2) {
@@ -24,7 +24,7 @@ Derivative<Value, Argument> FiniteDifference(
     // Σⱼ aⱼ (f(xⱼ) - f(xₙ₋ⱼ₋₁)), with j running from 0 to (n - 3) / 2.  Which
     // we cannot write naively because n is unsigned.
     for (int j = 0; 2 * j + 3 <= n; ++j) {
-      sum += numerators[j] * (values[j] - values[n - j - 1]);
+      sum += numerators(offset, j) * (values[j] - values[n - j - 1]);
     }
     return sum / (denominator * step);
   } else {
@@ -35,7 +35,7 @@ Derivative<Value, Argument> FiniteDifference(
     // k runs from 0 to j.
     double numerator = 0;
     for (int j = 0; j + 2 <= n; ++j) {
-      numerator += numerators[j];
+      numerator += numerators(offset, j);
       sum += numerator * (values[j] - values[j + 1]);
     }
   }

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -110,7 +110,7 @@ class FixedStrictlyLowerTriangularMatrix final {
   constexpr FixedStrictlyLowerTriangularMatrix(
       std::array<Scalar, size()> const& data);
 
-  // For  0 < j < i < rows, the entry a_ij is accessed as |a(i, j)|.
+  // For  0 ≤ j < i < rows, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
   constexpr Scalar& operator()(int row, int column);

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -47,6 +47,10 @@ class FixedVector final {
 
   template<typename L, typename R, int s>
   friend constexpr Product<L, R> operator*(
+      L* const left,
+      FixedVector<R, s> const& right);
+  template<typename L, typename R, int s>
+  friend constexpr Product<L, R> operator*(
       TransposedView<FixedVector<L, s>> const& left,
       FixedVector<R, s> const& right);
   template<typename L, typename R, int r, int c>
@@ -76,6 +80,9 @@ class FixedMatrix final {
   // |a(i, j)| implies undefined behaviour.
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
+
+  template<int r>
+  Scalar const* row() const;
 
   bool operator==(FixedMatrix const& right) const;
   bool operator!=(FixedMatrix const& right) const;
@@ -108,6 +115,9 @@ class FixedStrictlyLowerTriangularMatrix final {
   // implies undefined behaviour.
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
+
+  template<int r>
+  Scalar const* row() const;
 
   bool operator==(FixedStrictlyLowerTriangularMatrix const& right) const;
   bool operator!=(FixedStrictlyLowerTriangularMatrix const& right) const;
@@ -168,7 +178,7 @@ class FixedUpperTriangularMatrix final {
 
  private:
   // For ease of writing matrices in tests, the input data is received in row-
-  // major format.  This translates a trapezoidal slice to make it column-major.
+  // major format.  This transposes a trapezoidal slice to make it column-major.
   static std::array<Scalar, size()> Transpose(
       std::array<Scalar, size()> const& data);
 
@@ -178,6 +188,11 @@ class FixedUpperTriangularMatrix final {
 template<typename ScalarLeft, typename ScalarRight, int size>
 constexpr FixedVector<Difference<ScalarLeft, ScalarRight>, size> operator-(
     FixedVector<ScalarLeft, size> const& left,
+    FixedVector<ScalarRight, size> const& right);
+
+template<typename ScalarLeft, typename ScalarRight, int size>
+constexpr Product<ScalarLeft, ScalarRight> operator*(
+    ScalarLeft* const left,
     FixedVector<ScalarRight, size> const& right);
 
 template<typename ScalarLeft, typename ScalarRight, int size>

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -140,14 +140,14 @@ class FixedLowerTriangularMatrix final {
   bool operator!=(FixedLowerTriangularMatrix const& right) const;
 
  private:
-  std::array<Scalar, dimension> data_;
+  std::array<Scalar, size()> data_;
 };
 
 template<typename Scalar, int columns_>
 class FixedUpperTriangularMatrix final {
  public:
   static constexpr int rows() { return columns_; }
-  static constexpr int columns() { return rows_; }
+  static constexpr int columns() { return columns_; }
   static constexpr int size() { return columns_ * (columns_ + 1) / 2; }
 
   constexpr FixedUpperTriangularMatrix();
@@ -172,7 +172,7 @@ class FixedUpperTriangularMatrix final {
   static std::array<Scalar, size()> Transpose(
       std::array<Scalar, size()> const& data);
 
-  std::array<Scalar, dimension> data_;
+  std::array<Scalar, size()> data_;
 };
 
 template<typename ScalarLeft, typename ScalarRight, int size>

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -140,7 +140,7 @@ class FixedLowerTriangularMatrix final {
   constexpr FixedLowerTriangularMatrix(
       std::array<Scalar, size()> const& data);
 
-  // For  0 < j <= i < rows, the entry a_ij is accessed as |a(i, j)|.
+  // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
   constexpr Scalar& operator()(int row, int column);

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -173,7 +173,7 @@ FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size()> const& data)
 template<typename Scalar, int rows_>
 constexpr Scalar& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) {
-  CONSTEXPR_DCHECK(0 < column);
+  CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row - 1) / 2 + column];
@@ -182,7 +182,7 @@ operator()(int const row, int const column) {
 template<typename Scalar, int rows_>
 constexpr Scalar const& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) const {
-  CONSTEXPR_DCHECK(0 < column);
+  CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row - 1) / 2 + column];

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -173,20 +173,18 @@ FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size()> const& data)
 template<typename Scalar, int rows_>
 constexpr Scalar& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) {
-  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(0 < column);
+  CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
-  CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns());
   return data_[row * (row - 1) / 2 + column];
 }
 
 template<typename Scalar, int rows_>
 constexpr Scalar const& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) const {
-  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(0 < column);
+  CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
-  CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns());
   return data_[row * (row - 1) / 2 + column];
 }
 
@@ -226,20 +224,18 @@ FixedLowerTriangularMatrix(std::array<Scalar, size()> const& data)
 template<typename Scalar, int rows_>
 constexpr Scalar& FixedLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) {
-  CONSTEXPR_DCHECK(0 <= row);
-  CONSTEXPR_DCHECK(row < rows());
   CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns());
+  CONSTEXPR_DCHECK(column <= row);
+  CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar, int rows_>
 constexpr Scalar const& FixedLowerTriangularMatrix<Scalar, rows_>::
 operator()(int const row, int const column) const {
-  CONSTEXPR_DCHECK(0 <= row);
-  CONSTEXPR_DCHECK(row < rows());
   CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns());
+  CONSTEXPR_DCHECK(column <= row);
+  CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row + 1) / 2 + column];
 }
 
@@ -273,8 +269,7 @@ template<typename Scalar, int columns_>
 constexpr Scalar& FixedUpperTriangularMatrix<Scalar, columns_>::
 operator()(int const row, int const column) {
   CONSTEXPR_DCHECK(0 <= row);
-  CONSTEXPR_DCHECK(row < rows());
-  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(row <= column);
   CONSTEXPR_DCHECK(column < columns());
   return data_[column * (column + 1) / 2 + row];
 }
@@ -283,8 +278,7 @@ template<typename Scalar, int columns_>
 constexpr Scalar const& FixedUpperTriangularMatrix<Scalar, columns_>::
 operator()(int const row, int const column) const {
   CONSTEXPR_DCHECK(0 <= row);
-  CONSTEXPR_DCHECK(row < rows());
-  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(row <= column);
   CONSTEXPR_DCHECK(column < columns());
   return data_[column * (column + 1) / 2 + row];
 }

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -399,8 +399,8 @@ template<typename Scalar, int rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedLowerTriangularMatrix<Scalar, rows> const& matrix) {
-  out << "rows: " << matrix.rows << "\n";
-  for (int i = 0; i < matrix.rows; ++i) {
+  out << "rows: " << matrix.rows() << "\n";
+  for (int i = 0; i < matrix.rows(); ++i) {
     out << "{";
     for (int j = 0; j <= i; ++j) {
       out << matrix(i, j);

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -294,7 +294,7 @@ auto FixedUpperTriangularMatrix<Scalar, columns_>::Transpose(
     }
   }
 
-  std::array<Scalar, dimension> result;
+  std::array<Scalar, size()> result;
   index = 0;
   for (int column = 0; column < columns(); ++column) {
     for (int row = 0; row <= rows(); ++row) {

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -74,11 +74,6 @@ FixedVector<Scalar, size_>::Transpose() const {
 }
 
 template<typename Scalar, int size_>
-bool FixedVector<Scalar, size_>::operator==(FixedVector const& right) const {
-  return data_ == right.data_;
-}
-
-template<typename Scalar, int size_>
 constexpr Scalar& FixedVector<Scalar, size_>::operator[](int const index) {
   CONSTEXPR_DCHECK(0 <= index);
   CONSTEXPR_DCHECK(index < size());
@@ -100,6 +95,16 @@ FixedVector<Scalar, size_>::operator std::vector<Scalar>() const {
   return result;
 }
 
+template<typename Scalar, int size_>
+bool FixedVector<Scalar, size_>::operator==(FixedVector const& right) const {
+  return data_ == right.data_;
+}
+
+template<typename Scalar, int size_>
+bool FixedVector<Scalar, size_>::operator!=(FixedVector const& right) const {
+  return data_ != right.data_;
+}
+
 template<typename Scalar, int rows_, int columns_>
 constexpr FixedMatrix<Scalar, rows_, columns_>::FixedMatrix()
     : data_{} {}
@@ -109,8 +114,28 @@ FixedMatrix<Scalar, rows_, columns_>::FixedMatrix(uninitialized_t) {}
 
 template<typename Scalar, int rows_, int columns_>
 constexpr FixedMatrix<Scalar, rows_, columns_>::FixedMatrix(
-    std::array<Scalar, rows_ * columns_> const& data)
+    std::array<Scalar, size()> const& data)
     : data_(data) {}
+
+template<typename Scalar, int rows_, int columns_>
+constexpr Scalar& FixedMatrix<Scalar, rows_, columns_>::operator()(
+    int const row, int const column) {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * columns() + column];
+}
+
+template<typename Scalar, int rows_, int columns_>
+constexpr Scalar const& FixedMatrix<Scalar, rows_, columns_>::operator()(
+    int const row, int const column) const {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * columns() + column];
+}
 
 template<typename Scalar, int rows_, int columns_>
 bool FixedMatrix<Scalar, rows_, columns_>::operator==(
@@ -119,51 +144,9 @@ bool FixedMatrix<Scalar, rows_, columns_>::operator==(
 }
 
 template<typename Scalar, int rows_, int columns_>
-Scalar* FixedMatrix<Scalar, rows_, columns_>::operator[](int const index) {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows());
-  return &data_[index * columns()];
-}
-
-template<typename Scalar, int rows_, int columns_>
-constexpr Scalar const* FixedMatrix<Scalar, rows_, columns_>::operator[](
-    int const index) const {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows());
-  return &data_[index * columns()];
-}
-
-template<typename Scalar, int rows_, int columns_>
-template<int r>
-FixedMatrix<Scalar, rows_, columns_>::Row<r>::Row(
-    const FixedMatrix* const matrix)
-    : matrix_(matrix) {
-  static_assert(r < rows());
-}
-
-template<typename Scalar, int rows_, int columns_>
-template<int r>
-constexpr Scalar const& FixedMatrix<Scalar, rows_, columns_>::Row<r>::
-operator[](int index) const {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < columns());
-  return (matrix_->data_)[r * columns() + index];
-}
-
-template<typename Scalar, int rows_, int columns_>
-template<int r>
-template<typename S>
-Product<Scalar, S>
-FixedMatrix<Scalar, rows_, columns_>::Row<r>::operator*(
-    FixedVector<S, columns_> const& right) {
-  return DotProduct<Scalar, S, columns_>::Compute(*this, right);
-}
-
-template<typename Scalar, int rows_, int columns_>
-template<int r>
-typename FixedMatrix<Scalar, rows_, columns_>::template Row<r>
-FixedMatrix<Scalar, rows_, columns_>::row() const {
-  return Row<r>(this);
+bool FixedMatrix<Scalar, rows_, columns_>::operator!=(
+    FixedMatrix const& right) const {
+  return data_ != right.data_;
 }
 
 template<typename Scalar, int rows_>
@@ -177,9 +160,28 @@ FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
 
 template<typename Scalar, int rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
-    FixedStrictlyLowerTriangularMatrix(
-        std::array<Scalar, dimension> const& data)
+FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size()> const& data)
     : data_(data) {}
+
+template<typename Scalar, int rows_>
+constexpr Scalar& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
+operator()(int const row, int const column) {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * (row - 1) / 2 + column];
+}
+
+template<typename Scalar, int rows_>
+constexpr Scalar const& FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::
+operator()(int const row, int const column) const {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * (row - 1) / 2 + column];
+}
 
 template<typename Scalar, int rows_>
 bool FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::operator==(
@@ -188,38 +190,38 @@ bool FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::operator==(
 }
 
 template<typename Scalar, int rows_>
-Scalar* FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::operator[](
-    int const index) {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows);
-  return &data_[index * (index - 1) / 2];
-}
-
-template<typename Scalar, int rows_>
-constexpr Scalar const*
-FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::operator[](
-    int const index) const {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows);
-  return &data_[index * (index - 1) / 2];
-}
-
-template<typename Scalar, int rows_>
-constexpr int FixedStrictlyLowerTriangularMatrix<Scalar, rows_>::dimension;
-
-template<typename Scalar, int rows_>
 constexpr FixedLowerTriangularMatrix<Scalar, rows_>::
 FixedLowerTriangularMatrix()
     : data_{} {}
 
 template<typename Scalar, int rows_>
-FixedLowerTriangularMatrix<Scalar, rows_>::FixedLowerTriangularMatrix(
-    uninitialized_t) {}
+FixedLowerTriangularMatrix<Scalar, rows_>::
+FixedLowerTriangularMatrix(uninitialized_t) {}
 
 template<typename Scalar, int rows_>
 constexpr FixedLowerTriangularMatrix<Scalar, rows_>::
-    FixedLowerTriangularMatrix(std::array<Scalar, dimension> const& data)
+FixedLowerTriangularMatrix(std::array<Scalar, size()> const& data)
     : data_(data) {}
+
+template<typename Scalar, int rows_>
+constexpr Scalar& FixedLowerTriangularMatrix<Scalar, rows_>::
+operator()(int const row, int const column) {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * (row + 1) / 2 + column];
+}
+
+template<typename Scalar, int rows_>
+constexpr Scalar const& FixedLowerTriangularMatrix<Scalar, rows_>::
+operator()(int const row, int const column) const {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[row * (row + 1) / 2 + column];
+}
 
 template<typename Scalar, int rows_>
 bool FixedLowerTriangularMatrix<Scalar, rows_>::operator==(
@@ -228,24 +230,10 @@ bool FixedLowerTriangularMatrix<Scalar, rows_>::operator==(
 }
 
 template<typename Scalar, int rows_>
-Scalar* FixedLowerTriangularMatrix<Scalar, rows_>::operator[](
-    int const index) {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows);
-  return &data_[index * (index + 1) / 2];
+bool FixedLowerTriangularMatrix<Scalar, rows_>::operator!=(
+    FixedLowerTriangularMatrix const& right) const {
+  return data_ != right.data_;
 }
-
-template<typename Scalar, int rows_>
-constexpr Scalar const*
-FixedLowerTriangularMatrix<Scalar, rows_>::operator[](
-    int const index) const {
-  CONSTEXPR_DCHECK(0 <= index);
-  CONSTEXPR_DCHECK(index < rows);
-  return &data_[index * (index + 1) / 2];
-}
-
-template<typename Scalar, int rows_>
-constexpr int FixedLowerTriangularMatrix<Scalar, rows_>::dimension;
 
 template<typename Scalar, int columns_>
 constexpr FixedUpperTriangularMatrix<Scalar, columns_>::
@@ -258,8 +246,28 @@ FixedUpperTriangularMatrix<Scalar, columns_>::FixedUpperTriangularMatrix(
 
 template<typename Scalar, int columns_>
 constexpr FixedUpperTriangularMatrix<Scalar, columns_>::
-    FixedUpperTriangularMatrix(std::array<Scalar, dimension> const& data)
+FixedUpperTriangularMatrix(std::array<Scalar, size()> const& data)
     : data_(Transpose(data)) {}
+
+template<typename Scalar, int columns_>
+constexpr Scalar& FixedUpperTriangularMatrix<Scalar, columns_>::
+operator()(int const row, int const column) {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[column * (column + 1) / 2 + row];
+}
+
+template<typename Scalar, int columns_>
+constexpr Scalar const& FixedUpperTriangularMatrix<Scalar, columns_>::
+operator()(int const row, int const column) const {
+  CONSTEXPR_DCHECK(0 <= row);
+  CONSTEXPR_DCHECK(row < rows());
+  CONSTEXPR_DCHECK(0 <= column);
+  CONSTEXPR_DCHECK(column < columns());
+  return &data_[column * (column + 1) / 2 + row];
+}
 
 template<typename Scalar, int columns_>
 bool FixedUpperTriangularMatrix<Scalar, columns_>::operator==(
@@ -268,63 +276,29 @@ bool FixedUpperTriangularMatrix<Scalar, columns_>::operator==(
 }
 
 template<typename Scalar, int columns_>
-template<typename Matrix>
-Scalar& FixedUpperTriangularMatrix<Scalar, columns_>::Row<Matrix>::operator[](
-    int const column) {
-  CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns_);
-  return matrix_.data_[column * (column + 1) / 2 + row_];
-}
-
-template<typename Scalar, int columns_>
-template<typename Matrix>
-Scalar const&
-FixedUpperTriangularMatrix<Scalar, columns_>::Row<Matrix>::operator[](
-    int const column) const {
-  CONSTEXPR_DCHECK(0 <= column);
-  CONSTEXPR_DCHECK(column < columns_);
-  return matrix_.data_[column * (column + 1) / 2 + row_];
-}
-
-template<typename Scalar, int columns_>
-template<typename Matrix>
-FixedUpperTriangularMatrix<Scalar, columns_>::Row<Matrix>::Row(Matrix& matrix,
-                                                               int const row)
-    : matrix_(const_cast<std::remove_const_t<Matrix>&>(matrix)),
-      row_(row) {}
-
-template<typename Scalar, int columns_>
-auto FixedUpperTriangularMatrix<Scalar, columns_>::operator[](int const row)
-    -> Row<FixedUpperTriangularMatrix<Scalar, columns_>> {
-  CONSTEXPR_DCHECK(0 <= row);
-  CONSTEXPR_DCHECK(row < columns());
-  return Row<FixedUpperTriangularMatrix<Scalar, columns_>>{*this, row};
-}
-
-template<typename Scalar, int columns_>
-auto FixedUpperTriangularMatrix<Scalar, columns_>::operator[](int const row)
-    const -> Row<FixedUpperTriangularMatrix<Scalar, columns_> const> {
-  return Row<FixedUpperTriangularMatrix<Scalar, columns_> const>{*this, row};
+bool FixedUpperTriangularMatrix<Scalar, columns_>::operator!=(
+    FixedUpperTriangularMatrix const& right) const {
+  return data_ != right.data_;
 }
 
 template<typename Scalar, int columns_>
 auto FixedUpperTriangularMatrix<Scalar, columns_>::Transpose(
-    std::array<Scalar, dimension> const& data)
-    -> std::array<Scalar, dimension> {
-  std::array<Scalar, columns_ * columns_> full;
+    std::array<Scalar, size()> const& data)
+    -> std::array<Scalar, size()> {
+  std::array<Scalar, rows() * columns()> full;
   int index = 0;
-  for (int row = 0; row < columns_; ++row) {
-    for (int column = row; column < columns_; ++column) {
-      full[row * columns_ + column] = data[index];
+  for (int row = 0; row < rows(); ++row) {
+    for (int column = row; column < columns(); ++column) {
+      full[row * columns() + column] = data[index];
       ++index;
     }
   }
 
   std::array<Scalar, dimension> result;
   index = 0;
-  for (int column = 0; column < columns_; ++column) {
-    for (int row = 0; row <= column; ++row) {
-      result[index] = full[row * columns_ + column];
+  for (int column = 0; column < columns(); ++column) {
+    for (int row = 0; row <= rows(); ++row) {
+      result[index] = full[row * columns() + column];
       ++index;
     }
   }
@@ -429,9 +403,6 @@ std::ostream& operator<<(
   }
   return out;
 }
-
-template<typename Scalar, int columns_>
-constexpr int FixedUpperTriangularMatrix<Scalar, columns_>::dimension;
 
 }  // namespace internal_fixed_arrays
 }  // namespace numerics

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -84,47 +84,47 @@ TEST_F(FixedArraysTest, VectorIndexing) {
 }
 
 TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
-  EXPECT_EQ(6, (FixedStrictlyLowerTriangularMatrix<double, 4>::dimension));
-  EXPECT_EQ(1, sl4_[1][0]);
-  EXPECT_EQ(2, sl4_[2][0]);
-  EXPECT_EQ(3, sl4_[2][1]);
-  EXPECT_EQ(5, sl4_[3][0]);
-  EXPECT_EQ(8, sl4_[3][1]);
-  EXPECT_EQ(13, sl4_[3][2]);
-  sl4_[3][1] = -666;
-  EXPECT_EQ(-666, sl4_[3][1]);
+  EXPECT_EQ(6, (FixedStrictlyLowerTriangularMatrix<double, 4>::size()));
+  EXPECT_EQ(1, sl4_(1, 0));
+  EXPECT_EQ(2, sl4_(2, 0));
+  EXPECT_EQ(3, sl4_(2, 1));
+  EXPECT_EQ(5, sl4_(3, 0));
+  EXPECT_EQ(8, sl4_(3, 1));
+  EXPECT_EQ(13, sl4_(3, 2));
+  sl4_(3, 1) = -666;
+  EXPECT_EQ(-666, sl4_(3, 1));
 }
 
 TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {
-  EXPECT_EQ(10, (FixedLowerTriangularMatrix<double, 4>::dimension));
-  EXPECT_EQ(1, l4_[0][0]);
-  EXPECT_EQ(2, l4_[1][0]);
-  EXPECT_EQ(3, l4_[1][1]);
-  EXPECT_EQ(5, l4_[2][0]);
-  EXPECT_EQ(8, l4_[2][1]);
-  EXPECT_EQ(13, l4_[2][2]);
-  EXPECT_EQ(21, l4_[3][0]);
-  EXPECT_EQ(34, l4_[3][1]);
-  EXPECT_EQ(55, l4_[3][2]);
-  EXPECT_EQ(89, l4_[3][3]);
-  l4_[3][1] = -666;
-  EXPECT_EQ(-666, l4_[3][1]);
+  EXPECT_EQ(10, (FixedLowerTriangularMatrix<double, 4>::size()));
+  EXPECT_EQ(1, l4_(0, 0));
+  EXPECT_EQ(2, l4_(1, 0));
+  EXPECT_EQ(3, l4_(1, 1));
+  EXPECT_EQ(5, l4_(2, 0));
+  EXPECT_EQ(8, l4_(2, 1));
+  EXPECT_EQ(13, l4_(2, 2));
+  EXPECT_EQ(21, l4_(3, 0));
+  EXPECT_EQ(34, l4_(3, 1));
+  EXPECT_EQ(55, l4_(3, 2));
+  EXPECT_EQ(89, l4_(3, 3));
+  l4_(3, 1) = -666;
+  EXPECT_EQ(-666, l4_(3, 1));
 }
 
 TEST_F(FixedArraysTest, UpperTriangularMatrixIndexing) {
-  EXPECT_EQ(10, (FixedUpperTriangularMatrix<double, 4>::dimension));
-  EXPECT_EQ(1, u4_[0][0]);
-  EXPECT_EQ(2, u4_[0][1]);
-  EXPECT_EQ(3, u4_[0][2]);
-  EXPECT_EQ(5, u4_[0][3]);
-  EXPECT_EQ(8, u4_[1][1]);
-  EXPECT_EQ(13, u4_[1][2]);
-  EXPECT_EQ(21, u4_[1][3]);
-  EXPECT_EQ(34, u4_[2][2]);
-  EXPECT_EQ(55, u4_[2][3]);
-  EXPECT_EQ(89, u4_[3][3]);
-  u4_[1][3] = -666;
-  EXPECT_EQ(-666, u4_[1][3]);
+  EXPECT_EQ(10, (FixedUpperTriangularMatrix<double, 4>::size()));
+  EXPECT_EQ(1, u4_(0, 0));
+  EXPECT_EQ(2, u4_(0, 1));
+  EXPECT_EQ(3, u4_(0, 2));
+  EXPECT_EQ(5, u4_(0, 3));
+  EXPECT_EQ(8, u4_(1, 1));
+  EXPECT_EQ(13, u4_(1, 2));
+  EXPECT_EQ(21, u4_(1, 3));
+  EXPECT_EQ(34, u4_(2, 2));
+  EXPECT_EQ(55, u4_(2, 3));
+  EXPECT_EQ(89, u4_(3, 3));
+  u4_(1, 3) = -666;
+  EXPECT_EQ(-666, u4_(1, 3));
 }
 
 TEST_F(FixedArraysTest, Row) {

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -130,8 +130,8 @@ TEST_F(FixedArraysTest, UpperTriangularMatrixIndexing) {
 TEST_F(FixedArraysTest, Row) {
   FixedMatrix<double, 2, 3> m({1, 2, 3,
                                4, -5, 6});
-  FixedMatrix<double, 2, 3>::Row<0> r0 = m.row<0>();
-  FixedMatrix<double, 2, 3>::Row<1> r1 = m.row<1>();
+  auto const* const r0 = m.row<0>();
+  auto const* const r1 = m.row<1>();
   FixedVector<double, 3> v = {{1, 2, -3}};
 
   EXPECT_EQ(-4, r0 * v);

--- a/numerics/frequency_analysis_body.hpp
+++ b/numerics/frequency_analysis_body.hpp
@@ -318,7 +318,7 @@ IncrementalProjection(Function const& function,
 
       // Fill the QR decomposition.
       for (int i = 0; i <= m; ++i) {
-        r[i][m] = rₘ[i];
+        r(i, m) = rₘ[i];
       }
       q.push_back(qₘ);
       DCHECK_EQ(m + 1, q.size());

--- a/numerics/max_abs_normalized_associated_legendre_functions_test.cc
+++ b/numerics/max_abs_normalized_associated_legendre_functions_test.cc
@@ -34,17 +34,17 @@ class MaxAbsNormalizedAssociatedLegendreFunctionTest : public testing::Test {
 };
 
 TEST_F(MaxAbsNormalizedAssociatedLegendreFunctionTest, Polynomials) {
-  for (int n = 0; n < MaxAbsNormalizedAssociatedLegendreFunction.rows; ++n) {
-    EXPECT_THAT(MaxAbsNormalizedAssociatedLegendreFunction[n][0],
-                AlmostEquals(LegendreNormalizationFactor[n][0], 0))
+  for (int n = 0; n < MaxAbsNormalizedAssociatedLegendreFunction.rows(); ++n) {
+    EXPECT_THAT(MaxAbsNormalizedAssociatedLegendreFunction(n, 0),
+                AlmostEquals(LegendreNormalizationFactor(n, 0), 0))
         << "n = " << n;
   }
 }
 
 TEST_F(MaxAbsNormalizedAssociatedLegendreFunctionTest, HighestOrder) {
-  for (int n = 0; n < MaxAbsNormalizedAssociatedLegendreFunction.rows; ++n) {
-    EXPECT_THAT(MaxAbsNormalizedAssociatedLegendreFunction[n][n],
-                AlmostEquals(LegendreNormalizationFactor[n][n] *
+  for (int n = 0; n < MaxAbsNormalizedAssociatedLegendreFunction.rows(); ++n) {
+    EXPECT_THAT(MaxAbsNormalizedAssociatedLegendreFunction(n, n),
+                AlmostEquals(LegendreNormalizationFactor(n, n) *
                                  ApproximateDoubleFactorial(2 * n - 1),
                              0, 3))
         << "n = " << n;

--- a/numerics/quadrature_body.hpp
+++ b/numerics/quadrature_body.hpp
@@ -252,13 +252,13 @@ Primitive<std::invoke_result_t<Function, Argument>, Argument> GaussLegendre(
     Function const& f,
     Argument const& lower_bound,
     Argument const& upper_bound) {
-  static_assert(points < LegendreRoots.rows,
+  static_assert(points < LegendreRoots.rows(),
                 "No table for Gauss-Legendre with the chosen number of points");
   return Gauss<points>(f,
                        lower_bound,
                        upper_bound,
-                       LegendreRoots[points],
-                       GaussLegendreWeights[points]);
+                       LegendreRoots.row<points>(),
+                       GaussLegendreWeights.row<points>());
 }
 
 template<int initial_points, typename Argument, typename Function>

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -86,15 +86,16 @@ class UnboundedMatrix final {
 
   int columns() const;
   int rows() const;
-  int dimension() const;
-
-  bool operator==(UnboundedMatrix const& right) const;
+  int size() const;
 
   // For  0 ≤ i < rows and 0 ≤ j < columns, the entry a_ij is accessed as
-  // |a[i][j]|.  If i and j do not satisfy these conditions, the expression
-  // |a[i][j]| is erroneous.
-  Scalar* operator[](int index);
-  Scalar const* operator[](int index) const;
+  // |a(i, j)|.  If i and j do not satisfy these conditions, the expression
+  // |a(i, j)| implies undefined behaviour.
+  Scalar& operator()(int row, int column);
+  Scalar const& operator()(int row, int column) const;
+
+  bool operator==(UnboundedMatrix const& right) const;
+  bool operator!=(UnboundedMatrix const& right) const;
 
  private:
   int rows_;
@@ -127,15 +128,16 @@ class UnboundedLowerTriangularMatrix final {
 
   int columns() const;
   int rows() const;
-  int dimension() const;
-
-  bool operator==(UnboundedLowerTriangularMatrix const& right) const;
+  int size() const;
 
   // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a[i][j]|.
-  // If i and j do not satisfy these conditions, the expression |a[i][j]| is
-  // erroneous.
-  Scalar* operator[](int index);
-  Scalar const* operator[](int index) const;
+  // If i and j do not satisfy these conditions, the expression |a[i][j]|
+  // implies undefined behaviour.
+  Scalar& operator()(int row, int column);
+  Scalar const& operator()(int row, int column) const;
+
+  bool operator==(UnboundedLowerTriangularMatrix const& right) const;
+  bool operator!=(UnboundedLowerTriangularMatrix const& right) const;
 
  private:
   int rows_;
@@ -167,35 +169,17 @@ class UnboundedUpperTriangularMatrix final {
   UnboundedLowerTriangularMatrix<Scalar> Transpose() const;
 
   int columns() const;
-  int dimension() const;
-
-  bool operator==(UnboundedUpperTriangularMatrix const& right) const;
-
-  // A helper class for indexing column-major data in a human-friendly manner.
-  template<typename Matrix>
-  class Row {
-   public:
-    Scalar& operator[](int column);
-    Scalar const& operator[](int column) const;
-
-   private:
-    explicit Row(Matrix& matrix, int row);
-
-    // We need to remove the const because, when this class is instantiated with
-    // |UnboundedUpperTriangularMatrix const|, the first operator[], not the
-    // second, is picked by overload resolution.
-    std::remove_const_t<Matrix>& matrix_;
-    int row_;
-
-    template<typename S>
-    friend class UnboundedUpperTriangularMatrix;
-  };
+  int rows() const;
+  int size() const;
 
   // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a[i][j]|.
-  // If i and j do not satisfy these conditions, the expression |a[i][j]| is
-  // erroneous.
-  Row<UnboundedUpperTriangularMatrix> operator[](int row);
-  Row<UnboundedUpperTriangularMatrix const> operator[](int row) const;
+  // If i and j do not satisfy these conditions, the expression |a[i][j]|
+  // implies undefined behaviour.
+  Scalar& operator()(int row, int column);
+  Scalar const& operator()(int row, int column) const;
+
+  bool operator==(UnboundedUpperTriangularMatrix const& right) const;
+  bool operator!=(UnboundedUpperTriangularMatrix const& right) const;
 
  private:
   // For ease of writing matrices in tests, the input data is received in row-

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -52,10 +52,11 @@ class UnboundedVector final {
 
   int size() const;
 
-  bool operator==(UnboundedVector const& right) const;
-
   Scalar& operator[](int index);
   Scalar const& operator[](int index) const;
+
+  bool operator==(UnboundedVector const& right) const;
+  bool operator!=(UnboundedVector const& right) const;
 
  private:
   std::vector<Scalar, uninitialized_allocator<Scalar>> data_;
@@ -130,8 +131,8 @@ class UnboundedLowerTriangularMatrix final {
   int rows() const;
   int size() const;
 
-  // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a[i][j]|.
-  // If i and j do not satisfy these conditions, the expression |a[i][j]|
+  // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
+  // If i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
@@ -172,8 +173,8 @@ class UnboundedUpperTriangularMatrix final {
   int rows() const;
   int size() const;
 
-  // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a[i][j]|.
-  // If i and j do not satisfy these conditions, the expression |a[i][j]|
+  // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a(i, j)|.
+  // If i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -130,28 +130,38 @@ int UnboundedMatrix<Scalar>::rows() const {
 }
 
 template<typename Scalar>
-int UnboundedMatrix<Scalar>::dimension() const {
+int UnboundedMatrix<Scalar>::size() const {
   return rows_ * columns_;
 }
 
 template<typename Scalar>
-bool UnboundedMatrix<Scalar>::operator==(
-    UnboundedMatrix const& right) const {
+Scalar& UnboundedMatrix<Scalar>::operator()(
+    int const row, int const column) {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[row * columns_ + column];
+}
+
+template<typename Scalar>
+Scalar const& UnboundedMatrix<Scalar>::operator()(
+    int const row, int const column) const {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[row * columns_ + column];
+}
+
+template<typename Scalar>
+bool UnboundedMatrix<Scalar>::operator==(UnboundedMatrix const& right) const {
   return data_ == right.data_;
 }
 
 template<typename Scalar>
-Scalar* UnboundedMatrix<Scalar>::operator[](int index) {
-  DCHECK_LE(0, index);
-  DCHECK_LT(index, rows_);
-  return &data_[index * columns_];
-}
-
-template<typename Scalar>
-Scalar const* UnboundedMatrix<Scalar>::operator[](int index) const {
-  DCHECK_LE(0, index);
-  DCHECK_LT(index, rows_);
-  return &data_[index * columns_];
+bool UnboundedMatrix<Scalar>::operator==(UnboundedMatrix const& right) const {
+  return !(*this == right);
 }
 
 template<typename Scalar>
@@ -227,8 +237,28 @@ int UnboundedLowerTriangularMatrix<Scalar>::rows() const {
 }
 
 template<typename Scalar>
-int UnboundedLowerTriangularMatrix<Scalar>::dimension() const {
+int UnboundedLowerTriangularMatrix<Scalar>::size() const {
   return data_.size();
+}
+
+template<typename Scalar>
+Scalar& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+    int const row, int const column) {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[row * (row + 1) / 2 + column];
+}
+
+template<typename Scalar>
+Scalar const& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+    int const row, int const column) const {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar>
@@ -238,18 +268,9 @@ bool UnboundedLowerTriangularMatrix<Scalar>::operator==(
 }
 
 template<typename Scalar>
-Scalar* UnboundedLowerTriangularMatrix<Scalar>::operator[](int const index) {
-  DCHECK_LE(0, index);
-  DCHECK_LT(index, rows_);
-  return &data_[index * (index + 1) / 2];
-}
-
-template<typename Scalar>
-Scalar const* UnboundedLowerTriangularMatrix<Scalar>::operator[](
-    int const index) const {
-  DCHECK_LE(0, index);
-  DCHECK_LT(index, rows_);
-  return &data_[index * (index + 1) / 2];
+bool UnboundedLowerTriangularMatrix<Scalar>::operator!=(
+    UnboundedLowerTriangularMatrix const& right) const {
+  return !(*this == right);
 }
 
 template<typename Scalar>
@@ -330,8 +351,28 @@ int UnboundedUpperTriangularMatrix<Scalar>::columns() const {
 }
 
 template<typename Scalar>
-int UnboundedUpperTriangularMatrix<Scalar>::dimension() const {
+int UnboundedUpperTriangularMatrix<Scalar>::size() const {
   return data_.size();
+}
+
+template<typename Scalar>
+Scalar& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+    int const row, int const column) {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[column * (column + 1) / 2 + row];
+}
+
+template<typename Scalar>
+Scalar const& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+    int const row, int const column) const {
+  DCHECK_LE(0, row);
+  DCHECK_LT(row, rows_);
+  DCHECK_LE(0, column);
+  DCHECK_LT(column, columns_);
+  return &data_[column * (column + 1) / 2 + row];
 }
 
 template<typename Scalar>
@@ -341,45 +382,9 @@ bool UnboundedUpperTriangularMatrix<Scalar>::operator==(
 }
 
 template<typename Scalar>
-template<typename Matrix>
-Scalar& UnboundedUpperTriangularMatrix<Scalar>::Row<Matrix>::operator[](
-    int const column) {
-  DCHECK_LE(0, column);
-  DCHECK_LT(column, matrix_.columns_);
-  return matrix_.data_[column * (column + 1) / 2 + row_];
-}
-
-template<typename Scalar>
-template<typename Matrix>
-Scalar const&
-UnboundedUpperTriangularMatrix<Scalar>::Row<Matrix>::operator[](
-    int const column) const {
-  DCHECK_LE(0, column);
-  DCHECK_LT(column, matrix_.columns_);
-  return matrix_.data_[column * (column + 1) / 2 + row_];
-}
-
-template<typename Scalar>
-template<typename Matrix>
-UnboundedUpperTriangularMatrix<Scalar>::Row<Matrix>::Row(Matrix& matrix,
-                                                         int const row)
-    : matrix_(const_cast<std::remove_const_t<Matrix>&>(matrix)),
-      row_(row) {}
-
-template<typename Scalar>
-auto UnboundedUpperTriangularMatrix<Scalar>::operator[](int const row)
-    -> Row<UnboundedUpperTriangularMatrix> {
-  DCHECK_LE(0, row);
-  DCHECK_LT(row, columns_);
-  return Row<UnboundedUpperTriangularMatrix>{*this, row};
-}
-
-template<typename Scalar>
-auto UnboundedUpperTriangularMatrix<Scalar>::operator[](int const row) const
-    -> Row<UnboundedUpperTriangularMatrix const> {
-  DCHECK_LE(0, row);
-  DCHECK_LT(row, columns_);
-  return Row<UnboundedUpperTriangularMatrix const>{*this, row};
+bool UnboundedUpperTriangularMatrix<Scalar>::operator==(
+    UnboundedUpperTriangularMatrix const& right) const {
+  return !(*this == right);
 }
 
 template<typename Scalar>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -249,20 +249,18 @@ int UnboundedLowerTriangularMatrix<Scalar>::size() const {
 template<typename Scalar>
 Scalar& UnboundedLowerTriangularMatrix<Scalar>::operator()(
     int const row, int const column) {
-  DCHECK_LE(0, row);
-  DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
-  DCHECK_LT(column, columns());
+  DCHECK_LE(column, row);
+  DCHECK_LT(row, rows_);
   return data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar>
 Scalar const& UnboundedLowerTriangularMatrix<Scalar>::operator()(
     int const row, int const column) const {
-  DCHECK_LE(0, row);
-  DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
-  DCHECK_LT(column, columns());
+  DCHECK_LE(column, row);
+  DCHECK_LT(row, rows_);
   return data_[row * (row + 1) / 2 + column];
 }
 
@@ -369,8 +367,7 @@ template<typename Scalar>
 Scalar& UnboundedUpperTriangularMatrix<Scalar>::operator()(
     int const row, int const column) {
   DCHECK_LE(0, row);
-  DCHECK_LT(row, rows());
-  DCHECK_LE(0, column);
+  DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
   return data_[column * (column + 1) / 2 + row];
 }
@@ -379,8 +376,7 @@ template<typename Scalar>
 Scalar const& UnboundedUpperTriangularMatrix<Scalar>::operator()(
     int const row, int const column) const {
   DCHECK_LE(0, row);
-  DCHECK_LT(row, rows());
-  DCHECK_LE(0, column);
+  DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
   return data_[column * (column + 1) / 2 + row];
 }

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -356,6 +356,11 @@ int UnboundedUpperTriangularMatrix<Scalar>::columns() const {
 }
 
 template<typename Scalar>
+int UnboundedUpperTriangularMatrix<Scalar>::rows() const {
+  return columns_;
+}
+
+template<typename Scalar>
 int UnboundedUpperTriangularMatrix<Scalar>::size() const {
   return data_.size();
 }

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -69,11 +69,6 @@ int UnboundedVector<Scalar>::size() const {
 }
 
 template<typename Scalar>
-bool UnboundedVector<Scalar>::operator==(UnboundedVector const& right) const {
-  return data_ == right.data_;
-}
-
-template<typename Scalar>
 Scalar& UnboundedVector<Scalar>::operator[](int const index) {
   DCHECK_LE(0, index);
   DCHECK_LT(index, size());
@@ -85,6 +80,16 @@ Scalar const& UnboundedVector<Scalar>::operator[](int const index) const {
   DCHECK_LE(0, index);
   DCHECK_LT(index, size());
   return data_[index];
+}
+
+template<typename Scalar>
+bool UnboundedVector<Scalar>::operator==(UnboundedVector const& right) const {
+  return data_ == right.data_;
+}
+
+template<typename Scalar>
+bool UnboundedVector<Scalar>::operator==(UnboundedVector const& right) const {
+  return data_ != right.data_;
 }
 
 template<typename Scalar>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -88,7 +88,7 @@ bool UnboundedVector<Scalar>::operator==(UnboundedVector const& right) const {
 }
 
 template<typename Scalar>
-bool UnboundedVector<Scalar>::operator==(UnboundedVector const& right) const {
+bool UnboundedVector<Scalar>::operator!=(UnboundedVector const& right) const {
   return data_ != right.data_;
 }
 
@@ -118,7 +118,7 @@ UnboundedMatrix<Scalar> UnboundedMatrix<Scalar>::Transpose() const {
   UnboundedMatrix<Scalar> m(columns_, rows_, uninitialized);
   for (int i = 0; i < rows_; ++i) {
     for (int j = 0; j < columns_; ++j) {
-      m[j][i] = (*this)[i][j];
+      m(j, i) = (*this)(i, j);
     }
   }
   return m;
@@ -146,7 +146,7 @@ Scalar& UnboundedMatrix<Scalar>::operator()(
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
   DCHECK_LT(column, columns_);
-  return &data_[row * columns_ + column];
+  return data_[row * columns_ + column];
 }
 
 template<typename Scalar>
@@ -156,7 +156,7 @@ Scalar const& UnboundedMatrix<Scalar>::operator()(
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
   DCHECK_LT(column, columns_);
-  return &data_[row * columns_ + column];
+  return data_[row * columns_ + column];
 }
 
 template<typename Scalar>
@@ -165,7 +165,7 @@ bool UnboundedMatrix<Scalar>::operator==(UnboundedMatrix const& right) const {
 }
 
 template<typename Scalar>
-bool UnboundedMatrix<Scalar>::operator==(UnboundedMatrix const& right) const {
+bool UnboundedMatrix<Scalar>::operator!=(UnboundedMatrix const& right) const {
   return !(*this == right);
 }
 
@@ -225,7 +225,7 @@ UnboundedLowerTriangularMatrix<Scalar>::Transpose() const {
   UnboundedUpperTriangularMatrix<Scalar> u(rows_, uninitialized);
   for (int i = 0; i < rows_; ++i) {
     for (int j = 0; j <= i; ++j) {
-      u[j][i] = (*this)[i][j];
+      u(j, i) = (*this)(i, j);
     }
   }
   return u;
@@ -252,8 +252,8 @@ Scalar& UnboundedLowerTriangularMatrix<Scalar>::operator()(
   DCHECK_LE(0, row);
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
-  DCHECK_LT(column, columns_);
-  return &data_[row * (row + 1) / 2 + column];
+  DCHECK_LT(column, columns());
+  return data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar>
@@ -262,8 +262,8 @@ Scalar const& UnboundedLowerTriangularMatrix<Scalar>::operator()(
   DCHECK_LE(0, row);
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
-  DCHECK_LT(column, columns_);
-  return &data_[row * (row + 1) / 2 + column];
+  DCHECK_LT(column, columns());
+  return data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar>
@@ -342,9 +342,9 @@ template<typename Scalar>
 UnboundedLowerTriangularMatrix<Scalar>
 UnboundedUpperTriangularMatrix<Scalar>::Transpose() const {
   UnboundedLowerTriangularMatrix<Scalar> l(columns_, uninitialized);
-  for (int i = 0; i < columns_; ++i) {
+  for (int i = 0; i < rows(); ++i) {
     for (int j = i; j < columns_; ++j) {
-      l[j][i] = (*this)[i][j];
+      l(j, i) = (*this)(i, j);
     }
   }
   return l;
@@ -361,23 +361,23 @@ int UnboundedUpperTriangularMatrix<Scalar>::size() const {
 }
 
 template<typename Scalar>
-Scalar& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+Scalar& UnboundedUpperTriangularMatrix<Scalar>::operator()(
     int const row, int const column) {
   DCHECK_LE(0, row);
-  DCHECK_LT(row, rows_);
+  DCHECK_LT(row, rows());
   DCHECK_LE(0, column);
   DCHECK_LT(column, columns_);
-  return &data_[column * (column + 1) / 2 + row];
+  return data_[column * (column + 1) / 2 + row];
 }
 
 template<typename Scalar>
-Scalar const& UnboundedLowerTriangularMatrix<Scalar>::operator()(
+Scalar const& UnboundedUpperTriangularMatrix<Scalar>::operator()(
     int const row, int const column) const {
   DCHECK_LE(0, row);
-  DCHECK_LT(row, rows_);
+  DCHECK_LT(row, rows());
   DCHECK_LE(0, column);
   DCHECK_LT(column, columns_);
-  return &data_[column * (column + 1) / 2 + row];
+  return data_[column * (column + 1) / 2 + row];
 }
 
 template<typename Scalar>
@@ -387,7 +387,7 @@ bool UnboundedUpperTriangularMatrix<Scalar>::operator==(
 }
 
 template<typename Scalar>
-bool UnboundedUpperTriangularMatrix<Scalar>::operator==(
+bool UnboundedUpperTriangularMatrix<Scalar>::operator!=(
     UnboundedUpperTriangularMatrix const& right) const {
   return !(*this == right);
 }
@@ -460,7 +460,7 @@ UnboundedVector<Product<ScalarLeft, ScalarRight>> operator*(
   for (int i = 0; i < left.rows(); ++i) {
     auto& result_i = result.data_[i];
     for (int j = 0; j < left.columns(); ++j) {
-      result_i += left[i][j] * right[j];
+      result_i += left(i, j) * right[j];
     }
   }
   return result;
@@ -485,7 +485,7 @@ std::ostream& operator<<(std::ostream& out,
   for (int i = 0; i < matrix.rows(); ++i) {
     out << "{";
     for (int j = 0; j <= i; ++j) {
-      out << matrix[i][j];
+      out << matrix(i, j);
       if (j < i) {
         out << ", ";
       }
@@ -502,7 +502,7 @@ std::ostream& operator<<(std::ostream& out,
   for (int i = 0; i < matrix.rows(); ++i) {
     out << "{";
     for (int j = 0; j < matrix.columns(); ++j) {
-      out << matrix[i][j];
+      out << matrix(i, j);
       if (j < matrix.columns() - 1) {
         out << ", ";
       }
@@ -522,7 +522,7 @@ std::ostream& operator<<(std::ostream& out,
       if (j > i) {
         out << ", ";
       }
-      out << matrix[i][j];
+      out << matrix(i, j);
     }
     out << "}\n";
   }

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -105,47 +105,47 @@ TEST_F(UnboundedArraysTest, VectorIndexing) {
 }
 
 TEST_F(UnboundedArraysTest, MatrixIndexing) {
-  EXPECT_EQ(21, m4_[1][2]);
-  m4_[2][1] = -666;
-  EXPECT_EQ(-666, m4_[2][1]);
+  EXPECT_EQ(21, m4_(1, 2));
+  m4_(2, 1) = -666;
+  EXPECT_EQ(-666, m4_(2, 1));
 }
 
 TEST_F(UnboundedArraysTest, LowerTriangularMatrixIndexing) {
-  EXPECT_EQ(10, l4_.dimension());
-  EXPECT_EQ(1, l4_[0][0]);
-  EXPECT_EQ(2, l4_[1][0]);
-  EXPECT_EQ(3, l4_[1][1]);
-  EXPECT_EQ(5, l4_[2][0]);
-  EXPECT_EQ(8, l4_[2][1]);
-  EXPECT_EQ(13, l4_[2][2]);
-  EXPECT_EQ(21, l4_[3][0]);
-  EXPECT_EQ(34, l4_[3][1]);
-  EXPECT_EQ(55, l4_[3][2]);
-  EXPECT_EQ(89, l4_[3][3]);
-  l4_[3][1] = -666;
-  EXPECT_EQ(-666, l4_[3][1]);
+  EXPECT_EQ(10, l4_.size());
+  EXPECT_EQ(1, l4_(0, 0));
+  EXPECT_EQ(2, l4_(1, 0));
+  EXPECT_EQ(3, l4_(1, 1));
+  EXPECT_EQ(5, l4_(2, 0));
+  EXPECT_EQ(8, l4_(2, 1));
+  EXPECT_EQ(13, l4_(2, 2));
+  EXPECT_EQ(21, l4_(3, 0));
+  EXPECT_EQ(34, l4_(3, 1));
+  EXPECT_EQ(55, l4_(3, 2));
+  EXPECT_EQ(89, l4_(3, 3));
+  l4_(3, 1) = -666;
+  EXPECT_EQ(-666, l4_(3, 1));
 
   UnboundedLowerTriangularMatrix<double> const l4 = l4_;
-  EXPECT_EQ(1, l4[0][0]);
+  EXPECT_EQ(1, l4(0, 0));
 }
 
 TEST_F(UnboundedArraysTest, UpperTriangularMatrixIndexing) {
-  EXPECT_EQ(10, u4_.dimension());
-  EXPECT_EQ(1, u4_[0][0]);
-  EXPECT_EQ(2, u4_[0][1]);
-  EXPECT_EQ(3, u4_[0][2]);
-  EXPECT_EQ(5, u4_[0][3]);
-  EXPECT_EQ(8, u4_[1][1]);
-  EXPECT_EQ(13, u4_[1][2]);
-  EXPECT_EQ(21, u4_[1][3]);
-  EXPECT_EQ(34, u4_[2][2]);
-  EXPECT_EQ(55, u4_[2][3]);
-  EXPECT_EQ(89, u4_[3][3]);
-  u4_[1][3] = -666;
-  EXPECT_EQ(-666, u4_[1][3]);
+  EXPECT_EQ(10, u4_.size());
+  EXPECT_EQ(1, u4_(0, 0));
+  EXPECT_EQ(2, u4_(0, 1));
+  EXPECT_EQ(3, u4_(0, 2));
+  EXPECT_EQ(5, u4_(0, 3));
+  EXPECT_EQ(8, u4_(1, 1));
+  EXPECT_EQ(13, u4_(1, 2));
+  EXPECT_EQ(21, u4_(1, 3));
+  EXPECT_EQ(34, u4_(2, 2));
+  EXPECT_EQ(55, u4_(2, 3));
+  EXPECT_EQ(89, u4_(3, 3));
+  u4_(1, 3) = -666;
+  EXPECT_EQ(-666, u4_(1, 3));
 
   UnboundedUpperTriangularMatrix<double> const u4 = u4_;
-  EXPECT_EQ(1, u4[0][0]);
+  EXPECT_EQ(1, u4(0, 0));
 }
 
 TEST_F(UnboundedArraysTest, Extend) {

--- a/physics/body_test.cpp
+++ b/physics/body_test.cpp
@@ -264,7 +264,7 @@ TEST_F(BodyTest, OblateSerializationSuccess) {
                       GetExtension(serialization::OblateBody::extension);
   EXPECT_EQ(-6,
             oblate_body_extension.geopotential().row(2).column(0).cos() *
-                LegendreNormalizationFactor[2][0]);
+                LegendreNormalizationFactor(2, 0));
 
   // Dispatching from |MassiveBody|.
   not_null<std::unique_ptr<MassiveBody const>> const massive_body =

--- a/physics/geopotential_test.cpp
+++ b/physics/geopotential_test.cpp
@@ -126,8 +126,8 @@ class GeopotentialTest : public ::testing::Test {
     numerics::FixedMatrix<double, 10, 10> snm;
     for (int n = 0; n <= 9; ++n) {
       for (int m = 0; m <= n; ++m) {
-        cnm[n][m] = earth.cos()[n][m] * LegendreNormalizationFactor[n][m];
-        snm[n][m] = earth.sin()[n][m] * LegendreNormalizationFactor[n][m];
+        cnm(n, m) = earth.cos()(n, m) * LegendreNormalizationFactor(n, m);
+        snm(n, m) = earth.sin()(n, m) * LegendreNormalizationFactor(n, m);
       }
     }
     return Vector<Acceleration, ITRS>(
@@ -211,12 +211,12 @@ TEST_F(GeopotentialTest, C22S22) {
     degree2->set_degree(2);
     auto* const order0 = degree2->add_column();
     order0->set_order(0);
-    order0->set_cos(-6 / LegendreNormalizationFactor[2][0]);
+    order0->set_cos(-6 / LegendreNormalizationFactor(2, 0));
     order0->set_sin(0);
     auto* const order2 = degree2->add_column();
     order2->set_order(2);
-    order2->set_cos(10 / LegendreNormalizationFactor[2][2]);
-    order2->set_sin(-13 / LegendreNormalizationFactor[2][2]);
+    order2->set_cos(10 / LegendreNormalizationFactor(2, 2));
+    order2->set_sin(-13 / LegendreNormalizationFactor(2, 2));
   }
   OblateBody<World> const body =
       OblateBody<World>(massive_body_parameters_,
@@ -259,19 +259,19 @@ TEST_F(GeopotentialTest, J3) {
     degree2->set_degree(2);
     auto* const order0 = degree2->add_column();
     order0->set_order(0);
-    order0->set_cos(-6 / LegendreNormalizationFactor[2][0]);
+    order0->set_cos(-6 / LegendreNormalizationFactor(2, 0));
     order0->set_sin(0);
     auto* const order2 = degree2->add_column();
     order2->set_order(2);
-    order2->set_cos(1e-20 / LegendreNormalizationFactor[2][2]);
-    order2->set_sin(1e-20 / LegendreNormalizationFactor[2][2]);
+    order2->set_cos(1e-20 / LegendreNormalizationFactor(2, 2));
+    order2->set_sin(1e-20 / LegendreNormalizationFactor(2, 2));
   }
   {
     auto* const degree3 = message.add_row();
     degree3->set_degree(3);
     auto* const order0 = degree3->add_column();
     order0->set_order(0);
-    order0->set_cos(5 / LegendreNormalizationFactor[3][0]);
+    order0->set_cos(5 / LegendreNormalizationFactor(3, 0));
   }
   OblateBody<World> const body =
       OblateBody<World>(massive_body_parameters_,

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -37,7 +37,7 @@ OblateBody<Frame>::Parameters::Parameters(double const j2,
       degree_(2),
       is_zonal_(true) {
   CHECK_LT(0.0, j2) << "Oblate body must have positive j2";
-  cos_[2][0] = -j2 / LegendreNormalizationFactor[2][0];
+  cos_(2, 0) = -j2 / LegendreNormalizationFactor(2, 0);
 }
 
 template<typename Frame>
@@ -74,7 +74,7 @@ OblateBody<Frame>::Parameters::ReadFromMessage(
       double cos = column.cos();
       if (m == 0) {
         if (column.has_j()) {
-          cos = -column.j() / LegendreNormalizationFactor[n][0];
+          cos = -column.j() / LegendreNormalizationFactor(n, 0);
         } else {
           CHECK(column.has_cos())
               << "Cos and J missing for degree " << n << " order " << m;
@@ -83,23 +83,23 @@ OblateBody<Frame>::Parameters::ReadFromMessage(
         CHECK(column.has_cos())
             << "Cos missing for degree " << n << " order " << m;
       }
-      parameters.cos_[n][m] = cos;
-      parameters.sin_[n][m] = column.sin();
+      parameters.cos_(n, m) = cos;
+      parameters.sin_(n, m) = column.sin();
     }
   }
   parameters.degree_ = *degrees_seen.crbegin();
 
   // Unnormalization.
-  parameters.j2_ = -parameters.cos_[2][0] * LegendreNormalizationFactor[2][0];
-  parameters.j2_over_μ_ = -parameters.cos_[2][0] *
-                          LegendreNormalizationFactor[2][0] * reference_radius *
+  parameters.j2_ = -parameters.cos_(2, 0) * LegendreNormalizationFactor(2, 0);
+  parameters.j2_over_μ_ = -parameters.cos_(2, 0) *
+                          LegendreNormalizationFactor(2, 0) * reference_radius *
                           reference_radius;
 
   // Zonalness.
   parameters.is_zonal_ = true;
   for (int n = 0; n <= parameters.degree_; ++n) {
     for (int m = 1; m <= n; ++m) {
-      if (parameters.cos_[n][m] != 0 || parameters.sin_[n][m] != 0) {
+      if (parameters.cos_(n, m) != 0 || parameters.sin_(n, m) != 0) {
         parameters.is_zonal_ = false;
         break;
       }
@@ -118,8 +118,8 @@ void OblateBody<Frame>::Parameters::WriteToMessage(
     for (int m = 0; m <= n; ++m) {
       auto const column = row->add_column();
       column->set_order(m);
-      column->set_cos(cos_[n][m]);
-      column->set_sin(sin_[n][m]);
+      column->set_cos(cos_(n, m));
+      column->set_sin(sin_(n, m));
     }
   }
 }

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -325,7 +325,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   for (int i = 0; i < expected_.rows; ++i) {
     for (int j = 0; j <= i; ++j) {
       int const distance = NormalizedNaNULPDistance(
-          DoubleValue(actual[i][j]), DoubleValue(expected_[i][j]));
+          DoubleValue(actual(i, j)), DoubleValue(expected_(i, j)));
       if (distance > max_distance) {
         max_distance = distance;
         max_i = i;
@@ -357,7 +357,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   for (int i = 0; i < expected_.columns(); ++i) {
     for (int j = i; j < expected_.columns(); ++j) {
       int const distance = NormalizedNaNULPDistance(
-          DoubleValue(actual[i][j]), DoubleValue(expected_[i][j]));
+          DoubleValue(actual(i, j)), DoubleValue(expected_(i, j)));
       if (distance > max_distance) {
         max_distance = distance;
         max_i = i;
@@ -425,7 +425,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   for (int i = 0; i < expected_.rows(); ++i) {
     for (int j = 0; j <= i; ++j) {
       int const distance = NormalizedNaNULPDistance(
-          DoubleValue(actual[i][j]), DoubleValue(expected_[i][j]));
+          DoubleValue(actual(i, j)), DoubleValue(expected_(i, j)));
       if (distance > max_distance) {
         max_distance = distance;
         max_i = i;
@@ -462,7 +462,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   for (int i = 0; i < expected_.columns(); ++i) {
     for (int j = i; j < expected_.columns(); ++j) {
       int const distance = NormalizedNaNULPDistance(
-          DoubleValue(actual[i][j]), DoubleValue(expected_[i][j]));
+          DoubleValue(actual(i, j)), DoubleValue(expected_(i, j)));
       if (distance > max_distance) {
         max_distance = distance;
         max_i = i;

--- a/testing_utilities/almost_equals_body.hpp
+++ b/testing_utilities/almost_equals_body.hpp
@@ -322,7 +322,7 @@ bool AlmostEqualsMatcher<T>::MatchAndExplain(
   std::int64_t max_distance = -1;
   int max_i = -1;
   int max_j = -1;
-  for (int i = 0; i < expected_.rows; ++i) {
+  for (int i = 0; i < expected_.rows(); ++i) {
     for (int j = 0; j <= i; ++j) {
       int const distance = NormalizedNaNULPDistance(
           DoubleValue(actual(i, j)), DoubleValue(expected_(i, j)));

--- a/testing_utilities/almost_equals_test.cpp
+++ b/testing_utilities/almost_equals_test.cpp
@@ -185,12 +185,12 @@ TEST_F(AlmostEqualsTest, FixedLowerTriangularMatrix) {
   FixedLowerTriangularMatrix<double, 3> const m2 = m1;
   EXPECT_THAT(m2, AlmostEquals(m1, 0));
   EXPECT_THAT(m2, Not(AlmostEquals(m1, 4)));
-  double const δv = m1[1][0] / 100;
+  double const δv = m1(1, 0) / 100;
   FixedLowerTriangularMatrix<double, 3> m_accumulated({1,
                                                        0, 3,
                                                        4, 5, 6});
   for (int i = 1; i <= 100; ++i) {
-    m_accumulated[1][0] += δv;
+    m_accumulated(1, 0) += δv;
   }
   EXPECT_THAT(m_accumulated, AlmostEquals(m1, 3));
 }
@@ -202,12 +202,12 @@ TEST_F(AlmostEqualsTest, FixedUpperTriangularMatrix) {
   FixedUpperTriangularMatrix<double, 3> const m2 = m1;
   EXPECT_THAT(m2, AlmostEquals(m1, 0));
   EXPECT_THAT(m2, Not(AlmostEquals(m1, 4)));
-  double const δv = m1[0][1] / 100;
+  double const δv = m1(0, 1) / 100;
   FixedUpperTriangularMatrix<double, 3> m_accumulated({1, 0, 3,
                                                           4, 5,
                                                              6});
   for (int i = 1; i <= 100; ++i) {
-    m_accumulated[0][1] += δv;
+    m_accumulated(0, 1) += δv;
   }
   EXPECT_THAT(m_accumulated, AlmostEquals(m1, 3));
 }
@@ -232,12 +232,12 @@ TEST_F(AlmostEqualsTest, UnboundedLowerTriangularMatrix) {
   UnboundedLowerTriangularMatrix<double> const m2 = m1;
   EXPECT_THAT(m2, AlmostEquals(m1, 0));
   EXPECT_THAT(m2, Not(AlmostEquals(m1, 4)));
-  double const δv = m1[1][0] / 100;
+  double const δv = m1(1, 0) / 100;
   UnboundedLowerTriangularMatrix<double> m_accumulated({1,
                                                         0, 3,
                                                         4, 5, 6});
   for (int i = 1; i <= 100; ++i) {
-    m_accumulated[1][0] += δv;
+    m_accumulated(1, 0) += δv;
   }
   EXPECT_THAT(m_accumulated, AlmostEquals(m1, 3));
 }
@@ -249,12 +249,12 @@ TEST_F(AlmostEqualsTest, UnboundedUpperTriangularMatrix) {
   UnboundedUpperTriangularMatrix<double> const m2 = m1;
   EXPECT_THAT(m2, AlmostEquals(m1, 0));
   EXPECT_THAT(m2, Not(AlmostEquals(m1, 4)));
-  double const δv = m1[0][1] / 100;
+  double const δv = m1(0, 1) / 100;
   UnboundedUpperTriangularMatrix<double> m_accumulated({1, 0, 3,
                                                            4, 5,
                                                               6});
   for (int i = 1; i <= 100; ++i) {
-    m_accumulated[0][1] += δv;
+    m_accumulated(0, 1) += δv;
   }
   EXPECT_THAT(m_accumulated, AlmostEquals(m1, 3));
 }


### PR DESCRIPTION
Notably:
1. Change matrix indexing to use `A(i, j)` instead of `A[i][j]`.  It avoids having helper classes for the rows and we'll be able to convert it to `A[i, j]` in C++23.
2. Rename `dimension` into `size` because that's what it gives, the size of the storage (surely that the dimension of some vector space, but we don't care that much).
3. Add `!=` for all arrays.
4. Systematically declare `constexpr` functions `rows`, `columns` and `size`.