### PR TITLE
Fix a bug in the copy constructor of FlightPlan that caused hard crashes when touching a duplicated plan

### DIFF
--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -113,7 +113,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Scan) {
 // |method_out_return| protocol buffers.
 TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Journals\JOURNAL.20230506-192603)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Issues\3782\JOURNAL.20231025-212010)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -135,17 +135,20 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(
-        serialization::DeletePlugin::extension);
+        serialization::FlightPlanGetCoastAnalysis::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(2734566559920);
+    in->set_plugin(1813489403728);
+    in->set_vessel_guid("5f7e35b7-645a-4985-9734-7bdeb31b2336");
+    in->set_ground_track_revolution(0);
+    in->set_index(0);
   }
   serialization::Method method_out_return;
   {
     auto* extension = method_out_return.MutableExtension(
-        serialization::DeletePlugin::extension);
+        serialization::FlightPlanGetCoastAnalysis::extension);
   }
   LOG(ERROR) << "Running unpaired method:\n" << method_in.DebugString();
-  CHECK(RunIfAppropriate<DeletePlugin>(
+  CHECK(RunIfAppropriate<FlightPlanGetCoastAnalysis>(
       method_in, method_out_return, player));
 #endif
 #if 0

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -101,7 +101,7 @@ FlightPlan::FlightPlan(FlightPlan const& other)
        ++it) {
     segments_.push_back(it);
   }
-  for (int i = 0; i < coast_analysers_.size(); ++i) {
+  for (int i = 0; i < other.coast_analysers_.size(); ++i) {
     coast_analysers_.push_back(make_not_null_unique<OrbitAnalyser>(
         ephemeris_, DefaultHistoryParameters()));
   }


### PR DESCRIPTION
Fix #3782.