### PR TITLE
Clean up the arrays code

### DIFF
--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -39,6 +39,7 @@ class FixedVector final {
   constexpr FixedVector(
       std::array<Scalar, size_>&& data);  // NOLINT(runtime/explicit)
 
+  // This object must outlive the result of Transpose.
   TransposedView<FixedVector> Transpose() const;
 
   Scalar Norm() const;
@@ -102,6 +103,9 @@ class FixedMatrix final {
 
   template<int r>
   Scalar const* row() const;
+
+  // This object must outlive the result of Transpose.
+  TransposedView<FixedMatrix> Transpose() const;
 
   Scalar FrobeniusNorm() const;
 
@@ -378,12 +382,12 @@ std::ostream& operator<<(std::ostream& out,
 template<typename Scalar, int rows>
 std::ostream& operator<<(
     std::ostream& out,
-    FixedLowerTriangularMatrix<Scalar, rows> const& matrix);
+    FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix);
 
 template<typename Scalar, int rows>
 std::ostream& operator<<(
     std::ostream& out,
-    FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix);
+    FixedLowerTriangularMatrix<Scalar, rows> const& matrix);
 
 template<typename Scalar, int columns>
 std::ostream& operator<<(

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -108,6 +108,13 @@ class FixedMatrix final {
   bool operator==(FixedMatrix const& right) const;
   bool operator!=(FixedMatrix const& right) const;
 
+  // Applies the matrix as a bilinear form.  Present for compatibility with
+  // |SymmetricBilinearForm|.  Prefer to use |TransposedView| and |operator*|.
+  template<typename LScalar, typename RScalar>
+  Product<Scalar, Product<LScalar, RScalar>>
+      operator()(FixedVector<LScalar, columns_> const& left,
+                 FixedVector<RScalar, rows_> const& right) const;
+
   static FixedMatrix Identity();
 
  private:

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -39,9 +39,6 @@ class FixedVector final {
   constexpr FixedVector(
       std::array<Scalar, size_>&& data);  // NOLINT(runtime/explicit)
 
-  // This object must outlive the result of Transpose.
-  TransposedView<FixedVector> Transpose() const;
-
   Scalar Norm() const;
   Square<Scalar> Norm²() const;
 
@@ -104,8 +101,7 @@ class FixedMatrix final {
   template<int r>
   Scalar const* row() const;
 
-  // This object must outlive the result of Transpose.
-  TransposedView<FixedMatrix> Transpose() const;
+  FixedMatrix Transpose() const;
 
   Scalar FrobeniusNorm() const;
 

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -103,16 +103,10 @@ class FixedMatrix final {
   template<int r>
   Scalar const* row() const;
 
-  FixedMatrix Transpose() const;
   Scalar FrobeniusNorm() const;
 
   bool operator==(FixedMatrix const& right) const;
   bool operator!=(FixedMatrix const& right) const;
-
-  template<typename LScalar, typename RScalar>
-  Product<Scalar, Product<LScalar, RScalar>>
-      operator()(FixedVector<LScalar, columns_> const& left,
-                 FixedVector<RScalar, rows_> const& right) const;
 
   static FixedMatrix Identity();
 
@@ -214,6 +208,7 @@ class FixedUpperTriangularMatrix final {
   std::array<Scalar, size()> data_;
 };
 
+// Prefer using the operator* that takes a TransposedView.
 template<typename LScalar, typename RScalar, int size>
 constexpr Product<LScalar, RScalar> InnerProduct(
     FixedVector<LScalar, size> const& left,
@@ -363,7 +358,8 @@ constexpr FixedVector<Product<LScalar, RScalar>, rows> operator*(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedVector<RScalar, columns> const& right);
 
-// Use this operator to multiply a row vector with a matrix.
+// Use this operator to multiply a row vector with a matrix.  We don't have an
+// operator returning a TransposedView as that would cause dangling references.
 template<typename LScalar, typename RScalar, int rows, int columns>
 constexpr FixedVector<Product<LScalar, RScalar>, columns> operator*(
     TransposedView<FixedMatrix<LScalar, rows, columns>> const& left,
@@ -383,6 +379,11 @@ template<typename Scalar, int rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedLowerTriangularMatrix<Scalar, rows> const& matrix);
+
+template<typename Scalar, int rows>
+std::ostream& operator<<(
+    std::ostream& out,
+    FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix);
 
 template<typename Scalar, int columns>
 std::ostream& operator<<(

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -420,7 +420,7 @@ constexpr FixedVector<Scalar, size> operator-(
   for (int i = 0; i < size; ++i) {
     result[i] = -right[i];
   }
-  return FixedVector<Difference<Scalar>, size>(std::move(result));
+  return FixedVector<Scalar, size>(std::move(result));
 }
 
 template<typename Scalar, int rows, int columns>

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -168,24 +168,9 @@ Scalar const* FixedMatrix<Scalar, rows_, columns_>::row() const {
 }
 
 template<typename Scalar, int rows_, int columns_>
-template<typename LScalar, typename RScalar>
-Product<Scalar, Product<LScalar, RScalar>>
-FixedMatrix<Scalar, rows_, columns_>::operator()(
-    FixedVector<LScalar, columns_> const& left,
-    FixedVector<RScalar, rows_> const& right) const {
-  return left.Transpose() * (*this * right);
-}
-
-template<typename Scalar, int rows_, int columns_>
-FixedMatrix<Scalar, rows_, columns_>
+TransposedView<FixedMatrix<Scalar, rows_, columns_>>
 FixedMatrix<Scalar, rows_, columns_>::Transpose() const {
-  FixedMatrix<Scalar, rows(), columns()> m(uninitialized);
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
-      m(j, i) = (*this)(i, j);
-    }
-  }
-  return m;
+  return TransposedView{*this};
 }
 
 template<typename Scalar, int rows_, int columns_>
@@ -725,6 +710,24 @@ std::ostream& operator<<(std::ostream& out,
     for (int j = 0; j < columns; ++j) {
       out << matrix(i, j);
       if (j < columns - 1) {
+        out << ", ";
+      }
+    }
+    out << "}\n";
+  }
+  return out;
+}
+
+template<typename Scalar, int rows>
+std::ostream& operator<<(
+    std::ostream& out,
+    FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix) {
+  out << "rows: " << matrix.rows() << "\n";
+  for (int i = 0; i < matrix.rows(); ++i) {
+    out << "{";
+    for (int j = 0; j < i; ++j) {
+      out << matrix(i, j);
+      if (j < i - 1) {
         out << ", ";
       }
     }

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -197,6 +197,15 @@ bool FixedMatrix<Scalar, rows_, columns_>::operator!=(
 }
 
 template<typename Scalar, int rows_, int columns_>
+template<typename LScalar, typename RScalar>
+Product<Scalar, Product<LScalar, RScalar>>
+FixedMatrix<Scalar, rows_, columns_>::operator()(
+    FixedVector<LScalar, columns_> const& left,
+    FixedVector<RScalar, rows_> const& right) const {
+  return TransposedView{left} * (*this * right);
+}
+
+template<typename Scalar, int rows_, int columns_>
 FixedMatrix<Scalar, rows_, columns_>
 FixedMatrix<Scalar, rows_, columns_>::Identity() {
   FixedMatrix<Scalar, rows(), columns()> m;

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -202,7 +202,7 @@ Product<Scalar, Product<LScalar, RScalar>>
 FixedMatrix<Scalar, rows_, columns_>::operator()(
     FixedVector<LScalar, columns_> const& left,
     FixedVector<RScalar, rows_> const& right) const {
-  return TransposedView{left} * (*this * right);
+  return TransposedView{left} * (*this * right);  // NOLINT
 }
 
 template<typename Scalar, int rows_, int columns_>

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -72,12 +72,6 @@ constexpr FixedVector<Scalar, size_>::FixedVector(
     : data_(std::move(data)) {}
 
 template<typename Scalar, int size_>
-TransposedView<FixedVector<Scalar, size_>>
-FixedVector<Scalar, size_>::Transpose() const {
-  return {.transpose = *this};
-}
-
-template<typename Scalar, int size_>
 Scalar FixedVector<Scalar, size_>::Norm() const {
   return Sqrt(Norm²());
 }
@@ -168,9 +162,15 @@ Scalar const* FixedMatrix<Scalar, rows_, columns_>::row() const {
 }
 
 template<typename Scalar, int rows_, int columns_>
-TransposedView<FixedMatrix<Scalar, rows_, columns_>>
+FixedMatrix<Scalar, rows_, columns_>
 FixedMatrix<Scalar, rows_, columns_>::Transpose() const {
-  return TransposedView{*this};
+  FixedMatrix<Scalar, rows(), columns()> m(uninitialized);
+  for (int i = 0; i < rows(); ++i) {
+    for (int j = 0; j < columns(); ++j) {
+      m(j, i) = (*this)(i, j);
+    }
+  }
+  return m;
 }
 
 template<typename Scalar, int rows_, int columns_>

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -86,7 +86,7 @@ TEST_F(FixedArraysTest, Assignment) {
 }
 
 TEST_F(FixedArraysTest, Norm) {
-  EXPECT_EQ(35, v4_.Transpose() * v4_);
+  EXPECT_EQ(35, TransposedView{v4_} * v4_);
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
   EXPECT_EQ(35, v4_.Norm²());
   EXPECT_EQ(Sqrt(517.0), m34_.FrobeniusNorm());
@@ -121,11 +121,11 @@ TEST_F(FixedArraysTest, VectorSpaces) {
 }
 
 TEST_F(FixedArraysTest, Algebra) {
-  EXPECT_EQ(-535, u3_.Transpose() * v3_);
+  EXPECT_EQ(-535, TransposedView{u3_} * v3_);
   EXPECT_EQ((FixedMatrix<double, 3, 4>({-30, -30,  10,   40,
                                         -93, -93,  31,  124,
                                         141, 141, -47, -188})),
-             v3_ * v4_.Transpose());
+             v3_ * TransposedView{v4_});
   EXPECT_EQ((FixedMatrix<double, 2, 4>({ 0,  14, -22,   3,
                                         14, -63,   5, -92})),
             m23_ * m34_);

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -86,7 +86,7 @@ TEST_F(FixedArraysTest, Assignment) {
 }
 
 TEST_F(FixedArraysTest, Norm) {
-  EXPECT_EQ(35, TransposedView{v4_} * v4_);
+  EXPECT_EQ(35, TransposedView{v4_} * v4_);  // NOLINT
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
   EXPECT_EQ(35, v4_.Norm²());
   EXPECT_EQ(Sqrt(517.0), m34_.FrobeniusNorm());
@@ -121,7 +121,7 @@ TEST_F(FixedArraysTest, VectorSpaces) {
 }
 
 TEST_F(FixedArraysTest, Algebra) {
-  EXPECT_EQ(-535, TransposedView{u3_} * v3_);
+  EXPECT_EQ(-535, TransposedView{u3_} * v3_);  // NOLINT
   EXPECT_EQ((FixedMatrix<double, 3, 4>({-30, -30,  10,   40,
                                         -93, -93,  31,  124,
                                         141, 141, -47, -188})),

--- a/numerics/gradient_descent_body.hpp
+++ b/numerics/gradient_descent_body.hpp
@@ -12,7 +12,6 @@
 #include "geometry/symmetric_bilinear_form.hpp"
 #include "numerics/fixed_arrays.hpp"
 #include "numerics/hermite2.hpp"
-#include "numerics/transposed_view.hpp"
 #include "quantities/elementary_functions.hpp"
 
 namespace principia {
@@ -25,7 +24,6 @@ using namespace principia::geometry::_point;
 using namespace principia::geometry::_symmetric_bilinear_form;
 using namespace principia::numerics::_fixed_arrays;
 using namespace principia::numerics::_hermite2;
-using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_elementary_functions;
 
 template<typename Scalar, typename S, int s>
@@ -333,9 +331,9 @@ absl::StatusOr<Argument> BroydenFletcherGoldfarbShanno(
     // The formula (6.17) from [NW06] is inconvenient because it uses external
     // products.  Elementary transformations yield the formula below.
     auto const ρ = 1 / sₖyₖ;
-    auto const Hₖ₊₁ = Hₖ + ρ * ((ρ * (TransposedView{yₖ} * (Hₖ * yₖ)) + 1) *
-                                    SymmetricSquare(sₖ) -
-                                2 * SymmetricProduct(Hₖ * yₖ, sₖ));
+    auto const Hₖ₊₁ =
+        Hₖ + ρ * ((ρ * Hₖ(yₖ, yₖ) + 1) * SymmetricSquare(sₖ) -
+                  2 * SymmetricProduct(Hₖ * yₖ, sₖ));
 
     xₖ = xₖ₊₁;
     grad_f_xₖ = grad_f_xₖ₊₁;

--- a/numerics/gradient_descent_body.hpp
+++ b/numerics/gradient_descent_body.hpp
@@ -12,6 +12,7 @@
 #include "geometry/symmetric_bilinear_form.hpp"
 #include "numerics/fixed_arrays.hpp"
 #include "numerics/hermite2.hpp"
+#include "numerics/transposed_view.hpp"
 #include "quantities/elementary_functions.hpp"
 
 namespace principia {
@@ -24,6 +25,7 @@ using namespace principia::geometry::_point;
 using namespace principia::geometry::_symmetric_bilinear_form;
 using namespace principia::numerics::_fixed_arrays;
 using namespace principia::numerics::_hermite2;
+using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_elementary_functions;
 
 template<typename Scalar, typename S, int s>
@@ -331,9 +333,9 @@ absl::StatusOr<Argument> BroydenFletcherGoldfarbShanno(
     // The formula (6.17) from [NW06] is inconvenient because it uses external
     // products.  Elementary transformations yield the formula below.
     auto const ρ = 1 / sₖyₖ;
-    auto const Hₖ₊₁ =
-        Hₖ + ρ * ((ρ * Hₖ(yₖ, yₖ) + 1) * SymmetricSquare(sₖ) -
-                  2 * SymmetricProduct(Hₖ * yₖ, sₖ));
+    auto const Hₖ₊₁ = Hₖ + ρ * ((ρ * (TransposedView{yₖ} * (Hₖ * yₖ)) + 1) *
+                                    SymmetricSquare(sₖ) -
+                                2 * SymmetricProduct(Hₖ * yₖ, sₖ));
 
     xₖ = xₖ₊₁;
     grad_f_xₖ = grad_f_xₖ₊₁;

--- a/numerics/matrix_computations_body.hpp
+++ b/numerics/matrix_computations_body.hpp
@@ -924,7 +924,7 @@ template<typename Matrix, typename Vector>
 typename RayleighQuotientGenerator<Matrix, Vector>::Result
 RayleighQuotient(Matrix const& A, Vector const& x) {
   // [GV13], section 8.2.3.
-  return TransposedView{x} * (A * x) / (TransposedView{x} * x);
+  return TransposedView{x} * (A * x) / (TransposedView{x} * x);  // NOLINT
 }
 
 template<typename Matrix, typename Vector>

--- a/numerics/matrix_computations_body.hpp
+++ b/numerics/matrix_computations_body.hpp
@@ -788,7 +788,7 @@ template<typename Matrix, typename Vector>
 typename RayleighQuotientGenerator<Matrix, Vector>::Result
 RayleighQuotient(Matrix const& A, Vector const& x) {
   // [GV13], section 8.2.3.
-  return x.Transpose() * (A * x) / (x.Transpose() * x);
+  return TransposedView{x} * (A * x) / (TransposedView{x} * x);
 }
 
 template<typename Matrix, typename Vector>

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -86,9 +86,10 @@ class UnboundedMatrix final {
   UnboundedMatrix(int rows, int columns);
   UnboundedMatrix(int rows, int columns, uninitialized_t);
 
-  // The |data| must be in row-major format.
-  template<int rows>
+  // The |data| must be in row-major format and must be for a square matrix.
   UnboundedMatrix(std::initializer_list<Scalar> data);
+
+  UnboundedMatrix(int rows, int columns, std::initializer_list<Scalar> data);
 
   int rows() const;
   int columns() const;
@@ -127,14 +128,12 @@ class UnboundedLowerTriangularMatrix final {
   UnboundedLowerTriangularMatrix(int rows, uninitialized_t);
 
   // The |data| must be in row-major format.
-  template<int rows>
   UnboundedLowerTriangularMatrix(std::initializer_list<Scalar> data);
 
   void Extend(int extra_rows);
   void Extend(int extra_rows, uninitialized_t);
 
   // The |data| must be in row-major format.
-  template<int rows>
   void Extend(std::initializer_list<Scalar> data);
 
   void EraseToEnd(int begin_row_index);

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -8,6 +8,7 @@
 #include "base/tags.hpp"
 #include "numerics/transposed_view.hpp"
 #include "quantities/named_quantities.hpp"
+#include "quantities/si.hpp"
 
 namespace principia {
 namespace numerics {
@@ -19,6 +20,7 @@ namespace internal {
 using namespace principia::base::_tags;
 using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_named_quantities;
+using namespace principia::quantities::_si;
 
 // An allocator that does not initialize the allocated objects.
 template<class T>
@@ -42,8 +44,6 @@ class UnboundedVector final {
   explicit UnboundedVector(int size);  // Zero-initialized.
   UnboundedVector(int size, uninitialized_t);
   UnboundedVector(std::initializer_list<Scalar> data);
-
-  TransposedView<UnboundedVector> Transpose() const;
 
   void Extend(int extra_size);
   void Extend(int extra_size, uninitialized_t);
@@ -148,6 +148,8 @@ class UnboundedLowerTriangularMatrix final {
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
 
+  UnboundedUpperTriangularMatrix<Scalar> Transpose() const;
+
   bool operator==(UnboundedLowerTriangularMatrix const& right) const;
   bool operator!=(UnboundedLowerTriangularMatrix const& right) const;
 
@@ -187,6 +189,8 @@ class UnboundedUpperTriangularMatrix final {
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
+
+  UnboundedLowerTriangularMatrix<Scalar> Transpose() const;
 
   bool operator==(UnboundedUpperTriangularMatrix const& right) const;
   bool operator!=(UnboundedUpperTriangularMatrix const& right) const;

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -51,6 +51,9 @@ class UnboundedVector final {
 
   void EraseToEnd(int begin_index);
 
+  // This object must outlive the result of Transpose.
+  TransposedView<UnboundedVector> Transpose() const;
+
   Scalar Norm() const;
   Square<Scalar> Norm²() const;
 
@@ -96,6 +99,9 @@ class UnboundedMatrix final {
   // |a(i, j)| implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
+
+  // This object must outlive the result of Transpose.
+  TransposedView<UnboundedMatrix> Transpose() const;
 
   Scalar FrobeniusNorm() const;
 
@@ -210,7 +216,7 @@ class UnboundedUpperTriangularMatrix final {
 
 // Prefer using the operator* that takes a TransposedView.
 template<typename LScalar, typename RScalar>
-constexpr Product<LScalar, RScalar> InnerProduct(
+Product<LScalar, RScalar> InnerProduct(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right);
 
@@ -218,61 +224,61 @@ template<typename Scalar>
 UnboundedVector<double> Normalize(UnboundedVector<Scalar> const& vector);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedMatrix<Product<LScalar, RScalar>> SymmetricProduct(
+UnboundedMatrix<Product<LScalar, RScalar>> SymmetricProduct(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Square<Scalar>> SymmetricSquare(
+UnboundedMatrix<Square<Scalar>> SymmetricSquare(
     UnboundedVector<Scalar> const& vector);
 
 // Additive groups.
 
 template<typename Scalar>
-constexpr UnboundedVector<Scalar> operator-(
+UnboundedVector<Scalar> operator-(
     UnboundedVector<Scalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Scalar> operator-(
+UnboundedMatrix<Scalar> operator-(
     UnboundedMatrix<Scalar> const& right);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedVector<Sum<LScalar, RScalar>> operator+(
+UnboundedVector<Sum<LScalar, RScalar>> operator+(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedMatrix<Sum<LScalar, RScalar>> operator+(
+UnboundedMatrix<Sum<LScalar, RScalar>> operator+(
     UnboundedMatrix<LScalar> const& left,
     UnboundedMatrix<RScalar> const& right);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedVector<Difference<LScalar, RScalar>> operator-(
+UnboundedVector<Difference<LScalar, RScalar>> operator-(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedMatrix<Difference<LScalar, RScalar>> operator-(
+UnboundedMatrix<Difference<LScalar, RScalar>> operator-(
     UnboundedMatrix<LScalar> const& left,
     UnboundedMatrix<RScalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedVector<Scalar>& operator+=(
+UnboundedVector<Scalar>& operator+=(
     UnboundedVector<Scalar>& left,
     UnboundedVector<Scalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Scalar>& operator+=(
+UnboundedMatrix<Scalar>& operator+=(
     UnboundedMatrix<Scalar>& left,
     UnboundedMatrix<Scalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedVector<Scalar>& operator-=(
+UnboundedVector<Scalar>& operator-=(
     UnboundedVector<Scalar>& left,
     UnboundedVector<Scalar> const& right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Scalar>& operator-=(
+UnboundedMatrix<Scalar>& operator-=(
     UnboundedMatrix<Scalar>& left,
     UnboundedMatrix<Scalar> const& right);
 
@@ -304,27 +310,27 @@ UnboundedVector<Quotient<LScalar, RScalar>> operator/(
     RScalar const& right);
 
 template<typename LScalar, typename RScalar>
-constexpr UnboundedMatrix<Quotient<LScalar, RScalar>>
+UnboundedMatrix<Quotient<LScalar, RScalar>>
 operator/(UnboundedMatrix<LScalar> const& left,
           RScalar const& right);
 
 template<typename Scalar>
-constexpr UnboundedVector<Scalar>& operator*=(
+UnboundedVector<Scalar>& operator*=(
     UnboundedVector<Scalar>& left,
     double right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Scalar>& operator*=(
+UnboundedMatrix<Scalar>& operator*=(
     UnboundedMatrix<Scalar>& left,
     double right);
 
 template<typename Scalar>
-constexpr UnboundedVector<Scalar>& operator/=(
+UnboundedVector<Scalar>& operator/=(
     UnboundedVector<Scalar>& left,
     double right);
 
 template<typename Scalar>
-constexpr UnboundedMatrix<Scalar>& operator/=(
+UnboundedMatrix<Scalar>& operator/=(
     UnboundedMatrix<Scalar>& left,
     double right);
 

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -3,6 +3,7 @@
 #include <initializer_list>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "base/tags.hpp"
@@ -369,6 +370,7 @@ UnboundedVector<Product<LScalar, RScalar>> operator*(
     UnboundedVector<RScalar> const& right);
 
 // Use this operator to multiply a row vector with a matrix.  We don't have an
+// operator returning a TransposedView as that would cause dangling references.
 template<typename LScalar, typename RScalar>
 UnboundedVector<Product<LScalar, RScalar>> operator*(
     TransposedView<UnboundedMatrix<LScalar>> const& left,

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -51,9 +51,6 @@ class UnboundedVector final {
 
   void EraseToEnd(int begin_index);
 
-  // This object must outlive the result of Transpose.
-  TransposedView<UnboundedVector> Transpose() const;
-
   Scalar Norm() const;
   Square<Scalar> Norm²() const;
 
@@ -101,8 +98,7 @@ class UnboundedMatrix final {
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
 
-  // This object must outlive the result of Transpose.
-  TransposedView<UnboundedMatrix> Transpose() const;
+  UnboundedMatrix Transpose() const;
 
   Scalar FrobeniusNorm() const;
 

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -109,6 +109,13 @@ class UnboundedMatrix final {
   bool operator==(UnboundedMatrix const& right) const;
   bool operator!=(UnboundedMatrix const& right) const;
 
+  // Applies the matrix as a bilinear form.  Present for compatibility with
+  // |SymmetricBilinearForm|.  Prefer to use |TransposedView| and |operator*|.
+  template<typename LScalar, typename RScalar>
+  Product<Scalar, Product<LScalar, RScalar>>
+      operator()(UnboundedVector<LScalar> const& left,
+                 UnboundedVector<RScalar> const& right) const;
+
   static UnboundedMatrix Identity(int rows, int columns);
 
  private:

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -56,13 +56,6 @@ void UnboundedVector<Scalar>::EraseToEnd(int const begin_index) {
 }
 
 template<typename Scalar>
-TransposedView<UnboundedVector<Scalar>>
-UnboundedVector<Scalar>::Transpose() const {
-  return TransposedView<UnboundedVector>{*this};
-}
-
-
-template<typename Scalar>
 Scalar UnboundedVector<Scalar>::Norm() const {
   return Sqrt(Norm²());
 }
@@ -163,9 +156,14 @@ int UnboundedMatrix<Scalar>::size() const {
 }
 
 template<typename Scalar>
-TransposedView<UnboundedMatrix<Scalar>>
-UnboundedMatrix<Scalar>::Transpose() const {
-  return TransposedView<UnboundedMatrix>{*this};
+UnboundedMatrix<Scalar> UnboundedMatrix<Scalar>::Transpose() const {
+  UnboundedMatrix<Scalar> m(columns_, rows_, uninitialized);
+  for (int i = 0; i < rows_; ++i) {
+    for (int j = 0; j < columns_; ++j) {
+      m(j, i) = (*this)(i, j);
+    }
+  }
+  return m;
 }
 
 template<typename Scalar>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -126,13 +126,13 @@ UnboundedMatrix<Scalar>::UnboundedMatrix(std::initializer_list<Scalar> data)
 }
 
 template<typename Scalar>
-int UnboundedMatrix<Scalar>::columns() const {
-  return columns_;
+int UnboundedMatrix<Scalar>::rows() const {
+  return rows_;
 }
 
 template<typename Scalar>
-int UnboundedMatrix<Scalar>::rows() const {
-  return rows_;
+int UnboundedMatrix<Scalar>::columns() const {
+  return columns_;
 }
 
 template<typename Scalar>
@@ -253,13 +253,13 @@ void UnboundedLowerTriangularMatrix<Scalar>::EraseToEnd(
 }
 
 template<typename Scalar>
-int UnboundedLowerTriangularMatrix<Scalar>::columns() const {
+int UnboundedLowerTriangularMatrix<Scalar>::rows() const {
   return rows_;
 }
 
 template<typename Scalar>
-int UnboundedLowerTriangularMatrix<Scalar>::rows() const {
-  return rows_;
+int UnboundedLowerTriangularMatrix<Scalar>::columns() const {
+  return columns_;
 }
 
 template<typename Scalar>
@@ -370,12 +370,12 @@ void UnboundedUpperTriangularMatrix<Scalar>::EraseToEnd(
 }
 
 template<typename Scalar>
-int UnboundedUpperTriangularMatrix<Scalar>::columns() const {
-  return columns_;
+int UnboundedUpperTriangularMatrix<Scalar>::rows() const {
+  return rows_;
 }
 
 template<typename Scalar>
-int UnboundedUpperTriangularMatrix<Scalar>::rows() const {
+int UnboundedUpperTriangularMatrix<Scalar>::columns() const {
   return columns_;
 }
 

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -530,6 +530,85 @@ UnboundedMatrix<Square<Scalar>> SymmetricSquare(
 }
 
 template<typename Scalar>
+UnboundedVector<Scalar> operator-(UnboundedVector<Scalar> const& right) {
+  std::vector<Scalar> result;
+  result.reserve(right.size());
+  for (int i = 0; i < right.size(); ++i) {
+    result[i] = -right[i];
+  }
+  return UnboundedVector<Scalar>(std::move(result));
+}
+
+template<typename Scalar>
+UnboundedMatrix<Scalar> operator-(UnboundedMatrix<Scalar> const& right) {
+  UnboundedMatrix<Scalar> result(right.rows(), right.columns(), uninitialized);
+  for (int i = 0; i < right.rows(); ++i) {
+    for (int j = 0; j < right.columns(); ++j) {
+      result(i, j) = -right(i, j);
+    }
+  }
+  return result;
+}
+
+template<typename LScalar, typename RScalar>
+UnboundedVector<Sum<LScalar, RScalar>> operator+(
+    UnboundedVector<LScalar> const& left,
+    UnboundedVector<RScalar> const& right) {
+  CHECK_EQ(left.size(), right.size());
+  std::vector<Sum<LScalar, RScalar>> result;
+  result.resize(right.size());
+  for (int i = 0; i < right.size(); ++i) {
+    result[i] = left[i] + right[i];
+  }
+  return UnboundedVector<Sum<LScalar, RScalar>>(std::move(result));
+}
+
+template<typename LScalar, typename RScalar>
+UnboundedMatrix<Sum<LScalar, RScalar>> operator+(
+    UnboundedMatrix<LScalar> const& left,
+    UnboundedMatrix<RScalar> const& right) {
+  CHECK_EQ(left.rows(), right.rows());
+  CHECK_EQ(left.columns(), right.columns());
+  UnboundedMatrix<Sum<LScalar, RScalar>> result(
+      right.rows(), right.columns(), uninitialized);
+  for (int i = 0; i < right.rows(); ++i) {
+    for (int j = 0; j < right.columns(); ++j) {
+      result(i, j) = left(i, j) + right(i, j);
+    }
+  }
+  return result;
+}
+
+template<typename LScalar, typename RScalar>
+UnboundedVector<Difference<LScalar, RScalar>> operator-(
+    UnboundedVector<LScalar> const& left,
+    UnboundedVector<RScalar> const& right) {
+  CHECK_EQ(left.size(), right.size());
+  std::vector<Sum<LScalar, RScalar>> result;
+  result.resize(right.size());
+  for (int i = 0; i < right.size(); ++i) {
+    result[i] = left[i] - right[i];
+  }
+  return UnboundedVector<Difference<LScalar, RScalar>>(std::move(result));
+}
+
+template<typename LScalar, typename RScalar>
+UnboundedMatrix<Difference<LScalar, RScalar>> operator-(
+    UnboundedMatrix<LScalar> const& left,
+    UnboundedMatrix<RScalar> const& right) {
+  CHECK_EQ(left.rows(), right.rows());
+  CHECK_EQ(left.columns(), right.columns());
+  UnboundedMatrix<Sum<LScalar, RScalar>> result(
+      right.rows(), right.columns(), uninitialized);
+  for (int i = 0; i < right.rows(); ++i) {
+    for (int j = 0; j < right.columns(); ++j) {
+      result(i, j) = left(i, j) + right(i, j);
+    }
+  }
+  return result;
+}
+
+template<typename Scalar>
 UnboundedVector<Scalar>& operator+=(
     UnboundedVector<Scalar>& left,
     UnboundedVector<Scalar> const& right) {

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -131,10 +131,18 @@ UnboundedMatrix<Scalar>::UnboundedMatrix(int rows, int columns, uninitialized_t)
 
 
 template<typename Scalar>
-template<int rows>
 UnboundedMatrix<Scalar>::UnboundedMatrix(std::initializer_list<Scalar> data)
+    : rows_(Sqrt(data.size())),
+      columns_(Sqrt(data.size())),
+      data_(std::move(data)) {
+  CHECK_EQ(data.size(), rows_ * columns_);
+}
+
+template<typename Scalar>
+UnboundedMatrix<Scalar>::UnboundedMatrix(int const rows, int const columns,
+                                         std::initializer_list<Scalar> data)
     : rows_(rows),
-      columns_(data.size() / rows),
+      columns_(columns),
       data_(std::move(data)) {
   CHECK_EQ(data.size(), rows_ * columns_);
 }
@@ -225,10 +233,9 @@ UnboundedLowerTriangularMatrix<Scalar>::UnboundedLowerTriangularMatrix(
       data_(rows_ * (rows_ + 1) / 2) {}
 
 template<typename Scalar>
-template<int rows>
 UnboundedLowerTriangularMatrix<Scalar>::UnboundedLowerTriangularMatrix(
     std::initializer_list<Scalar> data)
-    : rows_(rows),
+    : rows_(static_cast<int>(std::lround((-1 + Sqrt(8 * data.size())) * 0.5))),
       data_(std::move(data)) {
   DCHECK_EQ(data_.size(), rows_ * (rows_ + 1) / 2);
 }
@@ -247,11 +254,10 @@ void UnboundedLowerTriangularMatrix<Scalar>::Extend(int const extra_rows,
 }
 
 template<typename Scalar>
-template<int rows>
 void UnboundedLowerTriangularMatrix<Scalar>::Extend(
     std::initializer_list<Scalar> data) {
   std::move(data.begin(), data.end(), std::back_inserter(data_));
-  rows_ += rows;
+  rows_ = static_cast<int>(std::lround((-1 + Sqrt(8 * data_.size())) * 0.5));
   DCHECK_EQ(data_.size(), rows_ * (rows_ + 1) / 2);
 }
 

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -213,6 +213,15 @@ bool UnboundedMatrix<Scalar>::operator!=(UnboundedMatrix const& right) const {
 }
 
 template<typename Scalar>
+template<typename LScalar, typename RScalar>
+Product<Scalar, Product<LScalar, RScalar>>
+UnboundedMatrix<Scalar>::operator()(
+    UnboundedVector<LScalar> const& left,
+    UnboundedVector<RScalar> const& right) const {
+  return TransposedView{left} * (*this * right);
+}
+
+template<typename Scalar>
 UnboundedMatrix<Scalar>
 UnboundedMatrix<Scalar>::Identity(int const rows, int const columns) {
   UnboundedMatrix<Scalar> m(rows, columns);

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -276,7 +276,7 @@ int UnboundedLowerTriangularMatrix<Scalar>::rows() const {
 
 template<typename Scalar>
 int UnboundedLowerTriangularMatrix<Scalar>::columns() const {
-  return columns_;
+  return rows_;
 }
 
 template<typename Scalar>
@@ -388,7 +388,7 @@ void UnboundedUpperTriangularMatrix<Scalar>::EraseToEnd(
 
 template<typename Scalar>
 int UnboundedUpperTriangularMatrix<Scalar>::rows() const {
-  return rows_;
+  return columns_;
 }
 
 template<typename Scalar>
@@ -522,7 +522,7 @@ UnboundedMatrix<Product<LScalar, RScalar>> SymmetricProduct(
 template<typename Scalar>
 UnboundedMatrix<Square<Scalar>> SymmetricSquare(
     UnboundedVector<Scalar> const& vector) {
-  UnboundedMatrix<Product<LScalar, RScalar>> result(
+  UnboundedMatrix<Square<Scalar>> result(
       vector.size(), vector.size(), uninitialized);
   for (int i = 0; i < vector.size(); ++i) {
     for (int j = 0; j < i; ++j) {

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -218,7 +218,7 @@ Product<Scalar, Product<LScalar, RScalar>>
 UnboundedMatrix<Scalar>::operator()(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) const {
-  return TransposedView{left} * (*this * right);
+  return TransposedView{left} * (*this * right);  // NOLINT
 }
 
 template<typename Scalar>
@@ -505,7 +505,7 @@ UnboundedUpperTriangularMatrix<Scalar>::Transpose(
 template<typename LScalar, typename RScalar>
 Product<LScalar, RScalar> InnerProduct(UnboundedVector<LScalar> const& left,
                                        UnboundedVector<RScalar> const& right) {
-  return TransposedView{left} * right;
+  return TransposedView{left} * right;  // NOLINT
 }
 
 template<typename Scalar>

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -230,9 +230,9 @@ TEST_F(UnboundedArraysTest, Erase) {
 TEST_F(UnboundedArraysTest, Transpose) {
   EXPECT_EQ(
       UnboundedMatrix<double>({1,  8,  55,  377,
-                                2, 13,  89,  610,
-                                3, 21, 144,  987,
-                                5, 34, 233, 1597}), m4_.Transpose());
+                               2, 13,  89,  610,
+                               3, 21, 144,  987,
+                               5, 34, 233, 1597}), m4_.Transpose());
   EXPECT_EQ(
       UnboundedUpperTriangularMatrix<double>({1, 2,  5, 21,
                                                  3,  8, 34,

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -2,12 +2,14 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "numerics/transposed_view.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "testing_utilities/almost_equals.hpp"
 
 namespace principia {
 namespace numerics {
 
+using namespace principia::numerics::_transposed_view;
 using namespace principia::numerics::_unbounded_arrays;
 using namespace principia::quantities::_elementary_functions;
 using namespace principia::testing_utilities::_almost_equals;
@@ -93,7 +95,7 @@ TEST_F(UnboundedArraysTest, Assignment) {
 }
 
 TEST_F(UnboundedArraysTest, Norm) {
-  EXPECT_EQ(35, v4_.Transpose() * v4_);
+  EXPECT_EQ(35, TransposedView{v4_} * v4_);
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
   EXPECT_EQ(Sqrt(4'126'647.0), m4_.FrobeniusNorm());
 }
@@ -109,7 +111,7 @@ TEST_F(UnboundedArraysTest, MultiplicationDivision) {
 }
 
 TEST_F(UnboundedArraysTest, Algebra) {
-  EXPECT_EQ(3270, v3_.Transpose() * v3_);
+  EXPECT_EQ(3270, TransposedView{v3_} * v3_);
 }
 
 TEST_F(UnboundedArraysTest, VectorIndexing) {

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -95,7 +95,7 @@ TEST_F(UnboundedArraysTest, Assignment) {
 }
 
 TEST_F(UnboundedArraysTest, Norm) {
-  EXPECT_EQ(35, TransposedView{v4_} * v4_);
+  EXPECT_EQ(35, TransposedView{v4_} * v4_);  // NOLINT
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
   EXPECT_EQ(Sqrt(4'126'647.0), m4_.FrobeniusNorm());
 }
@@ -111,7 +111,7 @@ TEST_F(UnboundedArraysTest, MultiplicationDivision) {
 }
 
 TEST_F(UnboundedArraysTest, Algebra) {
-  EXPECT_EQ(3270, TransposedView{v3_} * v3_);
+  EXPECT_EQ(3270, TransposedView{v3_} * v3_);  // NOLINT
 }
 
 TEST_F(UnboundedArraysTest, VectorIndexing) {


### PR DESCRIPTION
1. Make sure that `fixed` and `unbounded` arrays have the same operations where it makes sense.
2. Use `TransposedView` in more places.

This PR causes a fair amount of code replication that will be addressed later.