### PR TITLE
A bunch of micro-optimizations in the adapter

### DIFF
--- a/ksp_plugin_adapter/interface.cs
+++ b/ksp_plugin_adapter/interface.cs
@@ -45,8 +45,16 @@ internal partial class Status {
 }
 
 public partial struct XYZ {
-  public static explicit operator XYZ(Vector3d v) {
+  public static explicit operator XYZ(UnityEngine.Vector3 v) {
     return new XYZ{ x = v.x, y = v.y, z = v.z };
+  }
+
+  public static explicit operator XYZ(Vector3d v) {
+    return new XYZ { x = v.x, y = v.y, z = v.z };
+  }
+
+  public static explicit operator UnityEngine.Vector3(XYZ v) {
+    return new UnityEngine.Vector3((float)v.x, (float)v.y, (float)v.z);
   }
 
   public static explicit operator Vector3d(XYZ v) {
@@ -55,6 +63,10 @@ public partial struct XYZ {
 }
 
 internal partial struct WXYZ {
+  public static explicit operator WXYZ(UnityEngine.Quaternion q) {
+    return new WXYZ{ w = q.w, x = q.x, y = q.y, z = q.z };
+  }
+
   public static explicit operator WXYZ(UnityEngine.QuaternionD q) {
     return new WXYZ{ w = q.w, x = q.x, y = q.y, z = q.z };
   }

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -1152,8 +1152,8 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
         yield break;
       }
 
-      // We are not changing the |Transform|s, but if we don't disable auto-
-      // sync the profiles show |SyncColliderTransform|.
+      // We are going to touch plenty of |Transform|s, so we will prevent
+      // Unity from syncing with the physics system all the time.
       UnityEngine.Physics.autoSyncTransforms = false;
 
       double Δt = Planetarium.TimeScale * Planetarium.fetch.fixedDeltaTime;
@@ -1437,10 +1437,6 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       if (has_active_manageable_vessel() &&
           !FlightGlobals.ActiveVessel.packed &&
           plugin_.HasVessel(FlightGlobals.ActiveVessel.id.ToString())) {
-        // We are going to touch plenty of |Transform|s, so we will prevent
-        // Unity from syncing with the physics system all the time.
-        UnityEngine.Physics.autoSyncTransforms = false;
-
         Vector3d q_correction_at_root_part = Vector3d.zero;
         Vector3d v_correction_at_root_part = Vector3d.zero;
         CelestialBody main_body = FlightGlobals.ActiveVessel.mainBody;

--- a/ksp_plugin_adapter/mono_marshaler.cs
+++ b/ksp_plugin_adapter/mono_marshaler.cs
@@ -29,15 +29,12 @@ internal abstract class MonoMarshaler : ICustomMarshaler {
   void ICustomMarshaler.CleanUpManagedData(object managed_object) {}
 
   void ICustomMarshaler.CleanUpNativeData(IntPtr native_data) {
-    IntPtr actual_native_data = IntPtr.Zero;
+    bool found;
     lock (allocated_intptrs_) {
-      if (allocated_intptrs_.Contains(native_data)) {
-        actual_native_data = native_data;
-        allocated_intptrs_.Remove(native_data);
-      }
+      found = allocated_intptrs_.Remove(native_data);
     }
-    if (actual_native_data != IntPtr.Zero) {
-      CleanUpNativeDataImplementation(actual_native_data);
+    if (found) {
+      CleanUpNativeDataImplementation(native_data);
     }
   }
 
@@ -51,8 +48,8 @@ internal abstract class MonoMarshaler : ICustomMarshaler {
       return IntPtr.Zero;
     }
     IntPtr result = MarshalManagedToNativeImplementation(managed_object);
-    lock (allocated_intptrs_) {
-      if (result != IntPtr.Zero) {
+    if (result != IntPtr.Zero) {
+      lock (allocated_intptrs_) {
         allocated_intptrs_.Add(result);
       }
     }

--- a/ksp_plugin_adapter/utf8_marshaler.cs
+++ b/ksp_plugin_adapter/utf8_marshaler.cs
@@ -68,10 +68,12 @@ internal class NoOwnershipTransferUTF8Marshaler : UTF8Marshaler {
     }
     int size = utf8_.GetByteCount(value);
     IntPtr buffer = Marshal.AllocHGlobal(size + 1);
-    byte[] bytes = new byte[size + 1];
-    utf8_.GetBytes(value, 0, value.Length, bytes, 0);
-    bytes[size] = 0;
-    Marshal.Copy(bytes, 0, buffer, size + 1);
+    unsafe {
+      fixed (char* p = value) {
+        utf8_.GetBytes(p, value.Length, (byte*)buffer.ToPointer(), size);
+      }
+    }
+    Marshal.WriteByte(buffer, size, 0);
     return buffer;
   }
 


### PR DESCRIPTION
1. Avoid double conversions (e.g., `Vector3` → `Vector3d` → `XYZ`).
2. Use local variables to hold nontrivial expressions.
3. Disable physics auto-sync over a larger region.
4. Do a bit less work in the marshallers (notably, less allocations).

None of that makes a big difference.  Optimistically, this PR brings a 10% speed up in the test case of #3230.