### PR TITLE
A number of fixes related to #3332

### DIFF
--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -92,7 +92,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   // An example of how journaling may be used for debugging.  You must set
   // |path| and fill the |method_in| and |method_out_return| protocol buffers.
   std::string path =
-      R"(\\CHILDERIC\Users\Public\Public Mockingbird\Principia\Journals\JOURNAL.20220110-023344)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Journals\JOURNAL.20220110-023344)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -225,7 +225,8 @@ void Vessel::DetectCollapsibilityChange() {
       } else {
         // Not only don't we create a new checkpoint and a new segment, but we
         // also delete the current, non-collapsible, 1-point segment, so that we
-        // keep appending to the previous collapsible, 1-point segment.
+        // keep appending to the previous collapsible, 1-point segment.  See
+        // #3332.
         LOG(INFO) << "Not writing " << ShortDebugString()
                   << " to duplicate checkpoint at: " << checkpoint;
         segment_action = Delete;

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -186,39 +186,69 @@ void Vessel::DetectCollapsibilityChange() {
     // consider merging it with its predecessor and avoiding the creation of a
     // new segment.  The checkpointing code below would remain correct.
 
+    // In normal situations we create a new segment with the collapsibility
+    // given by |becomes_collapsible|.  In one cornercase we delete the current
+    // segment.
+    enum {
+      Create,
+      Delete,
+    } segment_action = Create;
+
     if (!is_collapsible_) {
       // If the segment that is being closed is not collapsible, we have no way
       // to reconstruct it, so we must serialize it in a checkpoint.  Note that
       // the last point of the backstory specifies the initial conditions of the
       // next (collapsible) segment.
       Instant const checkpoint = backstory_->back().time;
-      // This test is needed because in some cornercases we might try to create
-      // multiple checkpoints at the same time.  See #3280.
-      if (checkpointer_->newest_checkpoint() < checkpoint) {
+
+      // In some cornercases we might try to create multiple checkpoints at the
+      // same time, see #3280.  The checkpointer doesn't support that.
+      bool const create_checkpoint =
+          checkpointer_->newest_checkpoint() < checkpoint;
+
+      if (create_checkpoint) {
         LOG(INFO) << "Writing " << ShortDebugString()
                   << " to checkpoint at: " << checkpoint;
         checkpointer_->WriteToCheckpoint(checkpoint);
-      }
 
-      // If there are no checkpoints in the current trajectory (this would
-      // happen if we restored the last part of trajectory and it didn't overlap
-      // with a checkpoint and no reanimation happened) then the
-      // |oldest_reanimated_checkpoint_| need to be updated to reflect the newly
-      // created checkpoint.
-      {
+        // If there are no checkpoints in the current trajectory (this would
+        // happen if we restored the last part of trajectory and it didn't
+        // overlap with a checkpoint and no reanimation happened) then the
+        // |oldest_reanimated_checkpoint_| need to be updated to reflect the
+        // newly created checkpoint.
         absl::MutexLock l(&lock_);
         if (oldest_reanimated_checkpoint_ == InfiniteFuture) {
           oldest_reanimated_checkpoint_ = checkpoint;
         } else {
           CHECK_LT(oldest_reanimated_checkpoint_, checkpoint);
         }
+      } else {
+        // Not only don't we create a new checkpoint and a new segment, but we
+        // also delete the current, non-collapsible, 1-point segment, so that we
+        // keep appending to the previous collapsible, 1-point segment.
+        LOG(INFO) << "Not writing " << ShortDebugString()
+                  << " to duplicate checkpoint at: " << checkpoint;
+        segment_action = Delete;
       }
     }
+
     auto psychohistory = trajectory_.DetachSegments(psychohistory_);
-    backstory_ = trajectory_.NewSegment();
-    if (downsampling_parameters_.has_value()) {
-      backstory_->SetDownsampling(downsampling_parameters_.value());
-    }
+    switch (segment_action) {
+      case Create: {
+        backstory_ = trajectory_.NewSegment();
+        if (downsampling_parameters_.has_value()) {
+          backstory_->SetDownsampling(downsampling_parameters_.value());
+        }
+        break;
+      }
+      case Delete: {
+        // Let's hope that no-one has kept an iterator to the deleted backstory.
+        trajectory_.DeleteSegments(backstory_);
+        CHECK(!trajectory_.segments().empty());
+        backstory_ = std::prev(trajectory_.segments().end());
+        break;
+      }
+    };
     psychohistory_ = trajectory_.AttachSegments(std::move(psychohistory));
     is_collapsible_ = becomes_collapsible;
   }

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -782,25 +782,34 @@ absl::Status DiscreteTrajectory<Frame>::ConsistencyStatus() const {
       // times match.  We must look at the endpoints of the timeline explicitly.
       if (!sit->timeline_empty()) {
         auto const& [left_time, left_dof] = *--sit->timeline_end();
-        auto const& [right_time, right_dof] = *std::next(sit)->timeline_begin();
-        if (left_time != right_time) {
-          return absl::InternalError(absl::StrCat("Duplicated time mismatch ",
-                                                  DebugString(left_time),
-                                                  " and ",
-                                                  DebugString(right_time),
-                                                  " for segment #",
-                                                  i));
-        } else if (left_dof != right_dof) {
-          bool const left_is_nan = left_dof != left_dof;
-          bool const right_is_nan = right_dof != right_dof;
-          if (!(left_is_nan && right_is_nan)) {
-            return absl::InternalError(
-                absl::StrCat("Duplicated degrees of freedom mismatch ",
-                             DebugString(left_dof),
-                             " and ",
-                             DebugString(right_dof),
-                             " for segment #",
-                             i));
+        if (std::next(sit)->timeline_empty()) {
+          return absl::InternalError(
+              absl::StrCat("Empty segment follows non-empty one after time ",
+                           DebugString(left_time),
+                           " and segment #",
+                           i));
+        } else {
+          auto const& [right_time, right_dof] =
+              *std::next(sit)->timeline_begin();
+          if (left_time != right_time) {
+            return absl::InternalError(absl::StrCat("Duplicated time mismatch ",
+                                                    DebugString(left_time),
+                                                    " and ",
+                                                    DebugString(right_time),
+                                                    " for segment #",
+                                                    i));
+          } else if (left_dof != right_dof) {
+            bool const left_is_nan = left_dof != left_dof;
+            bool const right_is_nan = right_dof != right_dof;
+            if (!(left_is_nan && right_is_nan)) {
+              return absl::InternalError(
+                  absl::StrCat("Duplicated degrees of freedom mismatch ",
+                               DebugString(left_dof),
+                               " and ",
+                               DebugString(right_dof),
+                               " for segment #",
+                               i));
+            }
           }
         }
       }

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -127,7 +127,7 @@ class StackTraceDecoder {
     if (!unity_crash) {
       var version_regex = new Regex(
           @"^[EI].*\] Principia version " +
-          @"([0-9]{10}-\w+)-[0-9]+-g([0-9a-f]{40})(-dirty)? built");
+          @"([0-9]{10}-.+)-[0-9]+-g([0-9a-f]{40})(-dirty)? built");
       Match version_match;
       do {
         Check(!stream.EndOfStream,


### PR DESCRIPTION
1. Change the C# regexp that parses our info logs to handle properly handle indic scripts.
2. Change the consistency check that fires in [#3332](https://github.com/mockingbirdnest/Principia/issues/3332) to not cause undefined behaviour.  Not severe in itself, but it would be good if the failure message didn't have junk float values.
3. Make sure that, when we refuse to create a checkpoint because it would fall at the same time as a previous checkpoint, we leave the trajectory in a consistent state.

Consider what happens when we have the following collapsibility changes, all occurring at the same time `t`:
```
Segment #1 (NC) ⟶ Segment #2 (C) ⟶ Segment #3 (NC) ⟶ Segment #4 (C)
```
where `NC` indicates a non-collapsible segment and `C` a collapsible segment.

* At the end of `Segment #1`, we create a checkpoint at time `t` containing all of `Segment #1`. We then create a new segment, `Segment #2`, which has initially one point.
* `Segment #2` ends immediately (remember that all the transitions are at time `t`), so it is left with a single point, and we create `Segment #3`, which has initially one point.

Then `Segment #3` ends immediately and the story continues differently depending on the version of the code:
* Before [#3282](https://github.com/mockingbirdnest/Principia/issues/3282), we try to create a checkpoint at time `t` and fail a `CHECK` in the `Checkpointer` class.
* Before this PR, we don't create a second checkpoint at time `t`, but we create `Segment #4`.  So `Segment #3` is not collapsible, but it doesn't have a checkpoint either, and we are unable to reconstruct it.  That's the crash observed in [#3332](https://github.com/mockingbirdnest/Principia/issues/3332).
* After this PR, we don't create a second checkpoint at time `t`, we don't create `Segment #4`, *and* we destroy `Segment #3`, so that any future collapsible point gets appended to `Segment #2`.  The hope is that this preserves the following invariants: (1) a collapsible segment always follows a checkpoint (2) segments alternate in collapsibility.

I *believe* that this fixes #3332 but I don't have a way to check for sure.