### PR TITLE
Clean up the optimization UI

### DIFF
--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -221,6 +221,16 @@ bool __cdecl principia__FlightPlanExists(
   return m.Return(plugin->GetVessel(vessel_guid)->has_flight_plan());
 }
 
+double __cdecl principia__FlightPlanGetActualFinalTime(
+    Plugin const* const plugin,
+    char const* const vessel_guid) {
+  journal::Method<journal::FlightPlanGetActualFinalTime> m(
+      {plugin, vessel_guid});
+  return m.Return(
+      ToGameTime(*plugin,
+                 GetFlightPlan(*plugin, vessel_guid).actual_final_time()));
+}
+
 FlightPlanAdaptiveStepParameters __cdecl
 principia__FlightPlanGetAdaptiveStepParameters(
     Plugin const* const plugin,
@@ -232,16 +242,6 @@ principia__FlightPlanGetAdaptiveStepParameters(
   return m.Return(ToFlightPlanAdaptiveStepParameters(
                       flight_plan.adaptive_step_parameters(),
                       flight_plan.generalized_adaptive_step_parameters()));
-}
-
-double __cdecl principia__FlightPlanGetActualFinalTime(
-    Plugin const* const plugin,
-    char const* const vessel_guid) {
-  journal::Method<journal::FlightPlanGetActualFinalTime> m(
-      {plugin, vessel_guid});
-  return m.Return(
-      ToGameTime(*plugin,
-                 GetFlightPlan(*plugin, vessel_guid).actual_final_time()));
 }
 
 OrbitAnalysis* __cdecl principia__FlightPlanGetCoastAnalysis(
@@ -408,6 +408,79 @@ int __cdecl principia__FlightPlanNumberOfSegments(
   journal::Method<journal::FlightPlanNumberOfSegments> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
   return m.Return(GetFlightPlan(*plugin, vessel_guid).number_of_segments());
+}
+
+int __cdecl principia__FlightPlanOptimizationDriverInProgress(
+    Plugin const* const plugin,
+    char const* const vessel_guid) {
+  journal::Method<journal::FlightPlanOptimizationDriverInProgress> m(
+      {plugin, vessel_guid});
+  CHECK_NOTNULL(plugin);
+  auto& vessel = *plugin->GetVessel(vessel_guid);
+  auto const maybe_parameters = vessel.FlightPlanOptimizationDriverInProgress();
+  if (maybe_parameters.has_value()) {
+    return m.Return(maybe_parameters->index);
+  } else {
+    return m.Return(-1);
+  }
+}
+
+void __cdecl principia__FlightPlanOptimizationDriverMake(
+    Plugin const* const plugin,
+    char const* const vessel_guid,
+    double const distance,
+    double const* const inclination_in_degrees,
+    int const celestial_index,
+    NavigationFrameParameters const navigation_frame_parameters) {
+  journal::Method<journal::FlightPlanOptimizationDriverMake> m(
+      {plugin,
+       vessel_guid,
+       distance,
+       inclination_in_degrees,
+       celestial_index,
+       navigation_frame_parameters});
+  CHECK_NOTNULL(plugin);
+  auto& vessel = *plugin->GetVessel(vessel_guid);
+  const auto& celestial = plugin->GetCelestial(celestial_index);
+
+  std::vector<FlightPlanOptimizer::MetricFactory> factories = {
+      FlightPlanOptimizer::ForCelestialDistance(
+          /*celestial=*/&celestial,
+          /*target_distance=*/distance * Metre),
+      FlightPlanOptimizer::ForΔv()};
+  std::vector<double> weights = {1, 1e3};
+  if (inclination_in_degrees != nullptr) {
+    factories.push_back(FlightPlanOptimizer::ForInclination(
+        &celestial,
+        [plugin, navigation_frame_parameters]() {
+          return NewNavigationFrame(*plugin, navigation_frame_parameters);
+        },
+        *inclination_in_degrees * Degree));
+    weights.push_back(1e6);
+  }
+
+  vessel.MakeFlightPlanOptimizationDriver(
+      FlightPlanOptimizer::LinearCombination(factories, weights));
+
+  return m.Return();
+}
+
+void __cdecl principia__FlightPlanOptimizationDriverStart(
+    Plugin const* const plugin,
+    char const* const vessel_guid,
+    int const manœuvre_index) {
+  journal::Method<journal::FlightPlanOptimizationDriverStart> m(
+      {plugin,
+       vessel_guid,
+       manœuvre_index});
+  CHECK_NOTNULL(plugin);
+  auto& vessel = *plugin->GetVessel(vessel_guid);
+
+  vessel.StartFlightPlanOptimizationDriver(
+      {.index = manœuvre_index,
+       .Δv_tolerance = 1 * Micro(Metre) / Second});
+
+  return m.Return();
 }
 
 Status* __cdecl principia__FlightPlanRebase(Plugin const* const plugin,
@@ -577,80 +650,6 @@ int __cdecl principia__FlightPlanSelected(Plugin const* const plugin,
   journal::Method<journal::FlightPlanSelected> m({plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
   return m.Return(plugin->GetVessel(vessel_guid)->selected_flight_plan_index());
-}
-
-int __cdecl principia__FlightPlanOptimizationDriverInProgress(
-    Plugin const* const plugin,
-    char const* const vessel_guid) {
-  journal::Method<journal::FlightPlanOptimizationDriverInProgress> m(
-      {plugin, vessel_guid});
-  CHECK_NOTNULL(plugin);
-  auto& vessel = *plugin->GetVessel(vessel_guid);
-  auto const maybe_parameters = vessel.FlightPlanOptimizationDriverInProgress();
-  if (maybe_parameters.has_value()) {
-    return m.Return(maybe_parameters->index);
-  } else {
-    return m.Return(-1);
-  }
-}
-
-void __cdecl principia__FlightPlanOptimizationDriverMake(
-    Plugin const* const plugin,
-    char const* const vessel_guid,
-    double const distance,
-    double const* const inclination_in_degrees,
-    int const celestial_index,
-    NavigationFrameParameters const navigation_frame_parameters) {
-  journal::Method<journal::FlightPlanOptimizationDriverMake> m(
-      {plugin,
-       vessel_guid,
-       distance,
-       inclination_in_degrees,
-       celestial_index,
-       navigation_frame_parameters});
-  CHECK_NOTNULL(plugin);
-  auto& vessel = *plugin->GetVessel(vessel_guid);
-  const auto& celestial = plugin->GetCelestial(celestial_index);
-
-  std::vector<FlightPlanOptimizer::MetricFactory> factories = {
-      FlightPlanOptimizer::ForCelestialDistance(
-          /*celestial=*/&celestial,
-          /*target_distance=*/distance * Metre),
-      FlightPlanOptimizer::ForΔv()};
-  std::vector<double> weights = {1, 1e3};
-  if (inclination_in_degrees != nullptr) {
-    factories.push_back(FlightPlanOptimizer::ForInclination(
-        &celestial,
-        [plugin, navigation_frame_parameters]() {
-          return NewNavigationFrame(*plugin, navigation_frame_parameters);
-        },
-        *inclination_in_degrees * Degree));
-    weights.push_back(1e6);
-  }
-
-  vessel.MakeFlightPlanOptimizationDriver(
-      FlightPlanOptimizer::LinearCombination(factories, weights));
-
-  return m.Return();
-}
-
-// REMOVE BEFORE FLIGHT: Sort the functions.
-void __cdecl principia__FlightPlanOptimizationDriverStart(
-    Plugin const* const plugin,
-    char const* const vessel_guid,
-    int const manœuvre_index) {
-  journal::Method<journal::FlightPlanOptimizationDriverStart> m(
-      {plugin,
-       vessel_guid,
-       manœuvre_index});
-  CHECK_NOTNULL(plugin);
-  auto& vessel = *plugin->GetVessel(vessel_guid);
-
-  vessel.StartFlightPlanOptimizationDriver(
-      {.index = manœuvre_index,
-       .Δv_tolerance = 1 * Micro(Metre) / Second});
-
-  return m.Return();
 }
 
 Status* __cdecl principia__FlightPlanSetAdaptiveStepParameters(

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -581,7 +581,7 @@ int __cdecl principia__FlightPlanSelected(Plugin const* const plugin,
 bool __cdecl principia__FlightPlanOptimizationDriverInProgress(
     Plugin const* const plugin,
     char const* const vessel_guid) {
-  journal::Method<journal::FlightPlanOptimizationInProgress> m(
+  journal::Method<journal::FlightPlanOptimizationDriverInProgress> m(
       {plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
   auto& vessel = *plugin->GetVessel(vessel_guid);
@@ -591,9 +591,9 @@ bool __cdecl principia__FlightPlanOptimizationDriverInProgress(
 void __cdecl principia__FlightPlanOptimizationDriverMake(
     Plugin const* const plugin,
     char const* const vessel_guid,
-    int const celestial_index,
     double const distance,
     double const* const inclination_in_degrees,
+    int const celestial_index,
     NavigationFrameParameters const navigation_frame_parameters) {
   journal::Method<journal::FlightPlanOptimizationDriverMake> m(
       {plugin,

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -1,5 +1,6 @@
 #include "ksp_plugin/interface.hpp"
 
+#include <vector>
 #include <utility>
 
 #include "base/not_null.hpp"

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -578,14 +578,19 @@ int __cdecl principia__FlightPlanSelected(Plugin const* const plugin,
   return m.Return(plugin->GetVessel(vessel_guid)->selected_flight_plan_index());
 }
 
-bool __cdecl principia__FlightPlanOptimizationDriverInProgress(
+int __cdecl principia__FlightPlanOptimizationDriverInProgress(
     Plugin const* const plugin,
     char const* const vessel_guid) {
   journal::Method<journal::FlightPlanOptimizationDriverInProgress> m(
       {plugin, vessel_guid});
   CHECK_NOTNULL(plugin);
   auto& vessel = *plugin->GetVessel(vessel_guid);
-  return m.Return(vessel.FlightPlanOptimizationDriverInProgress());
+  auto const maybe_parameters = vessel.FlightPlanOptimizationDriverInProgress();
+  if (maybe_parameters.has_value()) {
+    return m.Return(maybe_parameters->index);
+  } else {
+    return m.Return(-1);
+  }
 }
 
 void __cdecl principia__FlightPlanOptimizationDriverMake(

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -364,13 +364,20 @@ void Vessel::StartFlightPlanOptimizationDriver(
   auto const& driver = std::get<OptimizableFlightPlan>(selected_flight_plan())
                            .optimization_driver;
   CHECK_NOTNULL(driver);
+  last_optimization_parameters_ = parameters;
   driver->RequestOptimization(parameters);
 }
 
-bool Vessel::FlightPlanOptimizationDriverInProgress() const {
+std::optional<FlightPlanOptimizationDriver::Parameters>
+Vessel::FlightPlanOptimizationDriverInProgress() const {
   auto const& driver = std::get<OptimizableFlightPlan>(selected_flight_plan())
                            .optimization_driver;
-  return driver != nullptr && !driver->done();
+  if (driver != nullptr && !driver->done()) {
+    CHECK(last_optimization_parameters_.has_value());
+    return last_optimization_parameters_;
+  } else {
+    return std::nullopt;
+  }
 }
 
 bool Vessel::UpdateFlightPlanFromOptimization() {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -195,7 +195,10 @@ class Vessel {
   virtual void StartFlightPlanOptimizationDriver(
       FlightPlanOptimizationDriver::Parameters const& parameters);
 
-  virtual bool FlightPlanOptimizationDriverInProgress() const;
+  // If an optimization is in progress, returns the parameters of the
+  // optimization.
+  virtual std::optional<FlightPlanOptimizationDriver::Parameters>
+  FlightPlanOptimizationDriverInProgress() const;
 
   virtual bool UpdateFlightPlanFromOptimization();
 
@@ -439,6 +442,8 @@ class Vessel {
 
   std::vector<LazilyDeserializedFlightPlan> flight_plans_;
   int selected_flight_plan_index_ = -1;
+  std::optional<FlightPlanOptimizationDriver::Parameters>
+      last_optimization_parameters_;
 
   std::optional<OrbitAnalyser> orbit_analyser_;
 

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -186,12 +186,18 @@ class Vessel {
   // flight plan or the flight plan has not been deserialized.
   virtual FlightPlan& flight_plan() const;
 
+  // Construct a new driver for the given metric (but doesn't start it).  If
+  // there is a driver currently running it is interrupted and destroyed.
   virtual void MakeFlightPlanOptimizationDriver(
       FlightPlanOptimizer::MetricFactory metric_factory);
 
-  virtual bool UpdateFlightPlanFromOptimization();
+  // Starts an optimization with the given parameters.
+  virtual void StartFlightPlanOptimizationDriver(
+      FlightPlanOptimizationDriver::Parameters const& parameters);
 
-  virtual FlightPlanOptimizationDriver* flight_plan_optimization_driver();
+  virtual bool FlightPlanOptimizationDriverInProgress() const;
+
+  virtual bool UpdateFlightPlanFromOptimization();
 
   // Deserializes the flight plan if it is held lazily by this object.  Does
   // nothing if there is no such flight plan.  If |has_flight_plan| returns

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -186,7 +186,7 @@ class Vessel {
   // flight plan or the flight plan has not been deserialized.
   virtual FlightPlan& flight_plan() const;
 
-  // Construct a new driver for the given metric (but doesn't start it).  If
+  // Constructs a new driver for the given metric (but doesn't start it).  If
   // there is a driver currently running it is interrupted and destroyed.
   virtual void MakeFlightPlanOptimizationDriver(
       FlightPlanOptimizer::MetricFactory metric_factory);

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -245,8 +245,9 @@ class BurnEditor : ScalingRenderer {
             index == 0
                 ? L10N.CacheFormat(
                     "#Principia_BurnEditor_TimeBase_StartOfFlightPlan")
-                : L10N.CacheFormat("#Principia_BurnEditor_TimeBase_EndOfManœuvre",
-                                   index),
+                : L10N.CacheFormat(
+                    "#Principia_BurnEditor_TimeBase_EndOfManœuvre",
+                    index),
             style : new UnityEngine.GUIStyle(UnityEngine.GUI.skin.label){
                 alignment = UnityEngine.TextAnchor.UpperLeft
             });

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -260,6 +260,26 @@ class BurnEditor : ScalingRenderer {
         UnityEngine.GUILayout.Label(L10N.CacheFormat(
                                         "#Principia_BurnEditor_Duration",
                                         duration_.ToString("0.0")));
+        if (adapter_.plotting_frame_selector_.
+                Centre() is CelestialBody centre) {
+          if (plugin.FlightPlanOptimizationInProgress(vessel_.id.ToString())) {
+            UnityEngine.GUILayout.Button("Optimizing…");
+          } else if (UnityEngine.GUILayout.Button(
+                         "#Principia_BurnEditor_Optimize")) {
+            plugin.FlightPlanOptimizeManoeuvre(vessel_.id.ToString(),
+                                               index,
+                                               centre.flightGlobalsIndex,
+                                               centre.Radius +
+                                               optimization_altitude_,
+                                               optimization_inclination_in_degrees_,
+                                               (NavigationFrameParameters)
+                                               adapter_.
+                                                   plotting_frame_selector_.
+                                                   FrameParameters());
+          }
+        } else {
+          UnityEngine.GUILayout.Button("Change plotting frame to optimize");
+        }
       }
       UnityEngine.GUILayout.Label(engine_warning_,
                                   Style.Warning(UnityEngine.GUI.skin.label));

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -260,25 +260,17 @@ class BurnEditor : ScalingRenderer {
         UnityEngine.GUILayout.Label(L10N.CacheFormat(
                                         "#Principia_BurnEditor_Duration",
                                         duration_.ToString("0.0")));
+
         if (adapter_.plotting_frame_selector_.
                 Centre() is CelestialBody centre) {
           if (plugin.FlightPlanOptimizationInProgress(vessel_.id.ToString())) {
             UnityEngine.GUILayout.Button("Optimizing…");
           } else if (UnityEngine.GUILayout.Button(
                          "#Principia_BurnEditor_Optimize")) {
-            plugin.FlightPlanOptimizeManoeuvre(vessel_.id.ToString(),
-                                               index,
-                                               centre.flightGlobalsIndex,
-                                               centre.Radius +
-                                               optimization_altitude_,
-                                               optimization_inclination_in_degrees_,
-                                               (NavigationFrameParameters)
-                                               adapter_.
-                                                   plotting_frame_selector_.
-                                                   FrameParameters());
+            plugin.FlightPlanOptimizationDriverStart(
+                vessel_.id.ToString(),
+                index);
           }
-        } else {
-          UnityEngine.GUILayout.Button("Change plotting frame to optimize");
         }
       }
       UnityEngine.GUILayout.Label(engine_warning_,

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -263,13 +263,13 @@ class BurnEditor : ScalingRenderer {
 
         if (adapter_.plotting_frame_selector_.
                 Centre() is CelestialBody centre) {
-          if (plugin.FlightPlanOptimizationInProgress(vessel_.id.ToString())) {
-            UnityEngine.GUILayout.Button("Optimizing…");
+          string vessel_guid = vessel_.id.ToString();
+          if (plugin.FlightPlanOptimizationDriverInProgress(vessel_guid)) {
+            UnityEngine.GUILayout.Label(
+                L10N.CacheFormat("#Principia_BurnEditor_Optimizing"));
           } else if (UnityEngine.GUILayout.Button(
-                         "#Principia_BurnEditor_Optimize")) {
-            plugin.FlightPlanOptimizationDriverStart(
-                vessel_.id.ToString(),
-                index);
+                         L10N.CacheFormat("#Principia_BurnEditor_Optimize"))) {
+            plugin.FlightPlanOptimizationDriverStart(vessel_guid, index);
           }
         }
       }

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -266,7 +266,6 @@ class BurnEditor : ScalingRenderer {
           string vessel_guid = vessel_.id.ToString();
           int optimized_index =
               plugin.FlightPlanOptimizationDriverInProgress(vessel_guid);
-          UnityEngine.Debug.LogError(optimized_index + " " + index);
           if (optimized_index == index) {
             UnityEngine.GUILayout.Label(
                 L10N.CacheFormat("#Principia_BurnEditor_OptimizingThis"));

--- a/ksp_plugin_adapter/burn_editor.cs
+++ b/ksp_plugin_adapter/burn_editor.cs
@@ -264,9 +264,15 @@ class BurnEditor : ScalingRenderer {
         if (adapter_.plotting_frame_selector_.
                 Centre() is CelestialBody centre) {
           string vessel_guid = vessel_.id.ToString();
-          if (plugin.FlightPlanOptimizationDriverInProgress(vessel_guid)) {
+          int optimized_index =
+              plugin.FlightPlanOptimizationDriverInProgress(vessel_guid);
+          UnityEngine.Debug.LogError(optimized_index + " " + index);
+          if (optimized_index == index) {
             UnityEngine.GUILayout.Label(
-                L10N.CacheFormat("#Principia_BurnEditor_Optimizing"));
+                L10N.CacheFormat("#Principia_BurnEditor_OptimizingThis"));
+          } else if (optimized_index != -1) {
+            UnityEngine.GUILayout.Label(
+                L10N.CacheFormat("#Principia_BurnEditor_OptimizingOther"));
           } else if (UnityEngine.GUILayout.Button(
                          L10N.CacheFormat("#Principia_BurnEditor_Optimize"))) {
             plugin.FlightPlanOptimizationDriverStart(vessel_guid, index);

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -396,7 +396,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
               double optimization_altitude = optimization_altitude_;
               double? optimization_inclination_in_degrees =
                   optimization_inclination_in_degrees_;
-              UnityEngine.Debug.LogError("1");
 
               using (new UnityEngine.GUILayout.HorizontalScope()) {
                 UnityEngine.GUILayout.Label(
@@ -411,7 +410,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 UnityEngine.GUILayout.Label(
                     text    : "",
                     options : GUILayoutWidth(2));
-                UnityEngine.Debug.LogError("2");
                 if (double.TryParse(text,
                                     System.Globalization.NumberStyles.Any,
                                     Culture.culture,
@@ -419,13 +417,10 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                   if (candidate >= 0 && candidate < double.PositiveInfinity) {
                     optimization_altitude = candidate;
                   }
-                  UnityEngine.Debug.LogError("3 " + text + " " +
-                                             optimization_altitude);
                 }
               }
 
               using (new UnityEngine.GUILayout.HorizontalScope()) {
-                UnityEngine.Debug.LogError("4");
                 UnityEngine.GUILayout.Label(
                     L10N.CacheFormat("#Principia_FlightPlan_TargetInclination"));
                 string text = UnityEngine.GUILayout.TextField(
@@ -446,7 +441,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                             : L10N.CacheFormat(
                                 "#Principia_FlightPlan_OptimizeInclinationOff"),
                         GUILayoutWidth(2));
-                UnityEngine.Debug.LogError("5");
                 if (!optimize_inclination) {
                   optimization_inclination_in_degrees = null;
                 } else if (text ==
@@ -461,7 +455,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                   optimization_inclination_in_degrees =
                       Math.Max(Math.Min(180, candidate), -180);
                 }
-                UnityEngine.Debug.LogError("6");
               }
 
               // If any of the parameters changed (that includes a change of
@@ -474,7 +467,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                   optimization_reference_frame_parameters_ !=
                   (NavigationFrameParameters)adapter_.plotting_frame_selector_.
                       FrameParameters()) {
-                UnityEngine.Debug.LogError("7");
                 optimization_altitude_ = optimization_altitude;
                 optimization_inclination_in_degrees_ =
                     optimization_inclination_in_degrees;
@@ -487,9 +479,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                     optimization_inclination_in_degrees_,
                     centre.flightGlobalsIndex,
                     optimization_reference_frame_parameters_);
-                UnityEngine.Debug.LogError("8");
               }
-              UnityEngine.Debug.LogError("8a");
             }
           }
         }
@@ -521,26 +511,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
             return;
           }
           Style.HorizontalLine();
-          //if (adapter_.plotting_frame_selector_.
-          //        Centre() is CelestialBody centre) {
-          //  if (plugin.FlightPlanOptimizationInProgress(vessel_guid)) {
-          //    UnityEngine.GUILayout.Button("Optimizing…");
-          //  } else if (UnityEngine.GUILayout.Button(
-          //                 $"Optimize {centre.Name()} flyby")) {
-          //    plugin.FlightPlanOptimizeManoeuvre(
-          //        vessel_guid,
-          //        i,
-          //        centre.flightGlobalsIndex,
-          //        centre.Radius + optimization_altitude_,
-          //        optimization_inclination_in_degrees_,
-          //        (NavigationFrameParameters)adapter_.plotting_frame_selector_.
-          //            FrameParameters());
-          //  }
-          //} else {
-          //  UnityEngine.GUILayout.Button("Change plotting frame to optimize");
-          //}
           BurnEditor burn = burn_editors_[i];
-          UnityEngine.Debug.LogError("9");
           switch (burn.Render(
               header          :
               L10N.CacheFormat("#Principia_FlightPlan_ManœuvreHeader", i + 1),
@@ -572,7 +543,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
             }
           }
         }
-        UnityEngine.Debug.LogError("10");
         Style.HorizontalLine();
         if (RenderCoast(burn_editors_.Count, orbital_period: out _)) {
           return;

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -1,5 +1,4 @@
-﻿using Steamworks;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -386,7 +385,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 Centre() is CelestialBody centre) {
           Style.HorizontalLine();
           using (new UnityEngine.GUILayout.HorizontalScope()) {
-            ////valign
             UnityEngine.GUILayout.Label(
                 L10N.CelestialString("#Principia_FlightPlan_Optimization",
                                      new[]{ centre }),
@@ -458,7 +456,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
               }
 
               // If any of the parameters changed (that includes a change of
-              // plotting frame in another window) recreated the optimization
+              // plotting frame in another window), recreate the optimization
               // driver.  This interrupts any optimization that might be
               // running, to avoid confusing results.
               if (optimization_altitude_ != optimization_altitude ||

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -407,6 +407,9 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 UnityEngine.GUILayout.Label(
                     text    : L10N.CacheFormat(
                         "#Principia_FlightPlan_AltitudeUnit"),
+                    options : GUILayoutWidth(1));
+                UnityEngine.GUILayout.Label(
+                    text    : "",
                     options : GUILayoutWidth(2));
                 UnityEngine.Debug.LogError("2");
                 if (double.TryParse(text,
@@ -425,28 +428,30 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 UnityEngine.Debug.LogError("4");
                 UnityEngine.GUILayout.Label(
                     L10N.CacheFormat("#Principia_FlightPlan_TargetInclination"));
-                bool optimize_inclination = UnityEngine.GUILayout.Toggle(
-                    optimization_inclination_in_degrees.HasValue,
-                    L10N.CacheFormat(
-                        "#Principia_FlightPlan_OptimizeInclination",
-                    GUILayoutWidth(0.2f)),
-                    style : Style.RightAligned(UnityEngine.GUI.skin.toggle));
                 string text = UnityEngine.GUILayout.TextField(
                     optimization_inclination_in_degrees.HasValue
                         ? optimization_inclination_in_degrees.Value.FormatN(0)
                         : L10N.CacheFormat(
-                            "#Principia_FlightPlan_DontOptimizeInclination"),
+                            "#Principia_FlightPlan_OptimizeInclinationNoText"),
                     GUILayoutWidth(3));
                 UnityEngine.GUILayout.Label(
                     text: L10N.CacheFormat(
                         "#Principia_FlightPlan_InclinationUnit"),
-                    options: GUILayoutWidth(2));
+                    options: GUILayoutWidth(1));
+                bool optimize_inclination = UnityEngine.GUILayout.Toggle(
+                        optimization_inclination_in_degrees.HasValue,
+                        optimization_inclination_in_degrees.HasValue
+                            ? L10N.CacheFormat(
+                                "#Principia_FlightPlan_OptimizeInclinationOn")
+                            : L10N.CacheFormat(
+                                "#Principia_FlightPlan_OptimizeInclinationOff"),
+                        GUILayoutWidth(2));
                 UnityEngine.Debug.LogError("5");
                 if (!optimize_inclination) {
                   optimization_inclination_in_degrees = null;
                 } else if (text ==
                            L10N.CacheFormat(
-                               "#Principia_FlightPlan_DontOptimizeInclination")) {
+                               "#Principia_FlightPlan_OptimizeInclinationNoText")) {
                   optimization_inclination_in_degrees = 0;
                 } else if (double.TryParse(text,
                                            System.Globalization.NumberStyles.

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -393,6 +393,13 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 style : Style.Aligned(UnityEngine.TextAnchor.LowerLeft,
                                       UnityEngine.GUI.skin.label));
             using (new UnityEngine.GUILayout.VerticalScope()) {
+              double optimization_altitude = optimization_altitude_;
+              double? optimization_inclination_in_degrees =
+                  optimization_inclination_in_degrees_;
+              IReferenceFrameParameters
+                  optimization_reference_frame_parameters =
+                      optimization_reference_frame_parameters_;
+
               using (new UnityEngine.GUILayout.HorizontalScope()) {
                 UnityEngine.GUILayout.Label(
                     L10N.CacheFormat("#Principia_FlightPlan_TargetAltitude"),
@@ -448,6 +455,27 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                   optimization_inclination_in_degrees_ =
                       Math.Max(Math.Min(180, candidate), -180);
                 }
+              }
+
+              if (optimization_altitude_ != optimization_altitude ||
+                  optimization_inclination_in_degrees_ !=
+                  optimization_inclination_in_degrees ||
+                  optimization_reference_frame_parameters_ !=
+                  (NavigationFrameParameters)adapter_.plotting_frame_selector_.
+                      FrameParameters()) {
+                plugin.FlightPlanOptimizationDriverMake(
+                    vessel_guid,
+                    centre.Radius + optimization_altitude_,
+                    optimization_inclination_in_degrees_,
+                    centre.flightGlobalsIndex,
+                    (NavigationFrameParameters)adapter_.
+                        plotting_frame_selector_.FrameParameters());
+                optimization_altitude_ = optimization_altitude;
+                optimization_inclination_in_degrees_ =
+                    optimization_inclination_in_degrees;
+                optimization_reference_frame_parameters_ =
+                    (NavigationFrameParameters)adapter_.
+                        plotting_frame_selector_.FrameParameters();
               }
             }
           }
@@ -903,6 +931,8 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
 
   private double optimization_altitude_ = 10e3;
   private double? optimization_inclination_in_degrees_ = 0;
+  private NavigationFrameParameters optimization_reference_frame_parameters_ =
+      null;
 }
 
 }  // namespace ksp_plugin_adapter

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -380,60 +380,60 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           }
         }
 
-        Style.HorizontalLine();
         // There is no Layout/Repaint trouble here because the frame is selected
         // in another window.
         if (adapter_.plotting_frame_selector_.
                 Centre() is CelestialBody centre) {
+          Style.HorizontalLine();
           using (new UnityEngine.GUILayout.HorizontalScope()) {
             ////valign
             UnityEngine.GUILayout.Label(
                 L10N.CelestialString("#Principia_FlightPlan_Optimization",
-                                     new[]{centre}),
-                style : Style.Aligned(UnityEngine.TextAnchor.LowerLeft,
-                                      UnityEngine.GUI.skin.label));
+                                     new[]{ centre }),
+                style: Style.MiddleLeftAligned(UnityEngine.GUI.skin.label,
+                                               Height(2)));
             using (new UnityEngine.GUILayout.VerticalScope()) {
               double optimization_altitude = optimization_altitude_;
               double? optimization_inclination_in_degrees =
                   optimization_inclination_in_degrees_;
-              IReferenceFrameParameters
-                  optimization_reference_frame_parameters =
-                      optimization_reference_frame_parameters_;
+              UnityEngine.Debug.LogError("1");
 
               using (new UnityEngine.GUILayout.HorizontalScope()) {
                 UnityEngine.GUILayout.Label(
-                    L10N.CacheFormat("#Principia_FlightPlan_TargetAltitude"),
-                    style : Style.RightAligned(UnityEngine.GUI.skin.label));
+                    L10N.CacheFormat("#Principia_FlightPlan_TargetAltitude"));
                 string text = UnityEngine.GUILayout.TextField(
-                    optimization_altitude_.FormatN(0),
+                    optimization_altitude.FormatN(0),
                     GUILayoutWidth(3));
                 UnityEngine.GUILayout.Label(
                     text    : L10N.CacheFormat(
                         "#Principia_FlightPlan_AltitudeUnit"),
                     options : GUILayoutWidth(2));
+                UnityEngine.Debug.LogError("2");
                 if (double.TryParse(text,
                                     System.Globalization.NumberStyles.Any,
                                     Culture.culture,
                                     out double candidate)) {
                   if (candidate >= 0 && candidate < double.PositiveInfinity) {
-                    optimization_altitude_ = candidate;
+                    optimization_altitude = candidate;
                   }
+                  UnityEngine.Debug.LogError("3 " + text + " " +
+                                             optimization_altitude);
                 }
               }
 
               using (new UnityEngine.GUILayout.HorizontalScope()) {
+                UnityEngine.Debug.LogError("4");
                 UnityEngine.GUILayout.Label(
-                    L10N.CacheFormat("#Principia_FlightPlan_TargetInclination"),
-                    style : Style.RightAligned(UnityEngine.GUI.skin.label));
+                    L10N.CacheFormat("#Principia_FlightPlan_TargetInclination"));
                 bool optimize_inclination = UnityEngine.GUILayout.Toggle(
-                    optimization_inclination_in_degrees_.HasValue,
+                    optimization_inclination_in_degrees.HasValue,
                     L10N.CacheFormat(
                         "#Principia_FlightPlan_OptimizeInclination",
-                    GUILayoutWidth(1)),
+                    GUILayoutWidth(0.2f)),
                     style : Style.RightAligned(UnityEngine.GUI.skin.toggle));
                 string text = UnityEngine.GUILayout.TextField(
-                    optimization_inclination_in_degrees_.HasValue
-                        ? optimization_inclination_in_degrees_.Value.FormatN(0)
+                    optimization_inclination_in_degrees.HasValue
+                        ? optimization_inclination_in_degrees.Value.FormatN(0)
                         : L10N.CacheFormat(
                             "#Principia_FlightPlan_DontOptimizeInclination"),
                     GUILayoutWidth(3));
@@ -441,42 +441,50 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                     text: L10N.CacheFormat(
                         "#Principia_FlightPlan_InclinationUnit"),
                     options: GUILayoutWidth(2));
+                UnityEngine.Debug.LogError("5");
                 if (!optimize_inclination) {
-                  optimization_inclination_in_degrees_ = null;
+                  optimization_inclination_in_degrees = null;
                 } else if (text ==
                            L10N.CacheFormat(
                                "#Principia_FlightPlan_DontOptimizeInclination")) {
-                  optimization_inclination_in_degrees_ = 0;
+                  optimization_inclination_in_degrees = 0;
                 } else if (double.TryParse(text,
                                            System.Globalization.NumberStyles.
                                                Any,
                                            Culture.culture,
                                            out double candidate)) {
-                  optimization_inclination_in_degrees_ =
+                  optimization_inclination_in_degrees =
                       Math.Max(Math.Min(180, candidate), -180);
                 }
+                UnityEngine.Debug.LogError("6");
               }
 
+              // If any of the parameters changed (that includes a change of
+              // plotting frame in another window) recreated the optimization
+              // driver.  This interrupts any optimization that might be
+              // running, to avoid confusing results.
               if (optimization_altitude_ != optimization_altitude ||
                   optimization_inclination_in_degrees_ !=
                   optimization_inclination_in_degrees ||
                   optimization_reference_frame_parameters_ !=
                   (NavigationFrameParameters)adapter_.plotting_frame_selector_.
                       FrameParameters()) {
-                plugin.FlightPlanOptimizationDriverMake(
-                    vessel_guid,
-                    centre.Radius + optimization_altitude_,
-                    optimization_inclination_in_degrees_,
-                    centre.flightGlobalsIndex,
-                    (NavigationFrameParameters)adapter_.
-                        plotting_frame_selector_.FrameParameters());
+                UnityEngine.Debug.LogError("7");
                 optimization_altitude_ = optimization_altitude;
                 optimization_inclination_in_degrees_ =
                     optimization_inclination_in_degrees;
                 optimization_reference_frame_parameters_ =
                     (NavigationFrameParameters)adapter_.
                         plotting_frame_selector_.FrameParameters();
+                plugin.FlightPlanOptimizationDriverMake(
+                    vessel_guid,
+                    centre.Radius + optimization_altitude_,
+                    optimization_inclination_in_degrees_,
+                    centre.flightGlobalsIndex,
+                    optimization_reference_frame_parameters_);
+                UnityEngine.Debug.LogError("8");
               }
+              UnityEngine.Debug.LogError("8a");
             }
           }
         }
@@ -527,6 +535,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           //  UnityEngine.GUILayout.Button("Change plotting frame to optimize");
           //}
           BurnEditor burn = burn_editors_[i];
+          UnityEngine.Debug.LogError("9");
           switch (burn.Render(
               header          :
               L10N.CacheFormat("#Principia_FlightPlan_ManœuvreHeader", i + 1),
@@ -558,6 +567,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
             }
           }
         }
+        UnityEngine.Debug.LogError("10");
         Style.HorizontalLine();
         if (RenderCoast(burn_editors_.Count, orbital_period: out _)) {
           return;

--- a/ksp_plugin_adapter/interface.cs
+++ b/ksp_plugin_adapter/interface.cs
@@ -113,10 +113,16 @@ internal partial class PlottingFrameParameters : IReferenceFrameParameters {
 
   public static bool operator ==(PlottingFrameParameters left,
                                  IReferenceFrameParameters right) {
-    return left.Extension == right.Extension &&
-           left.centre_index == right.CentreIndex &&
-           left.PrimaryIndices.SequenceEqual(right.PrimaryIndices) &&
-           left.SecondaryIndices.SequenceEqual(right.SecondaryIndices);
+    if ((object)left == null && (object)right == null) {
+      return true;
+    } else if ((object)left == null || (object)right == null) {
+      return false;
+    } else {
+      return left.Extension == right.Extension &&
+             left.centre_index == right.CentreIndex &&
+             left.PrimaryIndices.SequenceEqual(right.PrimaryIndices) &&
+             left.SecondaryIndices.SequenceEqual(right.SecondaryIndices);
+    }
   }
 
   public static bool operator !=(PlottingFrameParameters left,
@@ -165,10 +171,16 @@ internal partial class NavigationFrameParameters : IReferenceFrameParameters {
 
   public static bool operator ==(NavigationFrameParameters left,
                                  IReferenceFrameParameters right) {
-    return left.Extension == right.Extension &&
-           left.CentreIndex == right.CentreIndex &&
-           left.PrimaryIndices.SequenceEqual(right.PrimaryIndices) &&
-           left.SecondaryIndices.SequenceEqual(right.SecondaryIndices);
+    if ((object)left == null && (object)right == null) {
+      return true;
+    } else if ((object)left == null || (object)right == null) {
+      return false;
+    } else {
+      return left.Extension == right.Extension &&
+             left.CentreIndex == right.CentreIndex &&
+             left.PrimaryIndices.SequenceEqual(right.PrimaryIndices) &&
+             left.SecondaryIndices.SequenceEqual(right.SecondaryIndices);
+    }
   }
 
   public static bool operator !=(NavigationFrameParameters left,

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -170,6 +170,13 @@ Localization {
     #Principia_FlightPlan_Delete = Delete flight plan
     #Principia_FlightPlan_Rebase = Rebase
     #Principia_FlightPlan_Duplicate = Duplicate
+    #Principia_FlightPlan_Optimization = Optimization parameters for <<1>> flyby
+    #Principia_FlightPlan_TargetAltitude = Altitude
+    #Principia_FlightPlan_AltitudeUnit = m
+    #Principia_FlightPlan_TargetInclination = Inclination
+    #Principia_FlightPlan_OptimizeInclination =
+    #Principia_FlightPlan_DontOptimizeInclination = OFF
+    #Principia_FlightPlan_InclinationUnit = °
     #Principia_FlightPlan_ManœuvreHeader = Manœuvre #<<1>>
     #Principia_FlightPlan_UpcomingManœuvre = Upcoming manœuvre #<<1>>:
     #Principia_FlightPlan_IgnitionCountdown = Ignition <<1>>
@@ -227,6 +234,7 @@ Localization {
     #Principia_BurnEditor_TimeBase_EndOfManœuvre = Time base: end of manœuvre #<<1>>  // <<1>> index
     #Principia_BurnEditor_Δv = Manœuvre Δv : <<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = Duration : <<1>> s  // <<1>>: duration_.ToString("0.0").
+    #Principia_BurnEditor_Optimize = Optimize
     #Principia_BurnEditor_Warning_NoActiveEngines = No active engines, falling back to RCS.\u0020
     #Principia_BurnEditor_Warning_NoActiveRCS = No active RCS, modeling as instant burn.\u0020
 

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -174,8 +174,9 @@ Localization {
     #Principia_FlightPlan_TargetAltitude = Altitude
     #Principia_FlightPlan_AltitudeUnit = m
     #Principia_FlightPlan_TargetInclination = Inclination
-    #Principia_FlightPlan_OptimizeInclination =
-    #Principia_FlightPlan_DontOptimizeInclination = OFF
+    #Principia_FlightPlan_OptimizeInclinationOn = On
+    #Principia_FlightPlan_OptimizeInclinationOff = Off
+    #Principia_FlightPlan_OptimizeInclinationNoText =
     #Principia_FlightPlan_InclinationUnit = °
     #Principia_FlightPlan_ManœuvreHeader = Manœuvre #<<1>>
     #Principia_FlightPlan_UpcomingManœuvre = Upcoming manœuvre #<<1>>:
@@ -234,7 +235,8 @@ Localization {
     #Principia_BurnEditor_TimeBase_EndOfManœuvre = Time base: end of manœuvre #<<1>>  // <<1>> index
     #Principia_BurnEditor_Δv = Manœuvre Δv : <<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = Duration : <<1>> s  // <<1>>: duration_.ToString("0.0").
-    #Principia_BurnEditor_Optimizing = Optimizing…
+    #Principia_BurnEditor_OptimizingThis = Optimizing…
+    #Principia_BurnEditor_OptimizingOther =
     #Principia_BurnEditor_Optimize = Optimize
     #Principia_BurnEditor_Warning_NoActiveEngines = No active engines, falling back to RCS.\u0020
     #Principia_BurnEditor_Warning_NoActiveRCS = No active RCS, modeling as instant burn.\u0020

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -234,6 +234,7 @@ Localization {
     #Principia_BurnEditor_TimeBase_EndOfManœuvre = Time base: end of manœuvre #<<1>>  // <<1>> index
     #Principia_BurnEditor_Δv = Manœuvre Δv : <<1>> m/s  // <<1>>: Δv().ToString("0.000").
     #Principia_BurnEditor_Duration = Duration : <<1>> s  // <<1>>: duration_.ToString("0.0").
+    #Principia_BurnEditor_Optimizing = Optimizing…
     #Principia_BurnEditor_Optimize = Optimize
     #Principia_BurnEditor_Warning_NoActiveEngines = No active engines, falling back to RCS.\u0020
     #Principia_BurnEditor_Warning_NoActiveRCS = No active RCS, modeling as instant burn.\u0020

--- a/ksp_plugin_adapter/style.cs
+++ b/ksp_plugin_adapter/style.cs
@@ -96,8 +96,8 @@ internal static class Style {
       float height) {
     return new UnityEngine.GUIStyle(style){
         alignment = UnityEngine.TextAnchor.MiddleLeft,
-        fixedHeight = height;
-    }
+        fixedHeight = height
+    };
   }
 
   public static UnityEngine.GUIStyle RightAligned(UnityEngine.GUIStyle style) {

--- a/ksp_plugin_adapter/style.cs
+++ b/ksp_plugin_adapter/style.cs
@@ -91,6 +91,15 @@ internal static class Style {
     return aligned_style;
   }
 
+  public static UnityEngine.GUIStyle MiddleLeftAligned(
+      UnityEngine.GUIStyle style,
+      float height) {
+    return new UnityEngine.GUIStyle(style){
+        alignment = UnityEngine.TextAnchor.MiddleLeft,
+        fixedHeight = height;
+    }
+  }
+
   public static UnityEngine.GUIStyle RightAligned(UnityEngine.GUIStyle style) {
     return Aligned(UnityEngine.TextAnchor.MiddleRight, style);
   }

--- a/ksp_plugin_adapter/window_renderer.cs
+++ b/ksp_plugin_adapter/window_renderer.cs
@@ -25,6 +25,14 @@ internal class ScalingRenderer {
     return UnityEngine.GUILayout.Width(Width(units));
   }
 
+  protected UnityEngine.GUILayoutOption GUILayoutWidth(float units) {
+    return UnityEngine.GUILayout.Width(Width(units));
+  }
+
+  protected float Height(float units) {
+    return unit_ * units;
+  }
+
   protected float Width(float units) {
     return unit_ * units;
   }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -982,24 +982,6 @@ message FlightPlanInsert {
   optional Return return = 3;
 }
 
-message FlightPlanOptimizeManoeuvre {
-  extend Method {
-    optional FlightPlanOptimizeManoeuvre extension = 5189;
-  }
-  message In {
-    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
-                                 (is_subject) = true];
-    required string vessel_guid = 2;
-    required int32 manoeuvre_index = 3;
-    required int32 celestial_index = 4;
-    required double distance = 5;
-    required double inclination_in_degrees = 6;
-    required NavigationFrameParameters navigation_frame_parameters = 7;
-  }
-  optional In in = 1;
-}
-
-
 message FlightPlanNumberOfAnomalousManoeuvres {
   extend Method {
     optional FlightPlanNumberOfAnomalousManoeuvres extension = 5159;
@@ -1046,6 +1028,39 @@ message FlightPlanNumberOfSegments {
   }
   optional In in = 1;
   optional Return return = 3;
+}
+
+message FlightPlanOptimizationInProgress {
+  extend Method {
+    optional FlightPlanOptimizationInProgress extension = 5188;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+  }
+  message Return {
+    required bool result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
+message FlightPlanOptimizeManoeuvre {
+  extend Method {
+    optional FlightPlanOptimizeManoeuvre extension = 5189;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+    required int32 manoeuvre_index = 3;
+    required int32 celestial_index = 4;
+    required double distance = 5;
+    optional double inclination_in_degrees = 6;
+    required NavigationFrameParameters navigation_frame_parameters = 7;
+  }
+  optional In in = 1;
 }
 
 message FlightPlanRebase {
@@ -1215,22 +1230,6 @@ message FlightPlanSelected {
   }
   message Return {
     required int32 result = 1;
-  }
-  optional In in = 1;
-  optional Return return = 3;
-}
-
-message FlightPlanOptimizationInProgress {
-  extend Method {
-    optional FlightPlanOptimizationInProgress extension = 5188;
-  }
-  message In {
-    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
-                                 (is_subject) = true];
-    required string vessel_guid = 2;
-  }
-  message Return {
-    required bool result = 1;
   }
   optional In in = 1;
   optional Return return = 3;

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -238,7 +238,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5187.
+  extensions 5000 to 5999;  // Last used: 5191.
 }
 
 message AdvanceTime {
@@ -1030,9 +1030,9 @@ message FlightPlanNumberOfSegments {
   optional Return return = 3;
 }
 
-message FlightPlanOptimizationInProgress {
+message FlightPlanOptimizationDriverInProgress {
   extend Method {
-    optional FlightPlanOptimizationInProgress extension = 5188;
+    optional FlightPlanOptimizationDriverInProgress extension = 5188;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
@@ -1046,19 +1046,31 @@ message FlightPlanOptimizationInProgress {
   optional Return return = 3;
 }
 
-message FlightPlanOptimizeManoeuvre {
+message FlightPlanOptimizationDriverMake {
   extend Method {
-    optional FlightPlanOptimizeManoeuvre extension = 5189;
+    optional FlightPlanOptimizationDriverMake extension = 5191;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+    required double distance = 3;
+    optional double inclination_in_degrees = 4;
+    required int32 celestial_index = 5;
+    required NavigationFrameParameters navigation_frame_parameters = 6;
+  }
+  optional In in = 1;
+}
+
+message FlightPlanOptimizationDriverStart {
+  extend Method {
+    optional FlightPlanOptimizationDriverStart extension = 5189;
   }
   message In {
     required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
                                  (is_subject) = true];
     required string vessel_guid = 2;
     required int32 manoeuvre_index = 3;
-    required int32 celestial_index = 4;
-    required double distance = 5;
-    optional double inclination_in_degrees = 6;
-    required NavigationFrameParameters navigation_frame_parameters = 7;
   }
   optional In in = 1;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -1040,7 +1040,7 @@ message FlightPlanOptimizationDriverInProgress {
     required string vessel_guid = 2;
   }
   message Return {
-    required bool result = 1;
+    required int32 manoeuvre_index = 2;
   }
   optional In in = 1;
   optional Return return = 3;


### PR DESCRIPTION
What it looks like:
![Optimization explained](https://github.com/mockingbirdnest/Principia/assets/7423020/a3a5a92d-eb05-4bfd-84e6-546e58b12436)
This PR does the following:
1. Add localization tags.
2. Move the optimize button to the burn.
3. Move the optimization parameters up a bit, and makes inclination optimization optional.
4. Change the interface to separate the creation of an optimization driver from the actual run of the optimization driver.  The driver is updated when the parameters change.  This means in particular that changes the parameters interrupts the optimization.