### PR TITLE
A close window button.

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -52,7 +52,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   protected override string Title =>
       L10N.CacheFormat("#Principia_FlightPlan_Title");
 
-  protected override void RenderWindow(int window_id) {
+  protected override void RenderWindowContents(int window_id) {
     // We must ensure that the GUI elements don't change between Layout and
     // Repaint.  This means that any state change must occur before Layout or
     // after Repaint.  This if statement implements the former.  It updates the

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -142,7 +142,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
 
   protected override string Title => "Principia";
 
-  protected override void RenderWindow(int window_id) {
+  protected override void RenderWindowContents(int window_id) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
       if (!adapter_.PluginRunning()) {
         UnityEngine.GUILayout.Label(

--- a/ksp_plugin_adapter/orbit_analyser.cs
+++ b/ksp_plugin_adapter/orbit_analyser.cs
@@ -191,7 +191,7 @@ internal abstract class OrbitAnalyser : VesselSupervisedWindowRenderer {
                                                ToUpper() +
                                            orbit_description_.Substring(1);
 
-  protected override void RenderWindow(int window_id) {
+  protected override void RenderWindowContents(int window_id) {
     string vessel_guid = predicted_vessel?.id.ToString();
     if (vessel_guid == null) {
       return;

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -462,7 +462,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
                        Name(),
                        NavballName());
 
-  protected override void RenderWindow(int window_id) {
+  protected override void RenderWindowContents(int window_id) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
       UnityEngine.GUILayout.Label(
           L10N.CacheFormat(

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -267,14 +267,15 @@ internal abstract class BaseWindowRenderer : ScalingRenderer, IConfigNode {
   private UnityEngine.GUISkin skin_;
   private bool must_centre_ = true;
   private bool show_ = false;
-  private UnityEngine.Rect rectangle_;
+  protected UnityEngine.Rect rectangle_;
   private DateTime tooltip_begin_;
   private string tooltip_ = "";
   private UnityEngine.Rect tooltip_rectangle_;
 }
 
 // The supervisor of a window decides when to clear input locks, when to render
-// the window and when to delete it.
+// the window and when to delete it.  A supervised window has a “Hide” button,
+// in addition to the external toggle handled by the supervisor.
 internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
   public interface ISupervisor {
     event Action LockClearing;
@@ -291,7 +292,21 @@ internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
     supervisor_.WindowsRendering += RenderWindow;
   }
 
-  public void DisposeWindow() {
+  protected abstract void RenderWindowContents(int window_id);
+
+  protected sealed override void RenderWindow(int window_id) {
+    if (UnityEngine.GUI.Button(new UnityEngine.Rect(
+            x: rectangle_.width - Width(1),
+            y: 0,
+            width: Width(1),
+            height: Width(1)),
+            "×")) {
+      Hide();
+    }
+    RenderWindowContents(window_id);
+  }
+
+      public void DisposeWindow() {
     supervisor_.LockClearing -= ClearLock;
     supervisor_.WindowsDisposal -= DisposeWindow;
     supervisor_.WindowsRendering -= RenderWindow;

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -306,7 +306,7 @@ internal abstract class SupervisedWindowRenderer : BaseWindowRenderer {
     RenderWindowContents(window_id);
   }
 
-      public void DisposeWindow() {
+  public void DisposeWindow() {
     supervisor_.LockClearing -= ClearLock;
     supervisor_.WindowsDisposal -= DisposeWindow;
     supervisor_.WindowsRendering -= RenderWindow;


### PR DESCRIPTION
Not the prettiest thing, but it should help with usability when there are lots of windows around.

![image](https://user-images.githubusercontent.com/2284290/174906761-d9333de7-0c4d-4c3b-b7dd-1b4e4a36b1b6.png)


A potentially confusing quirk is that since closing the main window has the exact same effect as toggling the toolbar button, it closes all windows. It’s not clear that anything else would work well though, since there wouldn’t be an unambiguous interaction to bring it back.

Fix #2295.