### PR TITLE
Fix the diurnal build

### DIFF
--- a/physics/lagrange_equipotentials_test.cpp
+++ b/physics/lagrange_equipotentials_test.cpp
@@ -201,7 +201,7 @@ TEST_F(LagrangeEquipotentialsTest,
     std::vector<Position<World>> arg_maximorum;
     for (auto const& [maximum, arg_maximi] : equipotentials->maxima) {
       EXPECT_THAT((arg_maximi - World::origin).Norm(),
-                  AllOf(Gt(0.981 * Metre), Lt(1.016 * Metre)));
+                  AllOf(Gt(0.980 * Metre), Lt(1.016 * Metre)));
       maxima.push_back(maximum);
       arg_maximorum.push_back(arg_maximi);
     }


### PR DESCRIPTION
The theory is that the change is due to 7ded8d73dc1ac6d4e389de0064a53b7b538a8c64: in the case where we cannot meet the strong Wolfe condition, it seems logical to return our latest estimate, but it may sometimes be a bit worst than the previous one.  (Of course, the tests don't tell us about cases where it would be better.)