### PR TITLE
Optimizations for Checkpointer

### DIFF
--- a/benchmarks/checkpointer_benchmark.cpp
+++ b/benchmarks/checkpointer_benchmark.cpp
@@ -7,7 +7,6 @@
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
 #include "benchmark/benchmark.h"
-#include "physics/checkpointer.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
 #include "serialization/geometry.pb.h"

--- a/benchmarks/checkpointer_benchmark.cpp
+++ b/benchmarks/checkpointer_benchmark.cpp
@@ -54,8 +54,8 @@ absl::Status ReadFromCheckpoint(Ephemeris::Checkpoint const&) {
 
 // Constructs a Checkpointer with the specified number of points. Checkpoints
 // are spaced at an interval of one second.
-std::unique_ptr<Checkpointer<Ephemeris>> ConstructCheckpointerWithSize(
-    int size) {
+std::unique_ptr<Checkpointer<Ephemeris>> NewCheckpointerWithSize(
+    int const size) {
   auto checkpointer = std::make_unique<Checkpointer<Ephemeris>>(
       &WriteToCheckpoint, &ReadFromCheckpoint);
 
@@ -68,7 +68,7 @@ std::unique_ptr<Checkpointer<Ephemeris>> ConstructCheckpointerWithSize(
 
 void BM_CheckpointerOldestCheckpoint(benchmark::State& state) {
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(state.range(0));
+      NewCheckpointerWithSize(state.range(0));
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(checkpointer->oldest_checkpoint());
@@ -77,7 +77,7 @@ void BM_CheckpointerOldestCheckpoint(benchmark::State& state) {
 
 void BM_CheckpointerNewestCheckpoint(benchmark::State& state) {
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(state.range(0));
+      NewCheckpointerWithSize(state.range(0));
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(checkpointer->newest_checkpoint());
@@ -86,9 +86,8 @@ void BM_CheckpointerNewestCheckpoint(benchmark::State& state) {
 
 void BM_CheckpointerCheckpointAtOrAfter(benchmark::State& state) {
   int const size = state.range(0);
-
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(size);
+      NewCheckpointerWithSize(size);
   Instant const t = Instant() + (size / 3.0) * Second;
 
   for (auto _ : state) {
@@ -97,9 +96,8 @@ void BM_CheckpointerCheckpointAtOrAfter(benchmark::State& state) {
 }
 void BM_CheckpointerCheckpointAtOrBefore(benchmark::State& state) {
   int const size = state.range(0);
-
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(size);
+      NewCheckpointerWithSize(size);
   Instant const t = Instant() + (size * 2.0 / 3.0) * Second;
 
   for (auto _ : state) {
@@ -109,7 +107,7 @@ void BM_CheckpointerCheckpointAtOrBefore(benchmark::State& state) {
 
 void BM_CheckpointerAllCheckpoints(benchmark::State& state) {
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(state.range(0));
+      NewCheckpointerWithSize(state.range(0));
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(checkpointer->all_checkpoints());
@@ -119,7 +117,7 @@ void BM_CheckpointerAllCheckpoints(benchmark::State& state) {
 void BM_CheckpointerAllCheckpointsAtOrBefore(benchmark::State& state) {
   int const size = state.range(0);
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(state.range(0));
+      NewCheckpointerWithSize(state.range(0));
   Instant const t = Instant() + (size / 3.0) * Second;
 
   for (auto _ : state) {
@@ -129,7 +127,7 @@ void BM_CheckpointerAllCheckpointsAtOrBefore(benchmark::State& state) {
 void BM_CheckpointerAllCheckpointsBetween(benchmark::State& state) {
   int const size = state.range(0);
   std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
-      ConstructCheckpointerWithSize(state.range(0));
+      NewCheckpointerWithSize(state.range(0));
   Instant const t1 = Instant() + (size / 3.0) * Second;
   Instant const t2 = Instant() + (size * 2.0 / 3.0) * Second;
 

--- a/benchmarks/checkpointer_benchmark.cpp
+++ b/benchmarks/checkpointer_benchmark.cpp
@@ -1,0 +1,125 @@
+// .\Release\x64\benchmarks.exe --benchmark_filter=Checkpointer --benchmark_repetitions=5  // NOLINT(whitespace/line_length)
+
+#include "physics/checkpointer.hpp"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "base/not_null.hpp"
+#include "benchmark/benchmark.h"
+#include "quantities/named_quantities.hpp"
+#include "quantities/si.hpp"
+#include "serialization/physics.pb.h"
+
+namespace principia {
+namespace physics {
+
+using base::not_null;
+using geometry::Instant;
+using quantities::si::Second;
+using serialization::Ephemeris;
+
+// Stub writer for checkpointer. Does nothing.
+void WriteToCheckpoint(not_null<typename Ephemeris::Checkpoint*> checkpoint) {}
+
+// Stub reader for checkpointer. Does nothing.
+absl::Status ReadFromCheckpoint(Ephemeris::Checkpoint const&) {
+  return absl::OkStatus();
+}
+
+// Constructs a Checkpointer with the specified number of points. Checkpoints
+// are spaced at an interval of one second.
+std::unique_ptr<Checkpointer<Ephemeris>> ConstructCheckpointerWithSize(
+    int size) {
+  auto checkpointer = std::make_unique<Checkpointer<Ephemeris>>(
+      &WriteToCheckpoint, &ReadFromCheckpoint);
+
+  for (int i = 0; i < size; i++) {
+    checkpointer->WriteToCheckpoint(Instant() + i * Second);
+  }
+
+  return checkpointer;
+}
+
+void BM_CheckpointerOldestCheckpoint(benchmark::State& state) {
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(state.range(0));
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->oldest_checkpoint());
+  }
+}
+
+void BM_CheckpointerNewestCheckpoint(benchmark::State& state) {
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(state.range(0));
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->newest_checkpoint());
+  }
+}
+
+void BM_CheckpointerCheckpointAtOrAfter(benchmark::State& state) {
+  int const size = state.range(0);
+
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(size);
+  Instant const t = Instant() + (size / 3.0) * Second;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->checkpoint_at_or_after(t));
+  }
+}
+void BM_CheckpointerCheckpointAtOrBefore(benchmark::State& state) {
+  int const size = state.range(0);
+
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(size);
+  Instant const t = Instant() + (size * 2.0 / 3.0) * Second;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->checkpoint_at_or_before(t));
+  }
+}
+
+void BM_CheckpointerAllCheckpoints(benchmark::State& state) {
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(state.range(0));
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->all_checkpoints());
+  }
+}
+
+void BM_CheckpointerAllCheckpointsAtOrBefore(benchmark::State& state) {
+  int const size = state.range(0);
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(state.range(0));
+  Instant const t = Instant() + (size / 3.0) * Second;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->all_checkpoints_at_or_before(t));
+  }
+}
+void BM_CheckpointerAllCheckpointsBetween(benchmark::State& state) {
+  int const size = state.range(0);
+  std::unique_ptr<Checkpointer<Ephemeris>> checkpointer =
+      ConstructCheckpointerWithSize(state.range(0));
+  Instant const t1 = Instant() + (size / 3.0) * Second;
+  Instant const t2 = Instant() + (size * 2.0 / 3.0) * Second;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(checkpointer->all_checkpoints_between(t1, t2));
+  }
+}
+
+BENCHMARK(BM_CheckpointerOldestCheckpoint)->Range(1, 512);
+BENCHMARK(BM_CheckpointerNewestCheckpoint)->Range(1, 512);
+BENCHMARK(BM_CheckpointerCheckpointAtOrAfter)->Range(1, 512);
+BENCHMARK(BM_CheckpointerCheckpointAtOrBefore)->Range(1, 512);
+BENCHMARK(BM_CheckpointerAllCheckpoints)->Range(1, 512);
+BENCHMARK(BM_CheckpointerAllCheckpointsAtOrBefore)->Range(1, 512);
+BENCHMARK(BM_CheckpointerAllCheckpointsBetween)->Range(1, 512);
+
+}  // namespace physics
+}  // namespace principia

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/btree_set.h"
 #include "base/map_util.hpp"
 #include "geometry/named_quantities.hpp"
 #include "ksp_plugin/integrators.hpp"
@@ -865,7 +866,7 @@ absl::Status Vessel::Reanimate(Instant const desired_t_min) {
   // This method is very similar to Ephemeris::Reanimate.  See the comments
   // there for some of the subtle points.
   static_assert(base::is_serializable_v<Barycentric>);
-  std::set<Instant> checkpoints;
+  absl::btree_set<Instant> checkpoints;
   LOG(INFO) << "Reanimating " << ShortDebugString() << " until "
             << desired_t_min;
 

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -3,8 +3,8 @@
 
 #include <functional>
 #include <map>
-#include <set>
 
+#include "absl/container/btree_set.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "base/not_null.hpp"
@@ -67,15 +67,15 @@ class Checkpointer {
   Instant checkpoint_at_or_before(Instant const& t) const EXCLUDES(lock_);
 
   // Returns all the checkpoints in this object.
-  std::set<Instant> all_checkpoints() const EXCLUDES(lock_);
+  absl::btree_set<Instant> all_checkpoints() const EXCLUDES(lock_);
 
   // Returns all the checkpoints at or before |t|.
-  std::set<Instant> all_checkpoints_at_or_before(Instant const& t) const
+  absl::btree_set<Instant> all_checkpoints_at_or_before(Instant const& t) const
       EXCLUDES(lock_);
 
   // Returns all the checkpoints in interval [t1, t2].
-  std::set<Instant> all_checkpoints_between(Instant const& t1,
-                                            Instant const& t2) const
+  absl::btree_set<Instant> all_checkpoints_between(Instant const& t1,
+                                                   Instant const& t2) const
       EXCLUDES(lock_);
 
   // Creates a checkpoint at time |t|, which will be used to recreate the

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -124,7 +124,8 @@ class Checkpointer {
           message);
 
  private:
-  using CheckpointsByTime = absl::btree_map<Instant, typename Message::Checkpoint>;
+  using CheckpointsByTime =
+      absl::btree_map<Instant, typename Message::Checkpoint>;
 
   void WriteToCheckpointLocked(Instant const& t)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -2,8 +2,8 @@
 #pragma once
 
 #include <functional>
-#include <map>
 
+#include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
@@ -124,6 +124,8 @@ class Checkpointer {
           message);
 
  private:
+  using CheckpointsByTime = absl::btree_map<Instant, typename Message::Checkpoint>;
+
   void WriteToCheckpointLocked(Instant const& t)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
@@ -133,7 +135,7 @@ class Checkpointer {
 
   // The time field of the Checkpoint message may or may not be set.  The map
   // key is the source of truth.
-  std::map<Instant, typename Message::Checkpoint> checkpoints_;
+  CheckpointsByTime checkpoints_;
 };
 
 }  // namespace internal_checkpointer

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -4,10 +4,10 @@
 #include "physics/checkpointer.hpp"
 
 #include <map>
-#include <set>
 #include <vector>
 #include <utility>
 
+#include "absl/container/btree_set.h"
 #include "base/status_utilities.hpp"
 #include "geometry/named_quantities.hpp"
 
@@ -64,9 +64,9 @@ Instant Checkpointer<Message>::checkpoint_at_or_before(Instant const& t) const {
 }
 
 template<typename Message>
-std::set<Instant> Checkpointer<Message>::all_checkpoints() const {
+absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints() const {
   absl::ReaderMutexLock l(&lock_);
-  std::set<Instant> result;
+  absl::btree_set<Instant> result;
   std::transform(
       checkpoints_.cbegin(),
       checkpoints_.cend(),
@@ -78,12 +78,12 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints() const {
 }
 
 template<typename Message>
-std::set<Instant> Checkpointer<Message>::all_checkpoints_at_or_before(
+absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints_at_or_before(
     Instant const& t) const {
   absl::ReaderMutexLock l(&lock_);
   // |it| denotes an entry strictly greater than |t| (or end).
   auto const it = checkpoints_.upper_bound(t);
-  std::set<Instant> result;
+  absl::btree_set<Instant> result;
   std::transform(
       checkpoints_.cbegin(),
       it,
@@ -95,11 +95,11 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints_at_or_before(
 }
 
 template<typename Message>
-std::set<Instant> Checkpointer<Message>::all_checkpoints_between(
+absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints_between(
     Instant const& t1,
     Instant const& t2) const {
   if (t2 < t1) {
-    return std::set<Instant>();
+    return absl::btree_set<Instant>();
   }
 
   absl::ReaderMutexLock l(&lock_);
@@ -107,7 +107,7 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints_between(
   auto const it1 = checkpoints_.lower_bound(t1);
   // |it2| denotes an entry strictly greater than |t2| (or end).
   auto const it2 = checkpoints_.upper_bound(t2);
-  std::set<Instant> result;
+  absl::btree_set<Instant> result;
   std::transform(
       it1,
       it2,

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -71,7 +71,7 @@ absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints() const {
       checkpoints_.cbegin(),
       checkpoints_.cend(),
       std::inserter(result, result.end()),
-      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
+      [](typename CheckpointsByTime::value_type const& pair) {
         return pair.first;
       });
   return result;
@@ -88,7 +88,7 @@ absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints_at_or_before(
       checkpoints_.cbegin(),
       it,
       std::inserter(result, result.end()),
-      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
+      [](typename CheckpointsByTime::value_type const& pair) {
         return pair.first;
       });
   return result;
@@ -112,7 +112,7 @@ absl::btree_set<Instant> Checkpointer<Message>::all_checkpoints_between(
       it1,
       it2,
       std::inserter(result, result.end()),
-      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
+      [](typename CheckpointsByTime::value_type const& pair) {
         return pair.first;
       });
   return result;
@@ -183,7 +183,7 @@ template<typename Message>
 absl::Status Checkpointer<Message>::ReadFromCheckpointAt(
     Instant const& t,
     Reader const& reader) const {
-  typename std::map<Instant, typename Message::Checkpoint>::const_iterator it;
+  typename CheckpointsByTime::const_iterator it;
   {
     absl::ReaderMutexLock l(&lock_);
     it = checkpoints_.find(t);

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -71,7 +71,7 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints() const {
       checkpoints_.cbegin(),
       checkpoints_.cend(),
       std::inserter(result, result.end()),
-      [](std::pair<Instant, typename Message::Checkpoint> const& pair) {
+      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
         return pair.first;
       });
   return result;
@@ -88,7 +88,7 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints_at_or_before(
       checkpoints_.cbegin(),
       it,
       std::inserter(result, result.end()),
-      [](std::pair<Instant, typename Message::Checkpoint> const& pair) {
+      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
         return pair.first;
       });
   return result;
@@ -112,7 +112,7 @@ std::set<Instant> Checkpointer<Message>::all_checkpoints_between(
       it1,
       it2,
       std::inserter(result, result.end()),
-      [](std::pair<Instant, typename Message::Checkpoint> const& pair) {
+      [](std::pair<Instant const, typename Message::Checkpoint> const& pair) {
         return pair.first;
       });
   return result;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -7,10 +7,10 @@
 #include <functional>
 #include <limits>
 #include <optional>
-#include <set>
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_set.h"
 #include "absl/strings/str_cat.h"
 #include "astronomy/epoch.hpp"
 #include "base/jthread.hpp"
@@ -946,7 +946,7 @@ Ephemeris<Frame>::MakeCheckpointerReader() {
 
 template<typename Frame>
 absl::Status Ephemeris<Frame>::Reanimate(Instant const desired_t_min) {
-  std::set<Instant> checkpoints;
+  absl::btree_set<Instant> checkpoints;
   {
     absl::ReaderMutexLock l(&lock_);
 


### PR DESCRIPTION
Some optimizations for `Checkpointer`:
- Changed `std::pair<Instant, typename Message::Checkpoint>` to `std::pair<Instant const, typename Message::Checkpoint>`. The second of those is the correct `value_type` for `std::map`; using the incorrect type caused spurious proto copies (which I noticed when I captured [this flame graph](https://user-images.githubusercontent.com/71856888/158324434-79d23d8f-c951-48bc-a157-f27581214d07.svg) during gameplay).
 - Changed `std::set` to `absl::btree_set`, which provided some further gains.

To measure the effects of these changes I wrote some benchmarks. Here are the relevant results:
```
Benchmark                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------
BM_CheckpointerAllCheckpoints/1                            -0.9820         -0.9820          4401            79          4397            79
BM_CheckpointerAllCheckpoints/8                            -0.9911         -0.9911         35485           316         35477           316
BM_CheckpointerAllCheckpoints/64                           -0.9960         -0.9960        283824          1138        283796          1138
BM_CheckpointerAllCheckpoints/512                          -0.9971         -0.9971       2360338          6934       2357601          6934
BM_CheckpointerAllCheckpointsAtOrBefore/1                  -0.9822         -0.9821          4424            79          4417            79
BM_CheckpointerAllCheckpointsAtOrBefore/8                  -0.9836         -0.9836         13385           220         13357           220
BM_CheckpointerAllCheckpointsAtOrBefore/64                 -0.9944         -0.9944         98492           554         98371           554
BM_CheckpointerAllCheckpointsAtOrBefore/512                -0.9971         -0.9971        771610          2235        770321          2235
BM_CheckpointerAllCheckpointsBetween/1                     -0.0088         -0.0076            13            13            13            13
BM_CheckpointerAllCheckpointsBetween/8                     -0.9832         -0.9832         13310           223         13294           223
BM_CheckpointerAllCheckpointsBetween/64                    -0.9941         -0.9941         93269           550         93228           550
BM_CheckpointerAllCheckpointsBetween/512                   -0.9970         -0.9970        759691          2299        759471          2299
```
