### PR TITLE
Fix locking in PushPullCallback

### DIFF
--- a/base/push_pull_callback.hpp
+++ b/base/push_pull_callback.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <optional>
 #include <thread>
 #include <tuple>
@@ -45,9 +46,10 @@ class PushPullCallback {
   void Push(Arguments... arguments);
   Result Pull();
 
-  // These functions return |lock_| held exclusively.
-  void WaitUntilHasArgumentsOrShuttingDownAndLock();
-  void WaitUntilHasResultAndLock();
+  // These functions return a (held) |MutexLock| that the caller should use to
+  // ensure proper release of |lock_|.
+  std::unique_ptr<absl::MutexLock> WaitUntilHasArgumentsOrShuttingDownAndLock();
+  std::unique_ptr<absl::MutexLock> WaitUntilHasResultAndLock();
 
   absl::Mutex lock_;
   std::optional<std::tuple<Arguments...>> arguments_ GUARDED_BY(lock_);

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -113,7 +113,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Scan) {
 // |method_out_return| protocol buffers.
 TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
   std::string path =
-      R"(P:\Public Mockingbird\Principia\Issues\3569\JOURNAL.20231026-191142)";  // NOLINT
+      R"(P:\Public Mockingbird\Principia\Issues\3872\JOURNAL.20240210-173425)";  // NOLINT
   Player player(path);
   int count = 0;
   while (player.Play(count)) {
@@ -131,24 +131,22 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
              << player.last_method_out_return().DebugString();
   std::this_thread::sleep_for(10s);
 
-#if 0
+#if 1
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(
-        serialization::FlightPlanGetCoastAnalysis::extension);
+        serialization::CollisionDeleteExecutor::extension);
     auto* in = extension->mutable_in();
-    in->set_plugin(1813489403728);
-    in->set_vessel_guid("5f7e35b7-645a-4985-9734-7bdeb31b2336");
-    in->set_ground_track_revolution(0);
-    in->set_index(0);
+    in->set_plugin(2237555212240);
+    in->set_executor(2237561081696);
   }
   serialization::Method method_out_return;
   {
     auto* extension = method_out_return.MutableExtension(
-        serialization::FlightPlanGetCoastAnalysis::extension);
+        serialization::CollisionDeleteExecutor::extension);
   }
   LOG(ERROR) << "Running unpaired method:\n" << method_in.DebugString();
-  CHECK(RunIfAppropriate<FlightPlanGetCoastAnalysis>(
+  CHECK(RunIfAppropriate<CollisionDeleteExecutor>(
       method_in, method_out_return, player));
 #endif
 #if 0

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -131,7 +131,7 @@ TEST_F(PlayerTest, DISABLED_SECULAR_Debug) {
              << player.last_method_out_return().DebugString();
   std::this_thread::sleep_for(10s);
 
-#if 1
+#if 0
   serialization::Method method_in;
   {
     auto* extension = method_in.MutableExtension(

--- a/journal/profiles.cpp
+++ b/journal/profiles.cpp
@@ -79,7 +79,7 @@ std::uint64_t SerializePointer(T* t) {
 
 }  // namespace
 
-#define PRINCIPIA_PERFORM_RUN_CHECKS 0
+#define PRINCIPIA_PERFORM_RUN_CHECKS 1
 #define PRINCIPIA_SET_VERBOSE_LOGGING 1
 
 #if PRINCIPIA_PERFORM_RUN_CHECKS

--- a/journal/profiles.cpp
+++ b/journal/profiles.cpp
@@ -79,7 +79,7 @@ std::uint64_t SerializePointer(T* t) {
 
 }  // namespace
 
-#define PRINCIPIA_PERFORM_RUN_CHECKS 1
+#define PRINCIPIA_PERFORM_RUN_CHECKS 0
 #define PRINCIPIA_SET_VERBOSE_LOGGING 1
 
 #if PRINCIPIA_PERFORM_RUN_CHECKS


### PR DESCRIPTION
The journal replaying for #3872 was not completely conclusive as it didn't reproduce the crash.  However, it told us exactly what code we were executing when the crash happened.  After staring at this code for a while, @eggrobin noticed that the `PushPullCallback` class would always be destroyed with its internal mutex held.  That's violates the invariants of `Mutex` and might cause plague and pestilence.

This change may or may not address #3872.