### PR TITLE
Deserialize the flight plan when calling the optimization entry points

### DIFF
--- a/ksp_plugin/flight_plan_optimization_driver.cpp
+++ b/ksp_plugin/flight_plan_optimization_driver.cpp
@@ -72,6 +72,12 @@ void FlightPlanOptimizationDriver::RequestOptimization(
   }
 }
 
+std::optional<FlightPlanOptimizationDriver::Parameters> const&
+FlightPlanOptimizationDriver::last_parameters() const {
+  absl::MutexLock l(&lock_);
+  return last_parameters_;
+}
+
 void FlightPlanOptimizationDriver::Wait() const {
   absl::ReaderMutexLock l(&lock_);
   lock_.Await(absl::Condition(&optimizer_idle_));

--- a/ksp_plugin/flight_plan_optimization_driver.cpp
+++ b/ksp_plugin/flight_plan_optimization_driver.cpp
@@ -74,7 +74,7 @@ void FlightPlanOptimizationDriver::RequestOptimization(
 
 std::optional<FlightPlanOptimizationDriver::Parameters> const&
 FlightPlanOptimizationDriver::last_parameters() const {
-  absl::MutexLock l(&lock_);
+  absl::ReaderMutexLock l(&lock_);
   return last_parameters_;
 }
 

--- a/ksp_plugin/flight_plan_optimization_driver.hpp
+++ b/ksp_plugin/flight_plan_optimization_driver.hpp
@@ -46,6 +46,10 @@ class FlightPlanOptimizationDriver {
   // optimization is already happening.
   void RequestOptimization(Parameters const& parameters);
 
+  // Returns the last parameters passed to |RequestOptimization|, or nullopt if
+  // |RequestOptimization| was not called.
+  std::optional<Parameters> const& last_parameters() const;
+
   // Waits for the current optimization (if any) to complete.
   void Wait() const;
 
@@ -59,6 +63,7 @@ class FlightPlanOptimizationDriver {
   mutable absl::Mutex lock_;
   jthread optimizer_;
   bool optimizer_idle_ GUARDED_BY(lock_) = true;
+  std::optional<Parameters> last_parameters_ GUARDED_BY(lock_);
 
   // The last flight plan evaluated by the optimizer.
   not_null<std::shared_ptr<FlightPlan>> last_flight_plan_ GUARDED_BY(lock_);

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -366,7 +366,6 @@ void Vessel::StartFlightPlanOptimizationDriver(
   auto const& driver = std::get<OptimizableFlightPlan>(selected_flight_plan())
                            .optimization_driver;
   CHECK_NOTNULL(driver);
-  last_optimization_parameters_ = parameters;
   driver->RequestOptimization(parameters);
 }
 
@@ -374,11 +373,10 @@ std::optional<FlightPlanOptimizationDriver::Parameters>
 Vessel::FlightPlanOptimizationDriverInProgress() const {
   auto const& driver = std::get<OptimizableFlightPlan>(selected_flight_plan())
                            .optimization_driver;
-  if (driver != nullptr && !driver->done()) {
-    CHECK(last_optimization_parameters_.has_value());
-    return last_optimization_parameters_;
-  } else {
+  if (driver == nullptr || driver->done()) {
     return std::nullopt;
+  } else {
+    return driver->last_parameters();
   }
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -348,7 +348,7 @@ FlightPlan& Vessel::flight_plan() const {
 
 void Vessel::MakeFlightPlanOptimizationDriver(
     FlightPlanOptimizer::MetricFactory metric_factory) {
-  CHECK(has_deserialized_flight_plan());
+  ReadFlightPlanFromMessage();
   auto& [flight_plan, optimization_driver] =
       std::get<OptimizableFlightPlan>(selected_flight_plan());
   if (optimization_driver != nullptr) {
@@ -360,6 +360,8 @@ void Vessel::MakeFlightPlanOptimizationDriver(
 
 void Vessel::StartFlightPlanOptimizationDriver(
     FlightPlanOptimizationDriver::Parameters const& parameters) {
+  // No need to deserialize here, we have surely called
+  // |MakeFlightPlanOptimizationDriver|, otherwise the driver would be null.
   CHECK(has_deserialized_flight_plan());
   auto const& driver = std::get<OptimizableFlightPlan>(selected_flight_plan())
                            .optimization_driver;
@@ -381,7 +383,7 @@ Vessel::FlightPlanOptimizationDriverInProgress() const {
 }
 
 bool Vessel::UpdateFlightPlanFromOptimization() {
-  CHECK(has_deserialized_flight_plan());
+  ReadFlightPlanFromMessage();
   auto& [flight_plan, optimization_driver] =
       std::get<OptimizableFlightPlan>(selected_flight_plan());
   if (optimization_driver == nullptr) {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -323,6 +323,9 @@ class Vessel {
   using TrajectoryIterator =
       DiscreteTrajectory<Barycentric>::iterator (Part::*)();
 
+  // The optimization driver cannot be a member of the flight plan because it
+  // effectively acts as a factory for flight plans, and the flight plan gets
+  // replaced multiple times as the driver progresses in its optimization.
   struct OptimizableFlightPlan {
     not_null<std::shared_ptr<FlightPlan>> flight_plan;
     std::unique_ptr<FlightPlanOptimizationDriver> optimization_driver;
@@ -442,8 +445,6 @@ class Vessel {
 
   std::vector<LazilyDeserializedFlightPlan> flight_plans_;
   int selected_flight_plan_index_ = -1;
-  std::optional<FlightPlanOptimizationDriver::Parameters>
-      last_optimization_parameters_;
 
   std::optional<OrbitAnalyser> orbit_analyser_;
 


### PR DESCRIPTION
#3789 has a crash with `Check failed: has_deserialized_flight_plan()` in `UpdateFlightPlanFromOptimization`.  While I wasn't able to reproduce the crash, the API is unfriendly as it requires the UI to carefully keep track of the calls that may have deserialized the flight plan before calling `principia__FlightPlanUpdateFromOptimization `.  That's a very brittle precondition.  If we are going to optimize the flight plan, we might as well deserialize it.

I'm also moving the last parameters into the optimization driver, where they belong.  A given vessel may logically have multiple optimizations in flight for multiple flight plans, so having this information in the vessel was plain wrong.

Fix #3789.