### PR TITLE
Optimize the flight plan optimizer

### DIFF
--- a/ksp_plugin/flight_plan_optimizer.cpp
+++ b/ksp_plugin/flight_plan_optimizer.cpp
@@ -22,8 +22,10 @@ constexpr Acceleration time_homogeneization_factor = 1 * Metre / Pow<2>(Second);
 constexpr int max_apsides = 20;
 
 FlightPlanOptimizer::FlightPlanOptimizer(
-    not_null<FlightPlan*> const flight_plan)
-    : flight_plan_(flight_plan) {}
+    not_null<FlightPlan*> const flight_plan,
+    ProgressCallback progress_callback)
+    : flight_plan_(flight_plan),
+      progress_callback_(std::move(progress_callback)) {}
 
 absl::Status FlightPlanOptimizer::Optimize(int const index,
                                            Celestial const& celestial,
@@ -49,7 +51,6 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
     HomogeneousArgument const& homogeneous_argument,
     Difference<HomogeneousArgument> const&
         direction_homogeneous_argument) {
-LOG(ERROR)<<"Gateaux";
     return EvaluateGateauxDerivativeOfDistanceToCelestialWithReplacement(
         celestial,
         homogeneous_argument,
@@ -105,7 +106,6 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
           HomogeneousArgument const& homogeneous_argument,
           Difference<HomogeneousArgument> const&
               direction_homogeneous_argument) {
-LOG(ERROR)<<"Gateaux";
     auto const actual_distance = EvaluateDistanceToCelestialWithReplacement(
         celestial, homogeneous_argument, manœuvre, index, *flight_plan_, cache);
     auto const actual_gateaux_derivative =
@@ -170,6 +170,9 @@ Length FlightPlanOptimizer::EvaluateDistanceToCelestial(
                         (degrees_of_freedom.position() -
                          celestial_trajectory.EvaluatePosition(time))
                             .Norm());
+  }
+  if (progress_callback_ != nullptr) {
+    progress_callback_(flight_plan);
   }
   return distance;
 }

--- a/ksp_plugin/flight_plan_optimizer.hpp
+++ b/ksp_plugin/flight_plan_optimizer.hpp
@@ -33,9 +33,14 @@ using namespace principia::quantities::_quantities;
 // A class to optimize a flight to go through or near a celestial.
 class FlightPlanOptimizer {
  public:
+  // Called throughout the optimization to let the client know the tentative
+  // state of the flight plan.
+  using ProgressCallback = std::function<void(FlightPlan const&)>;
+
   // Constructs an optimizer for |flight_plan|.  |flight_plan| must outlive this
   // object.
-  explicit FlightPlanOptimizer(not_null<FlightPlan*> flight_plan);
+  FlightPlanOptimizer(not_null<FlightPlan*> flight_plan,
+                      ProgressCallback progress_callback = nullptr);
 
   // Optimizes the manœuvre at the given |index| to go through (or close to)
   // |celestial|.  The |Δv_tolerance| is used for the initial choice of the step
@@ -82,13 +87,13 @@ class FlightPlanOptimizer {
 
   // Compute the closest periapsis of the |flight_plan| with respect to the
   // |celestial|, occurring after |begin_time|.
-  static Length EvaluateDistanceToCelestial(Celestial const& celestial,
-                                            Instant const& begin_time,
-                                            FlightPlan const& flight_plan);
+  Length EvaluateDistanceToCelestial(Celestial const& celestial,
+                                     Instant const& begin_time,
+                                     FlightPlan const& flight_plan);
 
   // Replaces the manœuvre at the given |index| based on the |argument|, and
   // computes the closest periapis.  Leaves the |flight_plan| unchanged.
-  static Length EvaluateDistanceToCelestialWithReplacement(
+  Length EvaluateDistanceToCelestialWithReplacement(
       Celestial const& celestial,
       HomogeneousArgument const& homogeneous_argument,
       NavigationManœuvre const& manœuvre,
@@ -99,7 +104,7 @@ class FlightPlanOptimizer {
   // Replaces the manœuvre at the given |index| based on the |argument|, and
   // computes the gradient of the closest periapis with respect to the
   // |argument|.  Leaves the |flight_plan| unchanged.
-  static LengthGradient Evaluate𝛁DistanceToCelestialWithReplacement(
+  LengthGradient Evaluate𝛁DistanceToCelestialWithReplacement(
       Celestial const& celestial,
       HomogeneousArgument const& homogeneous_argument,
       NavigationManœuvre const& manœuvre,
@@ -107,7 +112,7 @@ class FlightPlanOptimizer {
       FlightPlan& flight_plan,
       EvaluationCache& cache);
 
-  static Length EvaluateGateauxDerivativeOfDistanceToCelestialWithReplacement(
+  Length EvaluateGateauxDerivativeOfDistanceToCelestialWithReplacement(
       Celestial const& celestial,
       HomogeneousArgument const& homogeneous_argument,
       Difference<HomogeneousArgument> const& direction_homogeneous_argument,
@@ -124,6 +129,7 @@ class FlightPlanOptimizer {
 
   static constexpr Argument start_argument_{};
   not_null<FlightPlan*> const flight_plan_;
+  ProgressCallback const progress_callback_;
 
   friend bool operator==(Argument const& left, Argument const& right);
   template<typename H>

--- a/ksp_plugin/flight_plan_optimizer.hpp
+++ b/ksp_plugin/flight_plan_optimizer.hpp
@@ -62,21 +62,16 @@ class FlightPlanOptimizer {
   struct Argument {
     Time Δinitial_time;
     Velocity<Frenet<Navigation>> ΔΔv;
-
-    friend bool operator==(Argument const& left, Argument const& right);
-
-    template<typename H>
-    friend H AbslHashValue(H h, Argument const& argument);
   };
+
+  // The data structure passed to the gradient descent algorithm.
+  using HomogeneousArgument = FixedVector<Speed, 4>;
 
   // Function evaluations are very expensive, as they require integrating a
   // flight plan and finding periapsides.  We don't want do to them
   // unnecessarily.  You generally don't want to hash floats, but it's a case
   // where it's kosher.
-  using EvaluationCache = absl::flat_hash_map<Argument, Length>;
-
-  // The data structure passed to the gradient descent algorithm.
-  using HomogeneousArgument = FixedVector<Speed, 4>;
+  using EvaluationCache = absl::flat_hash_map<HomogeneousArgument, Length>;
 
   using LengthField = Field<Length, HomogeneousArgument>;
   using LengthGradient = Gradient<Length, HomogeneousArgument>;
@@ -95,7 +90,7 @@ class FlightPlanOptimizer {
   // computes the closest periapis.  Leaves the |flight_plan| unchanged.
   static Length EvaluateDistanceToCelestialWithReplacement(
       Celestial const& celestial,
-      Argument const& argument,
+      HomogeneousArgument const& homogeneous_argument,
       NavigationManœuvre const& manœuvre,
       int index,
       FlightPlan& flight_plan,
@@ -106,16 +101,16 @@ class FlightPlanOptimizer {
   // |argument|.  Leaves the |flight_plan| unchanged.
   static LengthGradient Evaluate𝛁DistanceToCelestialWithReplacement(
       Celestial const& celestial,
-      Argument const& argument,
+      HomogeneousArgument const& homogeneous_argument,
       NavigationManœuvre const& manœuvre,
       int index,
       FlightPlan& flight_plan,
       EvaluationCache& cache);
 
-  static LengthGradient EvaluateDirectional𝛁DistanceToCelestialWithReplacement(
+  static Length EvaluateGateauxDerivativeOfDistanceToCelestialWithReplacement(
       Celestial const& celestial,
-      Argument const& argument,
-      Difference<Argument> const& direction,
+      HomogeneousArgument const& homogeneous_argument,
+      Difference<HomogeneousArgument> const& direction_homogeneous_argument,
       NavigationManœuvre const& manœuvre,
       int index,
       FlightPlan& flight_plan,

--- a/ksp_plugin/flight_plan_optimizer.hpp
+++ b/ksp_plugin/flight_plan_optimizer.hpp
@@ -112,6 +112,15 @@ class FlightPlanOptimizer {
       FlightPlan& flight_plan,
       EvaluationCache& cache);
 
+  static LengthGradient EvaluateDirectional𝛁DistanceToCelestialWithReplacement(
+      Celestial const& celestial,
+      Argument const& argument,
+      Difference<Argument> const& direction,
+      NavigationManœuvre const& manœuvre,
+      int index,
+      FlightPlan& flight_plan,
+      EvaluationCache& cache);
+
   // Replaces the burn at the given |index| based on the |argument|.
   static absl::Status ReplaceBurn(Argument const& argument,
                                   NavigationManœuvre const& manœuvre,

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -136,7 +136,10 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
   EXPECT_THAT(flyby_distance, IsNear(58591.4_(1) * Kilo(Metre)));
 
-  FlightPlanOptimizer optimizer(&flight_plan);
+  std::int64_t number_of_evaluations = 0;
+  FlightPlanOptimizer optimizer(
+      &flight_plan,
+      [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   // In the code below we cannot compute flybys because the flight plan
   // basically goes through the centre of the Moon.
@@ -153,6 +156,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan.GetManœuvre(5).Δv()).Norm(),
       IsNear(1.053_(1) * Metre / Second));
+  EXPECT_EQ(88, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre5.burn(), /*index=*/5));
 
@@ -166,6 +171,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
             flight_plan.GetManœuvre(6).initial_time());
   EXPECT_THAT((manœuvre6.Δv() - flight_plan.GetManœuvre(6).Δv()).Norm(),
               IsNear(1.279_(1) * Metre / Second));
+  EXPECT_EQ(57, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre6.burn(), /*index=*/6));
 
@@ -181,6 +188,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan.GetManœuvre(7).Δv()).Norm(),
       IsNear(62.3_(1) * Metre / Second));
+  EXPECT_EQ(47, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre7.burn(), /*index=*/7));
 }
@@ -222,7 +231,10 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
   EXPECT_THAT(flyby_distance, IsNear(58591.4_(1) * Kilo(Metre)));
 
-  FlightPlanOptimizer optimizer(&flight_plan);
+  std::int64_t number_of_evaluations = 0;
+  FlightPlanOptimizer optimizer(
+      &flight_plan,
+      [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
   auto const manœuvre5 = flight_plan.GetManœuvre(5);
@@ -239,6 +251,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:24:00"_DateTime));
   EXPECT_THAT(flyby_distance, IsNear(2255.3_(1) * Kilo(Metre)));
+  EXPECT_EQ(79, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre5.burn(), /*index=*/5));
 
@@ -256,6 +270,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:16:41"_DateTime));
   EXPECT_THAT(flyby_distance, IsNear(2001.4_(1) * Kilo(Metre)));
+  EXPECT_EQ(72, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre6.burn(), /*index=*/6));
 
@@ -274,6 +290,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:15:12"_DateTime));
   EXPECT_THAT(flyby_distance, IsNear(1999.6_(1) * Kilo(Metre)));
+  EXPECT_EQ(74, number_of_evaluations);
+  number_of_evaluations = 0;
 
   CHECK_OK(flight_plan.Replace(manœuvre7.burn(), /*index=*/7));
 }

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -149,10 +149,10 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan.number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan.GetManœuvre(5).initial_time(),
-      IsNear(-10.3_(1) * Micro(Second)));
+      IsNear(7.4_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan.GetManœuvre(5).Δv()).Norm(),
-      IsNear(1.09_(1) * Metre / Second));
+      IsNear(1.053_(1) * Metre / Second));
 
   CHECK_OK(flight_plan.Replace(manœuvre5.burn(), /*index=*/5));
 
@@ -165,7 +165,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(manœuvre6.initial_time(),
             flight_plan.GetManœuvre(6).initial_time());
   EXPECT_THAT((manœuvre6.Δv() - flight_plan.GetManœuvre(6).Δv()).Norm(),
-              IsNear(1.29_(1) * Metre / Second));
+              IsNear(1.279_(1) * Metre / Second));
 
   CHECK_OK(flight_plan.Replace(manœuvre6.burn(), /*index=*/6));
 
@@ -231,14 +231,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan.GetManœuvre(5).initial_time(),
-      IsNear(-1.3_(1) * Micro(Second)));
+      IsNear(34.2_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan.GetManœuvre(5).Δv()).Norm(),
-      IsNear(1.107_(1) * Metre / Second));
+      IsNear(1.116_(1) * Metre / Second));
 
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:24:04"_DateTime));
-  EXPECT_THAT(flyby_distance, IsNear(2216.0_(1) * Kilo(Metre)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:24:00"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2255.3_(1) * Kilo(Metre)));
 
   CHECK_OK(flight_plan.Replace(manœuvre5.burn(), /*index=*/5));
 
@@ -249,13 +249,13 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan.GetManœuvre(6).initial_time(),
-      IsNear(0.12_(1) * Micro(Second)));
+      IsNear(0.954_(1) * Micro(Second)));
   EXPECT_THAT((manœuvre6.Δv() - flight_plan.GetManœuvre(6).Δv()).Norm(),
-              IsNear(1.331_(1) * Metre / Second));
+              IsNear(1.312_(1) * Metre / Second));
 
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:16:08"_DateTime));
-  EXPECT_THAT(flyby_distance, IsNear(2001.7_(1) * Kilo(Metre)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:16:41"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2001.4_(1) * Kilo(Metre)));
 
   CHECK_OK(flight_plan.Replace(manœuvre6.burn(), /*index=*/6));
 
@@ -266,14 +266,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan.GetManœuvre(7).initial_time(),
-      IsNear(12.5_(1) * Milli(Second)));
+      IsNear(3.3_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan.GetManœuvre(7).Δv()).Norm(),
-      IsNear(61.2_(1) * Metre / Second));
+      IsNear(62.3_(1) * Metre / Second));
 
   ComputeFlyby(flight_plan, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:14:49"_DateTime));
-  EXPECT_THAT(flyby_distance, IsNear(2000.0_(1) * Kilo(Metre)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:15:12"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(1999.6_(1) * Kilo(Metre)));
 
   CHECK_OK(flight_plan.Replace(manœuvre7.burn(), /*index=*/7));
 }

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -6,6 +6,7 @@
 #include "base/tags.hpp"
 #include "numerics/transposed_view.hpp"
 #include "quantities/named_quantities.hpp"
+#include "quantities/si.hpp"
 
 namespace principia {
 namespace numerics {
@@ -15,6 +16,7 @@ namespace internal {
 using namespace principia::base::_tags;
 using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_named_quantities;
+using namespace principia::quantities::_si;
 
 template<typename Scalar, int rows, int columns>
 class FixedMatrix;
@@ -44,6 +46,14 @@ class FixedVector final {
 
   bool operator==(FixedVector const& right) const;
   bool operator!=(FixedVector const& right) const;
+
+  template<typename H>
+  friend H AbslHashValue(H h, FixedVector const& vector) {
+    for (int index = 0; index < size_; ++index) {
+      h = H::combine(std::move(h), vector.data_[index] / si::Unit<Scalar>);
+    }
+    return h;
+  }
 
  private:
   std::array<Scalar, size_> data_;

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -111,6 +111,10 @@ bool FixedVector<Scalar, size_>::operator!=(FixedVector const& right) const {
   return data_ != right.data_;
 }
 
+template<typename H, typename Scalar, int size_>
+H AbslHashValue(H h, FixedVector<Scalar, size_> const& vector) {
+}
+
 template<typename Scalar, int rows_, int columns_>
 constexpr FixedMatrix<Scalar, rows_, columns_>::FixedMatrix()
     : data_{} {}

--- a/t.txt
+++ b/t.txt
@@ -1,1 +1,0 @@
-[       OK ] FlightPlanOptimizerTest.DISABLED_GrazeTheMoon (497798 ms)

--- a/t.txt
+++ b/t.txt
@@ -1,0 +1,1 @@
+[       OK ] FlightPlanOptimizerTest.DISABLED_GrazeTheMoon (497798 ms)


### PR DESCRIPTION
1. Use a cache to avoid evaluating the flight plan multiple times with the same burn.
2. Use the Gateaux derivative instead of computing the full gradient when possible (i.e., in the line search).  This requires changing a bit the use of the gradient descent to pass `HomogeneousArgument`s instead of `Argument`s.
3. Add a callback executed when a flight plan is evaluated and use it to count the number of evaluations of the flight plan.

Overall, the number of evaluations is reduced by a factor of 2-2.5, although in some cases the use of the Gateaux derivative can increase the cost a bit:
|Test|Manœuvre #|Options|Evaluations|
|---|---|---|---|
|ReachTheMoon|5|Original|164|
|||Cache|102|
|||Cache+Gateaux|88|
||6|Original|130|
|||Cache|89|
|||Cache+Gateaux|57|
||7|Original|127|
|||Cache|101|
|||Cache+Gateaux|47|
|GrazeTheMoon|5|Original|160|
|||Cache|70|
|||Cache+Gateaux|79|
||6|Original|132|
|||Cache|70|
|||Cache+Gateaux|72|
||7|Original|174|
|||Cache|95|
|||Cache+Gateaux|74|