### PR TITLE
Fix a buglet introduced in Hesse

### DIFF
--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -634,8 +634,8 @@ void DiscreteTrajectorySegment<Frame>::WriteToMessage(
         timeline_size,
         std::max<std::int64_t>(
             0, number_of_dense_points_ - number_of_points_to_skip_at_end)));
-    message->set_was_downsampled(was_downsampled_);
   }
+  message->set_was_downsampled(was_downsampled_);
 
   // Convert the |exact| vector into a set, and add the extremities.  This
   // ensures that we don't have redundancies.  The set is sorted by time to


### PR DESCRIPTION
The new field added in Hesse was not (always) serialized so trajectories were perpetually considered pre-Hesse.