### PR TITLE
Add support for disabling flight plan orbit analysis

### DIFF
--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -117,6 +117,10 @@ class FlightPlan {
   GetSegment(int index) const;
   virtual DiscreteTrajectory<Barycentric> const& GetAllSegments() const;
 
+  // Orbit analysis is enabled at construction, and may be enabled/disabled
+  // dynamically.
+  void EnableAnalysis(bool enabled);
+
   // |coast_index| must be in [0, number_of_manœuvres()].
   virtual OrbitAnalyser::Analysis* analysis(int coast_index);
   double progress_of_analysis(int coast_index) const;
@@ -218,7 +222,12 @@ class FlightPlan {
   absl::Status anomalous_status_;
 
   std::vector<NavigationManœuvre> manœuvres_;
+
+  // The coast analysers always exist for each coast, but they may be idle if
+  // analysis is disabled.
   std::vector<not_null<std::unique_ptr<OrbitAnalyser>>> coast_analysers_;
+  bool analysis_is_enabled_ = true;
+
   not_null<Ephemeris<Barycentric>*> ephemeris_;
   Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters_;
   Ephemeris<Barycentric>::GeneralizedAdaptiveStepParameters

--- a/ksp_plugin/flight_plan_optimizer.cpp
+++ b/ksp_plugin/flight_plan_optimizer.cpp
@@ -30,6 +30,10 @@ FlightPlanOptimizer::FlightPlanOptimizer(
 absl::Status FlightPlanOptimizer::Optimize(int const index,
                                            Celestial const& celestial,
                                            Speed const& Δv_tolerance) {
+  // We are going to repeatedly tweak the |flight_plan_|, no point in running
+  // the orbit analysers.
+  flight_plan_->EnableAnalysis(/*enabled=*/false);
+
   // The following is a copy, and is not affected by changes to the
   // |flight_plan_|.
   NavigationManœuvre const manœuvre = flight_plan_->GetManœuvre(index);
@@ -69,9 +73,12 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
           gateaux_derivative_f,
           Δv_tolerance);
   if (solution.has_value()) {
-    return ReplaceBurn(
+    auto const replace_status = ReplaceBurn(
         Dehomogeneize(solution.value()), manœuvre, index, *flight_plan_);
+    flight_plan_->EnableAnalysis(/*enabled=*/true);
+    return replace_status;
   } else {
+    flight_plan_->EnableAnalysis(/*enabled=*/true);
     return absl::NotFoundError("No better burn");
   }
 }
@@ -80,6 +87,10 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
                                            Celestial const& celestial,
                                            Length const& target_distance,
                                            Speed const& Δv_tolerance) {
+  // We are going to repeatedly tweak the |flight_plan_|, no point in running
+  // the orbit analysers.
+  flight_plan_->EnableAnalysis(/*enabled=*/false);
+
   // The following is a copy, and is not affected by changes to the
   // |flight_plan_|.
   NavigationManœuvre const manœuvre = flight_plan_->GetManœuvre(index);
@@ -123,9 +134,12 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
           gateaux_derivative_f,
           Δv_tolerance);
   if (solution.has_value()) {
-    return ReplaceBurn(
+    auto const replace_status = ReplaceBurn(
         Dehomogeneize(solution.value()), manœuvre, index, *flight_plan_);
+    flight_plan_->EnableAnalysis(/*enabled=*/true);
+    return replace_status;
   } else {
+    flight_plan_->EnableAnalysis(/*enabled=*/true);
     return absl::NotFoundError("No better burn");
   }
 }


### PR DESCRIPTION
Disable orbit analysis during flight plan optimization.  It makes the test 2.5× faster.

#3681.