### PR TITLE
Add support for constructing a matrix from a TransposedView

### DIFF
--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -655,7 +655,7 @@ TEST_P(MetricTest, Gradient) {
               metric_->Evaluate(argument + Δargument),
               metric_->Evaluate(argument) +
                   TransposedView<FlightPlanOptimizer::HomogeneousArgument>{
-                      .transpose = metric_->EvaluateGradient(argument)} *
+                      metric_->EvaluateGradient(argument)} *
                       Δargument));
     }
   }

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -95,6 +95,9 @@ class FixedMatrix final {
   constexpr FixedMatrix(
       std::array<Scalar, size()> const& data);  // NOLINT(runtime/explicit)
 
+  constexpr explicit FixedMatrix(
+      TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view);
+
   // For  0 < i < rows and 0 < j < columns, the entry a_ij is accessed as
   // |a(i, j)|.  if i and j do not satisfy these conditions, the expression
   // |a(i, j)| implies undefined behaviour.

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -107,8 +107,6 @@ class FixedMatrix final {
   template<int r>
   Scalar const* row() const;
 
-  FixedMatrix Transpose() const;
-
   Scalar FrobeniusNorm() const;
 
   bool operator==(FixedMatrix const& right) const;

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -131,6 +131,17 @@ constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
     : data_(data) {}
 
 template<typename Scalar_, int rows_, int columns_>
+constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
+    TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view)
+    : FixedMatrix(uninitialized) {
+  for (int i = 0; i < rows_; ++i) {
+    for (int j = 0; j < columns_; ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
+}
+
+template<typename Scalar_, int rows_, int columns_>
 constexpr Scalar_& FixedMatrix<Scalar_, rows_, columns_>::operator()(
     int const row, int const column) {
   CONSTEXPR_DCHECK(0 <= row);
@@ -155,18 +166,6 @@ template<int r>
 Scalar_ const* FixedMatrix<Scalar_, rows_, columns_>::row() const {
   static_assert(r < rows_);
   return &data_[r * columns()];
-}
-
-template<typename Scalar_, int rows_, int columns_>
-FixedMatrix<Scalar_, rows_, columns_>
-FixedMatrix<Scalar_, rows_, columns_>::Transpose() const {
-  FixedMatrix<Scalar, rows(), columns()> m(uninitialized);
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
-      m(j, i) = (*this)(i, j);
-    }
-  }
-  return m;
 }
 
 template<typename Scalar_, int rows_, int columns_>

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -134,6 +134,9 @@ TEST_F(FixedArraysTest, Algebra) {
   EXPECT_EQ(v3_, m34_ * v4_);
   EXPECT_EQ((FixedVector<double, 4>({-486, -229, 333, 198})),
             TransposedView{m34_} * v3_);  // NOLINT
+  FixedMatrix<double, 4, 3> m43(TransposedView{m34_});
+  EXPECT_EQ((FixedVector<double, 4>({-486, -229, 333, 198})),
+            m43 * v3_);
 }
 
 TEST_F(FixedArraysTest, VectorIndexing) {

--- a/numerics/transposed_view.hpp
+++ b/numerics/transposed_view.hpp
@@ -9,8 +9,6 @@ namespace internal {
 
 using namespace principia::numerics::_concepts;
 
-// TODO(phl): Add a way to explicitly cast a |TransposedView| of a matrix to
-// another matrix.
 template<typename T>
 struct TransposedView {
   T const& transpose;

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -97,6 +97,8 @@ class UnboundedMatrix final {
 
   UnboundedMatrix(int rows, int columns, std::initializer_list<Scalar> data);
 
+  explicit UnboundedMatrix(TransposedView<UnboundedMatrix<Scalar>> const& view);
+
   int rows() const;
   int columns() const;
   // TODO(phl): The meaning of |size| for matrices is unclear.
@@ -107,8 +109,6 @@ class UnboundedMatrix final {
   // |a(i, j)| implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
-
-  UnboundedMatrix Transpose() const;
 
   Scalar FrobeniusNorm() const;
 

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -145,6 +145,9 @@ class UnboundedLowerTriangularMatrix final {
   // The |data| must be in row-major format.
   UnboundedLowerTriangularMatrix(std::initializer_list<Scalar> data);
 
+  UnboundedLowerTriangularMatrix(
+      TransposedView<UnboundedUpperTriangularMatrix<Scalar>> const& view);
+
   void Extend(int extra_rows);
   void Extend(int extra_rows, uninitialized_t);
 
@@ -162,8 +165,6 @@ class UnboundedLowerTriangularMatrix final {
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
-
-  UnboundedUpperTriangularMatrix<Scalar> Transpose() const;
 
   bool operator==(UnboundedLowerTriangularMatrix const& right) const;
   bool operator!=(UnboundedLowerTriangularMatrix const& right) const;
@@ -189,6 +190,9 @@ class UnboundedUpperTriangularMatrix final {
   // The |data| must be in row-major format.
   UnboundedUpperTriangularMatrix(std::initializer_list<Scalar> const& data);
 
+  UnboundedUpperTriangularMatrix(
+      TransposedView<UnboundedLowerTriangularMatrix<Scalar>> const& view);
+
   void Extend(int extra_columns);
   void Extend(int extra_columns, uninitialized_t);
 
@@ -206,8 +210,6 @@ class UnboundedUpperTriangularMatrix final {
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
-
-  UnboundedLowerTriangularMatrix<Scalar> Transpose() const;
 
   bool operator==(UnboundedUpperTriangularMatrix const& right) const;
   bool operator!=(UnboundedUpperTriangularMatrix const& right) const;

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -255,6 +255,17 @@ UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
 }
 
 template<typename Scalar_>
+UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
+    TransposedView<UnboundedUpperTriangularMatrix<Scalar>> const& view)
+    : UnboundedLowerTriangularMatrix(view.rows(), uninitialized) {
+  for (int i = 0; i < rows(); ++i) {
+    for (int j = 0; j <= i; ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
+}
+
+template<typename Scalar_>
 void UnboundedLowerTriangularMatrix<Scalar_>::Extend(int const extra_rows) {
   rows_ += extra_rows;
   data_.resize(rows_ * (rows_ + 1) / 2, Scalar{});
@@ -317,18 +328,6 @@ Scalar_ const& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
 }
 
 template<typename Scalar_>
-UnboundedUpperTriangularMatrix<Scalar_>
-UnboundedLowerTriangularMatrix<Scalar_>::Transpose() const {
-  UnboundedUpperTriangularMatrix<Scalar> u(rows_, uninitialized);
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j <= i; ++j) {
-      u(j, i) = (*this)(i, j);
-    }
-  }
-  return u;
-}
-
-template<typename Scalar_>
 bool UnboundedLowerTriangularMatrix<Scalar_>::operator==(
     UnboundedLowerTriangularMatrix const& right) const {
   return rows_ == right.rows_ && data_ == right.data_;
@@ -362,6 +361,17 @@ UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
                       /*current_columns=*/0,
                       /*extra_columns=*/columns_)) {
   DCHECK_EQ(data_.size(), columns_ * (columns_ + 1) / 2);
+}
+
+template<typename Scalar_>
+UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
+    TransposedView<UnboundedLowerTriangularMatrix<Scalar>> const& view)
+    : UnboundedUpperTriangularMatrix<Scalar>(view.columns(), uninitialized) {
+  for (int i = 0; i < columns(); ++i) {
+    for (int j = i; j < columns(); ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
 }
 
 template<typename Scalar_>
@@ -431,18 +441,6 @@ Scalar_ const& UnboundedUpperTriangularMatrix<Scalar_>::operator()(
   DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
   return data_[column * (column + 1) / 2 + row];
-}
-
-template<typename Scalar_>
-UnboundedLowerTriangularMatrix<Scalar_>
-UnboundedUpperTriangularMatrix<Scalar_>::Transpose() const {
-  UnboundedLowerTriangularMatrix<Scalar> l(columns_, uninitialized);
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = i; j < columns_; ++j) {
-      l(j, i) = (*this)(i, j);
-    }
-  }
-  return l;
 }
 
 template<typename Scalar_>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -148,6 +148,17 @@ UnboundedMatrix<Scalar_>::UnboundedMatrix(int const rows, int const columns,
 }
 
 template<typename Scalar_>
+UnboundedMatrix<Scalar_>::UnboundedMatrix(
+    TransposedView<UnboundedMatrix<Scalar>> const& view)
+    : UnboundedMatrix(view.rows(), view.columns(), uninitialized) {
+  for (int i = 0; i < rows_; ++i) {
+    for (int j = 0; j < columns_; ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
+}
+
+template<typename Scalar_>
 int UnboundedMatrix<Scalar_>::rows() const {
   return rows_;
 }
@@ -160,17 +171,6 @@ int UnboundedMatrix<Scalar_>::columns() const {
 template<typename Scalar_>
 int UnboundedMatrix<Scalar_>::size() const {
   return rows_ * columns_;
-}
-
-template<typename Scalar_>
-UnboundedMatrix<Scalar_> UnboundedMatrix<Scalar_>::Transpose() const {
-  UnboundedMatrix<Scalar> m(columns_, rows_, uninitialized);
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j < columns_; ++j) {
-      m(j, i) = (*this)(i, j);
-    }
-  }
-  return m;
 }
 
 template<typename Scalar_>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -367,7 +367,7 @@ template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
     TransposedView<UnboundedLowerTriangularMatrix<Scalar>> const& view)
     : UnboundedUpperTriangularMatrix<Scalar>(view.columns(), uninitialized) {
-  for (int i = 0; i < columns(); ++i) {
+  for (int i = 0; i < rows(); ++i) {
     for (int j = i; j < columns(); ++j) {
       (*this)(i, j) = view(i, j);
     }

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -242,12 +242,14 @@ TEST_F(UnboundedArraysTest, Transpose) {
       UnboundedUpperTriangularMatrix<double>({1, 2,  5, 21,
                                                  3,  8, 34,
                                                     13, 55,
-                                                        89}), l4_.Transpose());
+                                                        89}),
+      UnboundedUpperTriangularMatrix<double>(TransposedView{l4_}));
   EXPECT_EQ(
       UnboundedLowerTriangularMatrix<double>({1,
                                               2,  8,
                                               3, 13, 34,
-                                              5, 21, 55, 89}), u4_.Transpose());
+                                              5, 21, 55, 89}),
+      UnboundedLowerTriangularMatrix<double>(TransposedView{u4_}));
 }
 
 }  // namespace numerics

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -236,7 +236,8 @@ TEST_F(UnboundedArraysTest, Transpose) {
       UnboundedMatrix<double>({1,  8,  55,  377,
                                2, 13,  89,  610,
                                3, 21, 144,  987,
-                               5, 34, 233, 1597}), m4_.Transpose());
+                               5, 34, 233, 1597}),
+      UnboundedMatrix<double>(TransposedView{m4_}));
   EXPECT_EQ(
       UnboundedUpperTriangularMatrix<double>({1, 2,  5, 21,
                                                  3,  8, 34,


### PR DESCRIPTION
1. Remove `Transpose`.
2. Remove most references to `transpose`.

Contributes to #3302.