### PR TITLE
A benchmark for the PCP tree

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\numerics\fast_sin_cos_2π.cpp" />
     <ClCompile Include="..\physics\protector.cpp" />
     <ClCompile Include="apsides.cpp" />
+    <ClCompile Include="checkpointer_benchmark.cpp" />
     <ClCompile Include="discrete_trajectory.cpp" />
     <ClCompile Include="dynamic_frame.cpp" />
     <ClCompile Include="elliptic_integrals_benchmark.cpp" />
@@ -35,6 +36,7 @@
     <ClCompile Include="fast_sin_cos_2π_benchmark.cpp" />
     <ClCompile Include="geopotential.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="nearest_neighbour.cpp" />
     <ClCompile Include="newhall.cpp" />
     <ClCompile Include="perspective.cpp" />
     <ClCompile Include="planetarium_plot_methods.cpp" />

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -95,6 +95,12 @@
     <ClCompile Include="discrete_trajectory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="nearest_neighbour.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="checkpointer_benchmark.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp">

--- a/benchmarks/nearest_neighbour.cpp
+++ b/benchmarks/nearest_neighbour.cpp
@@ -66,30 +66,36 @@ void BM_PCPFindNearestNeighbour(benchmark::State& state) {
 
 BENCHMARK(BM_PCPBuildTree)
     ->Args({1'000, 1})
-    ->Args({1'000, 2})
     ->Args({1'000, 4})
-    ->Args({1'000, 8})
+    ->Args({1'000, 16})
+    ->Args({1'000, 64})
+    ->Args({1'000, 256})
     ->Args({10'000, 1})
-    ->Args({10'000, 2})
     ->Args({10'000, 4})
-    ->Args({10'000, 8})
+    ->Args({10'000, 16})
+    ->Args({10'000, 64})
+    ->Args({10'000, 256})
     ->Args({100'000, 1})
-    ->Args({100'000, 2})
     ->Args({100'000, 4})
-    ->Args({100'000, 8});
+    ->Args({100'000, 16})
+    ->Args({100'000, 64})
+    ->Args({100'000, 256});
 BENCHMARK(BM_PCPFindNearestNeighbour)
     ->Args({1'000, 1})
-    ->Args({1'000, 2})
     ->Args({1'000, 4})
-    ->Args({1'000, 8})
+    ->Args({1'000, 16})
+    ->Args({1'000, 64})
+    ->Args({1'000, 256})
     ->Args({10'000, 1})
-    ->Args({10'000, 2})
     ->Args({10'000, 4})
-    ->Args({10'000, 8})
+    ->Args({10'000, 16})
+    ->Args({10'000, 64})
+    ->Args({10'000, 256})
     ->Args({100'000, 1})
-    ->Args({100'000, 2})
     ->Args({100'000, 4})
-    ->Args({100'000, 8});
+    ->Args({100'000, 16})
+    ->Args({100'000, 64})
+    ->Args({100'000, 256});
 
 }  // namespace numerics
 }  // namespace principia

--- a/benchmarks/nearest_neighbour.cpp
+++ b/benchmarks/nearest_neighbour.cpp
@@ -1,3 +1,5 @@
+// .\Release\x64\benchmarks.exe --benchmark_filter=PCP --benchmark_repetitions=1  // NOLINT(whitespace/line_length)
+
 #include "numerics/nearest_neighbour.hpp"
 
 #include <random>

--- a/benchmarks/nearest_neighbour.cpp
+++ b/benchmarks/nearest_neighbour.cpp
@@ -1,0 +1,66 @@
+#include "numerics/nearest_neighbour.hpp"
+
+#include <random>
+#include <vector>
+
+#include "base/not_null.hpp"
+#include "benchmark/benchmark.h"
+#include "geometry/frame.hpp"
+#include "geometry/grassmann.hpp"
+
+namespace principia {
+namespace numerics {
+
+using base::not_null;
+using geometry::Frame;
+using geometry::Vector;
+
+using World = Frame<enum class WorldTag>;
+using V = Vector<double, World>;
+
+PrincipalComponentPartitioningTree<V> BuildTree(
+    std::int64_t const points_in_tree,
+    std::int64_t const max_values_per_cell,
+    std::vector<V>& values) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<double> coordinate_distribution(-10, 10);
+
+  std::vector<not_null<V const*>> pointers;
+  values.reserve(points_in_tree);  // To avoid pointer invalidation below.
+  values.clear();
+  for (int i = 0; i < points_in_tree; ++i) {
+    values.push_back(V({coordinate_distribution(random),
+                        coordinate_distribution(random),
+                        coordinate_distribution(random)}));
+    pointers.push_back(&values.back());
+  }
+  return PrincipalComponentPartitioningTree<V>(pointers, max_values_per_cell);
+}
+
+void BM_PCPBuildTree(benchmark::State& state) {
+  std::int64_t const points_in_tree = state.range(0);
+  std::int64_t const max_values_per_cell = state.range(1);
+  std::vector<V> values;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        BuildTree(points_in_tree, max_values_per_cell, values));
+  }
+}
+
+BENCHMARK(BM_PCPBuildTree)
+    ->Args({1'000, 1})
+    ->Args({1'000, 2})
+    ->Args({1'000, 4})
+    ->Args({1'000, 8})
+    ->Args({10'000, 1})
+    ->Args({10'000, 2})
+    ->Args({10'000, 4})
+    ->Args({10'000, 8})
+    ->Args({100'000, 1})
+    ->Args({100'000, 2})
+    ->Args({100'000, 4})
+    ->Args({100'000, 8});
+
+}  // namespace numerics
+}  // namespace principia

--- a/benchmarks/nearest_neighbour.cpp
+++ b/benchmarks/nearest_neighbour.cpp
@@ -48,7 +48,36 @@ void BM_PCPBuildTree(benchmark::State& state) {
   }
 }
 
+void BM_PCPFindNearestNeighbour(benchmark::State& state) {
+  std::int64_t const points_in_tree = state.range(0);
+  std::int64_t const max_values_per_cell = state.range(1);
+  std::vector<V> values;
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<double> coordinate_distribution(-10, 10);
+  auto const tree = BuildTree(points_in_tree, max_values_per_cell, values);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        tree.FindNearestNeighbour(V({coordinate_distribution(random),
+                                     coordinate_distribution(random),
+                                     coordinate_distribution(random)})));
+  }
+}
+
 BENCHMARK(BM_PCPBuildTree)
+    ->Args({1'000, 1})
+    ->Args({1'000, 2})
+    ->Args({1'000, 4})
+    ->Args({1'000, 8})
+    ->Args({10'000, 1})
+    ->Args({10'000, 2})
+    ->Args({10'000, 4})
+    ->Args({10'000, 8})
+    ->Args({100'000, 1})
+    ->Args({100'000, 2})
+    ->Args({100'000, 4})
+    ->Args({100'000, 8});
+BENCHMARK(BM_PCPFindNearestNeighbour)
     ->Args({1'000, 1})
     ->Args({1'000, 2})
     ->Args({1'000, 4})

--- a/numerics/nearest_neighbour_body.hpp
+++ b/numerics/nearest_neighbour_body.hpp
@@ -169,11 +169,11 @@ void PrincipalComponentPartitioningTree<Value_>::Find(
     std::int32_t& min_index,
     bool* const must_check_other_side) const {
   if (std::holds_alternative<Internal>(node)) {
-    return Find(displacement,
-                parent,
-                std::get<Internal>(node),
-                min_distance², min_index,
-                must_check_other_side);
+    Find(displacement,
+         parent,
+         std::get<Internal>(node),
+         min_distance², min_index,
+         must_check_other_side);
   } else if (std::holds_alternative<Leaf>(node)) {
     Find(displacement,
          parent,

--- a/numerics/nearest_neighbour_test.cpp
+++ b/numerics/nearest_neighbour_test.cpp
@@ -23,7 +23,6 @@ using ::testing::Pointee;
 class PrincipalComponentPartitioningTreeTest : public ::testing::Test {
  protected:
   using World = Frame<enum class WorldTag>;
-
   using V = Vector<double, World>;
 };
 


### PR DESCRIPTION
No optimization so far.  It demonstrates that there is a sweet spot in the number of values per node for the query.  Related to #3358.

The numbers:
```
Run on (4 X 3310 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
--------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations
--------------------------------------------------------------------------------
BM_PCPBuildTree/1000/1                   1742994 ns      1737205 ns          449
BM_PCPBuildTree/1000/4                    703417 ns       695192 ns         1122
BM_PCPBuildTree/1000/16                   387528 ns       383746 ns         1870
BM_PCPBuildTree/1000/64                   248415 ns       250353 ns         2991
BM_PCPBuildTree/1000/256                  184105 ns       183580 ns         3739
BM_PCPBuildTree/10000/1                 18981213 ns     18973095 ns           37
BM_PCPBuildTree/10000/4                 10173109 ns      9984064 ns           75
BM_PCPBuildTree/10000/16                 5766233 ns      5710751 ns          112
BM_PCPBuildTree/10000/64                 4062164 ns      3967655 ns          173
BM_PCPBuildTree/10000/256                3333376 ns      3288256 ns          204
BM_PCPBuildTree/100000/1               190323815 ns    182001167 ns            3
BM_PCPBuildTree/100000/4               112673797 ns    114400733 ns            6
BM_PCPBuildTree/100000/16               67603615 ns     65236782 ns           11
BM_PCPBuildTree/100000/64               53451681 ns     54600350 ns           10
BM_PCPBuildTree/100000/256              45305502 ns     44964994 ns           17
BM_PCPFindNearestNeighbour/1000/1           2060 ns         2034 ns       345165
BM_PCPFindNearestNeighbour/1000/4           1098 ns         1095 ns       641022
BM_PCPFindNearestNeighbour/1000/16           754 ns          730 ns       897430
BM_PCPFindNearestNeighbour/1000/64           713 ns          723 ns      1121788
BM_PCPFindNearestNeighbour/1000/256         1214 ns         1217 ns       641022
BM_PCPFindNearestNeighbour/10000/1          5000 ns         5148 ns       100000
BM_PCPFindNearestNeighbour/10000/4          3192 ns         3171 ns       236166
BM_PCPFindNearestNeighbour/10000/16         1921 ns         1874 ns       407923
BM_PCPFindNearestNeighbour/10000/64         1372 ns         1363 ns       560894
BM_PCPFindNearestNeighbour/10000/256        1628 ns         1599 ns       448715
BM_PCPFindNearestNeighbour/100000/1        29201 ns        28439 ns       897430
BM_PCPFindNearestNeighbour/100000/4        15000 ns        14115 ns       897430
BM_PCPFindNearestNeighbour/100000/16        6248 ns         6202 ns      1121788
BM_PCPFindNearestNeighbour/100000/64        4096 ns         4068 ns       897430
BM_PCPFindNearestNeighbour/100000/256       4506 ns         4422 ns       373929
```