### PR TITLE
No sign for a Δv of 0

### DIFF
--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -393,7 +393,7 @@ class BurnEditor : ScalingRenderer {
     string unsigned_format = "00,000." + new string('0', fractional_digits);
     return Regex.Replace(
         Regex.Replace(
-        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format};{en_space}{unsigned_format}",
+        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format};{figure_space}{unsigned_format}",
                                    Culture.culture),
         @"^[+−\s][0']{1,5}",
         match => match.Value.Replace('0', figure_space)),
@@ -478,7 +478,6 @@ class BurnEditor : ScalingRenderer {
   
   private static UnityEngine.Texture decrement_revolution;
   private static UnityEngine.Texture increment_revolution;
-  private const char en_space = '\u2002';
   private const char figure_space = '\u2007';
 }
 

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -393,7 +393,7 @@ class BurnEditor : ScalingRenderer {
     string unsigned_format = "00,000." + new string('0', fractional_digits);
     return Regex.Replace(
         Regex.Replace(
-        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format};{figure_space}{unsigned_format}",
+        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format};{en_space}{unsigned_format}",
                                    Culture.culture),
         @"^[+−\s][0']{1,5}",
         match => match.Value.Replace('0', figure_space)),
@@ -478,6 +478,7 @@ class BurnEditor : ScalingRenderer {
   
   private static UnityEngine.Texture decrement_revolution;
   private static UnityEngine.Texture increment_revolution;
+  private const char en_space = '\u2002';
   private const char figure_space = '\u2007';
 }
 

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -393,9 +393,9 @@ class BurnEditor : ScalingRenderer {
     string unsigned_format = "00,000." + new string('0', fractional_digits);
     return Regex.Replace(
         Regex.Replace(
-        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format}",
+        metres_per_second.ToString($"+{unsigned_format};−{unsigned_format};{figure_space}{unsigned_format}",
                                    Culture.culture),
-        "^[+−][0']{1,5}",
+        @"^[+−\s][0']{1,5}",
         match => match.Value.Replace('0', figure_space)),
         // Add grouping marks to the fractional part.
         @"\d{3}(?=\d)",

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -335,6 +335,13 @@ internal class DifferentialSlider : ScalingRenderer {
       return false;
     }
     increment = Math.Abs(adjusted_value - base_value);
+    if (adjusted_value + increment > max_value_ &&
+        base_value - increment < min_value_) {
+      // If the digit cannot be adjusted in either direction, don’t show arrows.
+      // This can happen if the digit is actually a figure space standing for
+      // the sign of 0.
+      return false;
+    }
     return true;
   }
 

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -335,7 +335,7 @@ internal class DifferentialSlider : ScalingRenderer {
       return false;
     }
     increment = Math.Abs(adjusted_value - base_value);
-    if (adjusted_value + increment > max_value_ &&
+    if (base_value + increment > max_value_ &&
         base_value - increment < min_value_) {
       // If the digit cannot be adjusted in either direction, don’t show arrows.
       // This can happen if the digit is actually a figure space standing for

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -37,6 +37,7 @@ internal class DifferentialSlider : ScalingRenderer {
       // marks, since .NET does not like those in the fractional part.
       parser_ = (string s, out double value) => double.TryParse(
           s.Replace(',', '.').Replace('-', '−')
+           .Replace(en_space, "")
            .Replace(figure_space, '0').Replace("'", ""),
           NumberStyles.AllowDecimalPoint |
           NumberStyles.AllowLeadingSign |
@@ -335,13 +336,6 @@ internal class DifferentialSlider : ScalingRenderer {
       return false;
     }
     increment = Math.Abs(adjusted_value - base_value);
-    if (adjusted_value + increment > max_value_ &&
-        base_value - increment < min_value_) {
-      // If the digit cannot be adjusted in either direction, don’t show arrows.
-      // This can happen if the digit is actually a figure space standing for
-      // the sign of 0.
-      return false;
-    }
     return true;
   }
 
@@ -389,6 +383,7 @@ internal class DifferentialSlider : ScalingRenderer {
   private static UnityEngine.Texture scroll_indicator;
 
   private string text_field_name => GetHashCode() + ":text_field";
+  private const string en_space = "\u2002";
   private const char figure_space = '\u2007';
 }
 

--- a/ksp_plugin_adapter/differential_slider.cs
+++ b/ksp_plugin_adapter/differential_slider.cs
@@ -37,7 +37,6 @@ internal class DifferentialSlider : ScalingRenderer {
       // marks, since .NET does not like those in the fractional part.
       parser_ = (string s, out double value) => double.TryParse(
           s.Replace(',', '.').Replace('-', '−')
-           .Replace(en_space, "")
            .Replace(figure_space, '0').Replace("'", ""),
           NumberStyles.AllowDecimalPoint |
           NumberStyles.AllowLeadingSign |
@@ -336,6 +335,13 @@ internal class DifferentialSlider : ScalingRenderer {
       return false;
     }
     increment = Math.Abs(adjusted_value - base_value);
+    if (adjusted_value + increment > max_value_ &&
+        base_value - increment < min_value_) {
+      // If the digit cannot be adjusted in either direction, don’t show arrows.
+      // This can happen if the digit is actually a figure space standing for
+      // the sign of 0.
+      return false;
+    }
     return true;
   }
 
@@ -383,7 +389,6 @@ internal class DifferentialSlider : ScalingRenderer {
   private static UnityEngine.Texture scroll_indicator;
 
   private string text_field_name => GetHashCode() + ":text_field";
-  private const string en_space = "\u2002";
   private const char figure_space = '\u2007';
 }
 


### PR DESCRIPTION
Fix #3480, to the extent that we want to fix it.

This relies on the sign being the size of a figure space, which appears to be the case in whichever font I get on Windows 10.
![image](https://user-images.githubusercontent.com/2284290/209346622-5ea153e2-16f4-490c-9a26-a371cf4f38b9.png)
