### PR TITLE
Avoid interpolations when computing mean elements

### DIFF
--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -361,9 +361,9 @@ TEST_F(OrbitAnalysisTest, 北斗MEO) {
   EXPECT_THAT(elements.mean_inclination_interval().midpoint(),
               IsNear(55.10_(1) * Degree));
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
-              IsNear(0.000558_(1)));
+              IsNear(0.000560_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(1.0035_(1) * Degree));
+              IsNear(0.9858_(1) * Degree));
 }
 
 // COSPAR ID 2016-030A.
@@ -395,7 +395,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
             RelativeErrorFrom(nominal_nodal_precession, IsNear(0.011_(1)))));
   EXPECT_THAT(2 * π * Radian / elements.anomalistic_period(),
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(0.53_(1) * Degree / Day)),
+                                      IsNear(0.54_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(0.00087_(1)))));
 
@@ -427,7 +427,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
               IsNear(88_(1) * Degree));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
-              IsNear(6.3_(1) * Degree));
+              IsNear(6.1_(1) * Degree));
 
   // Since the reference parameters conventionally set ω = 0, the given mean
   // anomaly is actually the mean argument of latitude; in order to get numbers
@@ -470,13 +470,13 @@ TEST_F(OrbitAnalysisTest, GalileoExtendedSlot) {
             RelativeErrorFrom(nominal_nodal_precession, IsNear(0.0059_(1)))));
   EXPECT_THAT(2 * π * Radian / elements.anomalistic_period(),
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(0.0014_(1) * Degree / Day)),
+                                      IsNear(0.0011_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(2.0e-06_(1)))));
 
   EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(27'977.6 * Kilo(Metre),
-                                IsNear(0.0513_(1) * Kilo(Metre))));
+                                IsNear(0.0505_(1) * Kilo(Metre))));
   EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               IsNear(00'000.099_(1) * Kilo(Metre)));
 
@@ -573,7 +573,7 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
   // bit less than 3 m above the nominal value around that time.
   EXPECT_THAT(
       elements.mean_semimajor_axis_interval().midpoint(),
-      DifferenceFrom(7714.42938 * Kilo(Metre), IsNear(3.38_(1) * Metre)));
+      DifferenceFrom(7714.42938 * Kilo(Metre), IsNear(2.41_(1) * Metre)));
   // Reference inclination from the legend of figure 9 of [BSFL98]; that
   // value is given as 66.040° in table 1 of [BSFL98], 66.039° in [BS96], and
   // 66.04° in [Ben97].
@@ -599,10 +599,10 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
   // theoretical and observed mean e and ω vary between 40 ppm and 140 ppm, and
   // between 60° and 120°, respectively.
   EXPECT_THAT(elements.mean_eccentricity_interval(),
-              AllOf(Field(&Interval<double>::min, IsNear(88e-6_(1))),
+              AllOf(Field(&Interval<double>::min, IsNear(85e-6_(1))),
                     Field(&Interval<double>::max, IsNear(110e-6_(1)))));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval(),
-              AllOf(Field(&Interval<Angle>::min, IsNear(73.8_(1) * Degree)),
+              AllOf(Field(&Interval<Angle>::min, IsNear(74.4_(1) * Degree)),
                     Field(&Interval<Angle>::max, IsNear(99.1_(1) * Degree))));
 
   // Nominal longitude of the equatorial crossing of the first ascending pass
@@ -685,7 +685,7 @@ TEST_F(OrbitAnalysisTest, SPOT5) {
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
               IsNear(0.0012_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(89.38_(1) * Degree));
+              IsNear(89.66_(1) * Degree));
 
   // The nominal mean solar times of the nodes are 22:30 ascending, 10:30
   // descending.
@@ -720,7 +720,7 @@ TEST_F(OrbitAnalysisTest, Sentinel3A) {
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
               IsNear(0.0011_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(89.99_(1) * Degree));
+              IsNear(90.03_(1) * Degree));
 
   // The nominal mean solar times of the nodes are 22:00 ascending, 10:00
   // descending.

--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -361,9 +361,9 @@ TEST_F(OrbitAnalysisTest, 北斗MEO) {
   EXPECT_THAT(elements.mean_inclination_interval().midpoint(),
               IsNear(55.10_(1) * Degree));
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
-              IsNear(0.000560_(1)));
+              IsNear(0.000557_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(0.9858_(1) * Degree));
+              IsNear(0.4737_(1) * Degree));
 }
 
 // COSPAR ID 2016-030A.
@@ -395,7 +395,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
             RelativeErrorFrom(nominal_nodal_precession, IsNear(0.011_(1)))));
   EXPECT_THAT(2 * π * Radian / elements.anomalistic_period(),
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(0.54_(1) * Degree / Day)),
+                                      IsNear(0.63_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(0.00088_(1)))));
 
@@ -408,7 +408,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
               IsNear(0.000'17_(1)));  // Nominal: 0.0.
   EXPECT_THAT(elements.mean_eccentricity_interval().measure(),
-              IsNear(0.000'015_(1)));
+              IsNear(0.000'020_(1)));
 
   EXPECT_THAT(elements.mean_inclination_interval().midpoint(),
               AbsoluteErrorFrom(56.0 * Degree, IsNear(0.61_(1) * Degree)));
@@ -425,9 +425,9 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
   // set ω = 0, ω′ = 0.
   // However, e is never quite 0; we can compute a mean ω.
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(88_(1) * Degree));
+              IsNear(89_(1) * Degree));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
-              IsNear(6.1_(1) * Degree));
+              IsNear(7.7_(1) * Degree));
 
   // Since the reference parameters conventionally set ω = 0, the given mean
   // anomaly is actually the mean argument of latitude; in order to get numbers
@@ -476,7 +476,7 @@ TEST_F(OrbitAnalysisTest, GalileoExtendedSlot) {
 
   EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(27'977.6 * Kilo(Metre),
-                                IsNear(0.0505_(1) * Kilo(Metre))));
+                                IsNear(0.0519_(1) * Kilo(Metre))));
   EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               IsNear(00'000.099_(1) * Kilo(Metre)));
 
@@ -685,7 +685,7 @@ TEST_F(OrbitAnalysisTest, SPOT5) {
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
               IsNear(0.0012_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(89.66_(1) * Degree));
+              IsNear(89.69_(1) * Degree));
 
   // The nominal mean solar times of the nodes are 22:30 ascending, 10:30
   // descending.

--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -397,7 +397,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(0.63_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(0.00088_(1)))));
+                                      IsNear(0.00102_(1)))));
 
   EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(29'599.8 * Kilo(Metre),

--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -397,7 +397,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(0.54_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(0.00087_(1)))));
+                                      IsNear(0.00088_(1)))));
 
   EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(29'599.8 * Kilo(Metre),
@@ -472,7 +472,7 @@ TEST_F(OrbitAnalysisTest, GalileoExtendedSlot) {
               AllOf(AbsoluteErrorFrom(nominal_anomalistic_mean_motion,
                                       IsNear(0.0011_(1) * Degree / Day)),
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
-                                      IsNear(2.0e-06_(1)))));
+                                      IsNear(1.7e-06_(1)))));
 
   EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(27'977.6 * Kilo(Metre),
@@ -600,10 +600,10 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
   // between 60° and 120°, respectively.
   EXPECT_THAT(elements.mean_eccentricity_interval(),
               AllOf(Field(&Interval<double>::min, IsNear(85e-6_(1))),
-                    Field(&Interval<double>::max, IsNear(110e-6_(1)))));
+                    Field(&Interval<double>::max, IsNear(109e-6_(1)))));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval(),
               AllOf(Field(&Interval<Angle>::min, IsNear(74.4_(1) * Degree)),
-                    Field(&Interval<Angle>::max, IsNear(99.1_(1) * Degree))));
+                    Field(&Interval<Angle>::max, IsNear(99.2_(1) * Degree))));
 
   // Nominal longitude of the equatorial crossing of the first ascending pass
   // East of the ITRF zero-meridian (pass 135), as given in section 2 of

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -306,10 +306,8 @@ OrbitalElements::MeanEquinoctialElements(
   // the osculating э from |mean_elements.t - period / 2| to
   // |mean_elements.t + period / 2|, divided by |period|.
 
-  //TODO(phl):Fix the comment.
-  // Instead of computing the integral from |t - period / 2| to |t + period / 2|
-  // directly, we precompute the integrals from |t_min|.  The integral from
-  // |t - period / 2| to |t + period / 2| is then computed by subtraction.
+  // We integrate the function (э(t + period / 2) - э(t - period / 2)) / period
+  // using as the initial value an integral obtain by Clenshaw-Curtis.
 
   using ODE =
       ExplicitFirstOrderOrdinaryDifferentialEquation<Instant,

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -300,14 +300,18 @@ OrbitalElements::MeanEquinoctialElements(
     Instant const& t_min,
     Instant const& t_max,
     Time const& period) {
-  // This function averages the elements in |osculating| over |period|.
-  // For each |mean_elements| in the result, for all э in the set of equinoctial
+  if (t_max - t_min < period) {
+    return std::vector<EquinoctialElements>{};
+  }
+
+  // This function averages the elements in |osculating| over |period|.  For
+  // each |mean_elements| in the result, for all э in the set of equinoctial
   // elements {a, h, k, λ, p, q, pʹ, qʹ}, |mean_elements.э| is the integral of
   // the osculating э from |mean_elements.t - period / 2| to
   // |mean_elements.t + period / 2|, divided by |period|.
 
   // We integrate the function (э(t + period / 2) - э(t - period / 2)) / period
-  // using as the initial value an integral obtain by Clenshaw-Curtis.
+  // using as the initial value an integral obtained by Clenshaw-Curtis.
 
   using ODE =
       ExplicitFirstOrderOrdinaryDifferentialEquation<Instant,

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -12,6 +12,7 @@
 #include "numerics/quadrature.hpp"
 #include "integrators/embedded_explicit_runge_kutta_integrator.hpp"
 #include "integrators/methods.hpp"
+#include "mathematica/logger.hpp"
 #include "physics/discrete_trajectory.hpp"
 #include "physics/kepler_orbit.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -354,12 +355,13 @@ OrbitalElements::MeanEquinoctialElements(
                                                 .qʹ = qʹ.value});
   };
 
+  Length tolerance = 10 * eerk_a_tolerance;
   auto const tolerance_to_error_ratio =
-      [](Time const& step,
+      [&tolerance](Time const& step,
          ODE::State const& state,
          ODE::State::Error const& error) -> double {
     auto const& [Δa, Δh, Δk, Δλ, Δp, Δq, Δpʹ, Δqʹ] = error;
-    return eerk_a_tolerance / Abs(Δa);
+    return tolerance / Abs(Δa);
   };
 
   auto const initial_integration =
@@ -400,21 +402,35 @@ OrbitalElements::MeanEquinoctialElements(
                      initial_integration(&EquinoctialElements::q),
                      initial_integration(&EquinoctialElements::pʹ),
                      initial_integration(&EquinoctialElements::qʹ)))};
-  append_state(problem.initial_state);
 
-  auto const instance =
-      EmbeddedExplicitRungeKuttaIntegrator<
-          integrators::methods::DormandPrince1986RK547FC,
-          ODE>()
-          .NewInstance(problem,
-                       append_state,
-                       tolerance_to_error_ratio,
-                       AdaptiveStepSizeIntegrator<ODE>::Parameters(
-                           /*first_step=*/t_max - t_min - period,
-                           /*safety_factor=*/0.9));
-  RETURN_IF_ERROR(instance->Solve(t_max - period / 2));
+  mathematica::Logger logger(TEMP_DIR / "orbital_elements.wl");
+  for (int i = 0; i < 1; ++i) {
+    mean_elements.clear();
+    append_state(problem.initial_state);
 
-  LOG(ERROR)<<mean_elements.size();
+    auto const instance =
+        EmbeddedExplicitRungeKuttaIntegrator<
+            integrators::methods::DormandPrince1986RK547FC,
+            ODE>()
+            .NewInstance(problem,
+                          append_state,
+                          tolerance_to_error_ratio,
+                          AdaptiveStepSizeIntegrator<ODE>::Parameters(
+                              /*first_step=*/t_max - t_min - period,
+                              /*safety_factor=*/0.9));
+    RETURN_IF_ERROR(instance->Solve(t_max - period / 2));
+
+    LOG(ERROR)<<mean_elements.size();
+    for (auto const& me : mean_elements) {
+      logger.Append(absl::StrCat("meanElements[", i, "]"),
+                    me,
+                    mathematica::ExpressInSIUnits);
+    }
+
+    tolerance *= Sqrt(Sqrt(2));
+  }
+  logger.Flush();
+  //LOG(FATAL)<<"Done";
   return mean_elements;
 }
 

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -172,7 +172,7 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
   // pumping energy into nor out of it.  The true values are 14'910.01 and
   // 14'910.28 km.
   EXPECT_THAT(elements.mean_semimajor_axis_interval().min,
-              IsNear(14'909.99_(1) * Kilo(Metre)));
+              IsNear(14'910.02_(1) * Kilo(Metre)));
   EXPECT_THAT(elements.mean_semimajor_axis_interval().max,
               IsNear(14'910.28_(1) * Kilo(Metre)));
 

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -169,9 +169,10 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
 
   // The conservation of the “тривиального интеграла a = const” [Лид61, p. 25]
   // is excellent: while the sun is nudging and deforming the orbit, it is not
-  // pumping energy into nor out of it.
+  // pumping energy into nor out of it.  The true values are 14'910.01 and
+  // 14'910.28 km.
   EXPECT_THAT(elements.mean_semimajor_axis_interval().min,
-              IsNear(14'909.96_(1) * Kilo(Metre)));
+              IsNear(14'909.99_(1) * Kilo(Metre)));
   EXPECT_THAT(elements.mean_semimajor_axis_interval().max,
               IsNear(14'910.28_(1) * Kilo(Metre)));
 

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -10,9 +10,9 @@
 #include "physics/body_centred_non_rotating_dynamic_frame.hpp"
 #include "physics/discrete_trajectory.hpp"
 #include "physics/solar_system.hpp"
-//#if PRINCIPIA_LOG_TO_MATHEMATICA
+#if PRINCIPIA_LOG_TO_MATHEMATICA
 #include "mathematica/logger.hpp"
-//#endif
+#endif
 #include "testing_utilities/matchers.hpp"
 #include "testing_utilities/is_near.hpp"
 
@@ -118,13 +118,11 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
           PRINCIPIA_UNICODE_PATH("лидов_古在.generated.wl"),
       /*make_unique=*/false);
 #endif
-  mathematica::Logger logger(TEMP_DIR / "mercury_orbiter.wl");
 
   DiscreteTrajectory<MercuryCentredInertial> mercury_centred_trajectory;
   for (auto const& [t, dof] : icrs_trajectory) {
     EXPECT_OK(mercury_centred_trajectory.Append(
         t, mercury_frame_.ToThisFrameAtTime(t)(dof)));
-    logger.Append("mercuryTimes", t, mathematica::ExpressInSIUnits);
 #if PRINCIPIA_LOG_TO_MATHEMATICA
     logger.Append(
         "q",

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -10,9 +10,9 @@
 #include "physics/body_centred_non_rotating_dynamic_frame.hpp"
 #include "physics/discrete_trajectory.hpp"
 #include "physics/solar_system.hpp"
-#if PRINCIPIA_LOG_TO_MATHEMATICA
+//#if PRINCIPIA_LOG_TO_MATHEMATICA
 #include "mathematica/logger.hpp"
-#endif
+//#endif
 #include "testing_utilities/matchers.hpp"
 #include "testing_utilities/is_near.hpp"
 
@@ -118,11 +118,13 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
           PRINCIPIA_UNICODE_PATH("лидов_古在.generated.wl"),
       /*make_unique=*/false);
 #endif
+  mathematica::Logger logger(TEMP_DIR / "mercury_orbiter.wl");
 
   DiscreteTrajectory<MercuryCentredInertial> mercury_centred_trajectory;
   for (auto const& [t, dof] : icrs_trajectory) {
     EXPECT_OK(mercury_centred_trajectory.Append(
         t, mercury_frame_.ToThisFrameAtTime(t)(dof)));
+    logger.Append("mercuryTimes", t, mathematica::ExpressInSIUnits);
 #if PRINCIPIA_LOG_TO_MATHEMATICA
     logger.Append(
         "q",


### PR DESCRIPTION
Benchmark:
```
Run on (4 X 3311 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
OrbitalElementsBenchmark/ComputeOrbitalElementsEquatorial  830357700 ns    828125000 ns            1
OrbitalElementsBenchmark/ComputeOrbitalElementsInclined    761847400 ns    765625000 ns            1
```