### PR TITLE
Compute the terrain altitude at the right place to determine whether the periapsis is underground

### DIFF
--- a/ksp_plugin_adapter/map_node_pool.cs
+++ b/ksp_plugin_adapter/map_node_pool.cs
@@ -188,7 +188,7 @@ internal class MapNodePool {
                               out double altitude);
           var terrain_altitude = centre.TerrainAltitude(
               latitude,
-              latitude,
+              longitude,
               allowNegative: !centre.ocean);
           if (altitude < terrain_altitude) {
             if (provenance.source == NodeSource.Prediction) {


### PR DESCRIPTION
Possibly fix #3826. The preconditions on `ComputeCollision` are a bit of a mess, but so long as we are underground at `last_time` it should work. However, we were instead checking whether we would have been underground had we been on one branch of the φ=λ analemma. The height above terrain calculation used to actually compute the collision was correct, which is why it would show up in the right place (up to the issue of multiple intersections). This may explain some oddities as to whether we would try to compute the collision at all—though the underground periapsis thing is of course fundamentally deficient as a criterion.