### PR TITLE
Use Brent's method instead of bisection for computing apsides and nodes

### DIFF
--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -287,13 +287,13 @@ TEST_F(KSPResonanceTest, MSVC_ONLY_TEST(Stock)) {
                      ephemeris->t_max() - 2 * longest_joolian_period_);
   EXPECT_THAT(RelativeError(periods_at_mid_term.at(laythe_),
                             expected_periods_.at(laythe_)),
-              IsNear(0.874_⑴));
+              IsNear(0.121_⑴));
   EXPECT_THAT(periods_at_mid_term.at(vall_), Eq(Infinity<Time>));
   EXPECT_THAT(periods_at_mid_term.at(tylo_), Eq(Infinity<Time>));
   EXPECT_THAT(RelativeError(periods_at_mid_term.at(bop_),
-                            expected_periods_.at(bop_)), IsNear(0.38_⑴));
+                            expected_periods_.at(bop_)), IsNear(0.19_⑴));
   EXPECT_THAT(RelativeError(periods_at_mid_term.at(pol_),
-                            expected_periods_.at(pol_)), IsNear(0.30_⑴));
+                            expected_periods_.at(pol_)), IsNear(0.13_⑴));
 
   LogEphemeris(*ephemeris,
                ephemeris->t_max() - 5 * longest_joolian_period_,
@@ -357,15 +357,15 @@ TEST_F(KSPResonanceTest, MSVC_ONLY_TEST(Corrected)) {
       ComputePeriods(*ephemeris,
                      ephemeris->t_max() - 2 * longest_joolian_period_);
   EXPECT_THAT(RelativeError(periods_at_long_term.at(laythe_),
-                            expected_periods_.at(laythe_)), IsNear(4.7e-3_⑴));
+                            expected_periods_.at(laythe_)), IsNear(4.3e-3_⑴));
   EXPECT_THAT(RelativeError(periods_at_long_term.at(vall_),
-                            expected_periods_.at(vall_)), IsNear(5.7e-3_⑴));
+                            expected_periods_.at(vall_)), IsNear(2.9e-3_⑴));
   EXPECT_THAT(RelativeError(periods_at_long_term.at(tylo_),
-                            expected_periods_.at(tylo_)), IsNear(0.75e-3_⑴));
+                            expected_periods_.at(tylo_)), IsNear(0.87e-3_⑴));
   EXPECT_THAT(RelativeError(periods_at_long_term.at(bop_),
-                            expected_periods_.at(bop_)), IsNear(43e-3_⑴));
+                            expected_periods_.at(bop_)), IsNear(1.3e-3_⑴));
   EXPECT_THAT(RelativeError(periods_at_long_term.at(pol_),
-                            expected_periods_.at(pol_)), IsNear(9.9e-3_⑴));
+                            expected_periods_.at(pol_)), IsNear(1.2e-3_⑴));
 
   LogEphemeris(*ephemeris,
                ephemeris->t_max() - 5 * longest_joolian_period_,

--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -365,7 +365,7 @@ TEST_F(KSPResonanceTest, MSVC_ONLY_TEST(Corrected)) {
   EXPECT_THAT(RelativeError(periods_at_long_term.at(bop_),
                             expected_periods_.at(bop_)), IsNear(1.3e-3_⑴));
   EXPECT_THAT(RelativeError(periods_at_long_term.at(pol_),
-                            expected_periods_.at(pol_)), IsNear(1.2e-3_⑴));
+                            expected_periods_.at(pol_)), IsNear(12e-3_⑴));
 
   LogEphemeris(*ephemeris,
                ephemeris->t_max() - 5 * longest_joolian_period_,

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -19,7 +19,7 @@ using geometry::Barycentre;
 using geometry::Instant;
 using geometry::Position;
 using geometry::Sign;
-using numerics::Bisect;
+using numerics::Brent;
 using numerics::Hermite3;
 using quantities::IsFinite;
 using quantities::Length;
@@ -176,10 +176,9 @@ absl::Status ComputeNodes(
         node_time = Barycentre<Instant, Length>({*previous_time, time},
                                                 {z, -*previous_z});
       } else {
-        // The normal case, find the intersection with z = 0 using bisection.
-        // TODO(egg): Bisection on a polynomial seems daft; we should have
-        // Newton's method.
-        node_time = Bisect(
+        // The normal case, find the intersection with z = 0 using Brent's
+        // method.
+        node_time = Brent(
             [&z_approximation](Instant const& t) {
               return z_approximation.Evaluate(t);
             },

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -49,7 +49,7 @@ using integrators::ExplicitSecondOrderOrdinaryDifferentialEquation;
 using integrators::IntegrationProblem;
 using integrators::Integrator;
 using integrators::methods::Fine1987RKNG34;
-using numerics::Bisect;
+using numerics::Brent;
 using numerics::DoublePrecision;
 using numerics::Hermite3;
 using quantities::Abs;
@@ -721,11 +721,11 @@ void Ephemeris<Frame>::ComputeApsides(not_null<MassiveBody const*> const body1,
       CHECK(previous_time);
 
       // The derivative of |squared_distance| changed sign.  Find its zero by
-      // bisection, this is the time of the apsis.  Then compute the apsis and
-      // append it to one of the output trajectories.
-      Instant const apsis_time = Bisect(evaluate_square_distance_derivative,
-                                        *previous_time,
-                                        time);
+      // Brent's method, this is the time of the apsis.  Then compute the apsis
+      // and append it to one of the output trajectories.
+      Instant const apsis_time = Brent(evaluate_square_distance_derivative,
+                                       *previous_time,
+                                       time);
       DegreesOfFreedom<Frame> const apsis1_degrees_of_freedom =
           body1_trajectory->EvaluateDegreesOfFreedomLocked(apsis_time);
       DegreesOfFreedom<Frame> const apsis2_degrees_of_freedom =

--- a/physics/kepler_orbit_body.hpp
+++ b/physics/kepler_orbit_body.hpp
@@ -29,7 +29,7 @@ using geometry::Sign;
 using geometry::Vector;
 using geometry::Velocity;
 using geometry::Wedge;
-using numerics::Bisect;
+using numerics::Brent;
 using quantities::Abs;
 using quantities::ArcCos;
 using quantities::ArcCosh;
@@ -642,9 +642,9 @@ void KeplerOrbit<Frame>::CompleteAnomalies(KeplerianElements<Frame>& elements) {
              (eccentric_anomaly - e * Sin(eccentric_anomaly) * Radian);
     };
     Angle const eccentric_anomaly = e == 0 ? *mean_anomaly
-                                           : Bisect(kepler_equation,
-                                                    *mean_anomaly - e * Radian,
-                                                    *mean_anomaly + e * Radian);
+                                           : Brent(kepler_equation,
+                                                   *mean_anomaly - e * Radian,
+                                                   *mean_anomaly + e * Radian);
     true_anomaly = 2 * ArcTan(Sqrt(1 + e) * Sin(eccentric_anomaly / 2),
                               Sqrt(1 - e) * Cos(eccentric_anomaly / 2));
     hyperbolic_mean_anomaly = NaN<Angle>;
@@ -657,9 +657,9 @@ void KeplerOrbit<Frame>::CompleteAnomalies(KeplerianElements<Frame>& elements) {
               hyperbolic_eccentric_anomaly);
     };
     Angle const hyperbolic_eccentric_anomaly =
-        Bisect(hyperbolic_kepler_equation,
-               0 * Radian,
-               *hyperbolic_mean_anomaly / (e - 1));
+        Brent(hyperbolic_kepler_equation,
+              0 * Radian,
+              *hyperbolic_mean_anomaly / (e - 1));
     true_anomaly =
         2 * ArcTan(Sqrt(e + 1) * Sinh(hyperbolic_eccentric_anomaly / 2),
                    Sqrt(e - 1) * Cosh(hyperbolic_eccentric_anomaly / 2));


### PR DESCRIPTION
This improves performance by a few percents.  Before:
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides  119451153 ns    115664830 ns          362
ApsidesBenchmark/ComputeNodes     36542126 ns     35692924 ns         1191
```
after:
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
ApsidesBenchmark/ComputeApsides  113703789 ns    112403921 ns          375
ApsidesBenchmark/ComputeNodes     33949542 ns     33410740 ns         1235
```
This improvement was discussed in #2913.