### PR TITLE
Restructure the class Geopotential

### DIFF
--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -80,7 +80,7 @@ class Geopotential {
 
   // Helper templates for iterating over the degrees/orders of the geopotential.
   template<int degree, int order>
-  struct DegreeNOrderM;
+  class DegreeNOrderM;
   template<int degree, typename>
   class DegreeNAllOrders;
   template<typename>

--- a/physics/geopotential.hpp
+++ b/physics/geopotential.hpp
@@ -82,7 +82,7 @@ class Geopotential {
   template<int degree, int order>
   struct DegreeNOrderM;
   template<int degree, typename>
-  struct DegreeNAllOrders;
+  class DegreeNAllOrders;
   template<typename>
   struct AllDegrees;
 

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -223,12 +223,12 @@ auto Geopotential<Frame>::DegreeNOrderM<degree, order>::Acceleration(
     auto const& grad_𝔅_vector = precomputations.grad_𝔅_vector;
     auto const& grad_𝔏_vector = precomputations.grad_𝔏_vector;
 
-    auto& cos_mλ = precomputations.cos_mλ[m];
-    auto& sin_mλ = precomputations.sin_mλ[m];
+    auto const& cos_mλ = precomputations.cos_mλ[m];
+    auto const& sin_mλ = precomputations.sin_mλ[m];
 
-    auto& cos_β_to_the_m = precomputations.cos_β_to_the_m[m];
+    auto const& cos_β_to_the_m = precomputations.cos_β_to_the_m[m];
 
-    auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
+    auto const& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
     auto const& cos = *precomputations.cos;
     auto const& sin = *precomputations.sin;
 
@@ -290,17 +290,13 @@ void Geopotential<Frame>::DegreeNOrderM<degree, order>::UpdatePrecomputations(
     constexpr int m = order;
     static_assert(0 <= m && m <= n);
 
-    double const cos_β = precomputations.cos_β;
     double const sin_β = precomputations.sin_β;
 
     auto& cos_mλ = precomputations.cos_mλ[m];
     auto& sin_mλ = precomputations.sin_mλ[m];
 
     auto& cos_β_to_the_m = precomputations.cos_β_to_the_m[m];
-
     auto& DmPn_of_sin_β = precomputations.DmPn_of_sin_β;
-    auto const& cos = *precomputations.cos;
-    auto const& sin = *precomputations.sin;
 
     // The caller ensures that we process n and m by increasing values.  Thus,
     // only the last value of m needs to be initialized for a given value of n.


### PR DESCRIPTION
1. Move the initialization of the `Precomputations` struct to a constructor.  Add a few extra fields to the struct to avoid having to pass them as extraneous parameters.
2. Factor out the code that updates the `Precomputations` in a method `UpdatePrecomputations` of the degree and order iterators.

These changes are preparatory work for #3358, as it is expected that the computation of the potential will be able to use the new functions.

Since the code is being restructed, I ran the benchmarks to check that the performance is unaffected.  The changes are in the noise.

Before:
```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2_median                   206 us          206 us           10
BM_ComputeGeopotentialCpp/3_median                   266 us          264 us           10
BM_ComputeGeopotentialCpp/5_median                   416 us          414 us           10
BM_ComputeGeopotentialCpp/10_median                 1216 us         1208 us           10
BM_ComputeGeopotentialF90/2_median                   194 us          191 us           10
BM_ComputeGeopotentialF90/3_median                   225 us          224 us           10
BM_ComputeGeopotentialF90/5_median                   312 us          311 us           10
BM_ComputeGeopotentialF90/10_median                  726 us          720 us           10
BM_ComputeGeopotentialDistance/150000_median         217 us          212 us           10
BM_ComputeGeopotentialDistance/500000_median        93.3 us         91.7 us           10
BM_ComputeGeopotentialDistance/5000000_median       17.8 us         17.5 us           10
```
After:
```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
BM_ComputeGeopotentialCpp/2_median                   206 us          203 us           10
BM_ComputeGeopotentialCpp/3_median                   261 us          261 us           10
BM_ComputeGeopotentialCpp/5_median                   412 us          412 us           10
BM_ComputeGeopotentialCpp/10_median                 1243 us         1229 us           10
BM_ComputeGeopotentialF90/2_median                   207 us          205 us           10
BM_ComputeGeopotentialF90/3_median                   224 us          222 us           10
BM_ComputeGeopotentialF90/5_median                   308 us          305 us           10
BM_ComputeGeopotentialF90/10_median                  717 us          715 us           10
BM_ComputeGeopotentialDistance/150000_median         210 us          209 us           10
BM_ComputeGeopotentialDistance/500000_median        92.2 us         90.2 us           10
BM_ComputeGeopotentialDistance/5000000_median       16.1 us         16.0 us           10
```