### PR TITLE
Disable the Optimize button when an optimization is in progress

### DIFF
--- a/ksp_plugin/flight_plan_optimization_driver.cpp
+++ b/ksp_plugin/flight_plan_optimization_driver.cpp
@@ -55,6 +55,7 @@ void FlightPlanOptimizationDriver::RequestOptimization(
   // Only process this request if there is no analysis in progress.
   absl::MutexLock l(&lock_);
   if (optimizer_idle_) {
+    last_parameters_ = parameters;
     optimizer_idle_ = false;
     optimizer_ = MakeStoppableThread([this, parameters]() {
       const absl::Status optimization_status = flight_plan_optimizer_.Optimize(


### PR DESCRIPTION
It used to disable itself, but that was lost in a code restructuring.  I noticed this in a video shared by **Prophet1313** on Discord.