### PR TITLE
Do not create a flight plan copy when creating an optimization driver

### DIFF
--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -306,9 +306,10 @@ double FlightPlan::progress_of_analysis(int coast_index) const {
 void FlightPlan::EnableAnalysis(bool const enabled) {
   if (enabled != analysis_is_enabled_) {
     if (enabled) {
-      // Request analysis of all the non-anomalous coasts.
+      // Request analysis of all non-anomalous coasts, and the first anomalous
+      // segment if it is a coast.
       for (int index = 0;
-           index < segments_.size() - anomalous_segments_;
+           index < segments_.size() - std::max(0, anomalous_segments_ - 1);
            ++index) {
         if (index % 2 == 0) {
           auto const& coast = segments_[index];

--- a/ksp_plugin/flight_plan_optimization_driver.cpp
+++ b/ksp_plugin/flight_plan_optimization_driver.cpp
@@ -16,16 +16,15 @@ namespace internal {
 using std::placeholders::_1;
 
 FlightPlanOptimizationDriver::FlightPlanOptimizationDriver(
-    FlightPlan const& flight_plan,
+    not_null<std::shared_ptr<FlightPlan>> const& flight_plan,
     FlightPlanOptimizer::MetricFactory metric_factory)
-    : flight_plan_under_optimization_(flight_plan),
+    : flight_plan_under_optimization_(*flight_plan),  // Copy.
       flight_plan_optimizer_(&flight_plan_under_optimization_,
                              std::move(metric_factory),
                              [this](FlightPlan const& flight_plan) {
                                UpdateLastFlightPlan(flight_plan);
                              }),
-      last_flight_plan_(
-          make_not_null_shared<FlightPlan>(flight_plan_under_optimization_)) {}
+      last_flight_plan_(flight_plan) {}
 
 FlightPlanOptimizationDriver::~FlightPlanOptimizationDriver() {
   // Ensure that we do not have a thread still running with references to the

--- a/ksp_plugin/flight_plan_optimization_driver.cpp
+++ b/ksp_plugin/flight_plan_optimization_driver.cpp
@@ -64,6 +64,7 @@ void FlightPlanOptimizationDriver::RequestOptimization(
       if (optimization_status.ok()) {
         last_flight_plan_ =
             make_not_null_shared<FlightPlan>(flight_plan_under_optimization_);
+        last_flight_plan_->EnableAnalysis(/*enabled=*/true);
       } else {
         LOG(WARNING) << "Optimization returned " << optimization_status;
       }
@@ -87,6 +88,9 @@ void FlightPlanOptimizationDriver::UpdateLastFlightPlan(
     FlightPlan const& flight_plan) {
   absl::MutexLock l(&lock_);
   last_flight_plan_ = make_not_null_shared<FlightPlan>(flight_plan);
+  // TODO(phl): This is wasteful, but otherwise, what happens if we interrupt
+  // optimization?
+  last_flight_plan_->EnableAnalysis(/*enabled=*/true);
 }
 
 }  // namespace internal

--- a/ksp_plugin/flight_plan_optimization_driver.hpp
+++ b/ksp_plugin/flight_plan_optimization_driver.hpp
@@ -28,7 +28,7 @@ class FlightPlanOptimizationDriver {
   };
 
   FlightPlanOptimizationDriver(
-      FlightPlan const& flight_plan,
+      not_null<std::shared_ptr<FlightPlan>> const& flight_plan,
       FlightPlanOptimizer::MetricFactory metric_factory);
 
   virtual ~FlightPlanOptimizationDriver();
@@ -54,6 +54,7 @@ class FlightPlanOptimizationDriver {
   void Wait() const;
 
  private:
+  // The progress callback of the optimizer.
   void UpdateLastFlightPlan(FlightPlan const& flight_plan);
 
   // The flight plan being optimized, asynchronously modified by the optimizer.

--- a/ksp_plugin/flight_plan_optimizer.cpp
+++ b/ksp_plugin/flight_plan_optimizer.cpp
@@ -544,12 +544,8 @@ absl::Status FlightPlanOptimizer::Optimize(int const index,
           Δv_tolerance / speed_homogeneization_factor);
   if (status_or_solution.ok()) {
     auto const& solution = status_or_solution.value();
-    auto const replace_status =
-        flight_plan_->Replace(UpdatedBurn(solution, manœuvre), index);
-    flight_plan_->EnableAnalysis(/*enabled=*/true);
-    return replace_status;
+    return flight_plan_->Replace(UpdatedBurn(solution, manœuvre), index);
   } else {
-    flight_plan_->EnableAnalysis(/*enabled=*/true);
     return status_or_solution.status();
   }
 }

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -355,7 +355,7 @@ void Vessel::MakeFlightPlanOptimizationDriver(
     optimization_driver->Interrupt();
   }
   optimization_driver = make_not_null_unique<FlightPlanOptimizationDriver>(
-      *flight_plan, std::move(metric_factory));
+      flight_plan, std::move(metric_factory));
 }
 
 void Vessel::StartFlightPlanOptimizationDriver(


### PR DESCRIPTION
The copy doesn't have an orbit analyser, we only want one when it was created by the optimizer.