### PR TITLE
Additional interactions for manœuvre markers

### DIFF
--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -71,6 +71,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   internal void RequestEditorFocus(int i) {
     requested_editor_focus_index_ = i;
   }
+
   protected override string Title =>
       L10N.CacheFormat("#Principia_FlightPlan_Title");
 
@@ -370,7 +371,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           RenderUpcomingEvents();
         }
 
-      // Fixme(al2me6): this current event check prevents the window from being
+      // TODO(al2me6): This current event check prevents the window from being
       // zero-sized for a single frame. How it does this is unclear to me and
       // should be investigated.
       if (UnityEngine.Event.current.type == UnityEngine.EventType.Repaint &&

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -68,6 +68,9 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
     }
   }
 
+  internal void RequestEditorFocus(int i) {
+    requested_editor_focus_index_ = i;
+  }
   protected override string Title =>
       L10N.CacheFormat("#Principia_FlightPlan_Title");
 
@@ -366,6 +369,18 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
         if (burn_editors_.Count > 0) {
           RenderUpcomingEvents();
         }
+
+      // Fixme(al2me6): this current event check prevents the window from being
+      // zero-sized for a single frame. How it does this is unclear to me and
+      // should be investigated.
+      if (UnityEngine.Event.current.type == UnityEngine.EventType.Repaint &&
+          requested_editor_focus_index_ is int requested_focus) {
+        requested_editor_focus_index_ = null;
+        for (int i = 0; i < burn_editors_.Count; ++i) {
+          burn_editors_[i].minimized = requested_focus != i;
+        }
+        Shrink();
+      }
 
         // Compute the final times for each manœuvre before displaying them.
         var final_times = new List<double>();
@@ -777,6 +792,8 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   private Status status_ = Status.OK;
   private int? first_error_manœuvre_;  // May exceed the number of manœuvres.
   private bool message_was_displayed_ = false;
+
+  private int? requested_editor_focus_index_;
 
   private const double log10_time_lower_rate = 0.0;
   private const double log10_time_upper_rate = 7.0;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -344,7 +344,10 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
     }
 
     map_node_pool_ = new MapNodePool(
-        show_unpinned: () => main_window_.show_unpinned_markers);
+        visibility_modifiers: () => new MapNodePool.VisibilityModifiers(
+            show_unpinned: main_window_.show_unpinned_markers,
+            can_hover: !ManœuvreMarker.has_interacting_marker)
+        );
     flight_planner_ = new FlightPlanner(this, PredictedVessel);
     orbit_analyser_ = new CurrentOrbitAnalyser(this, PredictedVessel);
     plotting_frame_selector_ =

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -2213,8 +2213,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                           manœuvre_index);
                   if (number_of_rendered_manœuvres
                       >= manœuvre_marker_pool_.Count) {
-                    manœuvre_marker_pool_.
-                        Add(ManœuvreMarker.Create(flight_planner_));
+                    manœuvre_marker_pool_.Add(
+                        ManœuvreMarker.Create(main_window_, flight_planner_));
                   }
                   var initial_plotted_velocity =
                       (Vector3d)plugin_.FlightPlanGetManoeuvreInitialPlottedVelocity(

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -2213,16 +2213,14 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
                           manœuvre_index);
                   if (number_of_rendered_manœuvres
                       >= manœuvre_marker_pool_.Count) {
-                    var marker = new UnityEngine.GameObject("manœuvre_marker");
                     manœuvre_marker_pool_.
-                        Add(marker.AddComponent<ManœuvreMarker>());
+                        Add(ManœuvreMarker.Create(flight_planner_));
                   }
                   var initial_plotted_velocity =
                       (Vector3d)plugin_.FlightPlanGetManoeuvreInitialPlottedVelocity(
                           main_vessel_guid, manœuvre_index);
                   manœuvre_marker_pool_[number_of_rendered_manœuvres].
                       Render(manœuvre_index,
-                             flight_planner_,
                              world_position: position_at_start,
                              initial_plotted_velocity,
                              trihedron);

--- a/ksp_plugin_adapter/manœuvre_marker.cs
+++ b/ksp_plugin_adapter/manœuvre_marker.cs
@@ -1,9 +1,16 @@
-﻿using System.Collections;
+using System.Collections;
 
 namespace principia {
 namespace ksp_plugin_adapter {
 
 internal class ManœuvreMarker : UnityEngine.MonoBehaviour {
+  public static ManœuvreMarker Create(FlightPlanner flight_planner) {
+    var game_object = new UnityEngine.GameObject("manœuvre_marker");
+    var marker = game_object.AddComponent<ManœuvreMarker>();
+    marker.flight_planner_ = flight_planner;
+    return marker;
+  }
+
   public bool is_hovered { get; private set; } = false;
   public bool is_dragged { get; private set; } = false;
   public bool is_pinned { get; private set; } = false;
@@ -53,13 +60,10 @@ internal class ManœuvreMarker : UnityEngine.MonoBehaviour {
 
   // Call on each frame (at or later than |Update|) to set the state of the marker.
   public void Render(int index,
-                     FlightPlanner flight_planner,
                      Vector3d world_position,
                      Vector3d initial_plotted_velocity,
                      NavigationManoeuvreFrenetTrihedron trihedron) {
     index_ = index;
-    flight_planner_ = flight_planner;
-
     initial_plotted_velocity_ = initial_plotted_velocity;
 
     var screen_position = ScaledSpace.LocalToScaledSpace(world_position);
@@ -282,6 +286,8 @@ internal class ManœuvreMarker : UnityEngine.MonoBehaviour {
     return (position, visible);
   }
 
+  private FlightPlanner flight_planner_;
+
   private UnityEngine.GameObject base_;
   private UnityEngine.GameObject tangent_;
   private UnityEngine.GameObject normal_;
@@ -297,7 +303,6 @@ internal class ManœuvreMarker : UnityEngine.MonoBehaviour {
 
   private Vector3d initial_plotted_velocity_;
   private int index_;
-  private FlightPlanner flight_planner_;
 
   // In scaled space units:
   private const float collider_radius = 0.75f;


### PR DESCRIPTION
As alluded to in #3692, this PR adds the following functionalities to manœuvre markers:

* A pinnable hover tooltip is displayed when the cursor is hovered over the marker, emulating stock node markers. When manœuvre markers overlap node markers, manœuvre markers will take precedence for hovering. However, the stock node markers have slightly larger colliders, so it remains possible to interact with node markers that are otherwise obscured.
* When a marker is single-clicked, the flight planner will open to the corresponding burn editor.

A new localization string has been introduced, and requires translations for fr and ru.