### PR TITLE
A benchmark for the Sun-Neptune equipotentials

### DIFF
--- a/benchmarks/lagrange_equipotentials.cpp
+++ b/benchmarks/lagrange_equipotentials.cpp
@@ -53,7 +53,7 @@ class LagrangeEquipotentialsBenchmark : public benchmark::Fixture {
                                          /*geopotential_tolerance=*/0x1p-24},
                 ephemeris_parameters)
             .release();
-    CHECK_OK(ephemeris_->Prolong(t0_ + number_of_days * Day));
+    CHECK_OK(ephemeris_->Prolong(t0_));
   }
 
   void SetUp(benchmark::State&) override {

--- a/benchmarks/lagrange_equipotentials.cpp
+++ b/benchmarks/lagrange_equipotentials.cpp
@@ -73,9 +73,8 @@ class LagrangeEquipotentialsBenchmark : public benchmark::Fixture {
 SolarSystem<Barycentric>* LagrangeEquipotentialsBenchmark::solar_system_;
 Ephemeris<Barycentric>* LagrangeEquipotentialsBenchmark::ephemeris_;
 
-BENCHMARK_F(LagrangeEquipotentialsBenchmark,
-            EarthMoon)
-(benchmark::State& state) {
+BENCHMARK_F(LagrangeEquipotentialsBenchmark, EarthMoon)(
+    benchmark::State& state) {
   auto const earth = solar_system_->massive_body(
       *ephemeris_, SolarSystemFactory::name(SolarSystemFactory::Earth));
   auto const moon = solar_system_->massive_body(
@@ -93,8 +92,8 @@ BENCHMARK_F(LagrangeEquipotentialsBenchmark,
   }
 }
 
-BENCHMARK_F(LagrangeEquipotentialsBenchmark, SunNeptune)
-(benchmark::State& state) {
+BENCHMARK_F(LagrangeEquipotentialsBenchmark, SunNeptune)(
+    benchmark::State& state) {
   LagrangeEquipotentials<Barycentric, World>::Parameters parameters;
   for (int i = SolarSystemFactory::Sun; i <= SolarSystemFactory::LastBody;
        ++i) {

--- a/benchmarks/lagrange_equipotentials.cpp
+++ b/benchmarks/lagrange_equipotentials.cpp
@@ -28,8 +28,6 @@ using namespace principia::physics::_solar_system;
 using namespace principia::quantities::_si;
 using namespace principia::testing_utilities::_solar_system_factory;
 
-constexpr std::int64_t number_of_days = 30;
-
 using Barycentric = Frame<struct BarycentricTag, Inertial>;
 using World = Frame<struct WorldTag, Arbitrary>;
 
@@ -81,14 +79,12 @@ BENCHMARK_F(LagrangeEquipotentialsBenchmark, EarthMoon)(
       *ephemeris_, SolarSystemFactory::name(SolarSystemFactory::Moon));
 
   for (auto _ : state) {
-    for (int j = 0; j < number_of_days; ++j) {
-      auto const equipotentials =
-          LagrangeEquipotentials<Barycentric, World>(ephemeris_)
-              .ComputeLines({.primaries = {earth},
-                             .secondaries = {moon},
-                             .time = t0_ + j * Day});
-      CHECK_OK(equipotentials.status());
-    }
+    auto const equipotentials =
+        LagrangeEquipotentials<Barycentric, World>(ephemeris_)
+            .ComputeLines({.primaries = {earth},
+                           .secondaries = {moon},
+                           .time = t0_});
+    CHECK_OK(equipotentials.status());
   }
 }
 
@@ -115,13 +111,11 @@ BENCHMARK_F(LagrangeEquipotentialsBenchmark, SunNeptune)(
   std::vector<not_null<MassiveBody const*>> primaries;
 
   for (auto _ : state) {
-    for (int j = 0; j < number_of_days; ++j) {
-      parameters.time = t0_ + j * Day;
-      auto const equipotentials =
-          LagrangeEquipotentials<Barycentric, World>(ephemeris_)
-              .ComputeLines(parameters);
-      CHECK_OK(equipotentials.status());
-    }
+    parameters.time = t0_;
+    auto const equipotentials =
+        LagrangeEquipotentials<Barycentric, World>(ephemeris_)
+            .ComputeLines(parameters);
+    CHECK_OK(equipotentials.status());
   }
 }
 


### PR DESCRIPTION
```
2023-06-05T16:53:16+02:00
Running C:\Users\robin\Projects\mockingbirdnest\Principia\Release\x64\benchmarks.exe
Run on (12 X 2688 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
LagrangeEquipotentialsBenchmark/EarthMoon  17350231900 ns   9843750000 ns            1
LagrangeEquipotentialsBenchmark/SunNeptune 519124848300 ns   190312500000 ns            1
```