### PR TITLE
Close the processes after running a test and retry process startup

### DIFF
--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -250,7 +250,6 @@ class ParallelTestRunner {
                      " " +
                      process.StartInfo.Arguments);
         }
-        process.Close();
         process_semaphore.Release();
       });
       tasks[2 * i + 1] = Task.Run(async () => {

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -234,14 +234,14 @@ class ParallelTestRunner {
       try {
         process.Start();
       } catch (Exception e) {
-        errors.Add("Exception " +
-                   e +
-                   " from (" +
-                   index.ToString() +
-                   ") " +
-                   process.StartInfo.FileName +
-                   " " +
-                   process.StartInfo.Arguments);
+        Console.WriteLine("Exception " +
+                          e +
+                          " from (" +
+                          index.ToString() +
+                          ") " +
+                          process.StartInfo.FileName +
+                          " " +
+                          process.StartInfo.Arguments);
         throw;
       }
       tasks[i] = Task.Run(() => {

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -39,7 +39,17 @@ class ParallelTestRunner {
         Console.WriteLine(await process.StandardOutput.ReadLineAsync());
       }
       process.WaitForExit();
+      process.Close();
     });
+  }
+
+  static void LogProcess(Process process, int index) {
+    Console.WriteLine("Running from (" +
+                      index.ToString() +
+                      ") " +
+                      process.StartInfo.FileName +
+                      " " +
+                      process.StartInfo.Arguments);
   }
 
   static void Main(string[] args) {
@@ -210,6 +220,7 @@ class ParallelTestRunner {
     foreach (Process process in death_test_processes) {
       process.StartInfo.RedirectStandardOutput = false;
       process.StartInfo.RedirectStandardError = false;
+      LogProcess(process, -1);
       process.Start();
       process.WaitForExit();
       if (process.ExitCode != 0) {
@@ -231,17 +242,12 @@ class ParallelTestRunner {
       // We cannot use i in the lambdas, it would be captured by reference.
       int index = i;
       process_semaphore.WaitOne();
+      LogProcess(process, index);
       try {
         process.Start();
       } catch (Exception e) {
-        Console.WriteLine("Exception " +
-                          e +
-                          " from (" +
-                          index.ToString() +
-                          ") " +
-                          process.StartInfo.FileName +
-                          " " +
-                          process.StartInfo.Arguments);
+        Console.WriteLine("Exception " + e);
+        LogProcess(process, index);
         throw;
       }
       tasks[i] = Task.Run(() => {

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -231,7 +231,19 @@ class ParallelTestRunner {
       // We cannot use i in the lambdas, it would be captured by reference.
       int index = i;
       process_semaphore.WaitOne();
-      process.Start();
+      try {
+        process.Start();
+      } catch (Exception e) {
+        errors.Add("Exception " +
+                   e +
+                   " from (" +
+                   index.ToString() +
+                   ") " +
+                   process.StartInfo.FileName +
+                   " " +
+                   process.StartInfo.Arguments);
+        throw;
+      }
       tasks[i] = Task.Run(() => {
         Task standard_output_writer = Task.Run(async () => {
           while (!process.StandardOutput.EndOfStream) {

--- a/parallel_test_runner/parallel_test_runner.cs
+++ b/parallel_test_runner/parallel_test_runner.cs
@@ -217,6 +217,7 @@ class ParallelTestRunner {
                           " from a death test");
         Environment.Exit(process.ExitCode);
       }
+      process.Close();
     }
 
     Console.WriteLine("Running " + processes.Count + " processes...");
@@ -238,6 +239,7 @@ class ParallelTestRunner {
                             " " +
                             await process.StandardOutput.ReadLineAsync());
         }
+        process.WaitForExit();
         if (process.ExitCode != 0) {
           errors.Add("Exit code " +
                      process.ExitCode +
@@ -248,6 +250,7 @@ class ParallelTestRunner {
                      " " +
                      process.StartInfo.Arguments);
         }
+        process.Close();
         process_semaphore.Release();
       });
       tasks[2 * i + 1] = Task.Run(async () => {


### PR DESCRIPTION
We occasionally see failures like:
```
09:48:42 System.ComponentModel.Win32Exception: The process cannot access the file because it is being used by another process
09:48:42    at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
09:48:42    at principia.parallel_test_runner.ParallelTestRunner.Main(String[] args) in C:\Program Files (x86)\Jenkins\workspace\Principia\parallel_test_runner\parallel_test_runner.cs:line 234
```
(The line can also be 214.)

I suspect that we must release the resources held by the process, see the discussion of `Close` in the documentation of [`WaitForExit`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-7.0).

Since that is not the whole story, I am putting a retry loop around calls to `Process.Start`.  It appears that waiting a bit is sufficient to make the error go away (look for `exception ` in [this test log](http://casanova.westeurope.cloudapp.azure.com:8080/job/Principia/5613/console)).