### PR TITLE
Fix the initialRotation

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -346,7 +346,9 @@ Rotation<CelestialSphere, World> Plugin::CelestialSphereRotation()
 
 Angle Plugin::CelestialInitialRotation(Index const celestial_index) const {
   auto const& body = *FindOrDie(celestials_, celestial_index)->body();
-  return body.AngleAt(game_epoch_);
+  // Offset by π/2 since |AngleAt| is with respect to the y axis of the
+  // celestial frame of the body, but KSP counts from the x axis.
+  return body.AngleAt(game_epoch_) + π / 2 * Radian;
 }
 
 Time Plugin::CelestialRotationPeriod(Index const celestial_index) const {

--- a/ksp_plugin_adapter/config_node_parsers.cs
+++ b/ksp_plugin_adapter/config_node_parsers.cs
@@ -78,6 +78,10 @@ internal static class ConfigNodeParsers {
         // The origin of rotation in KSP is the x of Barycentric, rather
         // than the y axis as is the case for Earth, so the right
         // ascension is -90 deg.
+        // Note that once we set the positions and orientations of everything,
+        // that original x axis will become the y axis when |body| is the main
+        // body, and the |initialRotation| will be correspondingly increased by
+        // 90°.
         reference_instant       =
             node?.GetAtMostOneValue("reference_instant") ?? "JD2451545.0",
         min_radius = (body.pqsController?.radiusMin ?? body.Radius) + " m",


### PR DESCRIPTION
Fix #3430. No change to the interpretation of the initial state, thus no change to the fingerprints. All hail retrobop.