### PR TITLE
Add a thread to asynchronously prolong the ephemeris in the FlightPlan

### DIFF
--- a/astronomy/geodesy_test.cpp
+++ b/astronomy/geodesy_test.cpp
@@ -150,8 +150,7 @@ TEST_F(GeodesyTest, DISABLED_LAGEOS2) {
                     Ephemeris<ICRS>::NewtonianMotionEquation>(),
                 std::numeric_limits<std::int64_t>::max(),
                 /*length_integration_tolerance=*/1 * Milli(Metre),
-                /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
-            /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max());
+                /*speed_integration_tolerance=*/1 * Milli(Metre) / Second));
   };
   Bundle bundle;
   bundle.Add([&flow_lageos2, &primary_lageos2_trajectory]() {

--- a/astronomy/standard_product_3_test.cpp
+++ b/astronomy/standard_product_3_test.cpp
@@ -392,8 +392,7 @@ TEST_P(StandardProduct3DynamicsTest, PerturbedKeplerian) {
                     Ephemeris<ICRS>::NewtonianMotionEquation>(),
                 std::numeric_limits<std::int64_t>::max(),
                 /*length_integration_tolerance=*/1 * Milli(Metre),
-                /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
-            /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max()));
+                /*speed_integration_tolerance=*/1 * Milli(Metre) / Second)));
         DegreesOfFreedom<ICRS> actual =
             integrated_arc.back().degrees_of_freedom;
         DegreesOfFreedom<ICRS> expected =

--- a/benchmarks/apsides_benchmark.cpp
+++ b/benchmarks/apsides_benchmark.cpp
@@ -98,8 +98,7 @@ class ApsidesBenchmark : public benchmark::Fixture {
                 Ephemeris<ICRS>::NewtonianMotionEquation>(),
             std::numeric_limits<std::int64_t>::max(),
             /*length_integration_tolerance=*/1 * Milli(Metre),
-            /*speed_integration_tolerance=*/1 * Milli(Metre) / Second),
-        /*max_ephemeris_steps=*/std::numeric_limits<std::int64_t>::max()));
+            /*speed_integration_tolerance=*/1 * Milli(Metre) / Second)));
 
     BodyCentredNonRotatingReferenceFrame<ICRS, GCRS> const gcrs(ephemeris_,
                                                                 earth_);

--- a/benchmarks/ephemeris_benchmark.cpp
+++ b/benchmarks/ephemeris_benchmark.cpp
@@ -543,8 +543,7 @@ void FlowEphemerisWithAdaptiveStep(
               Ephemeris<Barycentric>::NewtonianMotionEquation>(),
           /*max_steps=*/std::numeric_limits<std::int64_t>::max(),
           /*length_integration_tolerance=*/1 * Metre,
-          /*speed_integration_tolerance=*/1 * Metre / Second),
-      Ephemeris<Barycentric>::unlimited_max_ephemeris_steps));
+          /*speed_integration_tolerance=*/1 * Metre / Second)));
 }
 
 void FlowEphemerisWithFixedStepSLMS(

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -193,9 +193,8 @@ absl::Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
           q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σⱼ_aᵢⱼ_gⱼₖ;
           v_stage[k] = v̂[k].value + h * Σⱼ_aʹᵢⱼ_gⱼₖ;
         }
-        termination_condition::UpdateWithAbort(
-            equation.compute_acceleration(t_stage, q_stage, v_stage, g[i]),
-            step_status);
+        step_status.Update(
+            equation.compute_acceleration(t_stage, q_stage, v_stage, g[i]));
       }
 
       // Increment computation and step size control.

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -245,8 +245,8 @@ absl::Status EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
       q̂[k].Increment(Δq̂[k]);
       v̂[k].Increment(Δv̂[k]);
     }
-    RETURN_IF_STOPPED;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     ++step_count;
     if (absl::IsAborted(step_status)) {
       return step_status;

--- a/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
@@ -241,8 +241,8 @@ Solve(typename ODE::IndependentVariable const& s_final) {
       ŷ.Increment(Δŷ);
     });
 
-    RETURN_IF_STOPPED;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     ++step_count;
     if (absl::IsAborted(step_status)) {
       return step_status;

--- a/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
@@ -193,7 +193,7 @@ Solve(typename ODE::IndependentVariable const& s_final) {
                 y_stage = ŷ.value + Σⱼ_aᵢⱼ_kⱼ;
               });
 
-          step_satus.Update(equation.compute_derivative(s_stage, y_stage, f));
+          step_status.Update(equation.compute_derivative(s_stage, y_stage, f));
         }
         for_all_of(f, k[i]).loop([h](auto const& f, auto& kᵢ) {
           kᵢ = h * f;

--- a/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator_body.hpp
@@ -193,8 +193,7 @@ Solve(typename ODE::IndependentVariable const& s_final) {
                 y_stage = ŷ.value + Σⱼ_aᵢⱼ_kⱼ;
               });
 
-          termination_condition::UpdateWithAbort(
-              equation.compute_derivative(s_stage, y_stage, f), step_status);
+          step_satus.Update(equation.compute_derivative(s_stage, y_stage, f));
         }
         for_all_of(f, k[i]).loop([h](auto const& f, auto& kᵢ) {
           kᵢ = h * f;

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -185,8 +185,8 @@ Instance::Solve(Instant const& t_final) {
           }
           q_stage[k] = q̂[k].value + h * c[i] * v̂[k].value + h² * Σⱼ_aᵢⱼ_gⱼₖ;
         }
-        termination_condition::UpdateWithAbort(
-            equation.compute_acceleration(t_stage, q_stage, g[i]), step_status);
+        step_status.Update(
+            equation.compute_acceleration(t_stage, q_stage, g[i]));
       }
 
       // Increment computation and step size control.

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -236,8 +236,8 @@ Instance::Solve(Instant const& t_final) {
       q̂[k].Increment(Δq̂[k]);
       v̂[k].Increment(Δv̂[k]);
     }
-    RETURN_IF_STOPPED;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     ++step_count;
     if (step_count == parameters.max_steps && !at_end) {
       return absl::Status(termination_condition::ReachedMaximalStepCount,

--- a/integrators/explicit_linear_multistep_integrator_body.hpp
+++ b/integrators/explicit_linear_multistep_integrator_body.hpp
@@ -114,9 +114,8 @@ ExplicitLinearMultistepIntegrator<Method, ODE_>::Instance::Solve(
           y = yₙ₊₁;
         });
     current_step.y = std::move(yₙ₊₁);
-    termination_condition::UpdateWithAbort(
-        equation.compute_derivative(s.value, y_stage, current_step.yʹ),
-        status);
+    status.Update(
+        equation.compute_derivative(s.value, y_stage, current_step.yʹ));
     starter_.Push(std::move(current_step));
 
     // Inform the caller of the new state.

--- a/integrators/explicit_linear_multistep_integrator_body.hpp
+++ b/integrators/explicit_linear_multistep_integrator_body.hpp
@@ -120,9 +120,9 @@ ExplicitLinearMultistepIntegrator<Method, ODE_>::Instance::Solve(
     starter_.Push(std::move(current_step));
 
     // Inform the caller of the new state.
-    RETURN_IF_STOPPED;
     current_state.s = s;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     if (absl::IsAborted(status)) {
       return status;
     }

--- a/integrators/explicit_runge_kutta_integrator_body.hpp
+++ b/integrators/explicit_runge_kutta_integrator_body.hpp
@@ -127,10 +127,9 @@ Solve(typename ODE::IndependentVariable const& s_final) {
               y_stage = y.value + Σⱼ_aᵢⱼ_kⱼ;
             });
 
-        termination_condition::UpdateWithAbort(
+        status.Update(
             equation.compute_derivative(
-                s.value + (s.error + c[i] * h), y_stage, f),
-            status);
+                s.value + (s.error + c[i] * h), y_stage, f));
       }
       for_all_of(f, k[i]).loop([h](auto const& f, auto& kᵢ) {
         kᵢ = h * f;

--- a/integrators/explicit_runge_kutta_integrator_body.hpp
+++ b/integrators/explicit_runge_kutta_integrator_body.hpp
@@ -158,8 +158,8 @@ Solve(typename ODE::IndependentVariable const& s_final) {
       y.Increment(Δy);
     });
 
-    RETURN_IF_STOPPED;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     if (absl::IsAborted(status)) {
       return status;
     }

--- a/integrators/ordinary_differential_equations.hpp
+++ b/integrators/ordinary_differential_equations.hpp
@@ -24,8 +24,12 @@ using namespace principia::numerics::_double_precision;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 
+
 // The |Solve| function of the |AdaptiveStepSizeIntegrator| exclusively returns
 // one of the following statuses.
+// Beware!  Do not RETURN_IF_STOPPED from the right-hand side computation, it's
+// too hard to undo the state changes made half way through the loop of the
+// integrator.
 namespace termination_condition {
 
 constexpr absl::StatusCode Done = absl::StatusCode::kOk;
@@ -35,9 +39,6 @@ constexpr absl::StatusCode ReachedMaximalStepCount = absl::StatusCode::kAborted;
 // A singularity.
 constexpr absl::StatusCode VanishingStepSize =
     absl::StatusCode::kFailedPrecondition;
-
-// Same as absl::Status::Update, but prefers kAbort.
-void UpdateWithAbort(absl::Status const& updater, absl::Status& updated);
 
 }  // namespace termination_condition
 

--- a/integrators/ordinary_differential_equations_body.hpp
+++ b/integrators/ordinary_differential_equations_body.hpp
@@ -10,18 +10,6 @@ namespace principia {
 namespace integrators {
 namespace _ordinary_differential_equations {
 namespace internal {
-namespace termination_condition {
-
-inline void UpdateWithAbort(absl::Status const& updater,
-                            absl::Status& updated) {
-  if (absl::IsAborted(updater)) {
-    updated = updater;
-  } else {
-    updated.Update(updater);
-  }
-}
-
-}  // namespace termination_condition
 
 template<typename IndependentVariable_, typename... DependentVariable>
 ExplicitFirstOrderOrdinaryDifferentialEquation<IndependentVariable_,

--- a/integrators/symmetric_linear_multistep_integrator_body.hpp
+++ b/integrators/symmetric_linear_multistep_integrator_body.hpp
@@ -141,9 +141,9 @@ SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::Solve(
     ComputeVelocityUsingCohenHubbardOesterwinter();
 
     // Inform the caller of the new state.
-    RETURN_IF_STOPPED;
     current_state.time = t;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     if (absl::IsAborted(status)) {
       return status;
     }

--- a/integrators/symmetric_linear_multistep_integrator_body.hpp
+++ b/integrators/symmetric_linear_multistep_integrator_body.hpp
@@ -131,11 +131,10 @@ SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::Solve(
       positions[d] = current_position.value;
       current_state.positions[d] = current_position;
     }
-    termination_condition::UpdateWithAbort(
+    status.Update(
         equation.compute_acceleration(t.value,
                                       positions,
-                                      current_step.accelerations),
-        status);
+                                      current_step.accelerations));
     starter_.Push(std::move(current_step));
 
     ComputeVelocityUsingCohenHubbardOesterwinter();

--- a/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
@@ -134,8 +134,8 @@ Instance::Solve(Instant const& t_final) {
       q[k].Increment(Δq[k]);
       v[k].Increment(Δv[k]);
     }
-    RETURN_IF_STOPPED;
     append_state(current_state);
+    RETURN_IF_STOPPED;  // After the state has been updated.
     if (absl::IsAborted(status)) {
       return status;
     }

--- a/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/symplectic_runge_kutta_nyström_integrator_body.hpp
@@ -113,10 +113,9 @@ Instance::Solve(Instant const& t_final) {
       for (int k = 0; k < dimension; ++k) {
         q_stage[k] = q[k].value + Δq[k];
       }
-      termination_condition::UpdateWithAbort(
+      status.Update(
           equation.compute_acceleration(
-              t.value + (t.error + c[i] * h), q_stage, g),
-          status);
+              t.value + (t.error + c[i] * h), q_stage, g));
       for (int k = 0; k < dimension; ++k) {
         // exp(bᵢ h B)
         Δv[k] += h * b[i] * g[k];

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -125,6 +125,10 @@ int FlightPlan::number_of_anomalous_manœuvres() const {
   return (anomalous_segments_ - 1) / 2;
 }
 
+absl::Status const& FlightPlan::anomalous_status() const {
+  return anomalous_status_;
+}
+
 NavigationManœuvre const& FlightPlan::GetManœuvre(int const index) const {
   CHECK_LE(0, index);
   CHECK_LT(index, number_of_manœuvres());
@@ -546,6 +550,7 @@ absl::Status FlightPlan::ComputeSegments(
       overall_status.Update(status);
       anomalous_segments_ = 1;
       anomalous_status_ = status;
+LOG(WARNING)<<status<<" "<<overall_status<<" "<<anomalous_segments_;
     }
   }
   return overall_status;

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -422,8 +422,9 @@ absl::Status FlightPlan::RecomputeAllSegments() {
     PopLastSegment();
   }
   ResetLastSegment();
-  return ComputeSegments(
-      manœuvres_.begin(), manœuvres_.end(), max_ephemeris_steps_per_frame);
+  return ComputeSegments(manœuvres_.begin(),
+                         manœuvres_.end(),
+                         max_ephemeris_steps_per_frame);
 }
 
 absl::Status FlightPlan::RecomputeSegmentsAvoidingDeadlineIfNeeded() {

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -417,13 +417,15 @@ absl::Status FlightPlan::RecomputeSegmentsAvoidingDeadlineIfNeeded() {
     return absl::OkStatus();
   }
 
+  int const anomalous_manœuvres = anomalous_segments_ / 2;
   auto it = manœuvres_.end();
-  for (int i = 0; i < anomalous_segments_; ++i) {
+  for (int i = 0; i < anomalous_manœuvres; ++i) {
     PopLastSegment();
-    if (i % 2 == 1) {
-      --it;
-    }
+    PopLastSegment();
+    --it;
   }
+  ResetLastSegment();
+
   return ComputeSegments(it, manœuvres_.end());
 }
 

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -211,6 +211,9 @@ class FlightPlan {
   // initial masses from |manœuvres_[index].final_mass()|.
   void UpdateInitialMassOfManœuvresAfter(int index);
 
+  // Starts a thread to prolong the ephemeris if needed.
+  void MakeProlongator(Instant const& prolongation_time);
+
   Instant start_of_last_coast() const;
 
   // In the following functions, |index| refers to the index of a manœuvre.
@@ -248,7 +251,7 @@ class FlightPlan {
 
   // These members are only accessed by the main thread.
   jthread prolongator_;
-  Instant last_prolongation_time_;
+  Instant last_prolongation_time_ = InfinitePast;
 
   Ephemeris<Barycentric>::AdaptiveStepParameters adaptive_step_parameters_;
   Ephemeris<Barycentric>::GeneralizedAdaptiveStepParameters

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "absl/status/status.h"
+#include "base/jthread.hpp"
 #include "base/not_null.hpp"
 #include "geometry/instant.hpp"
 #include "ksp_plugin/frames.hpp"

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -72,6 +72,13 @@ class FlightPlan {
   // of anomalous manœuvres.
   virtual int number_of_anomalous_manœuvres() const;
 
+  // Returns the status associated with the first anomalous segment.  Note that
+  // this may be non-OK even if |number_of_anomalous_manœuvres()| is 0, in the
+  // case where only the final coast is anomalous.  The functions that change
+  // manœuvres as well as the function that "avoid deadlines" may change this
+  // status.
+  virtual absl::Status const& anomalous_status() const;
+
   // Returns the specified manœuvre.  |index| must be in
   // [0, number_of_manœuvres()[.
   virtual NavigationManœuvre const& GetManœuvre(int index) const;

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -117,8 +117,16 @@ class FlightPlan {
   // |index| must be in [0, number_of_segments()[.  These functions may try to
   // recompute the end of the flight plan to get rid of a deadline.
   virtual DiscreteTrajectorySegmentIterator<Barycentric>
-  GetSegment(int index);
-  virtual DiscreteTrajectory<Barycentric> const& GetAllSegments();
+  GetSegment(int index) const;
+  virtual DiscreteTrajectory<Barycentric> const& GetAllSegments() const;
+
+  // Same as above, but if the flight plan is anomalous because of a deadline,
+  // tries to recompute it in case the ephemeris is long enough.  This can still
+  // run into a deadline.
+  virtual DiscreteTrajectorySegmentIterator<Barycentric>
+  GetSegmentAvoidingDeadlines(int index);
+  virtual DiscreteTrajectory<Barycentric> const&
+  GetAllSegmentsAvoidingDeadlines();
 
   // Orbit analysis is enabled at construction, and may be enabled/disabled
   // dynamically.
@@ -155,8 +163,8 @@ class FlightPlan {
 
   // If the flight plan is anomalous because of an integration deadline, try to
   // recompute it from the first anomalous segment.  This might work better if
-  // the ephemeris has been prolonged.
-  absl::Status RecomputeSegmentsAfterDeadlineIfNeeded();
+  // the ephemeris has been prolonged enough.
+  absl::Status RecomputeSegmentsAvoidingDeadlineIfNeeded();
 
   // Flows the given |segment| for the duration of |manœuvre| using its
   // intrinsic acceleration.

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -177,13 +177,15 @@ class FlightPlan {
   // intrinsic acceleration.
   absl::Status BurnSegment(
       NavigationManœuvre const& manœuvre,
-      DiscreteTrajectorySegmentIterator<Barycentric> segment);
+      DiscreteTrajectorySegmentIterator<Barycentric> segment,
+      std::int64_t max_ephemeris_steps);
 
   // Flows the given |segment| until |desired_final_time| with no intrinsic
   // acceleration.
   absl::Status CoastSegment(
       Instant const& desired_final_time,
-      DiscreteTrajectorySegmentIterator<Barycentric> segment);
+      DiscreteTrajectorySegmentIterator<Barycentric> segment,
+      std::int64_t max_ephemeris_steps);
 
   // Computes new trajectories and appends them to |segments_|.  This updates
   // the last coast of |segments_| and then appends one coast and one burn for
@@ -193,7 +195,8 @@ class FlightPlan {
   // TODO(phl): The argument should really be an std::span, but then Apple has
   // invented the Macintosh.
   absl::Status ComputeSegments(std::vector<NavigationManœuvre>::iterator begin,
-                               std::vector<NavigationManœuvre>::iterator end);
+                               std::vector<NavigationManœuvre>::iterator end,
+                               std::int64_t max_ephemeris_steps);
 
   // Adds a trajectory to |segments_|, forked at the end of the last one.  If
   // there are already anomalous trajectories, the newly created trajectory is

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -122,8 +122,7 @@ class FlightPlan {
   // Returns the number of trajectories in this object.
   virtual int number_of_segments() const;
 
-  // |index| must be in [0, number_of_segments()[.  These functions may try to
-  // recompute the end of the flight plan to get rid of a deadline.
+  // |index| must be in [0, number_of_segments()[.
   virtual DiscreteTrajectorySegmentIterator<Barycentric>
   GetSegment(int index) const;
   virtual DiscreteTrajectory<Barycentric> const& GetAllSegments() const;
@@ -246,7 +245,7 @@ class FlightPlan {
   // Never empty; Starts and ends with a coast; coasts and burns alternate.
   std::vector<DiscreteTrajectorySegmentIterator<Barycentric>> segments_;
   // The last |anomalous_segments_| of |segments_| are anomalous, i.e., they
-  // either end prematurely or follow an anomalous segemnt; in the latter case
+  // either end prematurely or follow an anomalous segment; in the latter case
   // they are empty.
   int anomalous_segments_ = 0;
   // The status of the first anomalous segment.  Set and used exclusively by

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -534,8 +534,8 @@ Iterator* __cdecl principia__FlightPlanRenderedSegment(
   CHECK_NOTNULL(plugin);
 
   // This might force a (partial) recomputation of the flight plan to avoid a
-  // deadline, and a change in the number of anomalous manœuvres that will be
-  // noticed by the flight planner.
+  // deadline, and a change of the anomalous status that will be noticed by the
+  // flight planner.
   auto const segment =
       GetFlightPlan(*plugin, vessel_guid).GetSegmentAvoidingDeadlines(index);
 

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -239,6 +239,16 @@ double __cdecl principia__FlightPlanGetActualFinalTime(
                  GetFlightPlan(*plugin, vessel_guid).actual_final_time()));
 }
 
+Status* __cdecl principia__FlightPlanGetAnomalousStatus(
+    Plugin const* const plugin,
+    char const* const vessel_guid) {
+  journal::Method<journal::FlightPlanGetAnomalousStatus> m(
+      {plugin, vessel_guid});
+  CHECK_NOTNULL(plugin);
+  return m.Return(
+      ToNewStatus(GetFlightPlan(*plugin, vessel_guid).anomalous_status()));
+}
+
 OrbitAnalysis* __cdecl principia__FlightPlanGetCoastAnalysis(
     Plugin const* const plugin,
     char const* const vessel_guid,

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -522,7 +522,13 @@ Iterator* __cdecl principia__FlightPlanRenderedSegment(
                                                          sun_world_position,
                                                          index});
   CHECK_NOTNULL(plugin);
-  auto const segment = GetFlightPlan(*plugin, vessel_guid).GetSegment(index);
+
+  // This might force a (partial) recomputation of the flight plan to avoid a
+  // deadline, and a change in the number of anomalous manœuvres that will be
+  // noticed by the flight planner.
+  auto const segment =
+      GetFlightPlan(*plugin, vessel_guid).GetSegmentAvoidingDeadlines(index);
+
   auto rendered_trajectory =
       plugin->renderer().RenderBarycentricTrajectoryInWorld(
           plugin->CurrentTime(),

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -598,13 +598,11 @@ absl::Status PileUp::AdvanceTime(Instant const& t) {
     if (history_->back().time < t) {
       // Do not clear the |fixed_instance_| here, we will use it for the next
       // fixed-step integration.
-      status.Update(
-          ephemeris_->FlowWithAdaptiveStep(
-              &trajectory_,
-              Ephemeris<Barycentric>::NoIntrinsicAcceleration,
-              t,
-              adaptive_step_parameters_,
-              Ephemeris<Barycentric>::unlimited_max_ephemeris_steps));
+      status.Update(ephemeris_->FlowWithAdaptiveStep(
+          &trajectory_,
+          Ephemeris<Barycentric>::NoIntrinsicAcceleration,
+          t,
+          adaptive_step_parameters_));
     }
   } else {
     // Destroy the fixed instance, it wouldn't be correct to use it the next
@@ -625,12 +623,10 @@ absl::Status PileUp::AdvanceTime(Instant const& t) {
 
     auto const intrinsic_acceleration =
         [a = intrinsic_force_ / mass_](Instant const& t) { return a; };
-    status = ephemeris_->FlowWithAdaptiveStep(
-                 &trajectory_,
-                 intrinsic_acceleration,
-                 t,
-                 adaptive_step_parameters_,
-                 Ephemeris<Barycentric>::unlimited_max_ephemeris_steps);
+    status = ephemeris_->FlowWithAdaptiveStep(&trajectory_,
+                                              intrinsic_acceleration,
+                                              t,
+                                              adaptive_step_parameters_);
     psychohistory_ = trajectory_.NewSegment();
   }
 

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -194,16 +194,25 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
           break;
         }
       }
+
       // Must be computed during layout as it affects the layout of some of the
-      // differential sliders.
-      number_of_anomalous_manœuvres_ =
+      // differential sliders.  Also detect if the number of anomalous manœuvres
+      // has changed asynchronously because of the prolongator.
+      int number_of_anomalous_manœuvres =
           plugin.FlightPlanNumberOfAnomalousManoeuvres(vessel_guid);
+      number_of_anomalous_manœuvres_has_changed_ =
+          number_of_anomalous_manœuvres != number_of_anomalous_manœuvres_;
+      number_of_anomalous_manœuvres_ = number_of_anomalous_manœuvres;
     }
   }
 
   private void RenderFlightPlan(string vessel_guid) {
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      if (final_time_.Render(enabled : true)) {
+      // A change of the number of anomalous manœuvres "tickles" the flight
+      // plan.
+      if (number_of_anomalous_manœuvres_has_changed_ ||
+          final_time_.Render(enabled : true)) {
+        number_of_anomalous_manœuvres_has_changed_ = false;
         var status =
             plugin.FlightPlanSetDesiredFinalTime(
                 vessel_guid,
@@ -779,6 +788,7 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
   private readonly DifferentialSlider final_time_;
   private int? first_future_manœuvre_;
   private int number_of_anomalous_manœuvres_ = 0;
+  private bool number_of_anomalous_manœuvres_has_changed_ = false;
 
   private int length_integration_tolerance_index_;
   private int speed_integration_tolerance_index_;

--- a/ksp_plugin_adapter/flight_planner.cs
+++ b/ksp_plugin_adapter/flight_planner.cs
@@ -206,10 +206,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       bool reached_deadline = plugin.FlightPlanGetAnomalousStatus(vessel_guid).
           is_deadline_exceeded();
       must_tickle_ = reached_deadline != reached_deadline_;
-      UnityEngine.Debug.LogError("Prev " +
-                                 reached_deadline_ +
-                                 " Now " +
-                                 reached_deadline);
     }
   }
 
@@ -218,8 +214,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
       // A change of anomalous status "tickles" the flight plan.  Note that the
       // order of the terms in the || below matters, we always want to render
       // the |final_time_|.
-      UnityEngine.Debug.LogError("Status has changed: " +
-                                 must_tickle_);
       if (final_time_.Render(enabled : true) || must_tickle_) {
         must_tickle_ = false;
         var status =
@@ -227,7 +221,6 @@ class FlightPlanner : VesselSupervisedWindowRenderer {
                 vessel_guid,
                 final_time_.value);
         reached_deadline_ = status.is_deadline_exceeded();
-        UnityEngine.Debug.LogError(status.error + status.message);
         UpdateStatus(status, null);
       }
       // Always refresh the final time from C++ as it may have changed because

--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -183,7 +183,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = Add manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = changing the flight plan
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
-    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
+    #Principia_FlightPlan_StatusMessage_Tickle = shortening the flight plan or waiting for a few moments
     #Principia_FlightPlan_StatusMessage_FailedError = computation failed with error <<1>> and message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = after <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = integrator reached the maximum number of steps <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -187,7 +187,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = Ins. manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = de modifier le plan de vol
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = plan de vol dépasse la période sur laquelle les corps célestes ont été calculés
-    #Principia_FlightPlan_StatusMessage_Tickle = de raccourcir le plan de vol ou d'attendre quelques instant
+    #Principia_FlightPlan_StatusMessage_Tickle = de raccourcir le plan de vol ou d'attendre quelques instants
     #Principia_FlightPlan_StatusMessage_FailedError = le calcul a échoué avec l’erreur <<1>> et le message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = au bout de <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = l’intégrateur a atteint le nombre maximum de pas <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -187,7 +187,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = Ins. manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = de modifier le plan de vol
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = plan de vol dépasse la période sur laquelle les corps célestes ont été calculés
-    #Principia_FlightPlan_StatusMessage_Tickle = raccourcir le plan de vol ou d'attendre quelques instant
+    #Principia_FlightPlan_StatusMessage_Tickle = de raccourcir le plan de vol ou d'attendre quelques instant
     #Principia_FlightPlan_StatusMessage_FailedError = le calcul a échoué avec l’erreur <<1>> et le message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = au bout de <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = l’intégrateur a atteint le nombre maximum de pas <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/fr-fr.cfg
+++ b/ksp_plugin_adapter/localization/fr-fr.cfg
@@ -187,7 +187,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = Ins. manœuvre
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = de modifier le plan de vol
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = plan de vol dépasse la période sur laquelle les corps célestes ont été calculés
-    #Principia_FlightPlan_StatusMessage_Tickle = raccourcir et rallonger répétitivement le plan de vol
+    #Principia_FlightPlan_StatusMessage_Tickle = raccourcir le plan de vol ou d'attendre quelques instant
     #Principia_FlightPlan_StatusMessage_FailedError = le calcul a échoué avec l’erreur <<1>> et le message \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = au bout de <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = l’intégrateur a atteint le nombre maximum de pas <<1>>  // <<1>> Timeout
@@ -256,7 +256,6 @@ Localization {
     #Principia_MapNode_ApproachHeader = Rapprochement <<1>> à la cible : <<2>> m  // <<1>>: source, <<2>>: separation.FormatN(0).
     #Principia_MapNode_ApproachCaptionLine2 = <<1>> m/s  // <<1>>: speed.FormatN(0).
     #Principia_MapNode_ImpactHeader =  Impact <<1>> sur <<A:2>> // <<1>>: source, <<2>>: celestial.name.
-    // TODO(egg): translate.
-    #Principia_MapNode_ManœuvreCaption = <b>Manœuvre #<<1>> </b>\nΔv: <<2>> m/s\n Duration: <<3>> s\n <<4>>
+    #Principia_MapNode_ManœuvreCaption = <b>Manœuvre #<<1>> </b>\nΔv: <<2>> m/s\n Durée: <<3>> s\n <<4>>
   }
 }

--- a/ksp_plugin_adapter/localization/ru.cfg
+++ b/ksp_plugin_adapter/localization/ru.cfg
@@ -197,7 +197,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = Добав. манёвр
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = изменение плана полёта
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = flight plan exceeds the period over which celestials were computed
-    #Principia_FlightPlan_StatusMessage_Tickle = repeatedly increasing and shortening the flight plan a bit
+    #Principia_FlightPlan_StatusMessage_Tickle = shortening the flight plan or waiting for a few moments
     #Principia_FlightPlan_StatusMessage_FailedError = сбой расчёта с ошибкой <<1>> и сообщением \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = после <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = интегратор достиг максимального количества шагов <<1>>  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -213,7 +213,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = 新建轨道机动
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = 轨道规划长度超过天体计算长度
-    #Principia_FlightPlan_StatusMessage_Tickle = shortening the flight plan or waiting for a few moments
+    #Principia_FlightPlan_StatusMessage_Tickle = 缩短规划长度或稍等片刻
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout

--- a/ksp_plugin_adapter/localization/zh-cn.cfg
+++ b/ksp_plugin_adapter/localization/zh-cn.cfg
@@ -213,7 +213,7 @@ Localization {
     #Principia_FlightPlan_AddManœuvre = 新建轨道机动
     #Principia_FlightPlan_StatusMessage_ChangeFlightPlan = 请更换轨道规划
     #Principia_FlightPlan_StatusMessage_DeadlineExceeded = 轨道规划长度超过天体计算长度
-    #Principia_FlightPlan_StatusMessage_Tickle = 反复延长并缩短规划长度
+    #Principia_FlightPlan_StatusMessage_Tickle = shortening the flight plan or waiting for a few moments
     #Principia_FlightPlan_StatusMessage_FailedError = 计算失败，出现错误 <<1>> 错误信息 \"<<2>>\"  // <<1>> status_.error <<2>> status_.message
     #Principia_FlightPlan_StatusMessage_TimeOut = <<1>>  // <<1>> Timeout
     #Principia_FlightPlan_StatusMessage_MaxSteps = 积分器无法在最大步数以内算出 + <<1>> 时刻  // <<1>> Timeout

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -441,7 +441,6 @@ TEST_F(PluginCompatibilityTest, 3273) {
   auto const Ωʹᴛ = analysis.primary()->angular_frequency();
   auto const nd = 2 * π * Radian / analysis.elements()->nodal_period();
   double const κ = nd / (Ωʹᴛ - Ωʹ);
-  LOG(ERROR) << κ;
   EXPECT_THAT(vessel->flight_plan().analysis(2)->recurrence(),
               Eq(std::nullopt));
 }

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -458,7 +458,7 @@ TEST_F(PluginTest, Serialization) {
 TEST_F(PluginTest, Initialization) {
   InsertAllSolarSystemBodies();
   plugin_->EndInitialization();
-  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_)).Times(AnyNumber());
+  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_, _)).Times(AnyNumber());
   for (int index = SolarSystemFactory::Sun + 1;
        index <= SolarSystemFactory::LastMajorBody;
        ++index) {
@@ -596,7 +596,7 @@ TEST_F(PluginTest, HierarchicalInitialization) {
       initial_state);
 
   plugin_->EndInitialization();
-  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_)).Times(AnyNumber());
+  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_, _)).Times(AnyNumber());
   EXPECT_THAT(plugin_->CelestialFromParent(1).displacement().Norm(),
               AlmostEquals(3 * Kilo(Metre), 1, 7));
   EXPECT_THAT(plugin_->CelestialFromParent(2).displacement().Norm(),
@@ -696,7 +696,7 @@ TEST_F(PluginDeathTest, InsertUnloadedPartError) {
                                 /*loaded=*/false,
                                 inserted);
     Instant const initial_time = ParseTT(initial_time_);
-    EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(initial_time));
+    EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(initial_time, _));
     plugin_->InsertUnloadedPart(
         part_id,
         "part",
@@ -775,7 +775,7 @@ TEST_F(PluginTest, VesselInsertionAtInitialization) {
                               inserted);
   EXPECT_TRUE(inserted);
   Instant const initial_time = ParseTT(initial_time_);
-  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(initial_time))
+  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(initial_time, _))
       .Times(AnyNumber());
   plugin_->InsertUnloadedPart(
       part_id,
@@ -794,7 +794,7 @@ TEST_F(PluginTest, VesselInsertionAtInitialization) {
 TEST_F(PluginTest, UpdateCelestialHierarchy) {
   InsertAllSolarSystemBodies();
   plugin_->EndInitialization();
-  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_)).Times(AnyNumber());
+  EXPECT_CALL(plugin_->mock_ephemeris(), Prolong(_, _)).Times(AnyNumber());
   for (int index = SolarSystemFactory::Sun + 1;
        index <= SolarSystemFactory::LastMajorBody;
        ++index) {

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -382,8 +382,10 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
 }
 
 TEST_F(VesselTest, FlightPlan) {
+  EXPECT_CALL(ephemeris_, t_min())
+      .WillRepeatedly(Return(t0_));
   EXPECT_CALL(ephemeris_, t_max())
-      .WillRepeatedly(Return(t0_ + 2 * Second));
+      .WillRepeatedly(Return(t0_ + 4 * Second));
   EXPECT_CALL(ephemeris_,
               FlowWithAdaptiveStep(_, _, InfiniteFuture, _, _))
       .Times(AnyNumber());
@@ -392,6 +394,9 @@ TEST_F(VesselTest, FlightPlan) {
       .Times(AnyNumber());
   EXPECT_CALL(ephemeris_,
               FlowWithAdaptiveStep(_, _, t0_ + 3 * Second, _, _))
+      .Times(AnyNumber());
+  EXPECT_CALL(ephemeris_,
+              Prolong(_, _))
       .Times(AnyNumber());
   std::vector<not_null<MassiveBody const*>> const bodies;
   ON_CALL(ephemeris_, bodies()).WillByDefault(ReturnRef(bodies));
@@ -801,7 +806,7 @@ TEST_F(VesselTest, SerializationSuccess) {
   EXPECT_CALL(serialization_index_for_pile_up, Call(_)).Times(0);
 
   EXPECT_CALL(ephemeris_, t_max())
-      .WillRepeatedly(Return(t0_ + 2 * Second));
+      .WillRepeatedly(Return(t0_ + 4 * Second));
   EXPECT_CALL(ephemeris_,
               FlowWithAdaptiveStep(_, _, InfiniteFuture, _, _))
       .Times(AnyNumber());
@@ -812,6 +817,9 @@ TEST_F(VesselTest, SerializationSuccess) {
 
   EXPECT_CALL(ephemeris_,
               FlowWithAdaptiveStep(_, _, t0_ + 3 * Second, _, _))
+      .WillRepeatedly(Return(absl::OkStatus()));
+  EXPECT_CALL(ephemeris_,
+              Prolong(_, _))
       .WillRepeatedly(Return(absl::OkStatus()));
 
   std::vector<not_null<MassiveBody const*>> const bodies;

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -828,7 +828,7 @@ TEST_F(VesselTest, SerializationSuccess) {
   EXPECT_TRUE(message.has_history());
   EXPECT_FALSE(message.flight_plans().empty());
 
-  EXPECT_CALL(ephemeris_, Prolong(_)).Times(2);
+  EXPECT_CALL(ephemeris_, Prolong(_, _)).Times(2);
   auto const v = Vessel::ReadFromMessage(
       message, &celestial_, &ephemeris_, /*deletion_callback=*/nullptr);
   EXPECT_TRUE(v->has_flight_plan());

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -60,8 +60,7 @@ using namespace principia::quantities::_quantities;
 
 // Note on thread-safety: the integration functions (Prolong, FlowWithFixedStep,
 // FlowWithAdaptiveStep) can be called concurrently as long as their parameters
-// designated distinct objects.  No guarantee is offered for the other
-// functions.
+// designate distinct objects.  No guarantee is offered for the other functions.
 template<typename Frame>
 class Ephemeris {
   static_assert(Frame::is_inertial, "Frame must be inertial");
@@ -132,7 +131,7 @@ class Ephemeris {
   // The maximum of the |t_min|s of the trajectories.
   virtual Instant t_min() const EXCLUDES(lock_);
   // The mimimum of the |t_max|s of the trajectories.
-  virtual Instant t_max() const;
+  virtual Instant t_max() const EXCLUDES(lock_);
 
   virtual FixedStepSizeIntegrator<NewtonianMotionEquation> const&
   planetary_integrator() const;
@@ -180,7 +179,8 @@ class Ephemeris {
       IntrinsicAcceleration intrinsic_acceleration,
       Instant const& t,
       AdaptiveStepParameters const& parameters,
-      std::int64_t max_ephemeris_steps) EXCLUDES(lock_);
+      std::int64_t max_ephemeris_steps = unlimited_max_ephemeris_steps)
+      EXCLUDES(lock_);
 
   // Same as above, but uses a generalized integrator.
   virtual absl::Status FlowWithAdaptiveStep(
@@ -188,7 +188,8 @@ class Ephemeris {
       GeneralizedIntrinsicAcceleration intrinsic_acceleration,
       Instant const& t,
       GeneralizedAdaptiveStepParameters const& parameters,
-      std::int64_t max_ephemeris_steps) EXCLUDES(lock_);
+      std::int64_t max_ephemeris_steps = unlimited_max_ephemeris_steps)
+      EXCLUDES(lock_);
 
   // Integrates, until at most |t|, the trajectories followed by massless
   // bodies in the gravitational potential described by |*this|.  If

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -322,9 +322,7 @@ class Ephemeris {
   // ephemeris.
   NewtonianMotionEquation MakeMassiveBodiesNewtonianMotionEquation();
 
-  // Note the return by copy: the returned value is usable even if the
-  // |instance_| is being integrated.
-  Instant instance_time() const EXCLUDES(lock_);
+  Instant instance_time_locked() const REQUIRES_SHARED(lock_);
 
   virtual Instant t_min_locked() const REQUIRES_SHARED(lock_);
   virtual Instant t_max_locked() const REQUIRES_SHARED(lock_);

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -139,8 +139,12 @@ class Ephemeris {
   virtual absl::Status last_severe_integration_status() const;
 
   // Prolongs the ephemeris up to at least |t|.  Returns an error iff the thread
-  // is stopped.  After a successful call, |t_max() >= t|.
-  virtual absl::Status Prolong(Instant const& t) EXCLUDES(lock_);
+  // is stopped.  After a successful call with the second parameter defaulted,
+  // |t_max() >= t|.
+  virtual absl::Status Prolong(
+      Instant const& t,
+      std::int64_t max_ephemeris_steps = unlimited_max_ephemeris_steps)
+      EXCLUDES(lock_);
 
   // Asks the reanimator thread to asynchronously reconstruct the past so that
   // the |t_min()| of the ephemeris ultimately ends up at or before

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -1401,8 +1401,8 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationBetweenAllMassiveBodies(
     Instant const& t,
     std::vector<Position<Frame>> const& positions,
     std::vector<Vector<Acceleration, Frame>>& accelerations) const {
-  // Do not RETURN_IF_STOPPED here, it's too hard to undo the state changeds
-  // made half way through the loop of the integrator.
+  // Do not RETURN_IF_STOPPED here, it's too hard to undo the state changes made
+  // half way through the loop of the integrator.
 
   accelerations.assign(accelerations.size(), Vector<Acceleration, Frame>());
 

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -1402,7 +1402,8 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationBetweenAllMassiveBodies(
     Instant const& t,
     std::vector<Position<Frame>> const& positions,
     std::vector<Vector<Acceleration, Frame>>& accelerations) const {
-  RETURN_IF_STOPPED;
+  // Do not RETURN_IF_STOPPED here, it's too hard to undo the state changeds
+  // made half way through the loop of the integrator.
 
   accelerations.assign(accelerations.size(), Vector<Acceleration, Frame>());
 

--- a/physics/mock_ephemeris.hpp
+++ b/physics/mock_ephemeris.hpp
@@ -44,7 +44,10 @@ class MockEphemeris : public Ephemeris<Frame> {
               (),
               (const, override));
 
-  MOCK_METHOD(absl::Status, Prolong, (Instant const& t), (override));
+  MOCK_METHOD(absl::Status,
+              Prolong,
+              (Instant const& t, std::int64_t max_ephemeris_steps),
+              (override));
   MOCK_METHOD(
       not_null<std::unique_ptr<
           typename Integrator<NewtonianMotionEquation>::Instance>>,

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -238,7 +238,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5186.
+  extensions 5000 to 5999;  // Last used: 5187.
 }
 
 message AdvanceTime {
@@ -837,6 +837,23 @@ message FlightPlanGetActualFinalTime {
   }
   message Return {
     required double result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
+message FlightPlanGetAnomalousStatus {
+  extend Method {
+    optional FlightPlanGetAnomalousStatus extension = 5187;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+    required string vessel_guid = 2;
+  }
+  message Return {
+    required Status result = 1 [(is_produced) = true];
+    required fixed64 address = 2 [(address_of) = "result"];
   }
   optional In in = 1;
   optional Return return = 3;


### PR DESCRIPTION
This properly handles the "deadline exceeded" error, by effectively "tickling" the flight plan when necessary.

Fix #3483.