### PR TITLE
Improvements to Чебышёв polynomial approximants

### DIFF
--- a/numerics/approximation.hpp
+++ b/numerics/approximation.hpp
@@ -16,7 +16,10 @@ using namespace principia::quantities::_named_quantities;
 template<typename Argument, typename Function>
 using Value = std::invoke_result_t<Function, Argument>;
 
-template<typename Argument, typename Function>
+// Returns a Чебышёв polynomial approximant of f over
+// [lower_bound, upper_bound].  Stops if the absolute error is estimated to be
+// below |max_error| or if |max_degree| has been reached.
+template<int max_degree, typename Argument, typename Function>
 ЧебышёвSeries<Value<Argument, Function>, Argument> ЧебышёвPolynomialInterpolant(
     Function const& f,
     Argument const& lower_bound,

--- a/numerics/approximation.hpp
+++ b/numerics/approximation.hpp
@@ -18,13 +18,15 @@ using Value = std::invoke_result_t<Function, Argument>;
 
 // Returns a Чебышёв polynomial approximant of f over
 // [lower_bound, upper_bound].  Stops if the absolute error is estimated to be
-// below |max_error| or if |max_degree| has been reached.
+// below |max_error| or if |max_degree| has been reached.  If |error_estimate|
+// is nonnull, it receives the estimate of the L∞ error.
 template<int max_degree, typename Argument, typename Function>
 ЧебышёвSeries<Value<Argument, Function>, Argument> ЧебышёвPolynomialInterpolant(
     Function const& f,
     Argument const& lower_bound,
     Argument const& upper_bound,
-    Difference<Value<Argument, Function>> const& max_error);
+    Difference<Value<Argument, Function>> const& max_error,
+    Difference<Value<Argument, Function>>* error_estimate = nullptr);
 
 }  // namespace internal
 

--- a/numerics/approximation_body.hpp
+++ b/numerics/approximation_body.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "base/tags.hpp"
 #include "geometry/barycentre_calculator.hpp"
 #include "numerics/fixed_arrays.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -15,14 +16,30 @@ namespace numerics {
 namespace _approximation {
 namespace internal {
 
+using namespace principia::base::_tags;
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::numerics::_fixed_arrays;
 using namespace principia::quantities::_elementary_functions;
 using namespace principia::quantities::_si;
 
-constexpr std::int64_t max_чебышёв_degree = 500;
+// Compute the interpolation matrix and cache it in a static variable.
+template<int N>
+FixedMatrix<double, N + 1, N + 1> const& ЧебышёвInterpolationMatrix() {
+  static FixedMatrix<double, N + 1, N + 1> const ℐ = []() {
+    FixedMatrix<double, N + 1, N + 1> ℐ(uninitialized);
+    for (std::int64_t j = 0; j <= N; ++j) {
+      double const pⱼ = j == 0 || j == N ? 2 : 1;
+      for (std::int64_t k = 0; k <= N; ++k) {
+        double const pₖ = k == 0 || k == N ? 2 : 1;
+        ℐ(j, k) = 2 * Cos(π * j * k * Radian / N) / (pⱼ * pₖ * N);
+      }
+    }
+    return ℐ;
+  }();
+  return ℐ;
+}
 
-template<int N, typename Argument, typename Function>
+template<int N, int max_degree, typename Argument, typename Function>
 ЧебышёвSeries<Value<Argument, Function>, Argument>
 ЧебышёвPolynomialInterpolantImplementation(
     Function const& f,
@@ -39,7 +56,7 @@ template<int N, typename Argument, typename Function>
     return 0.5 * (b - a) * Cos(π * k * Radian / N) + midpoint;
   };
 
-  FixedVector<Value<Argument, Function>, N + 1> fₖ;
+  FixedVector<Value<Argument, Function>, N + 1> fₖ(uninitialized);
 
   // Reuse the previous evaluations of |f|.
   for (std::int64_t k = 0; k <= N / 2; ++k) {
@@ -51,16 +68,9 @@ template<int N, typename Argument, typename Function>
     fₖ[k] = f(чебышёв_lobato_point(k));
   }
 
-  FixedMatrix<double, N + 1, N + 1> ℐⱼₖ;
-  for (std::int64_t j = 0; j <= N; ++j) {
-    double const pⱼ = j == 0 || j == N ? 2 : 1;
-    for (std::int64_t k = 0; k <= N; ++k) {
-      double const pₖ = k == 0 || k == N ? 2 : 1;
-      ℐⱼₖ(j, k) = 2 * Cos(π * j * k * Radian / N) / (pⱼ * pₖ * N);
-    }
-  }
-
   // Compute the coefficients of the Чебышёв polynomial.
+  FixedMatrix<double, N + 1, N + 1> const& ℐⱼₖ =
+      ЧебышёвInterpolationMatrix<N>();
   auto const aⱼ = ℐⱼₖ * fₖ;
 
   // Compute an upper bound for the error, based on the previous and new
@@ -73,9 +83,12 @@ template<int N, typename Argument, typename Function>
     error_estimate += Abs(aⱼ[j]);
   }
 
-  if constexpr (2 * N <= max_чебышёв_degree) {
+  if constexpr (N <= max_degree) {
     if (error_estimate > max_error) {
-      return ЧебышёвPolynomialInterpolantImplementation<2 * N>(
+      // Note that this recursive call overflows the stack when
+      // max_degree >= 256.  We could allocate on the heap, but then we don't
+      // care about very high degree polynomials.
+      return ЧебышёвPolynomialInterpolantImplementation<2 * N, max_degree>(
           f, a, b, max_error, fₖ, aⱼ);
     }
   }
@@ -93,7 +106,7 @@ template<int N, typename Argument, typename Function>
       coefficients, a, b);
 }
 
-template<typename Argument, typename Function>
+template<int max_degree, typename Argument, typename Function>
 ЧебышёвSeries<Value<Argument, Function>, Argument>
 ЧебышёвPolynomialInterpolant(
     Function const& f,
@@ -108,6 +121,7 @@ template<typename Argument, typename Function>
   FixedVector<Value<Argument, Function>, 2> const aⱼ(
       {0.5 * (f_b + f_a), 0.5 * (f_b - f_a)});
   return ЧебышёвPolynomialInterpolantImplementation</*N=*/2,
+                                                    max_degree,
                                                     Argument,
                                                     Function>(
       f, a, b, max_error, fₖ, aⱼ);

--- a/numerics/approximation_test.cpp
+++ b/numerics/approximation_test.cpp
@@ -5,9 +5,9 @@
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
+#include "testing_utilities/approximate_quantity.hpp"
 #include "testing_utilities/is_near.hpp"
 #include "testing_utilities/numerics_matchers.hpp"
-#include "testing_utilities/approximate_quantity.hpp"
 
 namespace principia {
 namespace numerics {

--- a/numerics/approximation_test.cpp
+++ b/numerics/approximation_test.cpp
@@ -22,10 +22,10 @@ using ::testing::Lt;
 TEST(ApproximationTest, SinInverse) {
   auto const f = [](double const x) { return Sin(1 * Radian / x); };
   auto const approximation =
-      ЧебышёвPolynomialInterpolant<double>(f,
-                                           /*lower_bound=*/0.1,
-                                           /*upper_bound=*/10,
-                                           /*max_error=*/1e-6);
+      ЧебышёвPolynomialInterpolant<128>(f,
+                                        /*lower_bound=*/0.1,
+                                        /*upper_bound=*/10.0,
+                                        /*max_error=*/1e-6);
   EXPECT_EQ(128, approximation.degree());
   for (double x = 0.1; x < 10.0; x += 0.01) {
     EXPECT_THAT(approximation.Evaluate(x),
@@ -36,10 +36,10 @@ TEST(ApproximationTest, SinInverse) {
 TEST(ApproximationTest, Exp) {
   auto const f = [](double const x) { return std::exp(x); };
   auto const approximation =
-      ЧебышёвPolynomialInterpolant<double>(f,
-                                           /*lower_bound=*/0.01,
-                                           /*upper_bound=*/3,
-                                           /*max_error=*/1e-6);
+      ЧебышёвPolynomialInterpolant<128>(f,
+                                        /*lower_bound=*/0.01,
+                                        /*upper_bound=*/3.0,
+                                        /*max_error=*/1e-6);
   EXPECT_EQ(16, approximation.degree());
   for (double x = 0.01; x < 3; x += 0.01) {
     EXPECT_THAT(approximation.Evaluate(x),

--- a/numerics/approximation_test.cpp
+++ b/numerics/approximation_test.cpp
@@ -5,7 +5,9 @@
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
+#include "testing_utilities/is_near.hpp"
 #include "testing_utilities/numerics_matchers.hpp"
+#include "testing_utilities/approximate_quantity.hpp"
 
 namespace principia {
 namespace numerics {
@@ -14,6 +16,8 @@ namespace _approximation {
 using namespace principia::quantities::_elementary_functions;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_si;
+using namespace principia::testing_utilities::_approximate_quantity;
+using namespace principia::testing_utilities::_is_near;
 using namespace principia::testing_utilities::_numerics_matchers;
 using ::testing::AllOf;
 using ::testing::Ge;
@@ -21,12 +25,16 @@ using ::testing::Lt;
 
 TEST(ApproximationTest, SinInverse) {
   auto const f = [](double const x) { return Sin(1 * Radian / x); };
+  double error_estimate;
   auto const approximation =
       ЧебышёвPolynomialInterpolant<128>(f,
                                         /*lower_bound=*/0.1,
                                         /*upper_bound=*/10.0,
-                                        /*max_error=*/1e-6);
+                                        /*max_error=*/1e-6,
+                                        &error_estimate);
   EXPECT_EQ(128, approximation.degree());
+  // Didn't reach the desired accuracy.
+  EXPECT_THAT(error_estimate, IsNear(4.9e-6_(1)));
   for (double x = 0.1; x < 10.0; x += 0.01) {
     EXPECT_THAT(approximation.Evaluate(x),
                 AbsoluteErrorFrom(f(x), AllOf(Lt(3.0e-6), Ge(0))));
@@ -35,12 +43,15 @@ TEST(ApproximationTest, SinInverse) {
 
 TEST(ApproximationTest, Exp) {
   auto const f = [](double const x) { return std::exp(x); };
+  double error_estimate;
   auto const approximation =
       ЧебышёвPolynomialInterpolant<128>(f,
                                         /*lower_bound=*/0.01,
                                         /*upper_bound=*/3.0,
-                                        /*max_error=*/1e-6);
+                                        /*max_error=*/1e-6,
+                                        &error_estimate);
   EXPECT_EQ(16, approximation.degree());
+  EXPECT_THAT(error_estimate, IsNear(4.7e-14_(1)));
   for (double x = 0.01; x < 3; x += 0.01) {
     EXPECT_THAT(approximation.Evaluate(x),
                 AbsoluteErrorFrom(f(x), AllOf(Lt(7.2e-15), Ge(0))));

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -322,11 +322,12 @@ ComputeFirstCollision(
   };
 
   // Interpolate the height above the terrain using a Чебышёв polynomial.
-  auto const чебышёв_interpolant = ЧебышёвPolynomialInterpolant(
-      height_above_terrain_at_time,
-      interval.min,
-      interval.max,
-      reference_body.mean_radius() * max_error_relative_to_radius);
+  auto const чебышёв_interpolant =
+      ЧебышёвPolynomialInterpolant</*max_degree=*/128>(
+          height_above_terrain_at_time,
+          interval.min,
+          interval.max,
+          reference_body.mean_radius() * max_error_relative_to_radius);
   auto const& real_roots = чебышёв_interpolant.RealRoots(
       max_error_relative_to_radius);
   if (real_roots.empty()) {


### PR DESCRIPTION
1. Give the caller control over the `max_degree`.
2. Return the `error_estimate`.
3. Don't recompute the interpolation matrices all the time.

#2913.
