### PR TITLE
Don't try to render markers related to the target vessel when the target vessel does not exist

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -400,7 +400,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
 
   // Same as above but returns the GUID.
   private string TargetVesselGuid() {
-    return TargetVessel().id.ToString();
+    return TargetVessel()?.id.ToString();
   }
 
 


### PR DESCRIPTION
Fix #3636.