### PR TITLE
Pulsate the camera distance in the rotating-pulsating reference frame

### DIFF
--- a/ksp_plugin/interface_renderer.cpp
+++ b/ksp_plugin/interface_renderer.cpp
@@ -149,5 +149,14 @@ WXYZ __cdecl principia__CameraReferenceRotation(Plugin* const plugin) {
                  .quaternion()));
 }
 
+double __cdecl principia__CameraScale(Plugin* const plugin) {
+  journal::Method<journal::CameraScale> m({plugin});
+  CHECK_NOTNULL(plugin);
+  return m.Return(GetRenderer(plugin)
+                      .BarycentricToPlotting(plugin->CurrentTime())
+                      .conformal_map()
+                      .scale());
+}
+
 }  // namespace interface
 }  // namespace principia

--- a/ksp_plugin_adapter/planetarium_camera_adjuster.cs
+++ b/ksp_plugin_adapter/planetarium_camera_adjuster.cs
@@ -77,6 +77,7 @@ public class PlanetariumCameraAdjuster : UnityEngine.MonoBehaviour {
           reference_rotation *
           last_fresh_planetarium_camera_rotation_ *
           camera_roll;
+      PlanetariumCamera.fetch.transform.localPosition *= ???;
       ScaledCamera.Instance.galaxyCamera.transform.rotation =
           reference_rotation *
           (UnityEngine.QuaternionD)ScaledCamera.Instance.galaxyCamera.transform.

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -240,7 +240,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5184.
+  extensions 5000 to 5999;  // Last used: 5185.
 }
 
 message AdvanceTime {
@@ -281,6 +281,20 @@ message CameraReferenceRotation {
   }
   message Return {
     required WXYZ result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
+message CameraScale {
+  extend Method {
+    optional CameraScale extension = 5185;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
+  }
+  message Return {
+    required double result = 1;
   }
   optional In in = 1;
   optional Return return = 3;


### PR DESCRIPTION
This means that when the camera targets a fixed point in the reference frame (which can be a bit tricky since the interesting part may be the barycentre of multiple bodies; we should explore camera targeting later), the trajectories are fixed on the screen, and instead the bodies grow and shrink as expected.