### PR TITLE
Only show patched conics if the frame makes sense

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using KSP.Localization;
 
+using static principia.ksp_plugin_adapter.ReferenceFrameSelector.FrameType;
+
 namespace principia {
 namespace ksp_plugin_adapter {
 
@@ -2021,7 +2023,9 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       return;
     }
     celestial.orbitDriver.Renderer.drawMode =
-        main_window_.display_patched_conics
+        main_window_.display_patched_conics &&
+        plotting_frame_selector_.frame_type == BODY_CENTRED_NON_ROTATING &&
+        plotting_frame_selector_.Centre() == celestial.orbit.referenceBody
             ? OrbitRenderer.DrawMode.REDRAW_AND_RECALCULATE
             : OrbitRenderer.DrawMode.OFF;
   }
@@ -2032,7 +2036,11 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           PatchRendering.RelativityMode.RELATIVE;
     }
 
-    if (main_window_.display_patched_conics || !is_manageable(vessel)) {
+    if ((main_window_.display_patched_conics  &&
+         plotting_frame_selector_.frame_type == BODY_CENTRED_NON_ROTATING &&
+         plotting_frame_selector_.Centre() ==
+            vessel.orbitDriver.orbit.referenceBody) ||
+        !is_manageable(vessel)) {
       vessel.orbitDriver.Renderer.drawMode =
           vessel.PatchedConicsAttached
               ? OrbitRenderer.DrawMode.OFF


### PR DESCRIPTION
Progress on #3441.

Displaying patched conics is a way to visualize the discrepancy between Princpia’s modeling and the approximations used by stock (chiefly patched conics, as in Figure 1, but also impulsive manœuvres, as in Figure 2).
| Figure 1 | Figure 2 |
|---|---|
| ![screenshot4](https://user-images.githubusercontent.com/2284290/197392644-06c94e7d-eb94-414c-90a4-8357d57ef2a1.png) | ![screenshot2](https://user-images.githubusercontent.com/2284290/197392712-d5e45438-f30c-4901-ba1b-47923dafa1ad.png) |

However, enabling all patched conics leads to misleading display, as some conics, such as the trajectories of faraway planets, are displayed in a different reference frame (Figure 3). Depending on the choice of reference frame, all conics can be inappropriate, leading to a confusing mess (Figure 4).
| Figure 3 | Figure 4 |
|---|---|
| ![screenshot0](https://user-images.githubusercontent.com/2284290/197392838-89fddb1c-8edd-442d-9353-0a0d5797e54e.png) | ![screenshot5](https://user-images.githubusercontent.com/2284290/197392843-cbd6b734-952e-4c10-8281-d53bc2b62d24.png) |

This change avoids drawing most of the inappropriate conics. Further work is needed to avoid drawing those parts of a flight plan that are drawn as orbits about a parent of the current main body, as in Figure 5, which shows a planned conic in HCI but everything else in KCI.

| Figure 5 |
|---|
| ![screenshot7](https://user-images.githubusercontent.com/2284290/197393029-f85b8908-b4b9-4610-8383-f0affc3f65a8.png) |
