### PR TITLE
Use concepts to simplify our code

### DIFF
--- a/base/base.vcxproj
+++ b/base/base.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="bits.hpp" />
     <ClInclude Include="bits_body.hpp" />
     <ClInclude Include="bundle.hpp" />
+    <ClInclude Include="concepts.hpp" />
     <ClInclude Include="constant_function.hpp" />
     <ClInclude Include="cpuid.hpp" />
     <ClInclude Include="disjoint_sets.hpp" />

--- a/base/base.vcxproj.filters
+++ b/base/base.vcxproj.filters
@@ -224,6 +224,9 @@
     <ClInclude Include="push_pull_callback_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="concepts.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="not_null_test.cpp">

--- a/base/concepts.hpp
+++ b/base/concepts.hpp
@@ -7,6 +7,8 @@ namespace base {
 namespace _concepts {
 namespace internal {
 
+// True if and only if T has a (possibly templated) static member function named
+// ReadFromMessage.
 template<typename T>
 concept serializable = requires {
   &T::ReadFromMessage;

--- a/base/concepts.hpp
+++ b/base/concepts.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <concepts>
+
+#include "serialization/geometry.pb.h"
+
+namespace principia {
+namespace base {
+namespace _concepts {
+namespace internal {
+
+// TODO(phl): This concept applies to a frame.  Extend it.
+template<typename F>
+concept serializable = requires(serialization::Frame const& message) {
+  F::ReadFromMessage(message);
+};
+
+}  // namespace internal
+
+using internal::serializable;
+
+}  // namespace _concepts
+}  // namespace base
+}  // namespace principia

--- a/base/concepts.hpp
+++ b/base/concepts.hpp
@@ -2,17 +2,16 @@
 
 #include <concepts>
 
-#include "serialization/geometry.pb.h"
-
 namespace principia {
 namespace base {
 namespace _concepts {
 namespace internal {
 
-// TODO(phl): This concept applies to a frame.  Extend it.
-template<typename F>
-concept serializable = requires(serialization::Frame const& message) {
-  F::ReadFromMessage(message);
+template<typename T>
+concept serializable = requires {
+  &T::ReadFromMessage;
+} || requires {
+  &T::template ReadFromMessage<>;
 };
 
 }  // namespace internal

--- a/base/concepts.hpp
+++ b/base/concepts.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <concepts>
-
 namespace principia {
 namespace base {
 namespace _concepts {

--- a/base/traits.hpp
+++ b/base/traits.hpp
@@ -33,22 +33,6 @@ template<template<typename...> typename T>
 struct is_same_template<T, T> : std::true_type {};
 
 
-template<typename, typename = void, typename = void>
-struct has_sfinae_read_from_message : std::false_type {};
-
-template<typename T>
-struct has_sfinae_read_from_message<
-    T, std::void_t<decltype(&T::template ReadFromMessage<>)>>
-    : std::true_type {};
-
-template<typename, typename = void, typename = void>
-struct has_unconditional_read_from_message : std::false_type {};
-
-template<typename T>
-struct has_unconditional_read_from_message<
-    T, std::void_t<decltype(&T::ReadFromMessage)>>
-    : std::true_type {};
-
 template<typename T, typename T1, typename T2>
 struct other_type;
 
@@ -79,13 +63,6 @@ inline constexpr bool is_instance_of_v = internal::is_instance_of<T, U>::value;
 template<template<typename...> typename T, template<typename...> typename U>
 inline constexpr bool is_same_template_v =
     internal::is_same_template<T, U>::value;
-
-// True if and only if T has a (possibly templated) static member function named
-// ReadFromMessage.
-template<typename T>
-inline constexpr bool is_serializable_v =
-    internal::has_sfinae_read_from_message<T>::value ||
-    internal::has_unconditional_read_from_message<T>::value;
 
 // If T is T1, returns T2.  If T is T2, returns T1.  Otherwise fails.
 template<typename T, typename T1, typename T2>

--- a/geometry/affine_map.hpp
+++ b/geometry/affine_map.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/point.hpp"
 #include "serialization/geometry.pb.h"
@@ -11,8 +11,8 @@ namespace geometry {
 namespace _affine_map {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_point;
 
@@ -43,11 +43,8 @@ class AffineMap final {
   LinearMap<FromFrame, ToFrame> const& linear_map() const;
 
   void WriteToMessage(not_null<serialization::AffineMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static AffineMap ReadFromMessage(serialization::AffineMap const& message);
+  static AffineMap ReadFromMessage(serialization::AffineMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   Point<FromVector> from_origin_;

--- a/geometry/affine_map_body.hpp
+++ b/geometry/affine_map_body.hpp
@@ -82,10 +82,10 @@ void AffineMap<FromFrame, ToFrame, Scalar, LinearMap_>::WriteToMessage(
 
 template<typename FromFrame, typename ToFrame, typename Scalar,
          template<typename, typename> class LinearMap_>
-template<typename, typename, typename>
 AffineMap<FromFrame, ToFrame, Scalar, LinearMap_>
 AffineMap<FromFrame, ToFrame, Scalar, LinearMap_>::ReadFromMessage(
-    serialization::AffineMap const& message) {
+    serialization::AffineMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   FromFrame::ReadFromMessage(message.from_frame());
   ToFrame::ReadFromMessage(message.to_frame());
   return AffineMap(Point<FromVector>::ReadFromMessage(message.from_origin()),

--- a/geometry/concepts.hpp
+++ b/geometry/concepts.hpp
@@ -6,13 +6,13 @@ namespace _concepts {
 namespace internal {
 
 template<typename T1, typename T2>
-concept has_inner_product = requires(T1 const& t1, T2 const& t2) {
+concept hilbert = requires(T1 const& t1, T2 const& t2) {
   InnerProduct(t1, t2);
 };
 
 }  // namespace internal
 
-using internal::has_inner_product;
+using internal::hilbert;
 
 }  // namespace _concepts
 }  // namespace geometry

--- a/geometry/concepts.hpp
+++ b/geometry/concepts.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <concepts>
-
 namespace principia {
 namespace geometry {
 namespace _concepts {

--- a/geometry/concepts.hpp
+++ b/geometry/concepts.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <concepts>
+
+namespace principia {
+namespace geometry {
+namespace _concepts {
+namespace internal {
+
+template<typename T1, typename T2>
+concept has_inner_product = requires(T1 t1, T2 t2) {
+  InnerProduct(t1, t2);
+};
+
+}  // namespace internal
+
+using internal::has_inner_product;
+
+}  // namespace _concepts
+}  // namespace geometry
+}  // namespace principia

--- a/geometry/concepts.hpp
+++ b/geometry/concepts.hpp
@@ -8,7 +8,7 @@ namespace _concepts {
 namespace internal {
 
 template<typename T1, typename T2>
-concept has_inner_product = requires(T1 t1, T2 t2) {
+concept has_inner_product = requires(T1 const& t1, T2 const& t2) {
   InnerProduct(t1, t2);
 };
 

--- a/geometry/conformal_map.hpp
+++ b/geometry/conformal_map.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
@@ -29,9 +29,9 @@ FORWARD_DECLARE(TEMPLATE(typename FromFrame, typename ToFrame) class,
 namespace _conformal_map {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_frame;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;

--- a/geometry/conformal_map.hpp
+++ b/geometry/conformal_map.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
@@ -31,7 +31,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_frame;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
@@ -76,19 +76,13 @@ class ConformalMap : public LinearMap<ConformalMap<Scalar, FromFrame, ToFrame>,
   OrthogonalMap<FromFrame, ToFrame> orthogonal_map¹₁() const;
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static ConformalMap ReadFromMessage(serialization::LinearMap const& message);
+  static ConformalMap ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::ConformalMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
   static ConformalMap ReadFromMessage(
-      serialization::ConformalMap const& message);
+      serialization::ConformalMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   ConformalMap(Scalar const& scale,

--- a/geometry/conformal_map_body.hpp
+++ b/geometry/conformal_map_body.hpp
@@ -74,10 +74,10 @@ void ConformalMap<Scalar, FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename Scalar, typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 ConformalMap<Scalar, FromFrame, ToFrame>
 ConformalMap<Scalar, FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<ConformalMap, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::ConformalMap::extension));
   return ReadFromMessage(
@@ -92,10 +92,10 @@ void ConformalMap<Scalar, FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename Scalar, typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 ConformalMap<Scalar, FromFrame, ToFrame>
 ConformalMap<Scalar, FromFrame, ToFrame>::ReadFromMessage(
-    serialization::ConformalMap const& message) {
+    serialization::ConformalMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   return ConformalMap(Scalar::ReadFromMessage(message.scale()),
                       Quaternion::ReadFromMessage(message.quaternion()));
 }

--- a/geometry/frame_test.cpp
+++ b/geometry/frame_test.cpp
@@ -1,6 +1,6 @@
 #include "geometry/frame.hpp"
 
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "glog/logging.h"
 #include "google/protobuf/descriptor.h"
 #include "gtest/gtest.h"
@@ -9,7 +9,7 @@
 namespace principia {
 namespace geometry {
 
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_frame;
 
 class FrameTest : public testing::Test {
@@ -38,8 +38,8 @@ class FrameTest : public testing::Test {
   static_assert(!std::is_same_v<F1, F3>);
   static_assert(!std::is_same_v<F2, F3>);
 
-  static_assert(is_serializable_v<World1>);
-  static_assert(!is_serializable_v<F1>);
+  static_assert(serializable<World1>);
+  static_assert(!serializable<F1>);
 };
 
 using FrameDeathTest = FrameTest;

--- a/geometry/geometry.vcxproj
+++ b/geometry/geometry.vcxproj
@@ -15,6 +15,7 @@
     <ClInclude Include="cartesian_product_body.hpp" />
     <ClInclude Include="complexification.hpp" />
     <ClInclude Include="complexification_body.hpp" />
+    <ClInclude Include="concepts.hpp" />
     <ClInclude Include="conformal_map.hpp" />
     <ClInclude Include="conformal_map_body.hpp" />
     <ClInclude Include="frame.hpp" />

--- a/geometry/geometry.vcxproj.filters
+++ b/geometry/geometry.vcxproj.filters
@@ -194,6 +194,9 @@
     <ClInclude Include="homothecy_body.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="concepts.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="sign_test.cpp">

--- a/geometry/grassmann.hpp
+++ b/geometry/grassmann.hpp
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/r3_element.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -18,7 +18,7 @@ namespace _grassmann {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_r3_element;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
@@ -50,9 +50,8 @@ class Multivector<Scalar, Frame, 1> final {
 
   void WriteToMessage(
       not_null<serialization::Multivector*> message) const;
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
-  static Multivector ReadFromMessage(serialization::Multivector const& message);
+  static Multivector ReadFromMessage(serialization::Multivector const& message)
+    requires serializable<Frame>;
 
  private:
   R3Element<Scalar> coordinates_;
@@ -91,9 +90,8 @@ class Multivector<Scalar, Frame, 2> final {
       Multivector<S, Frame, 2> const& multivector) const;
 
   void WriteToMessage(not_null<serialization::Multivector*> message) const;
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
-  static Multivector ReadFromMessage(serialization::Multivector const& message);
+  static Multivector ReadFromMessage(serialization::Multivector const& message)
+    requires serializable<Frame>;
 
  private:
   R3Element<Scalar> coordinates_;
@@ -125,9 +123,8 @@ class Multivector<Scalar, Frame, 3> final {
   Square<Scalar> Norm²() const;
 
   void WriteToMessage(not_null<serialization::Multivector*> message) const;
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
-  static Multivector ReadFromMessage(serialization::Multivector const& message);
+  static Multivector ReadFromMessage(serialization::Multivector const& message)
+    requires serializable<Frame>;
 
  private:
   Scalar coordinates_;

--- a/geometry/grassmann.hpp
+++ b/geometry/grassmann.hpp
@@ -4,8 +4,8 @@
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>
 
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "geometry/r3_element.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -17,8 +17,8 @@ namespace geometry {
 namespace _grassmann {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_r3_element;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;

--- a/geometry/grassmann_body.hpp
+++ b/geometry/grassmann_body.hpp
@@ -115,27 +115,27 @@ void Multivector<Scalar, Frame, 3>::WriteToMessage(
 }
 
 template<typename Scalar, typename Frame>
-template<typename, typename>
 Multivector<Scalar, Frame, 1> Multivector<Scalar, Frame, 1>::ReadFromMessage(
-    serialization::Multivector const& message) {
+    serialization::Multivector const& message)
+  requires serializable<Frame> {
   Frame::ReadFromMessage(message.frame());
   CHECK(message.has_vector());
   return Multivector(R3Element<Scalar>::ReadFromMessage(message.vector()));
 }
 
 template<typename Scalar, typename Frame>
-template<typename, typename>
 Multivector<Scalar, Frame, 2> Multivector<Scalar, Frame, 2>::ReadFromMessage(
-    serialization::Multivector const& message) {
+    serialization::Multivector const& message)
+  requires serializable<Frame> {
   Frame::ReadFromMessage(message.frame());
   CHECK(message.has_bivector());
   return Multivector(R3Element<Scalar>::ReadFromMessage(message.bivector()));
 }
 
 template<typename Scalar, typename Frame>
-template<typename, typename>
 Multivector<Scalar, Frame, 3> Multivector<Scalar, Frame, 3>::ReadFromMessage(
-    serialization::Multivector const& message) {
+    serialization::Multivector const& message)
+  requires serializable<Frame> {
   Frame::ReadFromMessage(message.frame());
   CHECK(message.has_trivector());
   return Multivector(Scalar::ReadFromMessage(message.trivector()));

--- a/geometry/hilbert.hpp
+++ b/geometry/hilbert.hpp
@@ -62,22 +62,7 @@ struct Hilbert<T1, T2> : not_constructible {
 
   using InnerProductType =
       decltype(InnerProduct(std::declval<T1>(), std::declval<T2>()));
-  static InnerProductType InnerProduct(T1 const& t1, T2 const& t2)
-#if _MSC_FULL_VER == 193'431'937 || \
-    _MSC_FULL_VER == 193'431'942 || \
-    _MSC_FULL_VER == 193'431'944 || \
-    _MSC_FULL_VER == 193'532'216 || \
-    _MSC_FULL_VER == 193'532'217 || \
-    _MSC_FULL_VER == 193'632'532 || \
-    _MSC_FULL_VER == 193'632'535 || \
-    _MSC_FULL_VER == 193'732'822 || \
-    _MSC_FULL_VER == 193'833'135
-  {  // NOLINT
-    return _grassmann::internal::InnerProduct(t1, t2);
-  }
-#else
-  ;  // NOLINT
-#endif
+  static InnerProductType InnerProduct(T1 const& t1, T2 const& t2);
 };
 
 template<typename T>
@@ -87,58 +72,13 @@ struct Hilbert<T, T> : not_constructible {
 
   using InnerProductType =
       decltype(InnerProduct(std::declval<T>(), std::declval<T>()));
-  static InnerProductType InnerProduct(T const& t1, T const& t2)
-#if _MSC_FULL_VER == 193'431'937 || \
-    _MSC_FULL_VER == 193'431'942 || \
-    _MSC_FULL_VER == 193'431'944 || \
-    _MSC_FULL_VER == 193'532'216 || \
-    _MSC_FULL_VER == 193'532'217 || \
-    _MSC_FULL_VER == 193'632'532 || \
-    _MSC_FULL_VER == 193'632'535 || \
-    _MSC_FULL_VER == 193'732'822 || \
-    _MSC_FULL_VER == 193'833'135
-  {  // NOLINT
-    return _grassmann::internal::InnerProduct(t1, t2);
-  }
-#else
-  ;  // NOLINT
-#endif
+  static InnerProductType InnerProduct(T const& t1, T const& t2);
 
   using Norm²Type = InnerProductType;
-  static Norm²Type Norm²(T const& t)
-#if _MSC_FULL_VER == 193'431'937 || \
-    _MSC_FULL_VER == 193'431'942 || \
-    _MSC_FULL_VER == 193'431'944 || \
-    _MSC_FULL_VER == 193'532'216 || \
-    _MSC_FULL_VER == 193'532'217 || \
-    _MSC_FULL_VER == 193'632'532 || \
-    _MSC_FULL_VER == 193'632'535 || \
-    _MSC_FULL_VER == 193'732'822 || \
-    _MSC_FULL_VER == 193'833'135
-  {  // NOLINT
-    return t.Norm²();
-  }
-#else
-  ;  // NOLINT
-#endif
+  static Norm²Type Norm²(T const& t);
 
   using NormType = decltype(std::declval<T>().Norm());
-  static NormType Norm(T const& t)
-#if _MSC_FULL_VER == 193'431'937 || \
-    _MSC_FULL_VER == 193'431'942 || \
-    _MSC_FULL_VER == 193'431'944 || \
-    _MSC_FULL_VER == 193'532'216 || \
-    _MSC_FULL_VER == 193'532'217 || \
-    _MSC_FULL_VER == 193'632'532 || \
-    _MSC_FULL_VER == 193'632'535 || \
-    _MSC_FULL_VER == 193'732'822 || \
-    _MSC_FULL_VER == 193'833'135
-  {  // NOLINT
-    return t.Norm();
-  }
-#else
-  ;  // NOLINT
-#endif
+  static NormType Norm(T const& t);
 
   using NormalizedType = Quotient<T, NormType>;
 };

--- a/geometry/hilbert.hpp
+++ b/geometry/hilbert.hpp
@@ -55,7 +55,7 @@ struct Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>> : not_constructible {
 };
 
 template<typename T1, typename T2>
-  requires has_inner_product<T1, T2>
+  requires hilbert<T1, T2>
 struct Hilbert<T1, T2> : not_constructible {
   static_assert(T1::dimension == T2::dimension);
   static constexpr int dimension = T1::dimension;
@@ -66,7 +66,7 @@ struct Hilbert<T1, T2> : not_constructible {
 };
 
 template<typename T>
-  requires has_inner_product<T, T>
+  requires hilbert<T, T>
 struct Hilbert<T, T> : not_constructible {
   static constexpr int dimension = T::dimension;
 

--- a/geometry/hilbert.hpp
+++ b/geometry/hilbert.hpp
@@ -3,6 +3,7 @@
 #include <type_traits>
 
 #include "base/not_constructible.hpp"
+#include "geometry/concepts.hpp"
 #include "geometry/grassmann.hpp"  // 🧙 For _grassmann::internal.
 #include "quantities/named_quantities.hpp"
 #include "quantities/traits.hpp"
@@ -13,6 +14,7 @@ namespace _hilbert {
 namespace internal {
 
 using namespace principia::base::_not_constructible;
+using namespace principia::geometry::_concepts;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_traits;
 
@@ -53,10 +55,8 @@ struct Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>> : not_constructible {
 };
 
 template<typename T1, typename T2>
-struct Hilbert<T1, T2,
-               std::void_t<decltype(InnerProduct(std::declval<T1>(),
-                                                 std::declval<T2>()))>>
-    : not_constructible {
+  requires has_inner_product<T1, T2>
+struct Hilbert<T1, T2> : not_constructible {
   static_assert(T1::dimension == T2::dimension);
   static constexpr int dimension = T1::dimension;
 
@@ -81,10 +81,8 @@ struct Hilbert<T1, T2,
 };
 
 template<typename T>
-struct Hilbert<T, T,
-               std::void_t<decltype(InnerProduct(std::declval<T>(),
-                                                 std::declval<T>()))>>
-    : not_constructible {
+  requires has_inner_product<T, T>
+struct Hilbert<T, T> : not_constructible {
   static constexpr int dimension = T::dimension;
 
   using InnerProductType =

--- a/geometry/hilbert_body.hpp
+++ b/geometry/hilbert_body.hpp
@@ -39,7 +39,7 @@ auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::Norm(
 }
 
 template<typename T1, typename T2>
-  requires has_inner_product<T1, T2>
+  requires hilbert<T1, T2>
 auto Hilbert<T1, T2>::InnerProduct(T1 const& t1, T2 const& t2)
     -> InnerProductType {
   // Is there a better way to avoid recursion than to put our fingers inside
@@ -48,7 +48,7 @@ auto Hilbert<T1, T2>::InnerProduct(T1 const& t1, T2 const& t2)
 }
 
 template<typename T>
-  requires has_inner_product<T, T>
+  requires hilbert<T, T>
 auto Hilbert<T, T>::InnerProduct(T const& t1, T const& t2) -> InnerProductType {
   // Is there a better way to avoid recursion than to put our fingers inside
   // grassmann?
@@ -56,13 +56,13 @@ auto Hilbert<T, T>::InnerProduct(T const& t1, T const& t2) -> InnerProductType {
 }
 
 template<typename T>
-  requires has_inner_product<T, T>
+  requires hilbert<T, T>
 auto Hilbert<T, T>::Norm²(T const& t) -> Norm²Type {
   return t.Norm²();
 }
 
 template<typename T>
-  requires has_inner_product<T, T>
+  requires hilbert<T, T>
 auto Hilbert<T, T>::Norm(T const& t) -> NormType {
   return t.Norm();
 }

--- a/geometry/hilbert_body.hpp
+++ b/geometry/hilbert_body.hpp
@@ -38,51 +38,34 @@ auto Hilbert<T, T, std::enable_if_t<is_quantity_v<T>>>::Norm(
   return Abs(t);
 }
 
-#if !(_MSC_FULL_VER == 193'431'937 || \
-      _MSC_FULL_VER == 193'431'942 || \
-      _MSC_FULL_VER == 193'431'944 || \
-      _MSC_FULL_VER == 193'532'216 || \
-      _MSC_FULL_VER == 193'532'217 || \
-      _MSC_FULL_VER == 193'632'532 || \
-      _MSC_FULL_VER == 193'632'535 || \
-      _MSC_FULL_VER == 193'732'822 || \
-      _MSC_FULL_VER == 193'833'135)
 template<typename T1, typename T2>
-auto Hilbert<T1, T2,
-             std::void_t<decltype(InnerProduct(std::declval<T1>(),
-                                               std::declval<T2>()))>>::
-    InnerProduct(T1 const& t1, T2 const& t2) -> InnerProductType {
+  requires has_inner_product<T1, T2>
+auto Hilbert<T1, T2>::InnerProduct(T1 const& t1, T2 const& t2)
+    -> InnerProductType {
   // Is there a better way to avoid recursion than to put our fingers inside
   // grassmann?
   return _grassmann::internal::InnerProduct(t1, t2);
 }
 
 template<typename T>
-auto Hilbert<T, T,
-             std::void_t<decltype(InnerProduct(std::declval<T>(),
-                                               std::declval<T>()))>>::
-    InnerProduct(T const& t1, T const& t2) -> InnerProductType {
+  requires has_inner_product<T, T>
+auto Hilbert<T, T>::InnerProduct(T const& t1, T const& t2) -> InnerProductType {
   // Is there a better way to avoid recursion than to put our fingers inside
   // grassmann?
   return _grassmann::internal::InnerProduct(t1, t2);
 }
 
 template<typename T>
-auto Hilbert<T, T,
-             std::void_t<decltype(InnerProduct(std::declval<T>(),
-                                               std::declval<T>()))>>::
-Norm²(T const& t) -> Norm²Type {
+  requires has_inner_product<T, T>
+auto Hilbert<T, T>::Norm²(T const& t) -> Norm²Type {
   return t.Norm²();
 }
 
 template<typename T>
-auto Hilbert<T, T,
-             std::void_t<decltype(InnerProduct(std::declval<T>(),
-                                               std::declval<T>()))>>::
-Norm(T const& t) -> NormType {
+  requires has_inner_product<T, T>
+auto Hilbert<T, T>::Norm(T const& t) -> NormType {
   return t.Norm();
 }
-#endif
 
 }  // namespace internal
 }  // namespace _hilbert

--- a/geometry/homothecy.hpp
+++ b/geometry/homothecy.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/space.hpp"
@@ -15,7 +15,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_space;
@@ -54,18 +54,12 @@ class Homothecy : public LinearMap<Homothecy<Scalar, FromFrame, ToFrame>,
   static Homothecy Identity();
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Homothecy ReadFromMessage(serialization::LinearMap const& message);
+  static Homothecy ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::Homothecy*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Homothecy ReadFromMessage(serialization::Homothecy const& message);
+  static Homothecy ReadFromMessage(serialization::Homothecy const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   Scalar const scale_;

--- a/geometry/homothecy.hpp
+++ b/geometry/homothecy.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/space.hpp"
@@ -13,9 +13,9 @@ namespace geometry {
 namespace _homothecy {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_space;

--- a/geometry/homothecy_body.hpp
+++ b/geometry/homothecy_body.hpp
@@ -76,10 +76,10 @@ void Homothecy<Scalar, FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename Scalar, typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Homothecy<Scalar, FromFrame, ToFrame>
 Homothecy<Scalar, FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<Homothecy, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::Homothecy::extension));
   return ReadFromMessage(
@@ -93,10 +93,10 @@ void Homothecy<Scalar, FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename Scalar, typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Homothecy<Scalar, FromFrame, ToFrame>
 Homothecy<Scalar, FromFrame, ToFrame>::ReadFromMessage(
-    serialization::Homothecy const& message) {
+    serialization::Homothecy const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   return Homothecy(Scalar::ReadFromMessage(message.scale()));
 }
 

--- a/geometry/identity.hpp
+++ b/geometry/identity.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/r3_element.hpp"
@@ -23,9 +23,9 @@ FORWARD_DECLARE(
 namespace _identity {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_r3_element;

--- a/geometry/identity.hpp
+++ b/geometry/identity.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/r3_element.hpp"
@@ -25,7 +25,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_r3_element;
@@ -71,18 +71,12 @@ class Identity : public LinearMap<Identity<FromFrame, ToFrame>,
   ConformalMap<double, FromFrame, ToFrame> Forget() const;
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Identity ReadFromMessage(serialization::LinearMap const& message);
+  static Identity ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::Identity*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Identity ReadFromMessage(serialization::Identity const& message);
+  static Identity ReadFromMessage(serialization::Identity const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   template<typename Scalar>

--- a/geometry/identity_body.hpp
+++ b/geometry/identity_body.hpp
@@ -79,9 +79,9 @@ void Identity<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Identity<FromFrame, ToFrame> Identity<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<Identity, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::Identity::extension));
   return ReadFromMessage(
@@ -93,9 +93,9 @@ void Identity<FromFrame, ToFrame>::WriteToMessage(
     not_null<serialization::Identity*> const message) const {}
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Identity<FromFrame, ToFrame> Identity<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::Identity const& message) {
+    serialization::Identity const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   return Identity();
 }
 

--- a/geometry/linear_map.hpp
+++ b/geometry/linear_map.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "serialization/geometry.pb.h"
 
@@ -13,7 +13,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 
 template<typename Map, typename FromFrame, typename ToFrame>
@@ -48,11 +48,8 @@ class LinearMap {
 
   static void WriteToMessage(not_null<serialization::LinearMap*> message);
 
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static void ReadFromMessage(serialization::LinearMap const& message);
+  static void ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 };
 
 }  // namespace internal

--- a/geometry/linear_map.hpp
+++ b/geometry/linear_map.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "serialization/geometry.pb.h"
 
@@ -11,9 +11,9 @@ namespace geometry {
 namespace _linear_map {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 
 template<typename Map, typename FromFrame, typename ToFrame>

--- a/geometry/linear_map_body.hpp
+++ b/geometry/linear_map_body.hpp
@@ -34,9 +34,9 @@ void LinearMap<Map, FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename Map, typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 void LinearMap<Map, FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   FromFrame::ReadFromMessage(message.from_frame());
   ToFrame::ReadFromMessage(message.to_frame());
 }

--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
@@ -48,9 +48,9 @@ class OrthogonalMapTest;
 namespace _orthogonal_map {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_frame;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;

--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
@@ -50,7 +50,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_frame;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
@@ -104,19 +104,13 @@ class OrthogonalMap : public LinearMap<OrthogonalMap<FromFrame, ToFrame>,
   static OrthogonalMap Identity();
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static OrthogonalMap ReadFromMessage(serialization::LinearMap const& message);
+  static OrthogonalMap ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::OrthogonalMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
   static OrthogonalMap ReadFromMessage(
-      serialization::OrthogonalMap const& message);
+      serialization::OrthogonalMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   explicit OrthogonalMap(Quaternion const& quaternion);

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -98,10 +98,10 @@ void OrthogonalMap<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<OrthogonalMap, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::OrthogonalMap::extension));
   return ReadFromMessage(
@@ -115,10 +115,10 @@ void OrthogonalMap<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 OrthogonalMap<FromFrame, ToFrame>
 OrthogonalMap<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::OrthogonalMap const& message) {
+    serialization::OrthogonalMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   bool const is_pre_frege = message.has_rotation();
   LOG_IF(WARNING, is_pre_frege) << "Reading pre-Frege OrthogonalMap";
   return OrthogonalMap(

--- a/geometry/pair.hpp
+++ b/geometry/pair.hpp
@@ -3,7 +3,7 @@
 #include "base/mappable.hpp"  // 🧙 For base::_mappable::internal.
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/barycentre_calculator.hpp"  // 🧙 For friendship.
 #include "geometry/traits.hpp"
 #include "quantities/named_quantities.hpp"
@@ -23,7 +23,7 @@ namespace internal {
 
 using namespace principia::base::_not_constructible;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_traits;
 using namespace principia::quantities::_named_quantities;
 
@@ -94,11 +94,8 @@ class Pair {
   bool operator!=(Pair const& right) const;
 
   void WriteToMessage(not_null<serialization::Pair*> message) const;
-  template<typename U1 = T1,
-           typename U2 = T2,
-           typename = std::enable_if_t<is_serializable_v<U1> &&
-                                       is_serializable_v<U2>>>
-  static Pair ReadFromMessage(serialization::Pair const& message);
+  static Pair ReadFromMessage(serialization::Pair const& message)
+    requires serializable<T1> && serializable<T2>;
 
  protected:
   // The subclasses can access the members directly to implement accessors.

--- a/geometry/pair.hpp
+++ b/geometry/pair.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"  // 🧙 For base::_mappable::internal.
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/barycentre_calculator.hpp"  // 🧙 For friendship.
 #include "geometry/traits.hpp"
 #include "quantities/named_quantities.hpp"
@@ -21,9 +21,9 @@ namespace geometry {
 namespace _pair {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_not_constructible;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_traits;
 using namespace principia::quantities::_named_quantities;
 

--- a/geometry/pair_body.hpp
+++ b/geometry/pair_body.hpp
@@ -62,8 +62,8 @@ void Pair<T1, T2>::WriteToMessage(
 }
 
 template<typename T1, typename T2>
-template<typename, typename, typename>
-Pair<T1, T2> Pair<T1, T2>::ReadFromMessage(serialization::Pair const& message) {
+Pair<T1, T2> Pair<T1, T2>::ReadFromMessage(serialization::Pair const& message)
+  requires serializable<T1> && serializable<T2> {
   T1 const t1 = PointOrMultivectorSerializer<T1, serialization::Pair::Element>::
                     ReadFromMessage(message.t1());
   T2 const t2 = PointOrMultivectorSerializer<T2, serialization::Pair::Element>::

--- a/geometry/permutation.hpp
+++ b/geometry/permutation.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/r3_element.hpp"
@@ -16,7 +16,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_r3_element;
@@ -97,18 +97,12 @@ class Permutation : public LinearMap<Permutation<FromFrame, ToFrame>,
   static Permutation Identity();
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Permutation ReadFromMessage(serialization::LinearMap const& message);
+  static Permutation ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::Permutation*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Permutation ReadFromMessage(serialization::Permutation const& message);
+  static Permutation ReadFromMessage(serialization::Permutation const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  public:
   // TODO(phl): This used to be private, but it's convenient for operating on

--- a/geometry/permutation.hpp
+++ b/geometry/permutation.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/r3_element.hpp"
@@ -14,9 +14,9 @@ namespace geometry {
 namespace _permutation {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_r3_element;

--- a/geometry/permutation_body.hpp
+++ b/geometry/permutation_body.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 
+#include "base/traits.hpp"
 #include "geometry/orthogonal_map.hpp"
 #include "geometry/quaternion.hpp"
 #include "geometry/rotation.hpp"
@@ -16,6 +17,7 @@ namespace geometry {
 namespace _permutation {
 namespace internal {
 
+using namespace principia::base::_traits;
 using namespace principia::geometry::_orthogonal_map;
 using namespace principia::geometry::_quaternion;
 using namespace principia::geometry::_rotation;
@@ -119,10 +121,10 @@ void Permutation<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Permutation<FromFrame, ToFrame>
 Permutation<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<Permutation, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::Permutation::extension));
   return ReadFromMessage(
@@ -137,10 +139,10 @@ void Permutation<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Permutation<FromFrame, ToFrame>
 Permutation<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::Permutation const& message) {
+    serialization::Permutation const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   return Permutation(static_cast<CoordinatePermutation>(
       message.coordinate_permutation()));
 }

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/barycentre_calculator.hpp"  // 🧙 For friendship.
 #include "quantities/named_quantities.hpp"
 #include "quantities/traits.hpp"
@@ -18,7 +18,7 @@ namespace _point {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_traits;
 
@@ -53,9 +53,8 @@ class Point final {
   constexpr bool operator!=(Point const& right) const;
 
   void WriteToMessage(not_null<serialization::Point*> message) const;
-  template<typename V = Vector,
-           typename = std::enable_if_t<is_serializable_v<V>>>
-  static Point ReadFromMessage(serialization::Point const& message);
+  static Point ReadFromMessage(serialization::Point const& message)
+    requires serializable<Vector>;
 
  private:
   // This constructor allows for C++11 functional constexpr operators, and

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -5,8 +5,8 @@
 #include <utility>
 #include <vector>
 
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "geometry/barycentre_calculator.hpp"  // 🧙 For friendship.
 #include "quantities/named_quantities.hpp"
 #include "quantities/traits.hpp"
@@ -17,8 +17,8 @@ namespace geometry {
 namespace _point {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_traits;
 

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -112,9 +112,9 @@ void Point<Vector>::WriteToMessage(
 }
 
 template<typename Vector>
-template<typename, typename>
 Point<Vector> Point<Vector>::ReadFromMessage(
-    serialization::Point const& message) {
+    serialization::Point const& message)
+  requires serializable<Vector> {
   Point result;
   result.coordinates_ = PointSerializer<Vector>::ReadFromMessage(message);
   return result;

--- a/geometry/rotation.hpp
+++ b/geometry/rotation.hpp
@@ -2,7 +2,7 @@
 
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/quaternion.hpp"
@@ -31,7 +31,7 @@ namespace internal {
 
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_quaternion;
@@ -251,18 +251,12 @@ class Rotation : public LinearMap<Rotation<FromFrame, ToFrame>,
   Quaternion const& quaternion() const;
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Rotation ReadFromMessage(serialization::LinearMap const& message);
+  static Rotation ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::Rotation*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Rotation ReadFromMessage(serialization::Rotation const& message);
+  static Rotation ReadFromMessage(serialization::Rotation const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   template<typename Scalar>

--- a/geometry/rotation.hpp
+++ b/geometry/rotation.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "base/concepts.hpp"
 #include "base/mappable.hpp"
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/quaternion.hpp"
@@ -29,9 +29,9 @@ FORWARD_DECLARE(TEMPLATE(typename Scalar,
 namespace _rotation {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_mappable;
 using namespace principia::base::_not_null;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_quaternion;

--- a/geometry/rotation_body.hpp
+++ b/geometry/rotation_body.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "base/traits.hpp"
 #include "geometry/orthogonal_map.hpp"
 #include "geometry/r3x3_matrix.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -13,6 +14,7 @@ namespace geometry {
 namespace _rotation {
 namespace internal {
 
+using namespace principia::base::_traits;
 using namespace principia::geometry::_orthogonal_map;
 using namespace principia::geometry::_r3x3_matrix;
 using namespace principia::quantities::_elementary_functions;
@@ -311,9 +313,9 @@ void Rotation<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Rotation<FromFrame, ToFrame> Rotation<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<Rotation, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::Rotation::extension));
   return ReadFromMessage(
@@ -327,9 +329,9 @@ void Rotation<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Rotation<FromFrame, ToFrame> Rotation<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::Rotation const& message) {
+    serialization::Rotation const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   return Rotation(Quaternion::ReadFromMessage(message.quaternion()));
 }
 

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/sign.hpp"
@@ -20,8 +20,8 @@ FORWARD_DECLARE(
 namespace _signature {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_sign;

--- a/geometry/signature.hpp
+++ b/geometry/signature.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/linear_map.hpp"
 #include "geometry/sign.hpp"
@@ -21,7 +21,7 @@ namespace _signature {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_linear_map;
 using namespace principia::geometry::_sign;
@@ -83,18 +83,12 @@ class Signature : public LinearMap<Signature<FromFrame, ToFrame>,
   ConformalMap<double, FromFrame, ToFrame> Forget() const;
 
   void WriteToMessage(not_null<serialization::LinearMap*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Signature ReadFromMessage(serialization::LinearMap const& message);
+  static Signature ReadFromMessage(serialization::LinearMap const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
   void WriteToMessage(not_null<serialization::Signature*> message) const;
-  template<typename F = FromFrame,
-           typename T = ToFrame,
-           typename = std::enable_if_t<is_serializable_v<F> &&
-                                       is_serializable_v<T>>>
-  static Signature ReadFromMessage(serialization::Signature const& message);
+  static Signature ReadFromMessage(serialization::Signature const& message)
+    requires serializable<FromFrame> && serializable<ToFrame>;
 
  private:
   constexpr Signature(Sign x, Sign y, Sign z);

--- a/geometry/signature_body.hpp
+++ b/geometry/signature_body.hpp
@@ -2,6 +2,7 @@
 
 #include "geometry/signature.hpp"
 
+#include "base/traits.hpp"
 #include "geometry/orthogonal_map.hpp"
 #include "geometry/quaternion.hpp"
 #include "geometry/r3_element.hpp"
@@ -12,6 +13,7 @@ namespace geometry {
 namespace _signature {
 namespace internal {
 
+using namespace principia::base::_traits;
 using namespace principia::geometry::_orthogonal_map;
 using namespace principia::geometry::_quaternion;
 using namespace principia::geometry::_r3_element;
@@ -148,9 +150,9 @@ void Signature<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Signature<FromFrame, ToFrame> Signature<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::LinearMap const& message) {
+    serialization::LinearMap const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   LinearMap<Signature, FromFrame, ToFrame>::ReadFromMessage(message);
   CHECK(message.HasExtension(serialization::Signature::extension));
   return ReadFromMessage(
@@ -166,9 +168,9 @@ void Signature<FromFrame, ToFrame>::WriteToMessage(
 }
 
 template<typename FromFrame, typename ToFrame>
-template<typename, typename, typename>
 Signature<FromFrame, ToFrame> Signature<FromFrame, ToFrame>::ReadFromMessage(
-    serialization::Signature const& message) {
+    serialization::Signature const& message)
+  requires serializable<FromFrame> && serializable<ToFrame> {
   auto const x = Sign::ReadFromMessage(message.x());
   auto const y = Sign::ReadFromMessage(message.y());
   auto const z = Sign::ReadFromMessage(message.z());

--- a/geometry/symmetric_bilinear_form.hpp
+++ b/geometry/symmetric_bilinear_form.hpp
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "base/traits.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/r3x3_matrix.hpp"
@@ -16,8 +16,8 @@ namespace geometry {
 namespace _symmetric_bilinear_form {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_r3x3_matrix;

--- a/geometry/symmetric_bilinear_form.hpp
+++ b/geometry/symmetric_bilinear_form.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "base/not_null.hpp"
+#include "base/concepts.hpp"
 #include "base/traits.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/r3x3_matrix.hpp"
@@ -16,6 +17,7 @@ namespace _symmetric_bilinear_form {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_concepts;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_r3x3_matrix;
@@ -80,10 +82,9 @@ class SymmetricBilinearForm {
 
   void WriteToMessage(
       not_null<serialization::SymmetricBilinearForm*> message) const;
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
   static SymmetricBilinearForm ReadFromMessage(
-      serialization::SymmetricBilinearForm const& message);
+      serialization::SymmetricBilinearForm const& message)
+    requires serializable<Frame>;
 
  private:
   // All the operations on this class must ensure that this matrix remains

--- a/geometry/symmetric_bilinear_form_body.hpp
+++ b/geometry/symmetric_bilinear_form_body.hpp
@@ -255,10 +255,10 @@ void SymmetricBilinearForm<Scalar, Frame, Multivector>::WriteToMessage(
 template<typename Scalar,
          typename Frame,
          template<typename, typename> typename Multivector>
-template<typename, typename>
 SymmetricBilinearForm<Scalar, Frame, Multivector>
 SymmetricBilinearForm<Scalar, Frame, Multivector>::ReadFromMessage(
-    serialization::SymmetricBilinearForm const& message) {
+    serialization::SymmetricBilinearForm const& message)
+  requires serializable<Frame>{
   Frame::ReadFromMessage(message.frame());
   return SymmetricBilinearForm(
       R3x3Matrix<Scalar>::ReadFromMessage(message.matrix()));

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include "absl/status/status.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
@@ -28,8 +28,8 @@ namespace integrators {
 namespace _embedded_explicit_generalized_runge_kutta_nyström_integrator {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_integrators;

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -14,6 +14,7 @@
 
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
+#include "base/concepts.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
@@ -28,6 +29,7 @@ namespace _embedded_explicit_generalized_runge_kutta_nyström_integrator {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_concepts;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_integrators;
@@ -103,8 +105,6 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
 
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
-    template<typename DV = typename ODE::DependentVariable,
-             typename = std::enable_if_t<is_serializable_v<DV>>>
     static not_null<std::unique_ptr<Instance>> ReadFromMessage(
         serialization::
         EmbeddedExplicitGeneralizedRungeKuttaNystromIntegratorInstance const&
@@ -116,7 +116,8 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
         Time const& time_step,
         bool first_use,
         EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&
-            integrator);
+            integrator)
+      requires serializable<typename ODE::DependentVariable>;
 
    private:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator_body.hpp
@@ -293,7 +293,6 @@ Instance::WriteToMessage(
 }
 
 template<typename Method, typename ODE_>
-template<typename, typename>
 not_null<std::unique_ptr<
     typename EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator<
         Method, ODE_>::Instance>>
@@ -309,7 +308,8 @@ Instance::ReadFromMessage(
     Time const& time_step,
     bool const first_use,
     EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&
-        integrator) {
+        integrator)
+  requires serializable<typename ODE::DependentVariable> {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
   return std::unique_ptr<Instance>(new Instance(problem,

--- a/integrators/embedded_explicit_runge_kutta_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator.hpp
@@ -86,8 +86,6 @@ class EmbeddedExplicitRungeKuttaIntegrator
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
 #if 0
-    template<typename... DV = DependentVariable...,
-             typename = std::enable_if_t<is_serializable_v<DV...>>>
     static not_null<std::unique_ptr<Instance>> ReadFromMessage(
         serialization::
             EmbeddedExplicitRungeKuttaNystromIntegratorInstance const&
@@ -98,7 +96,8 @@ class EmbeddedExplicitRungeKuttaIntegrator
         Parameters const& parameters,
         typename ODE::IndependentVariableDifference const& step,
         bool first_use,
-        EmbeddedExplicitRungeKuttaIntegrator const& integrator);
+        EmbeddedExplicitRungeKuttaIntegrator const& integrator)
+      requires serializable<DependentVariable>...;
 #endif
 
    private:

--- a/integrators/embedded_explicit_runge_kutta_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator.hpp
@@ -13,6 +13,7 @@
 
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
+#include "base/concepts.hpp"
 #include "base/traits.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "numerics/fixed_arrays.hpp"
@@ -25,6 +26,7 @@ namespace _embedded_explicit_runge_kutta_integrator {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_concepts;
 using namespace principia::base::_traits;
 using namespace principia::integrators::_integrators;
 using namespace principia::integrators::_ordinary_differential_equations;

--- a/integrators/embedded_explicit_runge_kutta_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_integrator.hpp
@@ -12,8 +12,8 @@
 #include <memory>
 
 #include "absl/status/status.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "base/traits.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "numerics/fixed_arrays.hpp"
@@ -25,8 +25,8 @@ namespace integrators {
 namespace _embedded_explicit_runge_kutta_integrator {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::base::_traits;
 using namespace principia::integrators::_integrators;
 using namespace principia::integrators::_ordinary_differential_equations;

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -12,8 +12,8 @@
 #include <memory>
 
 #include "absl/status/status.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
@@ -27,8 +27,8 @@ namespace integrators {
 namespace _embedded_explicit_runge_kutta_nyström_integrator {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_integrators;

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -13,6 +13,7 @@
 
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
+#include "base/concepts.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
@@ -27,6 +28,7 @@ namespace _embedded_explicit_runge_kutta_nyström_integrator {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_concepts;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_integrators;
@@ -96,8 +98,6 @@ class EmbeddedExplicitRungeKuttaNyströmIntegrator
 
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
-    template<typename DV = typename ODE::DependentVariable,
-             typename = std::enable_if_t<is_serializable_v<DV>>>
     static not_null<std::unique_ptr<Instance>> ReadFromMessage(
         serialization::
             EmbeddedExplicitRungeKuttaNystromIntegratorInstance const&
@@ -108,7 +108,8 @@ class EmbeddedExplicitRungeKuttaNyströmIntegrator
         Parameters const& parameters,
         Time const& time_step,
         bool first_use,
-        EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator);
+        EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator)
+      requires serializable<typename ODE::DependentVariable>;
 
    private:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator_body.hpp
@@ -284,7 +284,6 @@ Instance::WriteToMessage(
 }
 
 template<typename Method, typename ODE_>
-template<typename, typename>
 not_null<std::unique_ptr<
     typename EmbeddedExplicitRungeKuttaNyströmIntegrator<Method,
                                                          ODE_>::Instance>>
@@ -299,7 +298,8 @@ ReadFromMessage(
     Parameters const& parameters,
     Time const& time_step,
     bool const first_use,
-    EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator) {
+    EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator)
+  requires serializable<typename ODE::DependentVariable> {
   // Cannot use |make_not_null_unique| because the constructor of |Instance| is
   // private.
   return std::unique_ptr<Instance>(new Instance(problem,

--- a/integrators/integrators.hpp
+++ b/integrators/integrators.hpp
@@ -7,7 +7,7 @@
 
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "numerics/double_precision.hpp"
@@ -20,7 +20,7 @@ namespace _integrators {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_ordinary_differential_equations;
 using namespace principia::numerics::_double_precision;
@@ -102,12 +102,11 @@ class FixedStepSizeIntegrator : public Integrator<ODE_> {
 
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
-    template<typename S = typename ODE::State,
-             typename = std::enable_if_t<is_serializable_v<S>>>
     static not_null<std::unique_ptr<typename Integrator<ODE>::Instance>>
     ReadFromMessage(serialization::IntegratorInstance const& message,
                     ODE const& equation,
-                    AppendState const& append_state);
+                    AppendState const& append_state)
+      requires serializable<typename ODE::State>;
 
    protected:
     Instance(InitialValueProblem<ODE> const& problem,
@@ -198,13 +197,12 @@ class AdaptiveStepSizeIntegrator : public Integrator<ODE_> {
 
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
-    template<typename S = typename ODE::State,
-             typename = std::enable_if_t<is_serializable_v<S>>>
     static not_null<std::unique_ptr<typename Integrator<ODE>::Instance>>
     ReadFromMessage(serialization::IntegratorInstance const& message,
                     ODE const& equation,
                     AppendState const& append_state,
-                    ToleranceToErrorRatio const& tolerance_to_error_ratio);
+                    ToleranceToErrorRatio const& tolerance_to_error_ratio)
+      requires serializable<typename ODE::State>;
 
    protected:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/integrators.hpp
+++ b/integrators/integrators.hpp
@@ -6,8 +6,8 @@
 #include <string>
 
 #include "absl/status/status.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/ordinary_differential_equations.hpp"
 #include "numerics/double_precision.hpp"
@@ -19,8 +19,8 @@ namespace integrators {
 namespace _integrators {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_ordinary_differential_equations;
 using namespace principia::numerics::_double_precision;

--- a/integrators/integrators_body.hpp
+++ b/integrators/integrators_body.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <utility>
 
-
+#include "base/traits.hpp"
 #include "integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp"
 #include "integrators/embedded_explicit_runge_kutta_integrator.hpp"  // 🧙 For the integrator subclass.  // NOLINT
 #include "integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp"
@@ -233,6 +233,7 @@ namespace integrators {
 namespace _integrators {
 namespace internal {
 
+using namespace principia::base::_traits;
 using namespace principia::integrators::_embedded_explicit_generalized_runge_kutta_nyström_integrator;  // NOLINT
 using namespace principia::integrators::_embedded_explicit_runge_kutta_nyström_integrator;  // NOLINT
 using namespace principia::integrators::_methods;
@@ -516,12 +517,12 @@ void FixedStepSizeIntegrator<ODE_>::Instance::WriteToMessage(
   }
 
 template<typename ODE_>
-template<typename, typename>
 not_null<std::unique_ptr<typename Integrator<ODE_>::Instance>>
 FixedStepSizeIntegrator<ODE_>::Instance::ReadFromMessage(
     serialization::IntegratorInstance const& message,
     ODE const& equation,
-    AppendState const& append_state) {
+    AppendState const& append_state)
+  requires serializable<typename ODE::State> {
   InitialValueProblem<ODE> problem;
   problem.equation = equation;
   problem.initial_state =
@@ -754,13 +755,13 @@ void AdaptiveStepSizeIntegrator<ODE_>::Instance::WriteToMessage(
 #define PRINCIPIA_READ_ASS_INTEGRATOR_INSTANCE_EERK(method) LOG(FATAL) << "NYI"
 
 template<typename ODE_>
-template<typename, typename>
 not_null<std::unique_ptr<typename Integrator<ODE_>::Instance>>
 AdaptiveStepSizeIntegrator<ODE_>::Instance::ReadFromMessage(
     serialization::IntegratorInstance const& message,
     ODE const& equation,
     AppendState const& append_state,
-    ToleranceToErrorRatio const& tolerance_to_error_ratio) {
+    ToleranceToErrorRatio const& tolerance_to_error_ratio)
+  requires serializable<typename ODE::State> {
   using Serializer = DoubleOrQuantitySerializer<
       IndependentVariableDifference,
       serialization::AdaptiveStepSizeIntegratorInstance::Step>;

--- a/integrators/symmetric_linear_multistep_integrator.hpp
+++ b/integrators/symmetric_linear_multistep_integrator.hpp
@@ -13,6 +13,7 @@
 
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
+#include "base/concepts.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/cohen_hubbard_oesterwinter.hpp"
@@ -28,6 +29,7 @@ namespace _symmetric_linear_multistep_integrator {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_concepts;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_cohen_hubbard_oesterwinter;
@@ -57,15 +59,14 @@ class SymmetricLinearMultistepIntegrator
 
     void WriteToMessage(
         not_null<serialization::IntegratorInstance*> message) const override;
-    template<typename DV = typename ODE::DependentVariable,
-             typename = std::enable_if_t<is_serializable_v<DV>>>
     static not_null<std::unique_ptr<Instance>> ReadFromMessage(
         serialization::SymmetricLinearMultistepIntegratorInstance const&
             extension,
         InitialValueProblem<ODE> const& problem,
         AppendState const& append_state,
         Time const& step,
-        SymmetricLinearMultistepIntegrator const& integrator);
+        SymmetricLinearMultistepIntegrator const& integrator)
+      requires serializable<typename ODE::DependentVariable>;
 
    private:
     // The data for a previous step of the integration.  The |Displacement|s
@@ -80,11 +81,10 @@ class SymmetricLinearMultistepIntegrator
       void WriteToMessage(
           not_null<serialization::SymmetricLinearMultistepIntegratorInstance::
                        Step*> message) const;
-      template<typename DV = typename ODE::DependentVariable,
-               typename = std::enable_if_t<is_serializable_v<DV>>>
       static Step ReadFromMessage(
           serialization::SymmetricLinearMultistepIntegratorInstance::Step const&
-              message);
+              message)
+        requires serializable<typename ODE::DependentVariable>;
     };
 
     class Starter : public _starter::Starter<ODE, Step, /*steps=*/order> {

--- a/integrators/symmetric_linear_multistep_integrator.hpp
+++ b/integrators/symmetric_linear_multistep_integrator.hpp
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "absl/status/status.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "base/traits.hpp"
 #include "geometry/instant.hpp"
 #include "integrators/cohen_hubbard_oesterwinter.hpp"
@@ -28,8 +28,8 @@ namespace integrators {
 namespace _symmetric_linear_multistep_integrator {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::base::_traits;
 using namespace principia::geometry::_instant;
 using namespace principia::integrators::_cohen_hubbard_oesterwinter;

--- a/integrators/symmetric_linear_multistep_integrator_body.hpp
+++ b/integrators/symmetric_linear_multistep_integrator_body.hpp
@@ -181,7 +181,6 @@ Instance::WriteToMessage(
 }
 
 template<typename Method, typename ODE_>
-template<typename, typename>
 not_null<std::unique_ptr<
     typename SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance>>
 SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::ReadFromMessage(
@@ -189,7 +188,8 @@ SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::ReadFromMessage(
     InitialValueProblem<ODE> const& problem,
     AppendState const& append_state,
     Time const& step,
-    SymmetricLinearMultistepIntegrator const& integrator) {
+    SymmetricLinearMultistepIntegrator const& integrator)
+  requires serializable<typename ODE::DependentVariable> {
   auto instance = std::unique_ptr<Instance>(new Instance(problem,
                                                          append_state,
                                                          step,
@@ -218,12 +218,12 @@ WriteToMessage(
 }
 
 template<typename Method, typename ODE_>
-template<typename, typename>
 typename SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::Step
 SymmetricLinearMultistepIntegrator<Method, ODE_>::Instance::Step::
 ReadFromMessage(
     serialization::SymmetricLinearMultistepIntegratorInstance::Step const&
-        message) {
+        message)
+  requires serializable<typename ODE::DependentVariable> {
   using AccelerationSerializer = QuantityOrMultivectorSerializer<
       typename ODE::DependentVariableDerivative2,
       serialization::SymmetricLinearMultistepIntegratorInstance::Step::

--- a/journal/concepts.hpp
+++ b/journal/concepts.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <concepts>
-
 namespace principia {
 namespace journal {
 namespace _concepts {

--- a/journal/concepts.hpp
+++ b/journal/concepts.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <concepts>
+
+namespace principia {
+namespace journal {
+namespace _concepts {
+namespace internal {
+
+template<typename P>
+concept has_in = requires {
+  typename P::In;
+};
+
+template<typename P>
+concept has_out = requires {
+  typename P::Out;
+};
+
+template<typename P>
+concept has_return = requires {
+  typename P::Return;
+};
+
+}  // namespace internal
+
+using internal::has_in;
+using internal::has_out;
+using internal::has_return;
+
+}  // namespace _concepts
+}  // namespace journal
+}  // namespace principia

--- a/journal/journal.vcxproj
+++ b/journal/journal.vcxproj
@@ -9,6 +9,7 @@
     <Import Project="..\shared\base.vcxitems" Label="Shared" />
   </ImportGroup>
   <ItemGroup>
+    <ClInclude Include="concepts.hpp" />
     <ClInclude Include="method.hpp" />
     <ClInclude Include="method_body.hpp" />
     <ClInclude Include="player.hpp" />

--- a/journal/journal.vcxproj.filters
+++ b/journal/journal.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClInclude Include="profiles.generated.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="concepts.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="player.cpp">

--- a/journal/method.hpp
+++ b/journal/method.hpp
@@ -6,6 +6,7 @@
 
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
+#include "journal/concepts.hpp"
 
 namespace principia {
 namespace journal {
@@ -14,6 +15,7 @@ namespace internal {
 
 using namespace principia::base::_not_constructible;
 using namespace principia::base::_not_null;
+using namespace principia::journal::_concepts;
 
 // The parameter |Profile| is expected to have the following structure:
 //
@@ -37,24 +39,6 @@ using namespace principia::base::_not_null;
 //                    not_null<Player::PointerMap*> pointer_map);
 //  };
 
-template<typename P, typename = void>
-struct has_in : std::false_type, not_constructible {};
-template<typename P>
-struct has_in<P, std::void_t<typename P::In>> : std::true_type,
-                                                not_constructible {};
-
-template<typename P, typename = void>
-struct has_out : std::false_type {};
-template<typename P>
-struct has_out<P, std::void_t<typename P::Out>> : std::true_type,
-                                                  not_constructible {};
-
-template<typename P, typename = void>
-struct has_return : std::false_type {};
-template<typename P>
-struct has_return<P, std::void_t<typename P::Return>> : std::true_type,
-                                                        not_constructible {};
-
 template<typename Profile>
 class Method final {
  public:
@@ -62,33 +46,32 @@ class Method final {
 
   // Only declare this constructor if the profile has an |In| type and no |Out|
   // type.
-  template<typename P = Profile,
-           typename = std::enable_if_t<has_in<P>::value && !has_out<P>::value>>
-  explicit Method(typename P::In const& in);
+  template<typename P = Profile>
+  explicit Method(typename P::In const& in)
+    requires has_in<P> && (!has_out<P>);
 
   // Only declare this constructor if the profile has an |Out| type and no |In|
   // type.
-  template<typename P = Profile,
-           typename = std::enable_if_t<has_out<P>::value && !has_in<P>::value>>
-  explicit Method(typename P::Out const& out);
+  template<typename P = Profile>
+  explicit Method(typename P::Out const& out)
+    requires has_out<P> && (!has_in<P>);
 
   // Only declare this constructor if the profile has an |In| and an |Out|
   // type.
-  template<typename P = Profile,
-           typename = std::enable_if_t<has_in<P>::value && has_out<P>::value>>
-  Method(typename P::In const& in, typename P::Out const& out);
+  template<typename P = Profile>
+  Method(typename P::In const& in, typename P::Out const& out)
+    requires has_in<P> && has_out<P>;
 
   ~Method();
 
   // Only declare this method if the profile has no |Return| type.
-  template<typename P = Profile,
-           typename = std::enable_if_t<!has_return<P>::value>>
-  void Return();
+  template<typename P = Profile>
+  void Return() requires (!has_return<P>);
 
   // Only declare this method if the profile has a |Return| type.
-  template<typename P = Profile,
-           typename = std::enable_if_t<has_return<P>::value>>
-  typename P::Return Return(typename P::Return const& result);
+  template<typename P = Profile>
+  typename P::Return Return(typename P::Return const& result)
+    requires has_return<P>;
 
  private:
   std::function<void(not_null<typename Profile::Message*> message)> out_filler_;

--- a/journal/method.hpp
+++ b/journal/method.hpp
@@ -66,7 +66,7 @@ class Method final {
 
   // Only declare this method if the profile has no |Return| type.
   template<typename P = Profile>
-  void Return() requires (!has_return<P>);
+  void Return() requires (!has_return<P>);  // NOLINT
 
   // Only declare this method if the profile has a |Return| type.
   template<typename P = Profile>

--- a/journal/method_body.hpp
+++ b/journal/method_body.hpp
@@ -14,7 +14,7 @@ namespace internal {
 using namespace principia::journal::_recorder;
 
 template<typename Profile>
-Method<Profile>::Method(){
+Method<Profile>::Method() {
   if (Recorder::active_recorder_ != nullptr) {
     serialization::Method method;
     [[maybe_unused]] auto* const message_in =
@@ -90,7 +90,7 @@ Method<Profile>::~Method() {
 template<typename Profile>
 template<typename P>
 void Method<Profile>::Return()
-  requires (!has_return<P>) {
+  requires (!has_return<P>) {  // NOLINT
   CHECK(!returned_);
   returned_ = true;
 }

--- a/journal/method_body.hpp
+++ b/journal/method_body.hpp
@@ -14,7 +14,7 @@ namespace internal {
 using namespace principia::journal::_recorder;
 
 template<typename Profile>
-Method<Profile>::Method() {
+Method<Profile>::Method(){
   if (Recorder::active_recorder_ != nullptr) {
     serialization::Method method;
     [[maybe_unused]] auto* const message_in =
@@ -24,8 +24,9 @@ Method<Profile>::Method() {
 }
 
 template<typename Profile>
-template<typename P, typename>
-Method<Profile>::Method(typename P::In const& in) {
+template<typename P>
+Method<Profile>::Method(typename P::In const& in)
+  requires has_in<P> && (!has_out<P>) {
   if (Recorder::active_recorder_ != nullptr) {
     serialization::Method method;
     auto* const message_in =
@@ -36,8 +37,9 @@ Method<Profile>::Method(typename P::In const& in) {
 }
 
 template<typename Profile>
-template<typename P, typename>
-Method<Profile>::Method(typename P::Out const& out) {
+template<typename P>
+Method<Profile>::Method(typename P::Out const& out)
+  requires has_out<P> && (!has_in<P>) {
   if (Recorder::active_recorder_ != nullptr) {
     serialization::Method method;
     [[maybe_unused]] auto* const message_in =
@@ -51,8 +53,10 @@ Method<Profile>::Method(typename P::Out const& out) {
 }
 
 template<typename Profile>
-template<typename P, typename>
-Method<Profile>::Method(typename P::In const& in, typename P::Out const& out) {
+template<typename P>
+Method<Profile>::Method(typename P::In const& in,
+                        typename P::Out const& out)
+  requires has_in<P> && has_out<P> {
   if (Recorder::active_recorder_ != nullptr) {
     serialization::Method method;
     auto* const message_in =
@@ -84,16 +88,18 @@ Method<Profile>::~Method() {
 }
 
 template<typename Profile>
-template<typename P, typename>
-void Method<Profile>::Return() {
+template<typename P>
+void Method<Profile>::Return()
+  requires (!has_return<P>) {
   CHECK(!returned_);
   returned_ = true;
 }
 
 template<typename Profile>
-template<typename P, typename>
+template<typename P>
 typename P::Return Method<Profile>::Return(
-    typename P::Return const& result) {
+    typename P::Return const& result)
+  requires has_return<P> {
   CHECK(!returned_);
   returned_ = true;
   if (Recorder::active_recorder_ != nullptr) {

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include "absl/container/btree_set.h"
-#include "base/map_util.hpp"
 #include "base/concepts.hpp"
+#include "base/map_util.hpp"
 #include "geometry/barycentre_calculator.hpp"
 #include "ksp_plugin/integrators.hpp"
 #include "testing_utilities/make_not_null.hpp"
@@ -21,8 +21,8 @@ namespace _vessel {
 namespace internal {
 
 using ::std::placeholders::_1;
-using namespace principia::base::_map_util;
 using namespace principia::base::_concepts;
+using namespace principia::base::_map_util;
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::ksp_plugin::_integrators;
 using namespace principia::testing_utilities::_make_not_null;

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -10,7 +10,7 @@
 
 #include "absl/container/btree_set.h"
 #include "base/map_util.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/barycentre_calculator.hpp"
 #include "ksp_plugin/integrators.hpp"
 #include "testing_utilities/make_not_null.hpp"
@@ -22,7 +22,7 @@ namespace internal {
 
 using ::std::placeholders::_1;
 using namespace principia::base::_map_util;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::ksp_plugin::_integrators;
 using namespace principia::testing_utilities::_make_not_null;
@@ -985,7 +985,7 @@ Checkpointer<serialization::Vessel>::Reader Vessel::MakeCheckpointerReader() {
 absl::Status Vessel::Reanimate(Instant const desired_t_min) {
   // This method is very similar to Ephemeris::Reanimate.  See the comments
   // there for some of the subtle points.
-  static_assert(is_serializable_v<Barycentric>);
+  static_assert(serializable<Barycentric>);
   absl::btree_set<Instant> checkpoints;
   LOG(INFO) << "Reanimating " << ShortDebugString() << " until "
             << desired_t_min;

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -22,7 +22,6 @@
 #include "numerics/polynomial_in_чебышёв_basis.hpp"
 #include "numerics/unbounded_arrays.hpp"
 #include "physics/degrees_of_freedom.hpp"
-#include "physics/discrete_trajectory_types.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -22,6 +22,7 @@
 #include "numerics/polynomial_in_чебышёв_basis.hpp"
 #include "numerics/unbounded_arrays.hpp"
 #include "physics/degrees_of_freedom.hpp"
+#include "physics/discrete_trajectory_types.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -54,6 +55,10 @@ using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;
 using namespace principia::quantities::_tuples;
+
+template<typename F>
+using DiscreteTrajectoryValueType =
+    principia::physics::_discrete_trajectory_types::internal::value_type<F>;
 
 // A helper class for type erasure of quantities.  It may be used with the
 // functions in this file to remove the dimensions of quantities (we know that
@@ -247,11 +252,9 @@ template<typename Scalar, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(UnboundedVector<Scalar> const& vector,
                           OptionalExpressIn express_in = std::nullopt);
 
-template<typename R,
-         typename = std::void_t<decltype(std::declval<R>().time)>,
-         typename = std::void_t<decltype(std::declval<R>().degrees_of_freedom)>,
+template<typename F,
          typename OptionalExpressIn = std::nullopt_t>
-std::string ToMathematica(R ref,
+std::string ToMathematica(DiscreteTrajectoryValueType<F> const& v,
                           OptionalExpressIn express_in = std::nullopt);
 
 template<typename V, typename A, int d,

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -527,13 +527,13 @@ std::string ToMathematica(UnboundedVector<Scalar> const& vector,
   return RawApply("List", elements);
 }
 
-template<typename R, typename, typename, typename OptionalExpressIn>
-std::string ToMathematica(R const ref,
+template<typename F, typename OptionalExpressIn>
+std::string ToMathematica(DiscreteTrajectoryValueType<F> const& v,
                           OptionalExpressIn express_in) {
   return RawApply("List",
                   std::vector<std::string>{
-                      ToMathematica(ref.time, express_in),
-                      ToMathematica(ref.degrees_of_freedom, express_in)});
+                      ToMathematica(v.time, express_in),
+                      ToMathematica(v.degrees_of_freedom, express_in)});
 }
 
 template<typename V, typename A, int d,

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -8,7 +8,7 @@
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "numerics/piecewise_poisson_series.hpp"
@@ -30,7 +30,7 @@ namespace _continuous_trajectory {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_piecewise_poisson_series;
@@ -121,14 +121,13 @@ class ContinuousTrajectory : public Trajectory<Frame> {
 
   void WriteToMessage(not_null<serialization::ContinuousTrajectory*> message)
       const EXCLUDES(lock_);
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
   // The parameter |desired_t_min| indicates that the trajectory must be
   // restored at a checkpoint such that, once it is appended to, its t_min() is
   // at or before |desired_t_min|.
   static not_null<std::unique_ptr<ContinuousTrajectory>> ReadFromMessage(
       Instant const& desired_t_min,
-      serialization::ContinuousTrajectory const& message);
+      serialization::ContinuousTrajectory const& message)
+    requires serializable<Frame>;
 
   // These members call the corresponding functions of the internal
   // checkpointer.

--- a/physics/continuous_trajectory.hpp
+++ b/physics/continuous_trajectory.hpp
@@ -7,8 +7,8 @@
 
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
-#include "base/not_null.hpp"
 #include "base/concepts.hpp"
+#include "base/not_null.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "numerics/piecewise_poisson_series.hpp"
@@ -29,8 +29,8 @@ class TestableContinuousTrajectory;
 namespace _continuous_trajectory {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_piecewise_poisson_series;

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -356,11 +356,11 @@ void ContinuousTrajectory<Frame>::WriteToMessage(
 }
 
 template<typename Frame>
-template<typename, typename>
 not_null<std::unique_ptr<ContinuousTrajectory<Frame>>>
 ContinuousTrajectory<Frame>::ReadFromMessage(
     Instant const& desired_t_min,
-    serialization::ContinuousTrajectory const& message) {
+    serialization::ContinuousTrajectory const& message)
+  requires serializable<Frame> {
   bool const is_pre_cohen = message.series_size() > 0;
   bool const is_pre_fatou = !message.has_checkpoint_time();
   bool const is_pre_grassmann = message.has_adjusted_tolerance() &&
@@ -504,7 +504,7 @@ absl::Status ContinuousTrajectory<Frame>::ReadFromCheckpointAt(
 template<typename Frame>
 Checkpointer<serialization::ContinuousTrajectory>::Writer
 ContinuousTrajectory<Frame>::MakeCheckpointerWriter() {
-  if constexpr (is_serializable_v<Frame>) {
+  if constexpr (serializable<Frame>) {
     return [this](
         not_null<
             serialization::ContinuousTrajectory::Checkpoint*> const message) {
@@ -531,7 +531,7 @@ ContinuousTrajectory<Frame>::MakeCheckpointerWriter() {
 template<typename Frame>
 Checkpointer<serialization::ContinuousTrajectory>::Reader
 ContinuousTrajectory<Frame>::MakeCheckpointerReader() {
-  if constexpr (is_serializable_v<Frame>) {
+  if constexpr (serializable<Frame>) {
     return [this](
                serialization::ContinuousTrajectory::Checkpoint const& message) {
       absl::MutexLock l(&lock_);

--- a/physics/degrees_of_freedom.hpp
+++ b/physics/degrees_of_freedom.hpp
@@ -3,8 +3,8 @@
 #include <string>
 #include <vector>
 
-#include "base/not_constructible.hpp"
 #include "base/concepts.hpp"
+#include "base/not_constructible.hpp"
 #include "geometry/pair.hpp"
 #include "geometry/space.hpp"
 
@@ -13,8 +13,8 @@ namespace physics {
 namespace _degrees_of_freedom {
 namespace internal {
 
-using namespace principia::base::_not_constructible;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_constructible;
 using namespace principia::geometry::_pair;
 using namespace principia::geometry::_space;
 

--- a/physics/degrees_of_freedom.hpp
+++ b/physics/degrees_of_freedom.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "base/not_constructible.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/pair.hpp"
 #include "geometry/space.hpp"
 
@@ -14,7 +14,7 @@ namespace _degrees_of_freedom {
 namespace internal {
 
 using namespace principia::base::_not_constructible;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_pair;
 using namespace principia::geometry::_space;
 
@@ -35,9 +35,8 @@ class DegreesOfFreedom : public Pair<Position<Frame>, Velocity<Frame>> {
       Pair<Position<Frame>,
            Velocity<Frame>> const& base);  // NOLINT(runtime/explicit)
 
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
-  static DegreesOfFreedom ReadFromMessage(serialization::Pair const& message);
+  static DegreesOfFreedom ReadFromMessage(serialization::Pair const& message)
+    requires serializable<Frame>;
 
   Position<Frame> const& position() const;
   Velocity<Frame> const& velocity() const;

--- a/physics/degrees_of_freedom_body.hpp
+++ b/physics/degrees_of_freedom_body.hpp
@@ -24,9 +24,9 @@ DegreesOfFreedom<Frame>::DegreesOfFreedom(
     : Pair<Position<Frame>, Velocity<Frame>>(base) {}
 
 template<typename Frame>
-template<typename, typename>
 DegreesOfFreedom<Frame> DegreesOfFreedom<Frame>::ReadFromMessage(
-    serialization::Pair const& message) {
+    serialization::Pair const& message)
+  requires serializable<Frame> {
   return Pair<Position<Frame>, Velocity<Frame>>::ReadFromMessage(message);
 }
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -9,7 +9,7 @@
 #include "absl/status/status.h"
 #include "base/not_null.hpp"
 #include "base/tags.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "physics/degrees_of_freedom.hpp"
@@ -27,7 +27,7 @@ namespace internal {
 
 using namespace principia::base::_not_null;
 using namespace principia::base::_tags;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::physics::_degrees_of_freedom;
@@ -145,11 +145,10 @@ class DiscreteTrajectory : public Trajectory<Frame> {
   // and the orders of the |tracked| iterators must be consistent during
   // serialization and deserialization.  Upon return, the iterators in |tracked|
   // are past-the-end iff they were past-the-end at serialization time.
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
   static DiscreteTrajectory ReadFromMessage(
       serialization::DiscreteTrajectory const& message,
-      std::vector<SegmentIterator*> const& tracked);
+      std::vector<SegmentIterator*> const& tracked)
+    requires serializable<Frame>;
 
  private:
   using DownsamplingParameters =

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -7,9 +7,9 @@
 
 #include "absl/container/btree_map.h"
 #include "absl/status/status.h"
+#include "base/concepts.hpp"
 #include "base/not_null.hpp"
 #include "base/tags.hpp"
-#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "physics/degrees_of_freedom.hpp"
@@ -25,9 +25,9 @@ namespace physics {
 namespace _discrete_trajectory {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_not_null;
 using namespace principia::base::_tags;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::physics::_degrees_of_freedom;

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -617,11 +617,11 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
 }
 
 template<typename Frame>
-template<typename F, typename>
 DiscreteTrajectory<Frame>
 DiscreteTrajectory<Frame>::ReadFromMessage(
     serialization::DiscreteTrajectory const& message,
-    std::vector<SegmentIterator*> const& tracked) {
+    std::vector<SegmentIterator*> const& tracked)
+  requires serializable<Frame> {
   DiscreteTrajectory trajectory(uninitialized);
 
   bool const is_pre_hamilton = message.segment_size() == 0;

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -9,7 +9,7 @@
 #include "absl/status/status.h"
 #include "base/macros.hpp"  // 🧙 For forward declarations.
 #include "base/not_null.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "numerics/hermite3.hpp"
@@ -43,7 +43,7 @@ namespace _discrete_trajectory_segment {
 namespace internal {
 
 using namespace principia::base::_not_null;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_hermite3;
@@ -143,11 +143,10 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
       iterator end,
       std::vector<iterator> const& exact) const;
 
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
   static DiscreteTrajectorySegment ReadFromMessage(
       serialization::DiscreteTrajectorySegment const& message,
-      DiscreteTrajectorySegmentIterator<Frame> self);
+      DiscreteTrajectorySegmentIterator<Frame> self)
+    requires serializable<Frame>;
 
  private:
   // Versions of find, lower_bound, and upper_bound that use optionals to

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -7,9 +7,9 @@
 
 #include "absl/container/btree_map.h"
 #include "absl/status/status.h"
+#include "base/concepts.hpp"
 #include "base/macros.hpp"  // 🧙 For forward declarations.
 #include "base/not_null.hpp"
-#include "base/concepts.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "numerics/hermite3.hpp"
@@ -42,8 +42,8 @@ class DiscreteTrajectorySegmentTest;
 namespace _discrete_trajectory_segment {
 namespace internal {
 
-using namespace principia::base::_not_null;
 using namespace principia::base::_concepts;
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_hermite3;

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -230,11 +230,11 @@ void DiscreteTrajectorySegment<Frame>::WriteToMessage(
 }
 
 template<typename Frame>
-template<typename F, typename>
 DiscreteTrajectorySegment<Frame>
 DiscreteTrajectorySegment<Frame>::ReadFromMessage(
     serialization::DiscreteTrajectorySegment const& message,
-    DiscreteTrajectorySegmentIterator<Frame> const self) {
+    DiscreteTrajectorySegmentIterator<Frame> const self)
+  requires serializable<Frame> {
   // Note that while is_pre_hardy means that the save is pre-Hardy,
   // !is_pre_hardy does not mean it is Hardy or later; a pre-Hardy segment with
   // downsampling will have both fields present.

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -11,7 +11,7 @@
 #include "absl/synchronization/mutex.h"
 #include "base/not_null.hpp"
 #include "base/recurring_thread.hpp"
-#include "base/traits.hpp"
+#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
@@ -40,7 +40,7 @@ namespace internal {
 
 using namespace principia::base::_not_null;
 using namespace principia::base::_recurring_thread;
-using namespace principia::base::_traits;
+using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
@@ -271,14 +271,13 @@ class Ephemeris {
 
   virtual void WriteToMessage(
       not_null<serialization::Ephemeris*> message) const EXCLUDES(lock_);
-  template<typename F = Frame,
-           typename = std::enable_if_t<is_serializable_v<F>>>
   // The parameter |desired_t_min| indicates that the ephemeris must be restored
   // at a checkpoint such that, once the ephemeris is prolonged, its |t_min()|
   // is at or before |desired_t_min|.
   static not_null<std::unique_ptr<Ephemeris>> ReadFromMessage(
       Instant const& desired_t_min,
-      serialization::Ephemeris const& message) EXCLUDES(lock_);
+      serialization::Ephemeris const& message) EXCLUDES(lock_)
+    requires serializable<Frame>;
 
  protected:
   // For mocking purposes, leaves everything uninitialized and uses the given

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -9,9 +9,9 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "base/concepts.hpp"
 #include "base/not_null.hpp"
 #include "base/recurring_thread.hpp"
-#include "base/concepts.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
@@ -38,9 +38,9 @@ namespace physics {
 namespace _ephemeris {
 namespace internal {
 
+using namespace principia::base::_concepts;
 using namespace principia::base::_not_null;
 using namespace principia::base::_recurring_thread;
-using namespace principia::base::_concepts;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;


### PR DESCRIPTION
In this PR I am removing all uses of `std::void_t`, as it is the hardest trait to use.

Incidentally, this is changing `Hilbert` in a way that avoids a bug, so no need to `#ifdef` code anymore.