### PR TITLE
Make it build on clang 16+

### DIFF
--- a/astronomy/orbit_recurrence_body.hpp
+++ b/astronomy/orbit_recurrence_body.hpp
@@ -98,9 +98,9 @@ inline int OrbitRecurrence::number_of_revolutions() const {
 
 inline Angle OrbitRecurrence::equatorial_shift() const {
   double const Nᴛₒ = number_of_revolutions();
-  double const ⅟κ = Cᴛₒ_ / Nᴛₒ;
+  double const κ⁻¹ = Cᴛₒ_ / Nᴛₒ;
   // See (8.24).
-  return -2 * π * Radian * ⅟κ;
+  return -2 * π * Radian * κ⁻¹;
 }
 
 inline Angle OrbitRecurrence::base_interval() const {

--- a/astronomy/orbital_elements_body.hpp
+++ b/astronomy/orbital_elements_body.hpp
@@ -212,8 +212,8 @@ absl::StatusOr<OrbitalElements> OrbitalElements::ForRelativeDegreesOfFreedom(
     Angle const& Ω = elements.longitude_of_ascending_node;
     Angle const& M = *elements.mean_anomaly;
     Angle const& i = elements.inclination;
-    double const tg_½i = Tan(i / 2);
-    double const cotg_½i = 1 / tg_½i;
+    double const tg_iⳆ2 = Tan(i / 2);
+    double const cotg_iⳆ2 = 1 / tg_iⳆ2;
     double const sin_Ω = Sin(Ω);
     double const cos_Ω = Cos(Ω);
     return {.t = time,
@@ -222,10 +222,10 @@ absl::StatusOr<OrbitalElements> OrbitalElements::ForRelativeDegreesOfFreedom(
             .k = e * Cos(ϖ),
             .λ = UnwindFrom(
                 unwound_λs[(time - t_min) / third_of_estimated_period], ϖ + M),
-            .p = tg_½i * sin_Ω,
-            .q = tg_½i * cos_Ω,
-            .pʹ = cotg_½i * sin_Ω,
-            .qʹ = cotg_½i * cos_Ω};
+            .p = tg_iⳆ2 * sin_Ω,
+            .q = tg_iⳆ2 * cos_Ω,
+            .pʹ = cotg_iⳆ2 * sin_Ω,
+            .qʹ = cotg_iⳆ2 * cos_Ω};
   };
 
   auto const sidereal_period =
@@ -453,12 +453,12 @@ OrbitalElements::ToClassicalElements(
   classical_elements.reserve(equinoctial_elements.size());
   for (auto const& equinoctial : equinoctial_elements) {
     RETURN_IF_STOPPED;
-    double const tg_½i = Sqrt(Pow<2>(equinoctial.p) + Pow<2>(equinoctial.q));
-    double const cotg_½i =
+    double const tg_iⳆ2 = Sqrt(Pow<2>(equinoctial.p) + Pow<2>(equinoctial.q));
+    double const cotg_iⳆ2 =
         Sqrt(Pow<2>(equinoctial.pʹ) + Pow<2>(equinoctial.qʹ));
     Angle const i =
-        cotg_½i > tg_½i ? 2 * ArcTan(tg_½i) : 2 * ArcTan(1 / cotg_½i);
-    Angle const Ω = cotg_½i > tg_½i ? ArcTan(equinoctial.p, equinoctial.q)
+        cotg_iⳆ2 > tg_iⳆ2 ? 2 * ArcTan(tg_iⳆ2) : 2 * ArcTan(1 / cotg_iⳆ2);
+    Angle const Ω = cotg_iⳆ2 > tg_iⳆ2 ? ArcTan(equinoctial.p, equinoctial.q)
                                     : ArcTan(equinoctial.pʹ, equinoctial.qʹ);
     double const e = Sqrt(Pow<2>(equinoctial.h) + Pow<2>(equinoctial.k));
     Angle const ϖ = ArcTan(equinoctial.h, equinoctial.k);

--- a/numerics/elliptic_integrals.cpp
+++ b/numerics/elliptic_integrals.cpp
@@ -1121,9 +1121,9 @@ PolynomialInMonomialBasis<double, double, 20, EstrinEvaluator> const
 // NOTE(phl): The following polynomials differ slightly from the original code
 // but they match more closely those in [Fuk11a].  The notation follows
 // [Fuk11a].
-// A polynomial for B٭X(m) / m.
+// A polynomial for B*X(m) / m.
 PolynomialInMonomialBasis<double, double, 7, EstrinEvaluator> const
-    fukushima_B٭X_maclaurin(std::make_tuple(-1.0 / 4.0,
+    fukushima_B𐌟X_maclaurin(std::make_tuple(-1.0 / 4.0,
                                             -1.0 / 32.0,
                                             -3.0 / 256.0,
                                             -25.0 / 4096.0,
@@ -1280,7 +1280,7 @@ void FukushimaEllipticBD(double const mc, Angle& B_m, Angle& D_m) {
     B_m = (X_mc * (EX_mc - mc * KX_mc) + one_over_two_KX_mc) * Radian / m;
     D_m = X_mc * KX_mc * Radian - B_m;
   } else if (m <= 0.01) {
-    B_m = (-π * Radian) * fukushima_B٭X_maclaurin(m);
+    B_m = (-π * Radian) * fukushima_B𐌟X_maclaurin(m);
     D_m = (π * Radian) * fukushima_EX_maclaurin(m);
   } else if (m <= 0.1) {
     double const mx = 0.95 - mc;


### PR DESCRIPTION
By restricting identifiers to [UAX31-R1](https://www.unicode.org/reports/tr31/#R1) with the [Mathematical Compatibility Notation Profile](https://www.unicode.org/reports/tr31/#Mathematical_Compatibility_Notation_Profile).