### PR TITLE
Try to emit a message slightly more useful than "error 4"

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -671,6 +671,12 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                       "#Principia_FlightPlan_StatusMessage_OutRange7")
                   : "",
               first_error_manœuvre_.Value + 1);
+        } else if (status_.is_deadline_exceeded()) {
+          status_message =
+              L10N.CacheFormat(
+                  "#Principia_FlightPlan_StatusMessage_DeadlineExceeded");
+          remedy_message =
+              L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_Tickle");
         } else {
           status_message =
               L10N.CacheFormat("#Principia_FlightPlan_StatusMessage_TooShort");

--- a/ksp_plugin_adapter/interface.cs
+++ b/ksp_plugin_adapter/interface.cs
@@ -13,6 +13,10 @@ internal partial class Status {
     return error == 10;
   }
 
+  public bool is_deadline_exceeded() {
+    return error == 4;
+  }
+
   public bool is_failed_precondition() {
     return error == 9;
   }

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -182,6 +182,8 @@ Localization {
     #Principia_FlightPlan_CoastInOrbit = Coast in <<1>> for <<2>>
     #Principia_FlightPlan_AddManœuvre = Add manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = changing the flight plan
+    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
+    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
     #Principia_FlightPlan_StatusMessage_FailedError = computation failed with error <<1>> and message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = after <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = integrator reached the maximum number of steps <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -186,6 +186,8 @@ Localization {
     #Principia_FlightPlan_CoastInOrbit = Vol en <<1>> pendant <<2>>
     #Principia_FlightPlan_AddManœuvre = Ins. manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = de modifier le plan de vol
+    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = plan de vol dépasse la période sur laquelle les corps célestes ont été calculés
+    #Principia_FlightPlan_StatusMessage_Tickle = raccourcir et rallonger répétitivement le plan de vol
     #Principia_FlightPlan_StatusMessage_FailedError = le calcul a échoué avec l’erreur <<1>> et le message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = au bout de <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = l’intégrateur a atteint le nombre maximum de pas <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -185,7 +185,6 @@ Localization {
     #Principia_FlightPlan_Coast = Vol non propulsé pendant <<1>>  // <<1>> coast_duration
     #Principia_FlightPlan_CoastInOrbit = Vol en <<1>> pendant <<2>>
     #Principia_FlightPlan_AddManœuvre = Ins. manœuvre
-    #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = changing the flight plan
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = de modifier le plan de vol
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = plan de vol dépasse la période sur laquelle les corps célestes ont été calculés
     #Principia_FlightPlan_StatusMessage_Tickle = raccourcir et rallonger répétitivement le plan de vol

--- a/ksp_plugin_adapter/localization/ru.cfg
+++ b/ksp_plugin_adapter/localization/ru.cfg
@@ -196,6 +196,8 @@ Localization {
     #Principia_FlightPlan_CoastInOrbit = Полёт в течение <<2>> (<<1>>)
     #Principia_FlightPlan_AddManœuvre = Добав. манёвр
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = изменение плана полёта
+    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
+    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
     #Principia_FlightPlan_StatusMessage_FailedError = сбой расчёта с ошибкой <<1>> и сообщением \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = после <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = интегратор достиг максимального количества шагов <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -212,6 +212,8 @@ Localization {
     #Principia_FlightPlan_CoastInOrbit = 停泊于 <<1>> 还需等待 <<2>>
     #Principia_FlightPlan_AddManœuvre = 新建轨道机动
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
+    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
+    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -212,8 +212,8 @@ Localization {
     #Principia_FlightPlan_CoastInOrbit = 停泊于 <<1>> 还需等待 <<2>>
     #Principia_FlightPlan_AddManœuvre = 新建轨道机动
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
-    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
-    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
+    #Principia_FlightPlan_StatusMessage_DeadlineExceeded = 轨道规划长度超过天体计算长度
+    #Principia_FlightPlan_StatusMessage_Tickle = 反复延长并缩短规划长度
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout


### PR DESCRIPTION
It is really hard to explain to the user what they should do in that case.  "Just tickle the flight plan length" is not going to be helpful.  I am not proud of the wording, but it's probably an improvement over the current situation.

This will need to be localized in Chinese and Russian.

Not a fix of #3483.