### PR TITLE
Bayesian stopping rule for multi-level single linkage

### DIFF
--- a/numerics/global_optimization.hpp
+++ b/numerics/global_optimization.hpp
@@ -57,7 +57,14 @@ class MultiLevelSingleLinkage {
       Field<Scalar, Argument> const& f,
       Field<Gradient<Scalar, Argument>, Argument> const& grad_f);
 
-  //TODO(phl)comment
+  // If |number_of_rounds| is given, the algorithm does |number_of_rounds|
+  // iterations, each time adding |points_per_round| to the sample.
+  // If |number_of_rounds| is omitted, the first iteration uses that number of
+  // points, and subsequent iterations adjust the number of points (or the
+  // decision to terminate) based on the optimal Bayesian stopping rule.
+  // Beware!  The Bayesian stopping rule is typically more efficient, but it is
+  // only technically correct (the best kind of correct) if the relative sizes
+  // of the regions of attraction follow a uniform distribution.
   std::vector<Argument> FindGlobalMinima(
       std::int64_t points_per_round,
       std::optional<std::int64_t> number_of_rounds,

--- a/numerics/global_optimization.hpp
+++ b/numerics/global_optimization.hpp
@@ -59,9 +59,10 @@ class MultiLevelSingleLinkage {
 
   // If |number_of_rounds| is given, the algorithm does |number_of_rounds|
   // iterations, each time adding |points_per_round| to the sample.
-  // If |number_of_rounds| is omitted, the first iteration uses that number of
-  // points, and subsequent iterations adjust the number of points (or the
-  // decision to terminate) based on the optimal Bayesian stopping rule.
+  // If |number_of_rounds| is omitted, the first iteration uses
+  // |points_per_round| points, and subsequent iterations adjust the number of
+  // points (or the decision to terminate) based on the optimal Bayesian
+  // stopping rule.
   // Beware!  The Bayesian stopping rule is typically more efficient, but it is
   // only technically correct (the best kind of correct) if the relative sizes
   // of the regions of attraction follow a uniform distribution.
@@ -71,7 +72,7 @@ class MultiLevelSingleLinkage {
       NormType local_search_tolerance);
 
  private:
-  // We need pointer stability for the arguments as we store pointer, e.g., in
+  // We need pointer stability for the arguments as we store pointers, e.g., in
   // PCP trees.  We generally cannot |reserve| because we don't know the final
   // size of the vector, hence the |unique_ptr|s.
   using Arguments = std::vector<not_null<std::unique_ptr<Argument>>>;

--- a/numerics/global_optimization_body.hpp
+++ b/numerics/global_optimization_body.hpp
@@ -89,7 +89,7 @@ MultiLevelSingleLinkage<Scalar, Argument>::FindGlobalMinima(
   // [RT87b]; or we can use the optimal Bayesian stopping rule described in
   // proposition 2 of [RT87a] and equations (3) and (4) of [RT87b].  For
   // consistency with most of the description in [RT87a] and [RT87b], we call
-  // |N| the number of points add in a particular iteration and |kN| the total
+  // |N| the number of points added in a particular iteration and |kN| the total
   // number of sampling points so far, even if |N| varies from one iteration to
   // the next and |kN| is not necessarily |k * N|.
   std::int64_t number_of_points_all_rounds;

--- a/numerics/global_optimization_body.hpp
+++ b/numerics/global_optimization_body.hpp
@@ -110,7 +110,8 @@ MultiLevelSingleLinkage<Scalar, Argument>::FindGlobalMinima(
       }
     } else {
       std::int64_t const w = stationary_points.size();
-      DCHECK_NE(w, 0);
+      DCHECK_GT(w, 0);
+      DCHECK_GT(kN, w + 2);
       // [RT87b] equation 3.
       if (kN > w + 2 &&
           static_cast<double>(w * (kN - 1)) / static_cast<double>(kN - w - 2) <=

--- a/numerics/global_optimization_test.cc
+++ b/numerics/global_optimization_test.cc
@@ -31,6 +31,7 @@ using testing_utilities::Componentwise;
 using testing_utilities::IsNear;
 using testing_utilities::RelativeErrorFrom;
 using testing_utilities::operator""_;
+using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
 // The test functions in this file are from
@@ -114,26 +115,58 @@ TEST_F(GlobalOptimizationTest, GoldsteinPrice) {
 
   const auto tolerance = 1e-6 * Metre;
   Optimizer optimizer(box, goldstein_price, grad_goldstein_price);
-  auto const minima = optimizer.FindGlobalMinima(/*points_per_round=*/10,
-                                                 /*number_of_rounds=*/10,
-                                                 tolerance);
 
-  EXPECT_EQ(2740, function_invocations);
-  EXPECT_EQ(1813, gradient_invocations);
-  EXPECT_THAT(minima,
-              UnorderedElementsAre(
-                  Componentwise(
-                      AbsoluteErrorFrom(0 * Metre, IsNear(7.6e-7_(1) * Metre)),
-                      AbsoluteErrorFrom(0 * Metre, IsNear(5.3e-8_(1) * Metre)),
-                      RelativeErrorFrom(-1 * Metre, IsNear(3.8e-8_(1)))),
-                  Componentwise(
-                      AbsoluteErrorFrom(0 * Metre, IsNear(5.6e-8_(1) * Metre)),
-                      RelativeErrorFrom(-0.6 * Metre, IsNear(6.8e-10_(1))),
-                      RelativeErrorFrom(-0.4 * Metre, IsNear(1.1e-9_(1)))),
-                  Componentwise(
-                      AbsoluteErrorFrom(0 * Metre, IsNear(5.6e-8_(1) * Metre)),
-                      RelativeErrorFrom(1.8 * Metre, IsNear(1.8e-10_(1))),
-                      RelativeErrorFrom(0.2 * Metre, IsNear(7.0e-10_(1))))));
+  {
+    auto const minima = optimizer.FindGlobalMinima(/*points_per_round=*/10,
+                                                   /*number_of_rounds=*/10,
+                                                   tolerance);
+
+    EXPECT_EQ(2740, function_invocations);
+    EXPECT_EQ(1813, gradient_invocations);
+    EXPECT_THAT(
+        minima,
+        UnorderedElementsAre(
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(7.6e-7_(1) * Metre)),
+                AbsoluteErrorFrom(0 * Metre, IsNear(5.3e-8_(1) * Metre)),
+                RelativeErrorFrom(-1 * Metre, IsNear(3.8e-8_(1)))),
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(5.6e-8_(1) * Metre)),
+                RelativeErrorFrom(-0.6 * Metre, IsNear(6.8e-10_(1))),
+                RelativeErrorFrom(-0.4 * Metre, IsNear(1.1e-9_(1)))),
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(5.6e-8_(1) * Metre)),
+                RelativeErrorFrom(1.8 * Metre, IsNear(1.8e-10_(1))),
+                RelativeErrorFrom(0.2 * Metre, IsNear(7.0e-10_(1))))));
+  }
+  {
+    auto const minima =
+        optimizer.FindGlobalMinima(/*points_per_round=*/10,
+                                   /*number_of_rounds=*/std::nullopt,
+                                   tolerance);
+
+    EXPECT_EQ(3620, function_invocations);
+    EXPECT_EQ(2474, gradient_invocations);
+    EXPECT_THAT(
+        minima,
+        ElementsAre(
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(1.6e-7_(1) * Metre)),
+                RelativeErrorFrom(-0.6 * Metre, IsNear(1.6e-8_(1))),
+                RelativeErrorFrom(-0.4 * Metre, IsNear(7.0e-8_(1)))),
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(4.0e-7_(1) * Metre)),
+                AbsoluteErrorFrom(0 * Metre, IsNear(1.1e-7_(1) * Metre)),
+                RelativeErrorFrom(-1 * Metre, IsNear(7.0e-8_(1)))),
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(1.3e-7_(1) * Metre)),
+                RelativeErrorFrom(1.2 * Metre, IsNear(6.7e-10_(1))),
+                RelativeErrorFrom(0.8 * Metre, IsNear(9.6e-10_(1)))),
+            Componentwise(
+                AbsoluteErrorFrom(0 * Metre, IsNear(3.6e-7_(1) * Metre)),
+                RelativeErrorFrom(1.8 * Metre, IsNear(4.4e-8_(1))),
+                RelativeErrorFrom(0.2 * Metre, IsNear(5.2e-7_(1))))));
+  }
 }
 
 }  // namespace numerics

--- a/numerics/global_optimization_test.cc
+++ b/numerics/global_optimization_test.cc
@@ -31,7 +31,6 @@ using testing_utilities::Componentwise;
 using testing_utilities::IsNear;
 using testing_utilities::RelativeErrorFrom;
 using testing_utilities::operator""_;
-using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
 // The test functions in this file are from
@@ -149,7 +148,7 @@ TEST_F(GlobalOptimizationTest, GoldsteinPrice) {
     EXPECT_EQ(2474, gradient_invocations);
     EXPECT_THAT(
         minima,
-        ElementsAre(
+        UnorderedElementsAre(
             Componentwise(
                 AbsoluteErrorFrom(0 * Metre, IsNear(1.6e-7_(1) * Metre)),
                 RelativeErrorFrom(-0.6 * Metre, IsNear(1.6e-8_(1))),


### PR DESCRIPTION
This reduces the number of local searches from 8 to 6, and finds 4 minima instead of 3.

Related to #3358.