### PR TITLE
Avoid an overflow when extending the prediction of the target vessel

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -95,6 +95,9 @@ using namespace principia::astronomy::_solar_system_fingerprints;
 using namespace principia::astronomy::_stabilize_ksp;
 using namespace principia::astronomy::_time_scales;
 
+// Keep this consistent with |prediction_steps_| in |main_window.cs|.
+constexpr std::int64_t max_steps_in_prediction = 1 << 24;
+
 Plugin::Plugin(std::string const& game_epoch,
                std::string const& solar_system_epoch,
                Angle const& planetarium_rotation)
@@ -964,7 +967,8 @@ void Plugin::ExtendPredictionForFlightPlan(GUID const& vessel_guid) const {
       auto prediction_adaptive_step_parameters =
           target_vessel.prediction_adaptive_step_parameters();
       prediction_adaptive_step_parameters.set_max_steps(
-          prediction_adaptive_step_parameters.max_steps() * 4);
+          std::min(max_steps_in_prediction,
+                   prediction_adaptive_step_parameters.max_steps() * 4));
       target_vessel.set_prediction_adaptive_step_parameters(
           prediction_adaptive_step_parameters);
     }

--- a/ksp_plugin_adapter/main_window.cs
+++ b/ksp_plugin_adapter/main_window.cs
@@ -535,6 +535,7 @@ internal class MainWindow : VesselSupervisedWindowRenderer {
       {1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4};
   private static readonly string[] prediction_length_tolerance_names_ =
       {"1 mm", "1 cm", "10 cm", "1 m", "10 m", "100 m", "1 km", "10 km"};
+  // Keep this consistent with |max_steps_in_prediction| in |plugin.cpp|.
   private static readonly long[] prediction_steps_ = {
       1 << 2, 1 << 4, 1 << 6, 1 << 8, 1 << 10, 1 << 12, 1 << 14, 1 << 16,
       1 << 18, 1 << 20, 1 << 22, 1 << 24


### PR DESCRIPTION
Fix #3593.