### PR TITLE
Single-line prediction settings

### DIFF
--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -13,7 +13,7 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Target: <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Clear
     #Principia_MainWindow_TargetVessel_SwitchTo = Switch to
-    #Principia_MainWindow_PredictionSettings = Prediction Settings
+    #Principia_MainWindow_PredictionSettings = Prediction:
     #Principia_MainWindow_KspFeatures = KSP Features
     #Principia_MainWindow_LoggingSettings = Logging Settings
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = Display patched conics (do not use for flight planning!)

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -13,7 +13,7 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Cible : <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Effacer
     #Principia_MainWindow_TargetVessel_SwitchTo = Échanger
-    #Principia_MainWindow_PredictionSettings = Paramètres de prédiction
+    #Principia_MainWindow_PredictionSettings = Prédiction :
     #Principia_MainWindow_KspFeatures = Fonctionalités de KSP
     #Principia_MainWindow_LoggingSettings = Paramètres de logging
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = Afficher les coniques juxtaposées (ne pas utiliser pour les plans de vol !)

--- a/ksp_plugin_adapter/localization/ru.cfg
+++ b/ksp_plugin_adapter/localization/ru.cfg
@@ -15,7 +15,7 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Цель: <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Сброс
     #Principia_MainWindow_TargetVessel_SwitchTo = Перейти
-    #Principia_MainWindow_PredictionSettings = Настройки прогноза траекторий
+    #Principia_MainWindow_PredictionSettings = Прогноз траекторий:
     #Principia_MainWindow_KspFeatures = Функции KSP
     #Principia_MainWindow_LoggingSettings = Настройки логирования
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = Показать сопряжённые конические сечения (не используйте для планирования полётов!)

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -12,7 +12,7 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = 当前目标：<<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = 清除
     #Principia_MainWindow_TargetVessel_SwitchTo = 切换至目标
-    #Principia_MainWindow_PredictionSettings = 轨道预测选项
+    #Principia_MainWindow_PredictionSettings = 轨道预测：
     #Principia_MainWindow_KspFeatures = KSP功能
     #Principia_MainWindow_LoggingSettings = 日志选项
     #Principia_MainWindow_KspFeature_DisplayPatchedConics = 显示圆锥曲线拼接轨道（不可用于轨道规划!）

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -65,12 +65,6 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
     if (show_logging_settings_value != null) {
       show_logging_settings_ = Convert.ToBoolean(show_logging_settings_value);
     }
-    string show_prediction_settings_value =
-        node.GetAtMostOneValue("show_prediction_settings");
-    if (show_prediction_settings_value != null) {
-      show_prediction_settings_ =
-          Convert.ToBoolean(show_prediction_settings_value);
-    }
 
     string history_length_value = node.GetAtMostOneValue("history_length");
     if (history_length_value != null) {
@@ -120,9 +114,6 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
                   createIfNotFound : true);
     node.SetValue("show_logging_settings",
                   show_logging_settings_,
-                  createIfNotFound : true);
-    node.SetValue("show_prediction_settings",
-                  show_prediction_settings_,
                   createIfNotFound : true);
 
     node.SetValue("history_length", history_length, createIfNotFound : true);
@@ -223,11 +214,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
           flight_planner_.RenderButton();
           orbit_analyser_.RenderButton();
         }
-        RenderToggleableSection(
-            name   :
-            L10N.CacheFormat("#Principia_MainWindow_PredictionSettings"),
-            show   : ref show_prediction_settings_,
-            render : RenderPredictionSettings);
+        RenderPredictionSettings();
       }
       RenderToggleableSection(
           name   : L10N.CacheFormat("#Principia_MainWindow_KspFeatures"),
@@ -394,101 +381,96 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   private void RenderPredictionSettings() {
     AdaptiveStepParameters? adaptive_step_parameters = null;
     string vessel_guid = predicted_vessel?.id.ToString();
-    if (vessel_guid != null) {
-      adaptive_step_parameters =
-          plugin.VesselGetPredictionAdaptiveStepParameters(vessel_guid);
-      prediction_length_tolerance_index_ = Array.FindIndex(
-          prediction_length_tolerances_,
-          (double tolerance) => tolerance >=
-                                adaptive_step_parameters.Value.
-                                    length_integration_tolerance);
-      if (prediction_length_tolerance_index_ < 0) {
-        prediction_length_tolerance_index_ =
-            default_prediction_length_tolerance_index;
+    using (new UnityEngine.GUILayout.HorizontalScope()) {
+      UnityEngine.GUILayout.Label(
+          L10N.CacheFormat("#Principia_MainWindow_PredictionSettings"),
+          UnityEngine.GUILayout.ExpandWidth(true));
+      if (vessel_guid != null) {
+        adaptive_step_parameters =
+            plugin.VesselGetPredictionAdaptiveStepParameters(vessel_guid);
+        prediction_length_tolerance_index_ = Array.FindIndex(
+            prediction_length_tolerances_,
+            (double tolerance) => tolerance >=
+                                  adaptive_step_parameters.Value.
+                                      length_integration_tolerance);
+        if (prediction_length_tolerance_index_ < 0) {
+          prediction_length_tolerance_index_ =
+              default_prediction_length_tolerance_index;
+        }
+        prediction_steps_index_ = Array.FindIndex(prediction_steps_,
+                                                  (long step) =>
+                                                      step >=
+                                                      adaptive_step_parameters.
+                                                          Value.max_steps);
+        if (prediction_steps_index_ < 0) {
+          prediction_steps_index_ = default_prediction_steps_index;
+        }
       }
-      prediction_steps_index_ = Array.FindIndex(prediction_steps_,
-                                                (long step) =>
-                                                    step >=
-                                                    adaptive_step_parameters.
-                                                        Value.max_steps);
-      if (prediction_steps_index_ < 0) {
-        prediction_steps_index_ = default_prediction_steps_index;
-      }
-    }
 
-    // TODO(egg): make the speed tolerance independent.
-    if (RenderSelector(prediction_length_tolerances_,
-                       ref prediction_length_tolerance_index_,
-                       L10N.CacheFormat(
-                           "#Principia_PredictionSettings_ToleranceLabel"),
-                       "{0:0.0e0} m",
-                       enabled: adaptive_step_parameters.HasValue)) {
-      AdaptiveStepParameters new_adaptive_step_parameters =
-          new AdaptiveStepParameters{
-              integrator_kind = adaptive_step_parameters.Value.integrator_kind,
-              max_steps = prediction_steps,
-              length_integration_tolerance = prediction_length_tolerance,
-              speed_integration_tolerance = prediction_length_tolerance
-          };
-      plugin.VesselSetPredictionAdaptiveStepParameters(
-          vessel_guid,
-          new_adaptive_step_parameters);
-    }
-    if (RenderSelector(prediction_steps_,
-                       ref prediction_steps_index_,
-                       L10N.CacheFormat("#Principia_PredictionSettings_Steps"),
-                       "{0:0.00e0}",
-                       enabled: adaptive_step_parameters.HasValue)) {
-      AdaptiveStepParameters new_adaptive_step_parameters =
-          new AdaptiveStepParameters{
-              integrator_kind = adaptive_step_parameters.Value.integrator_kind,
-              max_steps = prediction_steps,
-              length_integration_tolerance = prediction_length_tolerance,
-              speed_integration_tolerance = prediction_length_tolerance
-          };
-      plugin.VesselSetPredictionAdaptiveStepParameters(
-          vessel_guid,
-          new_adaptive_step_parameters);
+      // TODO(egg): make the speed tolerance independent.
+      if (RenderSelector(prediction_length_tolerances_,
+                         ref prediction_length_tolerance_index_,
+                         L10N.CacheFormat(
+                             "#Principia_PredictionSettings_ToleranceLabel"),
+                         (i) => prediction_length_tolerance_names_[i],
+                         enabled: adaptive_step_parameters.HasValue)) {
+        AdaptiveStepParameters new_adaptive_step_parameters =
+            new AdaptiveStepParameters{
+                integrator_kind = adaptive_step_parameters.Value.integrator_kind,
+                max_steps = prediction_steps,
+                length_integration_tolerance = prediction_length_tolerance,
+                speed_integration_tolerance = prediction_length_tolerance
+            };
+        plugin.VesselSetPredictionAdaptiveStepParameters(
+            vessel_guid,
+            new_adaptive_step_parameters);
+      }
+      if (RenderSelector(prediction_steps_,
+                         ref prediction_steps_index_,
+                         L10N.CacheFormat("#Principia_PredictionSettings_Steps"),
+                         (i) => string.Format(Culture.culture,
+                                              "{0:0.0e0}",
+                                              prediction_steps_[i]),
+                         enabled: adaptive_step_parameters.HasValue)) {
+        AdaptiveStepParameters new_adaptive_step_parameters =
+            new AdaptiveStepParameters{
+                integrator_kind = adaptive_step_parameters.Value.integrator_kind,
+                max_steps = prediction_steps,
+                length_integration_tolerance = prediction_length_tolerance,
+                speed_integration_tolerance = prediction_length_tolerance
+            };
+        plugin.VesselSetPredictionAdaptiveStepParameters(
+            vessel_guid,
+            new_adaptive_step_parameters);
+      }
     }
   }
 
   private bool RenderSelector<T>(T[] array,
                                  ref int index,
                                  string label,
-                                 string format,
+                                 Func<int, string> format,
                                  bool enabled) {
     bool changed = false;
-    using (new UnityEngine.GUILayout.HorizontalScope()) {
-      UnityEngine.GUILayout.Label(text    : label,
-                                  options : GUILayoutWidth(6));
-      if (UnityEngine.GUILayout.Button(
-              text    : index == 0
-                            ? L10N.CacheFormat(
-                                "#Principia_DiscreteSelector_Min")
-                            : "-",
-              options : GUILayoutWidth(2)) &&
-          enabled &&
-          index != 0) {
-        --index;
-        changed = true;
-      }
-      UnityEngine.GUILayout.TextArea(
-          text    : enabled
-                        ? string.Format(Culture.culture, format, array[index])
-                        : "",
-          style   : Style.RightAligned(UnityEngine.GUI.skin.textArea),
-          options : GUILayoutWidth(3));
-      if (UnityEngine.GUILayout.Button(
-              text    : index == array.Length - 1
-                            ? L10N.CacheFormat(
-                                "#Principia_DiscreteSelector_Max")
-                            : "+",
-              options : GUILayoutWidth(2)) &&
-          enabled &&
-          index != array.Length - 1) {
-        ++index;
-        changed = true;
-      }
+    UnityEngine.GUILayout.Label(label,
+                                UnityEngine.GUILayout.ExpandWidth(false));
+    if (UnityEngine.GUILayout.Button(index == 0 ? "" : "−",
+                                     GUILayoutWidth(1)) &&
+        enabled &&
+        index != 0) {
+      --index;
+      changed = true;
+    }
+    UnityEngine.GUILayout.TextArea(
+        text    : enabled ? format(index) : "",
+        style   : Style.RightAligned(UnityEngine.GUI.skin.textArea),
+        options : GUILayoutWidth(2));
+    if (UnityEngine.GUILayout.Button(index == array.Length - 1 ? "" : "+",
+                                     GUILayoutWidth(1)) &&
+        enabled &&
+        index != array.Length - 1) {
+      ++index;
+      changed = true;
     }
     return changed;
   }
@@ -531,7 +513,9 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
   };
 
   private static readonly double[] prediction_length_tolerances_ =
-      {1e-3, 1e-2, 1e0, 1e1, 1e2, 1e3, 1e4};
+      {1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4};
+  private static readonly string[] prediction_length_tolerance_names_ =
+      {"1 mm", "1 cm", "10 cm", "1 m", "10 m", "100 m", "1 km", "10 km"};
   private static readonly long[] prediction_steps_ = {
       1 << 2, 1 << 4, 1 << 6, 1 << 8, 1 << 10, 1 << 12, 1 << 14, 1 << 16,
       1 << 18, 1 << 20, 1 << 22, 1 << 24
@@ -549,7 +533,6 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
 
   private bool show_ksp_features_ = false;
   private bool show_logging_settings_ = false;
-  private bool show_prediction_settings_ = true;
 
   private bool show_selection_ui_ = false;
 


### PR DESCRIPTION
Inspired by the mock in #2275; also made the length tolerances a little more human readable.

This does not change the flight plan selectors to match; that is tracked by #3395.

![image](https://user-images.githubusercontent.com/2284290/179363267-25800024-f45f-4d2e-a288-764c2b6f2acc.png)

![image](https://user-images.githubusercontent.com/2284290/179363539-b26f0857-de88-4405-9fc7-05c113f09234.png)
