### PR TITLE
NaN resilience in equipotential computing

### DIFF
--- a/journal/player.cpp
+++ b/journal/player.cpp
@@ -12,7 +12,7 @@
 #include "journal/profiles.hpp"
 #include "glog/logging.h"
 
-#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 0
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
 
 namespace principia {
 namespace journal {

--- a/journal/player.cpp
+++ b/journal/player.cpp
@@ -12,7 +12,7 @@
 #include "journal/profiles.hpp"
 #include "glog/logging.h"
 
-#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 1
+#define PRINCIPIA_PLAYER_ALLOW_VERSION_MISMATCH 0
 
 namespace principia {
 namespace journal {

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -113,7 +113,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Scan) {
 // |method_out_return| protocol buffers.
 TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Issues\3520\JOURNAL.20230218-092106)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Journals\JOURNAL.20230506-192603)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -129,6 +129,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
              << player.last_method_in().DebugString();
   LOG(ERROR) << "Last successful method out/return: \n"
              << player.last_method_out_return().DebugString();
+  std::this_thread::sleep_for(10s);
 
 #if 0
   serialization::Method method_in;

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -916,6 +916,9 @@ HarmonicDamping const& Geopotential<Frame>::sectoral_damping() const {
 
 template<typename Frame>
 int Geopotential<Frame>::LimitingDegree(Length const& r_norm) const {
+  if (!IsFinite(r_norm)) {
+    return 2;
+  }
   return std::partition_point(
              degree_damping_.begin(),
              degree_damping_.end(),


### PR DESCRIPTION
#3358.
This should not happen (the reason why it happened is that we were using shaky bodies as secondaries, rather than the barycentres of their subsystems), but if it does, it should not bring down the game.

One of those will lead to Unity warnings about drawing NaNs, the other will lead to errors in the Principia log, but that is fine.
![screenshot3](https://user-images.githubusercontent.com/2284290/236719940-8e7eccfe-73d9-4ebb-a726-e8af6cbb6ce1.png)
