### PR TITLE
Clean up the two MockDynamicFrame

### DIFF
--- a/physics/dynamic_frame_test.cpp
+++ b/physics/dynamic_frame_test.cpp
@@ -5,6 +5,7 @@
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "physics/mock_dynamic_frame.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "testing_utilities/almost_equals.hpp"
@@ -51,42 +52,6 @@ using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::_;
 namespace si = quantities::si;
-
-namespace {
-
-template<typename InertialFrame, typename ThisFrame>
-class MockDynamicFrame : public DynamicFrame<InertialFrame, ThisFrame> {
- public:
-  MockDynamicFrame() = default;
-
-  MOCK_METHOD((RigidMotion<InertialFrame, ThisFrame>),
-              ToThisFrameAtTime,
-              (Instant const& t),
-              (const, override));
-  MOCK_METHOD((RigidMotion<ThisFrame, InertialFrame>),
-              FromThisFrameAtTime,
-              (Instant const& t),
-              (const, override));
-
-  MOCK_METHOD(Instant, t_min, (), (const, override));
-  MOCK_METHOD(Instant, t_max, (), (const, override));
-
-  MOCK_METHOD(void,
-              WriteToMessage,
-              (not_null<serialization::DynamicFrame*> message),
-              (const, override));
-
-  MOCK_METHOD((Vector<Acceleration, InertialFrame>),
-              GravitationalAcceleration,
-              (Instant const& t, Position<InertialFrame> const& q),
-              (const, override));
-  MOCK_METHOD((AcceleratedRigidMotion<InertialFrame, ThisFrame>),
-              MotionOfThisFrame,
-              (Instant const& t),
-              (const, override));
-};
-
-}  // namespace
 
 class DynamicFrameTest : public testing::Test {
  protected:

--- a/physics/mock_dynamic_frame.hpp
+++ b/physics/mock_dynamic_frame.hpp
@@ -26,26 +26,11 @@ class MockDynamicFrame : public DynamicFrame<InertialFrame, ThisFrame> {
   MOCK_METHOD(Instant, t_min, (), (const, override));
   MOCK_METHOD(Instant, t_max, (), (const, override));
 
-  MOCK_METHOD((Vector<Acceleration, ThisFrame>),
-              GeometricAcceleration,
-              (Instant const& t,
-               DegreesOfFreedom<ThisFrame> const& degrees_of_freedom),
-              (const, override));
-
-  using Rot = Rotation<Frenet<ThisFrame>, ThisFrame>;
-
-  MOCK_METHOD(Rot,
-              FrenetFrame,
-              (Instant const& t,
-               DegreesOfFreedom<ThisFrame> const& degrees_of_freedom),
-              (const, override));
-
   MOCK_METHOD(void,
               WriteToMessage,
               (not_null<serialization::DynamicFrame*> message),
               (const, override));
 
- private:
   MOCK_METHOD((Vector<Acceleration, InertialFrame>),
               GravitationalAcceleration,
               (Instant const& t, Position<InertialFrame> const& q),

--- a/physics/mock_dynamic_frame.hpp
+++ b/physics/mock_dynamic_frame.hpp
@@ -1,10 +1,11 @@
 ﻿
 #pragma once
 
+#include "physics/dynamic_frame.hpp"
+
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "gmock/gmock.h"
-#include "physics/dynamic_frame.hpp"
 #include "physics/rigid_motion.hpp"
 
 namespace principia {


### PR DESCRIPTION
Only keep one, which is public and only overrides the pure virtual methods.