### PR TITLE
Add a function to determine if a trajectory segment was ever downsampled

### DIFF
--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -115,6 +115,11 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   // segment are going to be retained.
   void ClearDownsampling();
 
+  // Returns true iff this segment was downsampled at least once since its
+  // creation or the last call to |clear|.  Only use for optimization purposes,
+  // not to depend on the actual structure of the timeline.
+  bool was_downsampled() const;
+
   // The points denoted by |exact| are written and re-read exactly and are not
   // affected by any errors introduced by zfp compression.  The endpoints of a
   // segment are always exact.
@@ -208,6 +213,8 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
   // The number of points at the end of the segment that are part of a "dense"
   // span, i.e., have not been subjected to downsampling yet.
   std::int64_t number_of_dense_points_ = 0;
+
+  bool was_downsampled_ = false;
 
   DiscreteTrajectorySegmentIterator<Frame> self_;
   Timeline timeline_;

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -249,7 +249,7 @@ DiscreteTrajectorySegment<Frame>::ReadFromMessage(
   LOG_IF(WARNING, is_pre_hesse)
       << "Reading pre-"
       << (is_pre_hardy ? "Hardy"
-          : "Hesse") << " DiscreteTrajectorySegment";
+                       : "Hesse") << " DiscreteTrajectorySegment";
 
   DiscreteTrajectorySegment<Frame> segment(self);
 

--- a/physics/discrete_trajectory_segment_test.cpp
+++ b/physics/discrete_trajectory_segment_test.cpp
@@ -259,7 +259,9 @@ TEST_F(DiscreteTrajectorySegmentTest, DownsamplingCircle) {
       /*to=*/downsampled_circle);
 
   EXPECT_THAT(circle.size(), Eq(1001));
+  EXPECT_FALSE(circle.was_downsampled());
   EXPECT_THAT(downsampled_circle.size(), Eq(77));
+  EXPECT_TRUE(downsampled_circle.was_downsampled());
   std::vector<Length> position_errors;
   std::vector<Speed> velocity_errors;
   for (auto const& [time, degrees_of_freedom] : circle) {

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -1078,7 +1078,7 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
   trajectory1.WriteToMessage(&message, /*tracked=*/{}, /*exact=*/{});
   std::string uncompressed;
   message.SerializePartialToString(&uncompressed);
-  EXPECT_EQ(18'696, uncompressed.size());
+  EXPECT_EQ(18'698, uncompressed.size());
 
   std::string compressed;
   auto compressor = google::compression::NewGipfeliCompressor();
@@ -1086,8 +1086,8 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
 
   // We want a change detector, but the actual compressed size varies depending
   // on the exact numerical values, and therefore on the mathematical library.
-  EXPECT_LE(17'149, compressed.size());
-  EXPECT_GE(17'149, compressed.size());
+  EXPECT_LE(17'151, compressed.size());
+  EXPECT_GE(17'151, compressed.size());
 
   auto const trajectory2 =
       DiscreteTrajectory<ICRS>::ReadFromMessage(message, /*tracked=*/{});

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -137,6 +137,7 @@ message DiscreteTrajectorySegment {
   }
   optional DownsamplingParameters downsampling_parameters = 1;
   optional int32 number_of_dense_points = 2;
+  optional bool was_downsampled = 5;  // Added in Hesse.
   repeated InstantaneousDegreesOfFreedom exact = 3;
   required Zfp zfp = 4;
 }


### PR DESCRIPTION
This will be useful to take decisions regarding the merging of a collapsible segment into the preceding non-collapsible segment without depending on the details of the downsampling decisions.

#3375.