### PR TITLE
More improvements to the Mathematica logger

### DIFF
--- a/mathematica/logger.hpp
+++ b/mathematica/logger.hpp
@@ -60,15 +60,20 @@ class Logger final {
   // construction of each logger.  This makes it possible for distant code to
   // perform operations on the logger, e.g., to disable it or log client-
   // specific data.  The path passed to the callback is the path passed to the
-  // constructor (i.e., before any alteration performed by |make_unique|).
+  // constructor (i.e., before any alteration performed by |make_unique|).  The
+  // |id| is the uniquely-generated id for the logger (if |make_unique| is true)
+  // or nullopt (if |make_unique| is false).
   using ConstructionCallback =
-      std::function<void(std::filesystem::path const&, not_null<Logger*>)>;
+      std::function<void(std::filesystem::path const&,
+                         std::optional<std::uint64_t> id,
+                         not_null<Logger*>)>;
 
   static void SetConstructionCallback(ConstructionCallback callback);
   static void ClearConstructionCallback();
 
  private:
   std::atomic_bool enabled_ = true;
+  std::optional<std::uint64_t> my_id_;
   OFStream file_;
   std::map<std::string, std::vector<std::string>> name_and_multiple_values_;
   std::map<std::string, std::string> name_and_single_value_;

--- a/mathematica/logger_body.hpp
+++ b/mathematica/logger_body.hpp
@@ -12,11 +12,12 @@ namespace mathematica {
 namespace internal_logger {
 
 inline Logger::Logger(std::filesystem::path const& path, bool const make_unique)
-    : file_([make_unique, &path]() {
+    : file_([this, make_unique, &path]() {
         if (make_unique || PRINCIPIA_MATHEMATICA_LOGGER_REGRESSION_TEST != 0) {
           std::filesystem::path filename = path.stem();
           if (make_unique) {
-            filename += std::to_string(id_++);
+            my_id_ = id_++;
+            filename += std::to_string(my_id_.value());
           }
 #if PRINCIPIA_MATHEMATICA_LOGGER_REGRESSION_TEST
           filename += "_new";
@@ -29,7 +30,7 @@ inline Logger::Logger(std::filesystem::path const& path, bool const make_unique)
       }()) {
   absl::ReaderMutexLock l(&construction_callback_lock_);
   if (construction_callback_ != nullptr) {
-    construction_callback_(path, this);
+    construction_callback_(path, my_id_, this);
   }
 }
 

--- a/mathematica/logger_test.cpp
+++ b/mathematica/logger_test.cpp
@@ -6,6 +6,7 @@
 
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "quantities/si.hpp"
 
@@ -16,6 +17,7 @@ using base::not_null;
 using geometry::Frame;
 using quantities::si::Metre;
 using quantities::si::Second;
+using ::testing::Optional;
 
 class LoggerTest : public ::testing::Test {
  protected:
@@ -32,8 +34,10 @@ TEST_F(LoggerTest, Logger) {
   Logger* logger_ptr;
   Logger::SetConstructionCallback(
       [&logger_ptr](std::filesystem::path const& path,
+                    std::optional<std::uint64_t> id,
                     not_null<Logger*> const logger) {
         EXPECT_EQ(TEMP_DIR / "mathematica_test.wl", path);
+        EXPECT_THAT(id, Optional(0));
         logger_ptr = logger;
         logger->Disable();
       });


### PR DESCRIPTION
1. Support for enabling/disabling a logger.
2. Support for informing distant code of the creation of loggers and letting it take action on the newly-created loggers.