### PR TITLE
Fix for inactive thrusters being considered

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -350,6 +350,7 @@ class BurnEditor : ScalingRenderer {
     double[] thrusts = (from engine in active_rcs
                         select engine.thrusterPower *
                                (from transform in engine.thrusterTransforms
+                                where transform.gameObject.activeInHierarchy
                                 select Math.Max(0,
                                                 Vector3d.Dot(
                                                     reference_direction,


### PR DESCRIPTION
Fixes #3419.

Only considers thrusters where the associated gameobject is active. This prevents parts there there are multiple switched variants from over estimating thrust.