### PR TITLE
Clang does not like non-type template parameters of a floating-point type

### DIFF
--- a/numerics/angle_reduction.hpp
+++ b/numerics/angle_reduction.hpp
@@ -11,6 +11,16 @@ namespace internal {
 using namespace principia::numerics::_double_precision;
 using namespace principia::quantities::_quantities;
 
+// Clang up to version 17 does not support non-type template parameters that are
+// floats.  So we wrap the float in a silly struct instead.
+#if PRINCIPIA_COMPILER_CLANG && __clang_major__ <= 17
+struct DoubleWrapper {
+  constexpr DoubleWrapper(double d) {}
+};
+#else
+using DoubleWrapper = double;
+#endif
+
 // Do not export these declarations, they are only exposed for tests.
 template<typename Angle>
 constexpr Angle one_π;
@@ -22,15 +32,15 @@ constexpr Angle two_π;
 // more, the reduction is modulo 2π.  If it covers only π, the reduction is
 // modulo π.
 
-template<double fractional_part_lower_bound,
-         double fractional_part_upper_bound,
+template<DoubleWrapper fractional_part_lower_bound,
+         DoubleWrapper fractional_part_upper_bound,
          typename Angle>
 void ReduceAngle(Angle const& θ,
                  Angle& fractional_part,
                  std::int64_t& integer_part);
 
-template<double fractional_part_lower_bound,
-         double fractional_part_upper_bound,
+template<DoubleWrapper fractional_part_lower_bound,
+         DoubleWrapper fractional_part_upper_bound,
          typename Angle>
 Angle ReduceAngle(Angle const& θ);
 

--- a/numerics/angle_reduction_body.hpp
+++ b/numerics/angle_reduction_body.hpp
@@ -49,8 +49,8 @@ inline std::int64_t StaticCastToInt64<DoublePrecision<double>>(
 }
 
 template<typename Angle,
-         double fractional_part_lower_bound,
-         double fractional_part_upper_bound>
+         DoubleWrapper fractional_part_lower_bound,
+         DoubleWrapper fractional_part_upper_bound>
 class AngleReduction;
 
 // TODO(phl): This is extremely imprecise near large multiples of π.  Use a
@@ -122,8 +122,8 @@ class AngleReduction<Angle, -2 * π, 2 * π> {
   }
 };
 
-template<double fractional_part_lower_bound,
-         double fractional_part_upper_bound,
+template<DoubleWrapper fractional_part_lower_bound,
+         DoubleWrapper fractional_part_upper_bound,
          typename Angle>
 void ReduceAngle(Angle const& θ,
                  Angle& fractional_part,
@@ -135,8 +135,8 @@ void ReduceAngle(Angle const& θ,
                                                       integer_part);
 }
 
-template<double fractional_part_lower_bound,
-         double fractional_part_upper_bound,
+template<DoubleWrapper fractional_part_lower_bound,
+         DoubleWrapper fractional_part_upper_bound,
          typename Angle>
 Angle ReduceAngle(Angle const& θ) {
   Angle fractional_part;


### PR DESCRIPTION
Try to work-around the problem.

#3768.