### PR TITLE
Cache the derivatives of the barycentres

### DIFF
--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -99,10 +99,10 @@ class BarycentricRotatingReferenceFrame
 
   struct CachedDerivatives {
     Derivatives<Position<InertialFrame>, Instant, 4> derivatives;
-    std::array<Instant, 4> times = {Instant{} + NaN<Time>,
-                                    Instant{} + NaN<Time>,
-                                    Instant{} + NaN<Time>,
-                                    Instant{} + NaN<Time>};
+    std::array<Instant, 4> times = {Instant() + NaN<Time>,
+                                    Instant() + NaN<Time>,
+                                    Instant() + NaN<Time>,
+                                    Instant() + NaN<Time>};
   };
 
   template<

--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -108,11 +108,10 @@ class BarycentricRotatingReferenceFrame
   template<
       int degree,
       std::vector<not_null<MassiveBody const*>> const
-          BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies,
-      CachedDerivatives
-          BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*cache>
+          BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
   Derivative<Position<InertialFrame>, Instant, degree> BarycentreDerivative(
-      Instant const& t) const;
+      Instant const& t,
+      CachedDerivatives& cache) const;
 
   Vector<Acceleration, InertialFrame> GravitationalAcceleration(
       Instant const& t,

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -105,11 +105,9 @@ template<int degree>
 Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::PrimaryDerivative(
     Instant const& t) const {
-  return BarycentreDerivative<
-      degree,
-      &BarycentricRotatingReferenceFrame::primaries_,
-      &BarycentricRotatingReferenceFrame::last_evaluated_primary_derivatives_>(
-      t);
+  return BarycentreDerivative<degree,
+                              &BarycentricRotatingReferenceFrame::primaries_>(
+      t, last_evaluated_primary_derivatives_);
 }
 
 template<typename InertialFrame, typename ThisFrame>
@@ -118,9 +116,8 @@ Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
     SecondaryDerivative(Instant const& t) const {
   return BarycentreDerivative<degree,
-                              &BarycentricRotatingReferenceFrame::secondaries_,
-                              &BarycentricRotatingReferenceFrame::
-                                  last_evaluated_secondary_derivatives_>(t);
+                              &BarycentricRotatingReferenceFrame::secondaries_>(
+      t, last_evaluated_secondary_derivatives_);
 }
 
 template<typename InertialFrame, typename ThisFrame>
@@ -189,15 +186,12 @@ template<typename InertialFrame, typename ThisFrame>
 template<
     int degree,
     std::vector<not_null<MassiveBody const*>> const
-        BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies,
-    typename BarycentricRotatingReferenceFrame<InertialFrame,
-                                               ThisFrame>::CachedDerivatives
-        BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*cache>
+        BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
 Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
-    BarycentreDerivative(Instant const& t) const {
-  auto& cache_key = this->*cache.times[degree];
-  auto& cached = std::get<degree>(this->*cache.derivatives);
+    BarycentreDerivative(Instant const& t, CachedDerivatives& cache) const {
+  Instant& cache_key = cache.times[degree];
+  auto& cached = std::get<degree>(cache.derivatives);
   if (cache_key == t) {
     return cached;
   }

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -105,6 +105,7 @@ template<int degree>
 Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::PrimaryDerivative(
     Instant const& t) const {
+  absl::MutexLock l(&lock_);
   return BarycentreDerivative<degree,
                               &BarycentricRotatingReferenceFrame::primaries_>(
       t, last_evaluated_primary_derivatives_);
@@ -115,6 +116,7 @@ template<int degree>
 Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
     SecondaryDerivative(Instant const& t) const {
+  absl::MutexLock l(&lock_);
   return BarycentreDerivative<degree,
                               &BarycentricRotatingReferenceFrame::secondaries_>(
       t, last_evaluated_secondary_derivatives_);

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -194,31 +194,31 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
     BarycentreDerivative(Instant const& t, CachedDerivatives& cache) const {
   Instant& cache_key = cache.times[degree];
   auto& cached = std::get<degree>(cache.derivatives);
-  if (cache_key == t) {
-    return cached;
-  }
-  BarycentreCalculator<Derivative<Position<InertialFrame>, Instant, degree>,
-                       GravitationalParameter>
-      result;
-  for (not_null const body : this->*bodies) {
-    if constexpr (degree == 0) {
-      result.Add(ephemeris_->trajectory(body)->EvaluatePosition(t),
-                 body->gravitational_parameter());
-    } else if constexpr (degree == 1) {
-      result.Add(ephemeris_->trajectory(body)->EvaluateVelocity(t),
-                 body->gravitational_parameter());
-    } else if constexpr (degree == 2) {
-      result.Add(
-          ephemeris_->ComputeGravitationalAccelerationOnMassiveBody(body, t),
-          body->gravitational_parameter());
-    } else {
-      static_assert(degree == 3);
-      result.Add(ephemeris_->ComputeGravitationalJerkOnMassiveBody(body, t),
-                 body->gravitational_parameter());
+  if (cache_key != t) {
+    BarycentreCalculator<Derivative<Position<InertialFrame>, Instant, degree>,
+                         GravitationalParameter>
+        result;
+    for (not_null const body : this->*bodies) {
+      if constexpr (degree == 0) {
+        result.Add(ephemeris_->trajectory(body)->EvaluatePosition(t),
+                   body->gravitational_parameter());
+      } else if constexpr (degree == 1) {
+        result.Add(ephemeris_->trajectory(body)->EvaluateVelocity(t),
+                   body->gravitational_parameter());
+      } else if constexpr (degree == 2) {
+        result.Add(
+            ephemeris_->ComputeGravitationalAccelerationOnMassiveBody(body, t),
+            body->gravitational_parameter());
+      } else {
+        static_assert(degree == 3);
+        result.Add(ephemeris_->ComputeGravitationalJerkOnMassiveBody(body, t),
+                   body->gravitational_parameter());
+      }
     }
+    cache_key = t;
+    cached = result.Get();
   }
-  cache_key = t;
-  return cached = result.Get();
+  return cached;
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -187,7 +187,7 @@ template<
     int degree,
     std::vector<not_null<MassiveBody const*>> const
         BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
-inline Derivative<Position<InertialFrame>, Instant, degree>
+Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
     BarycentreDerivative(Instant const& t) const {
   BarycentreCalculator<Derivative<Position<InertialFrame>, Instant, degree>,


### PR DESCRIPTION
Before:
```
2023-06-08T20:52:51+02:00
Running C:\Users\robin\Projects\mockingbirdnest\Principia\Release\x64\benchmarks.exe
Run on (12 X 2688 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
LagrangeEquipotentialsBenchmark/EarthMoon   399438500 ns    328125000 ns            2
LagrangeEquipotentialsBenchmark/SunNeptune 8773415400 ns   5171875000 ns            1
```

After:
```
2023-06-08T20:50:40+02:00
Running C:\Users\robin\Projects\mockingbirdnest\Principia\Release\x64\benchmarks.exe
Run on (12 X 2688 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1280 KiB (x6)
  L3 Unified 12288 KiB (x1)
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
LagrangeEquipotentialsBenchmark/EarthMoon    68671460 ns     50000000 ns           10
LagrangeEquipotentialsBenchmark/SunNeptune   82250800 ns     56250000 ns           10
```

399438500/68671460 = about 6 times faster for EarthMoo,
8773415400/82250800 = about 100 times faster for SunNeptune.