### PR TITLE
Declutter

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -269,6 +269,11 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
   [KSPField(isPersistant = true)]
   private MainWindow main_window_;
 
+  public bool show_celestial_trajectory(CelestialBody celestial) {
+    return !main_window_.show_only_pinned_celestials ||
+           plotting_frame_selector_.pinned[celestial];
+  }
+
   public event Action LockClearing;
   public event Action WindowsDisposal;
   public event Action WindowsRendering;
@@ -329,7 +334,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       }
     }
 
-    map_node_pool_ = new MapNodePool();
+    map_node_pool_ = new MapNodePool(
+        show_only_pinned: () => main_window_.show_only_pinned_markers);
     flight_planner_ = new FlightPlanner(this, PredictedVessel);
     orbit_analyser_ = new CurrentOrbitAnalyser(this, PredictedVessel);
     plotting_frame_selector_ = new ReferenceFrameSelector(this,

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -13,6 +13,10 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Target: <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Clear
     #Principia_MainWindow_TargetVessel_SwitchTo = Switch to
+    #Principia_MainWindow_Declutter = Declutter map
+    #Principia_MainWindow_Declutter_ShowOnly = Show only:
+    #Principia_MainWindow_Declutter_PinnedMarkers = Pinned markers
+    #Principia_MainWindow_Declutter_PinnedCelestials = Pinned celestials
     #Principia_MainWindow_PredictionSettings = Prediction:
     #Principia_MainWindow_KspFeatures = KSP Features
     #Principia_MainWindow_LoggingSettings = Logging Settings

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -13,6 +13,10 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Cible : <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Effacer
     #Principia_MainWindow_TargetVessel_SwitchTo = Échanger
+    #Principia_MainWindow_Declutter = Alléger la carte
+    #Principia_MainWindow_Declutter_ShowOnly = Afficher seulement :
+    #Principia_MainWindow_Declutter_PinnedMarkers = Marqueurs épinglés
+    #Principia_MainWindow_Declutter_PinnedCelestials = Corps épinglés
     #Principia_MainWindow_PredictionSettings = Prédiction :
     #Principia_MainWindow_KspFeatures = Fonctionalités de KSP
     #Principia_MainWindow_LoggingSettings = Paramètres de logging

--- a/ksp_plugin_adapter/localization/ru.cfg
+++ b/ksp_plugin_adapter/localization/ru.cfg
@@ -15,6 +15,11 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = Цель: <<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = Сброс
     #Principia_MainWindow_TargetVessel_SwitchTo = Перейти
+    // TODO(egg): Russian.
+    #Principia_MainWindow_Declutter = Declutter map
+    #Principia_MainWindow_Declutter_ShowOnly = Show only:
+    #Principia_MainWindow_Declutter_PinnedMarkers = Pinned markers
+    #Principia_MainWindow_Declutter_PinnedCelestials = Pinned celestials
     #Principia_MainWindow_PredictionSettings = Прогноз траекторий:
     #Principia_MainWindow_KspFeatures = Функции KSP
     #Principia_MainWindow_LoggingSettings = Настройки логирования

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -14,8 +14,8 @@ Localization {
     #Principia_MainWindow_TargetVessel_SwitchTo = 切换至目标
     #Principia_MainWindow_Declutter = 隐藏多余标记
     #Principia_MainWindow_Declutter_ShowOnly = 仅显示：
-    #Principia_MainWindow_Declutter_PinnedMarkers = 以固定标志
-    #Principia_MainWindow_Declutter_PinnedCelestials = 以固定天体
+    #Principia_MainWindow_Declutter_PinnedMarkers = 已固定标志
+    #Principia_MainWindow_Declutter_PinnedCelestials = 已固定天体
     #Principia_MainWindow_PredictionSettings = 轨道预测：
     #Principia_MainWindow_KspFeatures = KSP功能
     #Principia_MainWindow_LoggingSettings = 日志选项

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -12,6 +12,10 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = 当前目标：<<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = 清除
     #Principia_MainWindow_TargetVessel_SwitchTo = 切换至目标
+    #Principia_MainWindow_Declutter = 简化星图
+    #Principia_MainWindow_Declutter_ShowOnly = 仅显示：
+    #Principia_MainWindow_Declutter_PinnedMarkers = 以固定标记
+    #Principia_MainWindow_Declutter_PinnedCelestials = 以固定天体
     #Principia_MainWindow_PredictionSettings = 轨道预测：
     #Principia_MainWindow_KspFeatures = KSP功能
     #Principia_MainWindow_LoggingSettings = 日志选项

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -12,9 +12,9 @@ Localization {
     #Principia_MainWindow_TargetVessel_Name = 当前目标：<<1>>  // <<1>> vessel name
     #Principia_MainWindow_TargetVessel_Clear = 清除
     #Principia_MainWindow_TargetVessel_SwitchTo = 切换至目标
-    #Principia_MainWindow_Declutter = 简化星图
+    #Principia_MainWindow_Declutter = 隐藏多余标记
     #Principia_MainWindow_Declutter_ShowOnly = 仅显示：
-    #Principia_MainWindow_Declutter_PinnedMarkers = 以固定标记
+    #Principia_MainWindow_Declutter_PinnedMarkers = 以固定标志
     #Principia_MainWindow_Declutter_PinnedCelestials = 以固定天体
     #Principia_MainWindow_PredictionSettings = 轨道预测：
     #Principia_MainWindow_KspFeatures = KSP功能

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -214,21 +214,21 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       if (adapter_.PluginRunning()) {
         plotting_frame_selector_.RenderButton();
         using (new UnityEngine.GUILayout.HorizontalScope()) {
-        if (UnityEngine.GUILayout.Button(
-                L10N.CacheFormat("#Principia_MainWindow_Declutter"),
-                GUILayoutWidth(5))) {
-          show_only_pinned_markers = true;
-          show_only_pinned_celestials = true;
-        }
-        UnityEngine.GUILayout.Label(
-            L10N.CacheFormat("#Principia_MainWindow_Declutter_ShowOnly"));
-        show_only_pinned_markers = UnityEngine.GUILayout.Toggle(
-            show_only_pinned_markers,
-            L10N.CacheFormat("#Principia_MainWindow_Declutter_PinnedMarkers"));
-        show_only_pinned_celestials = UnityEngine.GUILayout.Toggle(
-            show_only_pinned_celestials,
-            L10N.CacheFormat(
-                "#Principia_MainWindow_Declutter_PinnedCelestials"));
+          if (UnityEngine.GUILayout.Button(
+                  L10N.CacheFormat("#Principia_MainWindow_Declutter"),
+                  GUILayoutWidth(5))) {
+            show_only_pinned_markers = true;
+            show_only_pinned_celestials = true;
+          }
+          UnityEngine.GUILayout.Label(
+              L10N.CacheFormat("#Principia_MainWindow_Declutter_ShowOnly"));
+          show_only_pinned_markers = UnityEngine.GUILayout.Toggle(
+              show_only_pinned_markers,
+              L10N.CacheFormat("#Principia_MainWindow_Declutter_PinnedMarkers"));
+          show_only_pinned_celestials = UnityEngine.GUILayout.Toggle(
+              show_only_pinned_celestials,
+              L10N.CacheFormat(
+                  "#Principia_MainWindow_Declutter_PinnedCelestials"));
         }
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           flight_planner_.RenderButton();

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -45,6 +45,9 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       PlanetariumCamera.fetch.SetTarget(map_object);
     }
   }
+  
+  public bool show_only_pinned_markers { get; private set; } = false;
+  public bool show_only_pinned_celestials { get; private set; } = false;
 
   public bool selecting_active_vessel_target { get; private set; } = false;
 
@@ -210,6 +213,23 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       // interface.
       if (adapter_.PluginRunning()) {
         plotting_frame_selector_.RenderButton();
+        using (new UnityEngine.GUILayout.HorizontalScope()) {
+        if (UnityEngine.GUILayout.Button(
+                L10N.CacheFormat("#Principia_MainWindow_Declutter"),
+                GUILayoutWidth(5))) {
+          show_only_pinned_markers = true;
+          show_only_pinned_celestials = true;
+        }
+        UnityEngine.GUILayout.Label(
+            L10N.CacheFormat("#Principia_MainWindow_Declutter_ShowOnly"));
+        show_only_pinned_markers = UnityEngine.GUILayout.Toggle(
+            show_only_pinned_markers,
+            L10N.CacheFormat("#Principia_MainWindow_Declutter_PinnedMarkers"));
+        show_only_pinned_celestials = UnityEngine.GUILayout.Toggle(
+            show_only_pinned_celestials,
+            L10N.CacheFormat(
+                "#Principia_MainWindow_Declutter_PinnedCelestials"));
+        }
         using (new UnityEngine.GUILayout.HorizontalScope()) {
           flight_planner_.RenderButton();
           orbit_analyser_.RenderButton();

--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -45,10 +45,11 @@ internal class MapNodePool {
         new List<KSP.UI.Screens.Mapview.MapNode>(MaxNodesPerProvenance);
   }
 
-  public MapNodePool() {
+  public MapNodePool(Func<bool> show_only_pinned) {
     nodes_ = new Dictionary<Provenance, SingleProvenancePool>();
     properties_ =
         new Dictionary<KSP.UI.Screens.Mapview.MapNode, MapNodeProperties>();
+    show_only_pinned_ = show_only_pinned;
   }
 
   public void Clear() {
@@ -193,7 +194,8 @@ internal class MapNodePool {
     new_node.OnUpdateVisible += (KSP.UI.Screens.Mapview.MapNode node,
                                  KSP.UI.Screens.Mapview.MapNode.IconData
                                      icon) => {
-      icon.visible = properties_[node].visible;
+      icon.visible = properties_[node].visible &&
+                     (!show_only_pinned_() || node.Pinned);
       icon.color = properties_[node].colour;
     };
     new_node.OnUpdateType += (KSP.UI.Screens.Mapview.MapNode node,
@@ -313,6 +315,7 @@ internal class MapNodePool {
   private Dictionary<Provenance, SingleProvenancePool> nodes_;
   private Dictionary<KSP.UI.Screens.Mapview.MapNode, MapNodeProperties>
       properties_;
+  private Func<bool> show_only_pinned_;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/plotter.cs
+++ b/ksp_plugin_adapter/plotter.cs
@@ -137,7 +137,8 @@ class Plotter {
         PlanetariumCamera.fetch.transform.position);
     double min_distance_from_camera =
         (root.position - camera_world_position).magnitude;
-    if (!adapter_.plotting_frame_selector_.FixesBody(root)) {
+    if (!adapter_.plotting_frame_selector_.FixesBody(root) &&
+        adapter_.show_celestial_trajectory(root)) {
       {
         planetarium.PlanetariumPlotCelestialPastTrajectory(
             Plugin,
@@ -171,8 +172,10 @@ class Plotter {
     foreach (CelestialBody child in root.orbitingBodies) {
       // Plot the trajectory of an orbiting body if it could be separated from
       // that of its parent by a pixel of empty space, instead of merely making
-      // the line wider.
-      if (child.orbit.ApR / min_distance_from_camera >
+      // the line wider; but always traverse the subtree if the current body is
+      // hidden.
+      if (!adapter_.show_celestial_trajectory(root) ||
+          child.orbit.ApR / min_distance_from_camera >
               2 * tan_angular_resolution) {
         PlotSubtreeTrajectories(planetarium, main_vessel_guid, history_length,
                                 child, tan_angular_resolution);

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using KSP.Localization;
 
 namespace principia {
@@ -45,10 +46,10 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     is_freshly_constructed_ = true;
 
     expanded_ = new Dictionary<CelestialBody, bool>();
-    pinned_ = new Dictionary<CelestialBody, bool>();
+    pinned = new Dictionary<CelestialBody, bool>();
     foreach (CelestialBody celestial in FlightGlobals.Bodies) {
       expanded_.Add(celestial, false);
-      pinned_.Add(celestial, false);
+      pinned.Add(celestial, false);
     }
   }
 
@@ -490,7 +491,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
   }
 
   private bool AnyDescendantPinned(CelestialBody celestial) {
-    if (pinned_[celestial]) {
+    if (pinned[celestial]) {
       return true;
     }
     if (target_pinned_ && target?.orbit.referenceBody == celestial) {
@@ -525,9 +526,9 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
       if (celestial.is_root()) {
         UnityEngine.GUILayout.Label(
             L10N.CacheFormat("#Principia_ReferenceFrameSelector_Pin"));
-      } else if (UnityEngine.GUILayout.Toggle(pinned_[celestial], "") !=
-                 pinned_[celestial]) {
-        pinned_[celestial] = !pinned_[celestial];
+      } else if (UnityEngine.GUILayout.Toggle(pinned[celestial], "") !=
+                 pinned[celestial]) {
+        pinned[celestial] = !pinned[celestial];
         Shrink();
       }
     }
@@ -638,7 +639,7 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
     var target_frame_was_selected = target_frame_selected;
     action();
     if (is_freshly_constructed_) {
-      pinned_[selected_celestial] = true;
+      pinned[selected_celestial] = true;
       if (!selected_celestial.is_leaf(target)) {
         expanded_[selected_celestial] = true;
       }
@@ -668,10 +669,11 @@ internal class ReferenceFrameSelector : SupervisedWindowRenderer {
         options) ? !value : value;
   }
 
+  public readonly Dictionary<CelestialBody, bool> pinned;
+
   private readonly Callback on_change_;
   private readonly string name_;
   private readonly Dictionary<CelestialBody, bool> expanded_;
-  private readonly Dictionary<CelestialBody, bool> pinned_;
   private bool target_pinned_ = true;
   private bool is_freshly_constructed_;
   private ReferenceFrameSelector.FrameType last_orbital_type_ =


### PR DESCRIPTION
On top of #3397.

Fixes #3394.
Fixes #2578.

Adds the following line to the main window:
![image](https://user-images.githubusercontent.com/2284290/179380863-15b53638-58ed-4e33-b8bf-2c39fbc02b08.png)

The buttons serves as a general-purpose « my screen is a mess, make it stop » button; it checks both options. In the future as we add more clutter (for instance as part of #3358) it would remove that too.

Demonstration in ECEF with a flight plan from LEO; the prediction is set to 16 000 steps at 10 m, it seems to span about a month—and thus we get a month’s worth of the solar system’s path in the sky—:
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/2284290/179380937-3c4684d4-2e26-43f2-ab2e-24fdcf89bca0.png) | ![image](https://user-images.githubusercontent.com/2284290/179380955-e4c2102c-aa91-4cce-895f-e66aaebf09b0.png) |
