### PR TITLE
Migration to Clang 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,12 +100,13 @@ SHARED_ARGS   := \
 	-fno-char8_t -fbracket-depth=257                              \
 	-Wall -Wpedantic                                              \
 	-Wno-char-subscripts                                          \
+	-Wno-elaborated-enum-class                                    \
 	-Wno-gnu-anonymous-struct                                     \
 	-Wno-c99-extensions                                           \
 	-Wno-gnu-zero-variadic-macro-arguments                        \
+	-Wno-mathematical-notation-identifier-extension               \
 	-Wno-nested-anon-types                                        \
 	-Wno-unknown-pragmas                                          \
-	-Wno-elaborated-enum-class                                    \
 	-DPROJECT_DIR='std::filesystem::path("$(PROJECT_DIR)")'       \
 	-DSOLUTION_DIR='std::filesystem::path("$(SOLUTION_DIR)")'     \
 	-DTEMP_DIR='std::filesystem::path("/tmp")'                    \

--- a/base/version.hpp
+++ b/base/version.hpp
@@ -13,7 +13,7 @@ extern char const Version[];
 #if PRINCIPIA_COMPILER_MSVC
 #pragma message("Compiler version: " STRINGIFY_EXPANSION(_MSC_FULL_VER))
 #elif PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL
-#pragma message("Compiler version: " STRINGIFY_EXPANSION(__clang_major__) "." STRINGIFY_EXPANSION(__clang_minor__) "." STRINGIFY_EXPANSION(__clang_patchlevel__))
+#pragma message("Compiler version: " STRINGIFY_EXPANSION(__clang_major__) "." STRINGIFY_EXPANSION(__clang_minor__) "." STRINGIFY_EXPANSION(__clang_patchlevel__))  // NOLINT
 #endif
 
 }  // namespace internal

--- a/base/version.hpp
+++ b/base/version.hpp
@@ -10,8 +10,10 @@ namespace internal {
 extern char const BuildDate[];
 extern char const Version[];
 
-#if OS_WIN
+#if PRINCIPIA_COMPILER_MSVC
 #pragma message("Compiler version: " STRINGIFY_EXPANSION(_MSC_FULL_VER))
+#elif PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL
+#pragma message("Compiler version: " STRINGIFY_EXPANSION(__clang_major__) "." STRINGIFY_EXPANSION(__clang_minor__) "." STRINGIFY_EXPANSION(__clang_patchlevel__))
 #endif
 
 }  // namespace internal

--- a/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_generalized_runge_kutta_nyström_integrator.hpp
@@ -117,7 +117,7 @@ class EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator
         bool first_use,
         EmbeddedExplicitGeneralizedRungeKuttaNyströmIntegrator const&
             integrator)
-      requires serializable<typename ODE::DependentVariable>;
+      requires serializable<typename ODE_::DependentVariable>;
 
    private:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
+++ b/integrators/embedded_explicit_runge_kutta_nyström_integrator.hpp
@@ -109,7 +109,7 @@ class EmbeddedExplicitRungeKuttaNyströmIntegrator
         Time const& time_step,
         bool first_use,
         EmbeddedExplicitRungeKuttaNyströmIntegrator const& integrator)
-      requires serializable<typename ODE::DependentVariable>;
+      requires serializable<typename ODE_::DependentVariable>;
 
    private:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/integrators.hpp
+++ b/integrators/integrators.hpp
@@ -106,7 +106,7 @@ class FixedStepSizeIntegrator : public Integrator<ODE_> {
     ReadFromMessage(serialization::IntegratorInstance const& message,
                     ODE const& equation,
                     AppendState const& append_state)
-      requires serializable<typename ODE::State>;
+      requires serializable<typename ODE_::State>;
 
    protected:
     Instance(InitialValueProblem<ODE> const& problem,
@@ -202,7 +202,7 @@ class AdaptiveStepSizeIntegrator : public Integrator<ODE_> {
                     ODE const& equation,
                     AppendState const& append_state,
                     ToleranceToErrorRatio const& tolerance_to_error_ratio)
-      requires serializable<typename ODE::State>;
+      requires serializable<typename ODE_::State>;
 
    protected:
     Instance(InitialValueProblem<ODE> const& problem,

--- a/integrators/symmetric_linear_multistep_integrator.hpp
+++ b/integrators/symmetric_linear_multistep_integrator.hpp
@@ -66,7 +66,7 @@ class SymmetricLinearMultistepIntegrator
         AppendState const& append_state,
         Time const& step,
         SymmetricLinearMultistepIntegrator const& integrator)
-      requires serializable<typename ODE::DependentVariable>;
+      requires serializable<typename ODE_::DependentVariable>;
 
    private:
     // The data for a previous step of the integration.  The |Displacement|s
@@ -84,7 +84,7 @@ class SymmetricLinearMultistepIntegrator
       static Step ReadFromMessage(
           serialization::SymmetricLinearMultistepIntegratorInstance::Step const&
               message)
-        requires serializable<typename ODE::DependentVariable>;
+        requires serializable<typename ODE_::DependentVariable>;
     };
 
     class Starter : public _starter::Starter<ODE, Step, /*steps=*/order> {

--- a/numerics/angle_reduction.hpp
+++ b/numerics/angle_reduction.hpp
@@ -13,7 +13,8 @@ using namespace principia::quantities::_quantities;
 
 // Clang up to version 17 does not support non-type template parameters that are
 // floats.  So we wrap the float in a silly struct instead.
-#if PRINCIPIA_COMPILER_CLANG && __clang_major__ <= 17
+#if (PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL) && \
+    __clang_major__ <= 17
 struct DoubleWrapper {
   constexpr DoubleWrapper(double const d) : d(d) {}  // NOLINT(runtime/explicit)
   constexpr DoubleWrapper(int const i) : d(i) {}  // NOLINT(runtime/explicit)

--- a/physics/mechanical_system_test.cpp
+++ b/physics/mechanical_system_test.cpp
@@ -83,13 +83,13 @@ TEST_F(MechanicalSystemTest, RigidTwoPointMasses) {
   DegreesOfFreedom<InertialFrame> const unmoving_origin = {
       InertialFrame::origin, InertialFrame::unmoving};
 
-  constexpr double ⅞ = 7.0 / 8;
   EXPECT_THAT(
       system_.LinearMotion()({SystemFrame::origin, SystemFrame::unmoving}) -
           unmoving_origin,
       Componentwise(
-          Componentwise(⅞ * r, 0 * Metre, 0 * Metre),
-          Componentwise(0 * Metre / Second, ⅞ * v, 0 * Metre / Second)));
+          Componentwise(7.0 * r / 8.0, 0 * Metre, 0 * Metre),
+          Componentwise(
+              0 * Metre / Second, 7.0 * v / 8.0, 0 * Metre / Second)));
   EXPECT_THAT(
       system_.AngularMomentum(),
       Componentwise(AngularMomentum{}, AngularMomentum{}, r * μ * v * Radian));

--- a/principia.props
+++ b/principia.props
@@ -84,25 +84,38 @@
       <AdditionalOptions Condition="$(PrincipiaCompilerClangLLVM)">
         <!-- \-\-version-->
         <!-- \-v-->
+        -fbracket-depth=257
+        -ferror-limit=1000
         -Werror=typename-missing
         -Werror=microsoft-template
         -Werror=unknown-argument
         -Wno-c++98-compat-pedantic
         -Wno-c++98-compat
         -Wno-c99-compat
-        -Wno-undef
+        -Wno-exit-time-destructors
         -Wno-float-equal
-        -Wno-shadow-field-in-constructor
+        -Wno-format-nonliteral
+        -Wno-global-constructors
+        -Wno-gnu-anonymous-struct
+        -Wno-gnu-zero-variadic-macro-arguments
+        -Wno-macro-redefined
+        -Wno-mathematical-notation-identifier-extension
+        -Wno-nested-anon-types
+        -Wno-reserved-macro-identifier
+        -Wno-shadow-uncaptured-local
         -Wno-sign-conversion
-        -Wno-covered-switch-default
+        -Wno-undef
+        -Wno-unknown-pragmas
         <!--Warnings in protobuf generated code are none of our business.-->
         -Xclang --system-header-prefix=serialization/
         <!--Same for warnings in dependencies.-->
+        -Xclang --system-header-prefix=absl/
         -Xclang --system-header-prefix=benchmark/
         -Xclang --system-header-prefix=google/
         -Xclang --system-header-prefix=glog/
         -Xclang --system-header-prefix=gtest/
         -Xclang --system-header-prefix=gmock/
+        -Xclang --system-header-prefix=zfp/
       </AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions Condition="!$(PrincipiaCompilerClangLLVM)">


### PR DESCRIPTION
Includes resurrecting `Release_LLVM`.