### PR TITLE
Fix mac build

### DIFF
--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <set>
 
 #include "geometry/barycentre_calculator.hpp"
 #include "geometry/r3x3_matrix.hpp"

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -45,9 +45,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
       secondaries_(std::move(secondaries)),
       primary_trajectory_(ephemeris_->trajectory(primary_)) {
   CHECK_GE(secondaries_.size(), 1);
-  CHECK_EQ(std::set(secondaries_.begin(), secondaries_.end()).size(),
-           secondaries_.size())
-      << secondaries_;
+  CHECK_EQ(std::set<not_null<MassiveBody const*>>(secondaries_.begin(),
+                                                  secondaries_.end()).size(),
+           secondaries_.size()) << secondaries_;
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -3,6 +3,7 @@
 #include "physics/rotating_pulsating_reference_frame.hpp"
 
 #include <vector>
+#include <set>
 
 namespace principia {
 namespace physics {

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -35,9 +35,9 @@ RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::
       secondaries_(std::move(secondaries)),
       rotating_frame_(ephemeris_, primary_, secondaries_) {
   CHECK_GE(secondaries_.size(), 1);
-  CHECK_EQ(std::set(secondaries_.begin(), secondaries_.end()).size(),
-           secondaries_.size())
-      << secondaries_;
+  CHECK_EQ(std::set<not_null<MassiveBody const*>>(secondaries_.begin(),
+                                                  secondaries_.end()).size(),
+           secondaries_.size()) << secondaries_;
 }
 
 template<typename InertialFrame, typename ThisFrame>


### PR DESCRIPTION
On mac, we are still in C++17, and `std::set` is actually an alias, so that we don’t get deduction guides.  We can revert this when we upgrade the mac build to C++20.

https://github.com/mockingbirdnest/Principia/blob/e90cf7e462da0ba4a809650e9838b4da6ac9f365/base/macos_allocator_replacement.hpp#L55-L57