### PR TITLE
Gracefully handle trajectories that are not gravitationally bound in OrbitalElements

### DIFF
--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -186,6 +186,10 @@ absl::StatusOr<OrbitalElements> OrbitalElements::ForRelativeDegreesOfFreedom(
   KeplerianElements<Frame> const initial_osculating_elements =
       osculating_elements(t_min);
   Time const estimated_period = *initial_osculating_elements.period;
+  if (!IsFinite(estimated_period) || estimated_period <= Time{}) {
+    return absl::OutOfRangeError("estimated period is " +
+                                 DebugString(estimated_period));
+  }
 
   std::vector<Angle> unwound_λs;
   // 3 is greater than 2 to make sure that we start in the right direction.

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -435,7 +435,7 @@ TEST_F(OrbitalElementsTest, Escape) {
   initial_osculating.inclination = 10 * Milli(ArcSecond);
   initial_osculating.longitude_of_ascending_node = 10 * Degree;
   initial_osculating.argument_of_periapsis = 20 * Degree;
-  initial_osculating.mean_anomaly = 30 * Degree;
+  initial_osculating.hyperbolic_mean_anomaly = 30 * Degree;
   auto const status_or_elements = OrbitalElements::ForTrajectory(
       *EarthCentredTrajectory(
           initial_osculating, J2000, J2000 + mission_duration, *ephemeris),

--- a/astronomy/orbital_elements_test.cpp
+++ b/astronomy/orbital_elements_test.cpp
@@ -412,6 +412,92 @@ TEST_F(OrbitalElementsTest, RealPerturbation) {
              mathematica::ExpressIn(Metre, Second, Radian));
 }
 
+TEST_F(OrbitalElementsTest, Escape) {
+  SolarSystem<ICRS> solar_system(
+      SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",
+      SOLUTION_DIR / "astronomy" /
+          "sol_initial_state_jd_2451545_000000000.proto.txt");
+  auto const ephemeris = solar_system.MakeEphemeris(
+      /*accuracy_parameters=*/{/*fitting_tolerance=*/1 * Milli(Metre),
+                               /*geopotential_tolerance=*/0x1p-24},
+      Ephemeris<ICRS>::FixedStepParameters(
+          SymmetricLinearMultistepIntegrator<
+              QuinlanTremaine1990Order12,
+              Ephemeris<ICRS>::NewtonianMotionEquation>(),
+          /*step=*/10 * Minute));
+  MassiveBody const& earth = *solar_system.massive_body(*ephemeris, "Earth");
+
+  Time const mission_duration = 10 * Day;
+
+  KeplerianElements<GCRS> initial_osculating;
+  initial_osculating.periapsis_distance = 7000 * Kilo(Metre);
+  initial_osculating.eccentricity = 1.2;
+  initial_osculating.inclination = 10 * Milli(ArcSecond);
+  initial_osculating.longitude_of_ascending_node = 10 * Degree;
+  initial_osculating.argument_of_periapsis = 20 * Degree;
+  initial_osculating.mean_anomaly = 30 * Degree;
+  auto const status_or_elements = OrbitalElements::ForTrajectory(
+      *EarthCentredTrajectory(
+          initial_osculating, J2000, J2000 + mission_duration, *ephemeris),
+      earth,
+      MasslessBody{},
+      /*fill_osculating_equinoctial_elements=*/true);
+  ASSERT_THAT(status_or_elements, IsOk());
+  OrbitalElements const& elements = status_or_elements.value();
+  EXPECT_THAT(
+      elements.anomalistic_period(),
+      DifferenceFrom(*initial_osculating.period, IsNear(-8.0_(1) * Second)));
+  EXPECT_THAT(
+      elements.nodal_period(),
+      DifferenceFrom(*initial_osculating.period, IsNear(-14_(1) * Second)));
+  EXPECT_THAT(
+      elements.sidereal_period(),
+      DifferenceFrom(*initial_osculating.period, IsNear(-16_(1) * Second)));
+
+  // This value is meaningless, see below.
+  EXPECT_THAT(elements.nodal_precession(), IsNear(2.0_(1) * Degree / Day));
+
+  // Mean element values.
+  EXPECT_THAT(elements.mean_semimajor_axis_interval().midpoint(),
+              AbsoluteErrorFrom(*initial_osculating.semimajor_axis,
+                                IsNear(104_(1) * Metre)));
+  EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
+              IsNear(0.0014_(1)));
+  EXPECT_THAT(elements.mean_inclination_interval().midpoint(),
+              AbsoluteErrorFrom(initial_osculating.inclination,
+                                IsNear(6.0_(1) * ArcSecond)));
+
+  // Mean element stability: Ω and ω exhibit a daily oscillation (likely due to
+  // the tesseral terms of the geopotential) as the very low inclination means
+  // that these elements are singular.
+  // The other elements are stable.
+  // A closer analysis would show that the longitude of periapsis ϖ = Ω + ω
+  // exhibits a precession that is largely free of oscillations, and that, if
+  // its oscillations are filtered, the argument of periapsis ω precesses as
+  // expected; the longitude of the ascending node Ω exhibits no obvious
+  // precession even if its daily oscillation is filtered out.
+  EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
+              IsNear(20_(1) * Metre));
+  EXPECT_THAT(elements.mean_eccentricity_interval().measure(),
+              IsNear(1.0e-4_(1)));
+  EXPECT_THAT(elements.mean_inclination_interval().measure(),
+              IsNear(11_(1) * ArcSecond));
+  EXPECT_THAT(elements.mean_longitude_of_ascending_node_interval().measure(),
+              IsNear(136_(1) * Degree));
+  EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
+              IsNear(154_(1) * Degree));
+
+  mathematica::Logger logger(
+      SOLUTION_DIR / "mathematica" / "fully_perturbed_elements.generated.wl",
+      /*make_unique=*/false);
+  logger.Set("fullyPerturbedOsculating",
+             elements.osculating_equinoctial_elements(),
+             mathematica::ExpressIn(Metre, Second, Radian));
+  logger.Set("fullyPerturbedMean",
+             elements.mean_equinoctial_elements(),
+             mathematica::ExpressIn(Metre, Second, Radian));
+}
+
 TEST_F(OrbitalElementsTest, Years) {
   SolarSystem<ICRS> solar_system(
       SOLUTION_DIR / "astronomy" / "sol_gravity_model.proto.txt",


### PR DESCRIPTION
Test failure:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from OrbitalElementsTest
[ RUN      ] OrbitalElementsTest.Escape
unknown file: error: C++ exception with description "vector too long" thrown in the test body.
[  FAILED  ] OrbitalElementsTest.Escape (131 ms)
[----------] 1 test from OrbitalElementsTest (131 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (134 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] OrbitalElementsTest.Escape
```

