### PR TITLE
Add a test to plot equipotentials at equidistant energies

### DIFF
--- a/geometry/symmetric_bilinear_form.hpp
+++ b/geometry/symmetric_bilinear_form.hpp
@@ -87,12 +87,6 @@ class SymmetricBilinearForm {
       serialization::SymmetricBilinearForm const& message);
 
  private:
-  // Given a matrix that contains in columns eigenvectors for a form, picks the
-  // column with the largest norm and return its value.  This is useful to
-  // extract eigenvectors when eigenvalues are known.
-  template<typename S>
-  static R3Element<S> PickEigenvector(R3x3Matrix<S> const& matrix);
-
   // All the operations on this class must ensure that this matrix remains
   // symmetric.
   R3x3Matrix<Scalar> matrix_;

--- a/geometry/symmetric_bilinear_form_body.hpp
+++ b/geometry/symmetric_bilinear_form_body.hpp
@@ -272,28 +272,6 @@ SymmetricBilinearForm<Scalar, Frame, Multivector>::ReadFromMessage(
       R3x3Matrix<Scalar>::ReadFromMessage(message.matrix()));
 }
 
-template<typename Scalar,
-         typename Frame,
-         template<typename, typename> typename Multivector>
-template<typename S>
-R3Element<S>
-SymmetricBilinearForm<Scalar, Frame, Multivector>::PickEigenvector(
-    R3x3Matrix<S> const& matrix) {
-  static R3Element<double> const e₀{1, 0, 0};
-  static R3Element<double> const e₁{0, 1, 0};
-  static R3Element<double> const e₂{0, 0, 1};
-  std::array<R3Element<S>, 3> vs = {matrix * e₀, matrix * e₁, matrix * e₂};
-
-  // It's possible for a column to be identically 0.  To deal with this we
-  // extract the column with the largest norm.
-  std::sort(vs.begin(),
-            vs.end(),
-            [](R3Element<S> const& left, R3Element<S> const& right) {
-              return left.Norm²() < right.Norm²();
-            });
-  return vs.back();
-}
-
 template<typename Frame, template<typename, typename> typename Multivector>
 SymmetricBilinearForm<double, Frame, Multivector> const& InnerProductForm() {
   static auto const identity =

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -295,6 +295,11 @@ class Logger final {
          bool make_unique = true);
   ~Logger();
 
+  // Flushes the contents of the logger to the file.  This should not normally
+  // be called explicitly, but it's useful when debugging crashes.  Beware, the
+  // resulting file may contain many assignments to the same variable.
+  void Flush();
+
   // Appends an element to the list of values for the List variable |name|.  The
   // |args...| are passed verbatim to ToMathematica for stringification.  When
   // this object is destroyed, an assignment is generated for each of the

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -551,6 +551,10 @@ inline Logger::Logger(std::filesystem::path const& path, bool const make_unique)
       }()) {}
 
 inline Logger::~Logger() {
+  Flush();
+}
+
+inline void Logger::Flush() {
   for (auto const& [name, values] : name_and_multiple_values_) {
     file_ << Apply("Set", {name, Apply("List", values)}) + ";\n";
   }

--- a/numerics/gradient_descent_body.hpp
+++ b/numerics/gradient_descent_body.hpp
@@ -139,6 +139,10 @@ Position<Frame> BroydenFletcherGoldfarbShanno(
   auto const x₀ = start_position;
   auto const grad_f_x₀ = grad_f(x₀);
 
+  if (grad_f_x₀ == Gradient<Scalar, Frame>{}) {
+    return x₀;
+  }
+
   // We (ab)use the tolerance to determine the first step size.  The assumption
   // is that, if the caller provides a reasonable value then (1) we won't miss
   // "interesting features" of f; (2) the finite differences won't underflow or

--- a/numerics/gradient_descent_body.hpp
+++ b/numerics/gradient_descent_body.hpp
@@ -52,7 +52,9 @@ double Zoom(double α_lo,
             Displacement<Frame> const& p,
             Field<Scalar, Frame> const& f,
             Field<Gradient<Scalar, Frame>, Frame> const& grad_f) {
+  std::optional<Scalar> previous_ϕ_αⱼ;
   for (;;) {
+    DCHECK_NE(α_lo, α_hi);
     double αⱼ;
     {
       // Quadratic interpolation.
@@ -68,6 +70,15 @@ double Zoom(double α_lo,
     }
 
     auto const ϕ_αⱼ = f(x + αⱼ * p);
+
+    // If the function has become (numerically) constant, we might as well
+    // return, even though the value of αⱼ may not meet the strong Wolfe
+    // condition.
+    if (previous_ϕ_αⱼ.has_value() && previous_ϕ_αⱼ.value() == ϕ_αⱼ) {
+      return αⱼ;
+    }
+    previous_ϕ_αⱼ = ϕ_αⱼ;
+
     if (ϕ_αⱼ > ϕ_0 + c₁ * αⱼ * ϕʹ_0 || ϕ_αⱼ >= ϕ_α_lo) {
       α_hi = αⱼ;
       ϕ_α_hi = ϕ_αⱼ;
@@ -170,6 +181,12 @@ Position<Frame> BroydenFletcherGoldfarbShanno(
     double const αₖ = LineSearch(xₖ, pₖ, f, grad_f);
     auto const xₖ₊₁ = xₖ + αₖ * pₖ;
     auto const grad_f_xₖ₊₁ = grad_f(xₖ₊₁);
+
+    // If we can't make progress, e.g., because αₖ is too small, give up.
+    if (xₖ₊₁ == xₖ || grad_f_xₖ₊₁ == grad_f_xₖ) {
+      return xₖ;
+    }
+
     auto const sₖ = xₖ₊₁ - xₖ;
     auto const yₖ = grad_f_xₖ₊₁ - grad_f_xₖ;
     // The formula (6.17) from [NW06] is inconvenient because it uses external

--- a/physics/equipotential.hpp
+++ b/physics/equipotential.hpp
@@ -71,15 +71,15 @@ class Equipotential {
 
   // Computes an equipotential line going through the given point.
   typename ODE::State ComputeLine(Bivector<double, Frame> const& plane,
-                                  Position<Frame> const& position,
-                                  Instant const& t) const;
+                                  Instant const& t,
+                                  Position<Frame> const& position) const;
 
   // Computes an equipotential line for the total energy determined by the
   // |degrees_of_freedom|.
   typename ODE::State ComputeLine(
       Bivector<double, Frame> const& plane,
-      DegreesOfFreedom<Frame> const& degrees_of_freedom,
-      Instant const& t) const;
+      Instant const& t,
+      DegreesOfFreedom<Frame> const& degrees_of_freedom) const;
 
  private:
   using IndependentVariableDifference =

--- a/physics/equipotential.hpp
+++ b/physics/equipotential.hpp
@@ -7,6 +7,7 @@
 #include "geometry/grassmann.hpp"
 #include "geometry/named_quantities.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
+#include "physics/degrees_of_freedom.hpp"
 #include "physics/dynamic_frame.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"

--- a/physics/equipotential.hpp
+++ b/physics/equipotential.hpp
@@ -69,9 +69,17 @@ class Equipotential {
       AdaptiveParameters const& adaptive_parameters,
       not_null<DynamicFrame<InertialFrame, Frame> const*> dynamic_frame);
 
+  // Computes an equipotential line going through the given point.
   typename ODE::State ComputeLine(Bivector<double, Frame> const& plane,
                                   Position<Frame> const& position,
                                   Instant const& t) const;
+
+  // Computes an equipotential line for the total energy determined by the
+  // |degrees_of_freedom|.
+  typename ODE::State ComputeLine(
+      Bivector<double, Frame> const& plane,
+      DegreesOfFreedom<Frame> const& degrees_of_freedom,
+      Instant const& t) const;
 
  private:
   using IndependentVariableDifference =

--- a/physics/equipotential_body.hpp
+++ b/physics/equipotential_body.hpp
@@ -61,8 +61,8 @@ Equipotential<InertialFrame, Frame>::Equipotential(
 template<typename InertialFrame, typename Frame>
 auto Equipotential<InertialFrame, Frame>::ComputeLine(
     Bivector<double, Frame> const& plane,
-    Position<Frame> const& position,
-    Instant const& t) const -> State {
+    Instant const& t,
+    Position<Frame> const& position) const -> State {
   ODE equation{
       .compute_derivative = std::bind(
           &Equipotential::RightHandSide, this, plane, position, t, _1, _2, _3)};
@@ -100,8 +100,8 @@ auto Equipotential<InertialFrame, Frame>::ComputeLine(
 template<typename InertialFrame, typename Frame>
 auto Equipotential<InertialFrame, Frame>::ComputeLine(
     Bivector<double, Frame> const& plane,
-    DegreesOfFreedom<Frame> const& degrees_of_freedom,
-    Instant const& t) const -> State {
+    Instant const& t,
+    DegreesOfFreedom<Frame> const& degrees_of_freedom) const -> State {
 }
 
 template<typename InertialFrame, typename Frame>

--- a/physics/equipotential_body.hpp
+++ b/physics/equipotential_body.hpp
@@ -23,6 +23,8 @@ using numerics::DoublePrecision;
 using quantities::Abs;
 using quantities::Frequency;
 using quantities::Pow;
+using quantities::SpecificEnergy;
+using quantities::Square;
 using quantities::Time;
 using ::std::placeholders::_1;
 using ::std::placeholders::_2;
@@ -118,7 +120,7 @@ auto Equipotential<InertialFrame, Frame>::ComputeLine(
   };
 
   auto const grad_f = [this, t, total_energy](Position<Frame> const& position) {
-    return 2 *
+    return -2 *
            (dynamic_frame_->GeometricPotential(t, position) - total_energy) *
            dynamic_frame_->RotationFreeGeometricAccelerationAtRest(t, position);
   };
@@ -127,11 +129,12 @@ auto Equipotential<InertialFrame, Frame>::ComputeLine(
   // total energy.
   // NOTE(phl): Unclear if |length_integration_tolerance| is the right thing to
   // use below.
-  auto const equipotential_position = BroydenFletcherGoldfarbShanno(
-      degrees_of_freedom.position(),
-      f,
-      grad_f,
-      adaptive_parameters_.length_integration_tolerance());
+  auto const equipotential_position =
+      BroydenFletcherGoldfarbShanno<Square<SpecificEnergy>, Frame>(
+          degrees_of_freedom.position(),
+          f,
+          grad_f,
+          adaptive_parameters_.length_integration_tolerance());
 
   // Compute that equipotential.
   return ComputeLine(plane, t, equipotential_position);

--- a/physics/equipotential_body.hpp
+++ b/physics/equipotential_body.hpp
@@ -98,6 +98,13 @@ auto Equipotential<InertialFrame, Frame>::ComputeLine(
 }
 
 template<typename InertialFrame, typename Frame>
+auto Equipotential<InertialFrame, Frame>::ComputeLine(
+    Bivector<double, Frame> const& plane,
+    DegreesOfFreedom<Frame> const& degrees_of_freedom,
+    Instant const& t) const -> State {
+}
+
+template<typename InertialFrame, typename Frame>
 absl::Status Equipotential<InertialFrame, Frame>::RightHandSide(
     Bivector<double, Frame> const& plane,
     Position<Frame> const& position,

--- a/physics/equipotential_test.cpp
+++ b/physics/equipotential_test.cpp
@@ -110,8 +110,8 @@ TEST_F(EquipotentialTest, BodyCentredNonRotating) {
     CHECK_OK(ephemeris_->Prolong(t1));
     auto const& [positions, βs] = equipotential.ComputeLine(
         plane,
-        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Mercury),
-        t1);
+        t1,
+        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Mercury));
     logger.Set(
         "equipotentialMercury", positions, mathematica::ExpressIn(Metre));
     logger.Set("betaMercury", βs);
@@ -121,8 +121,8 @@ TEST_F(EquipotentialTest, BodyCentredNonRotating) {
     CHECK_OK(ephemeris_->Prolong(t1));
     auto const& [positions, βs] = equipotential.ComputeLine(
         plane,
-        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Earth),
-        t1);
+        t1,
+        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Earth));
     logger.Set("equipotentialEarth", positions, mathematica::ExpressIn(Metre));
     logger.Set("betaEarth", βs);
   }
@@ -131,8 +131,10 @@ TEST_F(EquipotentialTest, BodyCentredNonRotating) {
     CHECK_OK(ephemeris_->Prolong(t1));
     auto const& [positions, βs] = equipotential.ComputeLine(
         plane,
-        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Jupiter),
-        t1);
+        t1,
+        ComputePositionInWorld(t0_,
+                               dynamic_frame,
+                               SolarSystemFactory::Jupiter));
     logger.Set(
         "equipotentialJupiterClose", positions, mathematica::ExpressIn(Metre));
     logger.Set("betaJupiterClose", βs);
@@ -142,8 +144,10 @@ TEST_F(EquipotentialTest, BodyCentredNonRotating) {
     CHECK_OK(ephemeris_->Prolong(t1));
     auto const& [positions, βs] = equipotential.ComputeLine(
         plane,
-        ComputePositionInWorld(t0_, dynamic_frame, SolarSystemFactory::Jupiter),
-        t1);
+        t1,
+        ComputePositionInWorld(t0_,
+                               dynamic_frame,
+                               SolarSystemFactory::Jupiter));
     logger.Set(
         "equipotentialJupiterFar", positions, mathematica::ExpressIn(Metre));
     logger.Set("betaJupiterFar", βs);
@@ -189,7 +193,7 @@ TEST_F(EquipotentialTest, BodyCentredBodyDirection) {
       Position<World> const p =
           Barycentre(std::pair{l4, l5},
                      std::pair{i / 10.0, (10.0 - i) / 10.0});
-      auto const& [positions, βs] = equipotential.ComputeLine(plane, p, t);
+      auto const& [positions, βs] = equipotential.ComputeLine(plane, t, p);
       all_positions.back().push_back(positions);
       all_βs.back().push_back(βs);
     }

--- a/physics/equipotential_test.cpp
+++ b/physics/equipotential_test.cpp
@@ -151,7 +151,6 @@ class EquipotentialTest : public ::testing::Test {
       auto const l5 = moon_l5 + moon_position;
 
       for (auto const& line_parameter : get_line_parameters(l4, l5)) {
-        LOG(ERROR)<<line_parameter;
         auto const& [positions, βs] =
             equipotential.ComputeLine(plane, t, line_parameter);
         all_positions.back().push_back(positions);
@@ -172,7 +171,7 @@ class EquipotentialTest : public ::testing::Test {
       equipotential_parameters_;
 };
 
-//#if !_DEBUG
+#if !_DEBUG
 TEST_F(EquipotentialTest, BodyCentredNonRotating) {
   mathematica::Logger logger(TEMP_DIR / "equipotential_bcnr.wl",
                              /*make_unique=*/false);
@@ -260,15 +259,22 @@ TEST_F(EquipotentialTest, BodyCentredBodyDirection_EquidistantEnergies) {
         for (int i = 0; i <= 10; ++i) {
           degrees_of_freedom.push_back(
               DegreesOfFreedom<World>(midpoint,
-                                      Velocity<World>({i * 200 * Metre / Second,
+                                      Velocity<World>({i * 100 * Metre / Second,
                                                        0 * Metre / Second,
                                                        0 * Metre / Second})));
+        }
+        for (int i = 0; i <= 10; ++i) {
+          degrees_of_freedom.push_back(DegreesOfFreedom<World>(
+              midpoint,
+              Velocity<World>({(1100 + i * 10) * Metre / Second,
+                               0 * Metre / Second,
+                               0 * Metre / Second})));
         }
         return degrees_of_freedom;
       });
 }
 
-//#endif
+#endif
 
 }  // namespace physics
 }  // namespace principia

--- a/physics/equipotential_test.cpp
+++ b/physics/equipotential_test.cpp
@@ -1,6 +1,7 @@
 ﻿
 #include "physics/equipotential.hpp"
 
+#include <string>
 #include <vector>
 
 #include "absl/strings/str_cat.h"


### PR DESCRIPTION
This requires support for computing an equipotential given a `DegreesOfFreedom` (to specify position and energy).

Also make gradient descent more robust and remove some zombie code in `geometry`.

#3358.