### PR TITLE
Bring back the typename

### DIFF
--- a/physics/lagrange_equipotentials_body.hpp
+++ b/physics/lagrange_equipotentials_body.hpp
@@ -82,7 +82,7 @@ LagrangeEquipotentials<Inertial, RotatingPulsating>::ComputeLines(
   Equipotential<Inertial, RotatingPulsating> const equipotential(
       {EmbeddedExplicitRungeKuttaIntegrator<
            DormandPrince1986RK547FC,
-           Equipotential<Inertial, RotatingPulsating>::ODE>(),
+           typename Equipotential<Inertial, RotatingPulsating>::ODE>(),
        max_steps,
        /*length_integration_tolerance=*/characteristic_length},
       &reference_frame,


### PR DESCRIPTION
See #3665. Accidentally reverted in #3666.