### PR TITLE
Make the tests for fixed and unbounded arrays consistent

### DIFF
--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -19,8 +19,10 @@ using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_si;
 
-template<typename Scalar_, int rows, int columns>
+template<typename Scalar_, int rows_, int columns_>
 class FixedMatrix;
+template<typename Scalar_, int rows_>
+class FixedUpperTriangularMatrix;
 
 template<typename Scalar_, int size_>
 class FixedVector final {
@@ -178,6 +180,9 @@ class FixedLowerTriangularMatrix final {
   constexpr FixedLowerTriangularMatrix(
       std::array<Scalar, size()> const& data);
 
+  explicit FixedLowerTriangularMatrix(
+      TransposedView<FixedUpperTriangularMatrix<Scalar, rows_>> const& view);
+
   // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
@@ -205,6 +210,9 @@ class FixedUpperTriangularMatrix final {
   // The |data| must be in row-major format.
   constexpr FixedUpperTriangularMatrix(
       std::array<Scalar, size()> const& data);
+
+  explicit FixedUpperTriangularMatrix(
+      TransposedView<FixedLowerTriangularMatrix<Scalar, columns_>> const& view);
 
   // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -281,6 +281,17 @@ FixedLowerTriangularMatrix(std::array<Scalar, size()> const& data)
     : data_(data) {}
 
 template<typename Scalar_, int rows_>
+FixedLowerTriangularMatrix<Scalar_, rows_>::FixedLowerTriangularMatrix(
+    TransposedView<FixedUpperTriangularMatrix<Scalar, rows_>> const& view)
+    : FixedLowerTriangularMatrix(uninitialized) {
+  for (int i = 0; i < rows(); ++i) {
+    for (int j = 0; j <= i; ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
+}
+
+template<typename Scalar_, int rows_>
 constexpr Scalar_& FixedLowerTriangularMatrix<Scalar_, rows_>::
 operator()(int const row, int const column) {
   CONSTEXPR_DCHECK(0 <= column);
@@ -323,6 +334,17 @@ template<typename Scalar_, int columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
 FixedUpperTriangularMatrix(std::array<Scalar, size()> const& data)
     : data_(Transpose(data)) {}
+
+template<typename Scalar_, int columns_>
+FixedUpperTriangularMatrix<Scalar_, columns_>::FixedUpperTriangularMatrix(
+    TransposedView<FixedLowerTriangularMatrix<Scalar, columns_>> const& view)
+    : FixedUpperTriangularMatrix(uninitialized) {
+  for (int i = 0; i < rows(); ++i) {
+    for (int j = i; j < columns(); ++j) {
+      (*this)(i, j) = view(i, j);
+    }
+  }
+}
 
 template<typename Scalar_, int columns_>
 constexpr Scalar_& FixedUpperTriangularMatrix<Scalar_, columns_>::

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -24,7 +24,7 @@ class FixedArraysTest : public ::testing::Test {
              6,  -3, -2, -9}),
       m23_({1, -2,  0,
             2,  3,  7}),
-      n23_({ 5,  -1,  3,
+      n23_({ 5, -1,  3,
             12, 13, -4}),
       sl4_({
             1,

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -186,6 +186,12 @@ TEST_F(FixedArraysTest, VectorIndexing) {
   EXPECT_EQ(-666, v3_[2]);
 }
 
+TEST_F(FixedArraysTest, MatrixIndexing) {
+  EXPECT_EQ(9, m34_(1, 2));
+  m34_(2, 1) = -666;
+  EXPECT_EQ(-666, m34_(2, 1));
+}
+
 TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
   EXPECT_EQ(6, (FixedStrictlyLowerTriangularMatrix<double, 4>::size()));
   EXPECT_EQ(1, sl4_(1, 0));

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -16,16 +16,16 @@ using namespace principia::quantities::_elementary_functions;
 class FixedArraysTest : public ::testing::Test {
  protected:
   FixedArraysTest()
-    : m34_({-8,  -6, -4, -7,
+    : u3_({6, -1, 12}),
+      v3_({10, 31, -47}),
+      v4_({-3, -3, 1, 4}),
+      m34_({-8,  -6, -4, -7,
             -4, -10,  9, -5,
              6,  -3, -2, -9}),
       m23_({1, -2,  0,
             2,  3,  7}),
-      n23_({5,  -1,  3,
+      n23_({ 5,  -1,  3,
             12, 13, -4}),
-      u3_({6, -1, 12}),
-      v3_({10, 31, -47}),
-      v4_({-3, -3, 1, 4}),
       sl4_({
             1,
             2, 3,
@@ -39,52 +39,93 @@ class FixedArraysTest : public ::testing::Test {
                   34, 55,
                       89}) {}
 
-  FixedMatrix<double, 3, 4> m34_;
-  FixedMatrix<double, 2, 3> m23_;
-  FixedMatrix<double, 2, 3> n23_;
   FixedVector<double, 3> u3_;
   FixedVector<double, 3> v3_;
   FixedVector<double, 4> v4_;
+  FixedMatrix<double, 3, 4> m34_;
+  FixedMatrix<double, 2, 3> m23_;
+  FixedMatrix<double, 2, 3> n23_;
   FixedStrictlyLowerTriangularMatrix<double, 4> sl4_;
   FixedLowerTriangularMatrix<double, 4> l4_;
   FixedUpperTriangularMatrix<double, 4> u4_;
 };
 
 TEST_F(FixedArraysTest, Assignment) {
-  FixedVector<double, 2> u2({1, 2});
-  FixedVector<double, 2> v2 = {{1, 2}};
-  FixedVector<double, 2> w2;
-  w2 = {{1, 2}};
-  EXPECT_EQ(u2, v2);
-  EXPECT_EQ(u2, w2);
+  {
+    FixedVector<double, 2> u2({1, 2});
+    FixedVector<double, 2> v2 = {{1, 2}};
+    FixedVector<double, 2> w2;
+    w2 = {{1, 2}};
+    EXPECT_EQ(u2, v2);
+    EXPECT_EQ(u2, w2);
+  }
 
-  FixedMatrix<double, 2, 3> l23({1, 2, 3,
-                                 4, 5, 6});
-  FixedMatrix<double, 2, 3> m23 = {{1, 2, 3,
-                                    4, 5, 6}};
-  FixedMatrix<double, 2, 3> n23 = {{0, 0, 0,
-                                    0, 0, 0}};
-  n23 = {{1, 2, 3,
-          4, 5, 6}};
-  EXPECT_EQ(l23, m23);
-  EXPECT_EQ(l23, n23);
-
-  FixedStrictlyLowerTriangularMatrix<double, 3> l3({
-                                                    1,
-                                                    2, 3});
-  FixedStrictlyLowerTriangularMatrix<double, 3> m3 = {{
-                                                       1,
-                                                       2, 3}};
-  FixedStrictlyLowerTriangularMatrix<double, 3> n3 = {{
-                                                       0,
-                                                       0, 0}};
-  FixedStrictlyLowerTriangularMatrix<double, 3> o3;
-  EXPECT_EQ(o3, n3);
-  n3 = {{
-         1,
-         2, 3}};
-  EXPECT_EQ(l3, m3);
-  EXPECT_EQ(l3, n3);
+  {
+    FixedMatrix<double, 2, 3> l23({1, 2, 3,
+                                   4, 5, 6});
+    FixedMatrix<double, 2, 3> m23 = {{1, 2, 3,
+                                      4, 5, 6}};
+    FixedMatrix<double, 2, 3> n23 = {{0, 0, 0,
+                                      0, 0, 0}};
+    n23 = {{1, 2, 3,
+            4, 5, 6}};
+    EXPECT_EQ(l23, m23);
+    EXPECT_EQ(l23, n23);
+  }
+  {
+    FixedStrictlyLowerTriangularMatrix<double, 3> l3({
+                                                      1,
+                                                      2, 3 });
+    FixedStrictlyLowerTriangularMatrix<double, 3> m3 = {{
+                                                         1,
+                                                         2, 3}};
+    FixedStrictlyLowerTriangularMatrix<double, 3> n3 = {{
+                                                         0,
+                                                         0, 0}};
+    FixedStrictlyLowerTriangularMatrix<double, 3> o3;
+    EXPECT_EQ(o3, n3);
+    n3 = {{
+           1,
+           2, 3}};
+    EXPECT_EQ(l3, m3);
+    EXPECT_EQ(l3, n3);
+  }
+  {
+    FixedLowerTriangularMatrix<double, 3> l3({1,
+                                              2, 3,
+                                              4, 5, 6});
+    FixedLowerTriangularMatrix<double, 3> m3 = {{1,
+                                                 2, 3,
+                                                 4, 5, 6}};
+    FixedLowerTriangularMatrix<double, 3> n3 = {{0,
+                                                 0, 0,
+                                                 0, 0, 0}};
+    FixedLowerTriangularMatrix<double, 3> o3;
+    EXPECT_EQ(o3, n3);
+    n3 = {{1,
+           2, 3,
+           4, 5, 6}};
+    EXPECT_EQ(l3, m3);
+    EXPECT_EQ(l3, n3);
+  }
+  {
+    FixedUpperTriangularMatrix<double, 3> l3({1, 2, 3,
+                                                 4, 5,
+                                                    6});
+    FixedUpperTriangularMatrix<double, 3> m3 = {{1, 2, 3,
+                                                    4, 5,
+                                                       6}};
+    FixedUpperTriangularMatrix<double, 3> n3 = {{0, 0, 0,
+                                                    0, 0,
+                                                       0}};
+    FixedUpperTriangularMatrix<double, 3> o3;
+    EXPECT_EQ(o3, n3);
+    n3 = {{1, 2, 3,
+              4, 5,
+                 6}};
+    EXPECT_EQ(l3, m3);
+    EXPECT_EQ(l3, n3);
+  }
 }
 
 TEST_F(FixedArraysTest, Norm) {

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -196,6 +196,9 @@ TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
   EXPECT_EQ(13, sl4_(3, 2));
   sl4_(3, 1) = -666;
   EXPECT_EQ(-666, sl4_(3, 1));
+
+  FixedStrictlyLowerTriangularMatrix<double, 4> const sl4 = sl4_;
+  EXPECT_EQ(1, sl4(0, 0));
 }
 
 TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {
@@ -212,6 +215,9 @@ TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {
   EXPECT_EQ(89, l4_(3, 3));
   l4_(3, 1) = -666;
   EXPECT_EQ(-666, l4_(3, 1));
+
+  FixedLowerTriangularMatrix<double, 4> const l4 = l4_;
+  EXPECT_EQ(1, l4(0, 0));
 }
 
 TEST_F(FixedArraysTest, UpperTriangularMatrixIndexing) {
@@ -228,6 +234,9 @@ TEST_F(FixedArraysTest, UpperTriangularMatrixIndexing) {
   EXPECT_EQ(89, u4_(3, 3));
   u4_(1, 3) = -666;
   EXPECT_EQ(-666, u4_(1, 3));
+
+  FixedUpperTriangularMatrix<double, 4> const u4 = u4_;
+  EXPECT_EQ(1, u4(0, 0));
 }
 
 TEST_F(FixedArraysTest, Row) {
@@ -239,6 +248,27 @@ TEST_F(FixedArraysTest, Row) {
 
   EXPECT_EQ(-4, r0 * v);
   EXPECT_EQ(-24, r1 * v);
+}
+
+TEST_F(FixedArraysTest, Transpose) {
+  EXPECT_EQ(
+      (FixedMatrix<double, 4, 3>({-8,  -4,  6,
+                                  -6, -10, -3,
+                                  -4,   9, -2,
+                                  -7,  -5, -9})),
+      (FixedMatrix<double, 4, 3>(TransposedView{m34_})));
+  EXPECT_EQ(
+      (FixedUpperTriangularMatrix<double, 4>({1, 2,  5, 21,
+                                                 3,  8, 34,
+                                                    13, 55,
+                                                        89})),
+      (FixedUpperTriangularMatrix<double, 4>(TransposedView{l4_})));
+  EXPECT_EQ(
+      (FixedLowerTriangularMatrix<double, 4>({1,
+                                              2,  8,
+                                              3, 13, 34,
+                                              5, 21, 55, 89})),
+      (FixedLowerTriangularMatrix<double, 4>(TransposedView{u4_})));
 }
 
 }  // namespace numerics

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -198,7 +198,7 @@ TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
   EXPECT_EQ(-666, sl4_(3, 1));
 
   FixedStrictlyLowerTriangularMatrix<double, 4> const sl4 = sl4_;
-  EXPECT_EQ(1, sl4(0, 0));
+  EXPECT_EQ(1, sl4(1, 0));
 }
 
 TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -159,7 +159,7 @@ class UnboundedLowerTriangularMatrix final {
   // The |data| must be in row-major format.
   UnboundedLowerTriangularMatrix(std::initializer_list<Scalar> data);
 
-  UnboundedLowerTriangularMatrix(
+  explicit UnboundedLowerTriangularMatrix(
       TransposedView<UnboundedUpperTriangularMatrix<Scalar>> const& view);
 
   void Extend(int extra_rows);
@@ -204,7 +204,7 @@ class UnboundedUpperTriangularMatrix final {
   // The |data| must be in row-major format.
   UnboundedUpperTriangularMatrix(std::initializer_list<Scalar> const& data);
 
-  UnboundedUpperTriangularMatrix(
+  explicit UnboundedUpperTriangularMatrix(
       TransposedView<UnboundedLowerTriangularMatrix<Scalar>> const& view);
 
   void Extend(int extra_columns);

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -150,7 +150,7 @@ UnboundedMatrix<Scalar_>::UnboundedMatrix(std::initializer_list<Scalar_> data)
     : rows_(Sqrt(data.size())),
       columns_(Sqrt(data.size())),
       data_(std::move(data)) {
-  CHECK_EQ(data.size(), rows_ * columns_);
+  DCHECK_EQ(data.size(), rows_ * columns_);
 }
 
 template<typename Scalar_>
@@ -159,7 +159,7 @@ UnboundedMatrix<Scalar_>::UnboundedMatrix(int const rows, int const columns,
     : rows_(rows),
       columns_(columns),
       data_(std::move(data)) {
-  CHECK_EQ(data.size(), rows_ * columns_);
+  DCHECK_EQ(data.size(), rows_ * columns_);
 }
 
 template<typename Scalar_>
@@ -532,7 +532,7 @@ template<typename LScalar, typename RScalar>
 UnboundedMatrix<Product<LScalar, RScalar>> SymmetricProduct(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.size(), right.size());
+  DCHECK_EQ(left.size(), right.size());
   UnboundedMatrix<Product<LScalar, RScalar>> result(
       left.size(), right.size(), uninitialized);
   for (int i = 0; i < left.size(); ++i) {
@@ -586,7 +586,7 @@ template<typename LScalar, typename RScalar>
 UnboundedVector<Sum<LScalar, RScalar>> operator+(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.size(), right.size());
+  DCHECK_EQ(left.size(), right.size());
   UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
   for (int i = 0; i < right.size(); ++i) {
     result[i] = left[i] + right[i];
@@ -598,8 +598,8 @@ template<typename LScalar, typename RScalar>
 UnboundedMatrix<Sum<LScalar, RScalar>> operator+(
     UnboundedMatrix<LScalar> const& left,
     UnboundedMatrix<RScalar> const& right) {
-  CHECK_EQ(left.rows(), right.rows());
-  CHECK_EQ(left.columns(), right.columns());
+  DCHECK_EQ(left.rows(), right.rows());
+  DCHECK_EQ(left.columns(), right.columns());
   UnboundedMatrix<Sum<LScalar, RScalar>> result(
       right.rows(), right.columns(), uninitialized);
   for (int i = 0; i < right.rows(); ++i) {
@@ -614,7 +614,7 @@ template<typename LScalar, typename RScalar>
 UnboundedVector<Difference<LScalar, RScalar>> operator-(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.size(), right.size());
+  DCHECK_EQ(left.size(), right.size());
   UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
   for (int i = 0; i < right.size(); ++i) {
     result[i] = left[i] - right[i];
@@ -626,13 +626,13 @@ template<typename LScalar, typename RScalar>
 UnboundedMatrix<Difference<LScalar, RScalar>> operator-(
     UnboundedMatrix<LScalar> const& left,
     UnboundedMatrix<RScalar> const& right) {
-  CHECK_EQ(left.rows(), right.rows());
-  CHECK_EQ(left.columns(), right.columns());
+  DCHECK_EQ(left.rows(), right.rows());
+  DCHECK_EQ(left.columns(), right.columns());
   UnboundedMatrix<Sum<LScalar, RScalar>> result(
       right.rows(), right.columns(), uninitialized);
   for (int i = 0; i < right.rows(); ++i) {
     for (int j = 0; j < right.columns(); ++j) {
-      result(i, j) = left(i, j) + right(i, j);
+      result(i, j) = left(i, j) - right(i, j);
     }
   }
   return result;
@@ -775,7 +775,7 @@ template<typename LScalar, typename RScalar>
 Product<LScalar, RScalar> operator*(
     TransposedView<UnboundedVector<LScalar>> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.size(), right.size());
+  DCHECK_EQ(left.size(), right.size());
   Product<LScalar, RScalar> result{};
   for (int i = 0; i < left.size(); ++i) {
     result += left[i] * right[i];
@@ -802,7 +802,7 @@ template<typename LScalar, typename RScalar>
 UnboundedMatrix<Product<LScalar, RScalar>> operator*(
     UnboundedMatrix<LScalar> const& left,
     UnboundedMatrix<RScalar> const& right) {
-  CHECK_EQ(left.columns(), right.rows());
+  DCHECK_EQ(left.columns(), right.rows());
   UnboundedMatrix<Product<LScalar, RScalar>> result(left.rows(),
                                                            right.columns());
   for (int i = 0; i < left.rows(); ++i) {
@@ -819,7 +819,7 @@ template<typename LScalar, typename RScalar>
 UnboundedVector<Product<LScalar, RScalar>> operator*(
     UnboundedMatrix<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.columns(), right.size());
+  DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<LScalar, RScalar>> result(left.rows());
   for (int i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];
@@ -834,7 +834,7 @@ template<typename LMatrix, typename RScalar>
 UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> operator*(
     BlockView<LMatrix> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.columns(), right.size());
+  DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> result(
       left.rows());
   for (int i = 0; i < left.rows(); ++i) {
@@ -850,7 +850,7 @@ template<typename LMatrix, typename RScalar>
 UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> operator*(
     TransposedView<BlockView<LMatrix>> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.columns(), right.size());
+  DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> result(
       left.rows());
   for (int i = 0; i < left.rows(); ++i) {
@@ -866,7 +866,7 @@ template<typename LScalar, typename RScalar>
 UnboundedVector<Product<LScalar, RScalar>> operator*(
     TransposedView<UnboundedMatrix<LScalar>> const& left,
     UnboundedVector<RScalar> const& right) {
-  CHECK_EQ(left.rows(), right.size());
+  DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<LScalar, RScalar>> result(left.rows());
   for (int i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -564,12 +564,11 @@ UnboundedMatrix<Square<Scalar>> SymmetricSquare(
 
 template<typename Scalar>
 UnboundedVector<Scalar> operator-(UnboundedVector<Scalar> const& right) {
-  std::vector<Scalar> result;
-  result.reserve(right.size());
+  UnboundedVector<Scalar> result(right.size(), uninitialized);
   for (int i = 0; i < right.size(); ++i) {
     result[i] = -right[i];
   }
-  return UnboundedVector<Scalar>(std::move(result));
+  return result;
 }
 
 template<typename Scalar>
@@ -588,12 +587,11 @@ UnboundedVector<Sum<LScalar, RScalar>> operator+(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
   CHECK_EQ(left.size(), right.size());
-  std::vector<Sum<LScalar, RScalar>> result;
-  result.resize(right.size());
+  UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
   for (int i = 0; i < right.size(); ++i) {
     result[i] = left[i] + right[i];
   }
-  return UnboundedVector<Sum<LScalar, RScalar>>(std::move(result));
+  return result;
 }
 
 template<typename LScalar, typename RScalar>
@@ -617,12 +615,11 @@ UnboundedVector<Difference<LScalar, RScalar>> operator-(
     UnboundedVector<LScalar> const& left,
     UnboundedVector<RScalar> const& right) {
   CHECK_EQ(left.size(), right.size());
-  std::vector<Sum<LScalar, RScalar>> result;
-  result.resize(right.size());
+  UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
   for (int i = 0; i < right.size(); ++i) {
     result[i] = left[i] - right[i];
   }
-  return UnboundedVector<Difference<LScalar, RScalar>>(std::move(result));
+  return result;
 }
 
 template<typename LScalar, typename RScalar>
@@ -738,7 +735,7 @@ UnboundedVector<Quotient<LScalar, RScalar>> operator/(
 template<typename LScalar, typename RScalar>
 UnboundedMatrix<Quotient<LScalar, RScalar>> operator/(
     UnboundedMatrix<LScalar> const& left,
-    RScalar const right) {
+    RScalar const& right) {
   UnboundedMatrix<Quotient<LScalar, RScalar>> result(left.rows(),
                                                      left.columns(),
                                                      uninitialized);

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -49,7 +49,6 @@ class UnboundedArraysTest : public ::testing::Test {
   UnboundedMatrix<double> m34_;
   UnboundedMatrix<double> m23_;
   UnboundedMatrix<double> n23_;
-  UnboundedMatrix<double> m4_;//????
   UnboundedLowerTriangularMatrix<double> l4_;
   UnboundedUpperTriangularMatrix<double> u4_;
 };

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -30,10 +30,6 @@ class UnboundedArraysTest : public ::testing::Test {
       n23_(2, 3,
            { 5, -1,  3,
             12, 13, -4}),
-      m4_({  1,   2,   3,    5,
-             8,  13,  21,   34,
-            55,  89, 144,  233,
-           377, 610, 987, 1597}),
       l4_({ 1,
             2,  3,
             5,  8,  13,
@@ -185,9 +181,9 @@ TEST_F(UnboundedArraysTest, VectorIndexing) {
 }
 
 TEST_F(UnboundedArraysTest, MatrixIndexing) {
-  EXPECT_EQ(21, m4_(1, 2));
-  m4_(2, 1) = -666;
-  EXPECT_EQ(-666, m4_(2, 1));
+  EXPECT_EQ(9, m34_(1, 2));
+  m34_(2, 1) = -666;
+  EXPECT_EQ(-666, m34_(2, 1));
 }
 
 TEST_F(UnboundedArraysTest, LowerTriangularMatrixIndexing) {
@@ -295,11 +291,12 @@ TEST_F(UnboundedArraysTest, Erase) {
 
 TEST_F(UnboundedArraysTest, Transpose) {
   EXPECT_EQ(
-      UnboundedMatrix<double>({1,  8,  55,  377,
-                               2, 13,  89,  610,
-                               3, 21, 144,  987,
-                               5, 34, 233, 1597}),
-      UnboundedMatrix<double>(TransposedView{m4_}));
+      UnboundedMatrix<double>(4, 3,
+                              {-8,  -4,  6,
+                               -6, -10, -3,
+                               -4,   9, -2,
+                               -7,  -5, -9}),
+      UnboundedMatrix<double>(TransposedView{m34_}));
   EXPECT_EQ(
       UnboundedUpperTriangularMatrix<double>({1, 2,  5, 21,
                                                  3,  8, 34,

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -28,7 +28,7 @@ class UnboundedArraysTest : public ::testing::Test {
            {1, -2,  0,
             2,  3,  7}),
       n23_(2, 3,
-           { 5,  -1,  3,
+           { 5, -1,  3,
             12, 13, -4}),
       m4_({  1,   2,   3,    5,
              8,  13,  21,   34,
@@ -122,7 +122,7 @@ TEST_F(UnboundedArraysTest, Assignment) {
 TEST_F(UnboundedArraysTest, Norm) {
   EXPECT_EQ(35, TransposedView{v4_} * v4_);  // NOLINT
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
-  EXPECT_EQ(35, v4_.Norm²());
+  EXPECT_EQ(35, v4_.NormÂ²());
   EXPECT_EQ(Sqrt(517.0), m34_.FrobeniusNorm());
 }
 
@@ -141,6 +141,23 @@ TEST_F(UnboundedArraysTest, AdditiveGroups) {
   EXPECT_EQ((UnboundedMatrix<double>(2, 3,
                                      { -4,  -1, -3,
                                       -10, -10, 11})), m23_ - n23_);
+}
+
+TEST_F(UnboundedArraysTest, VectorSpaces) {
+  EXPECT_EQ((UnboundedVector<double>({12, -2, 24})), 2 * u3_);
+  EXPECT_EQ((UnboundedVector<double>({-30, -93, 141})), v3_ * -3);
+
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     {2, -4,  0,
+                                      4,  6, 14})), 2 * m23_);
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     {-15,   3, -9,
+                                      -36, -39, 12})), n23_ * -3);
+
+  EXPECT_EQ((UnboundedVector<double>({2.5, 7.75, -11.75})), v3_ / 4);
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     {-2.5,  0.5, -1.5,
+                                        -6, -6.5,  2})), n23_ / -2);
 }
 
 TEST_F(UnboundedArraysTest, MultiplicationDivision) {

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -160,20 +160,23 @@ TEST_F(UnboundedArraysTest, VectorSpaces) {
                                         -6, -6.5,  2})), n23_ / -2);
 }
 
-TEST_F(UnboundedArraysTest, MultiplicationDivision) {
-  EXPECT_EQ(UnboundedVector<double>({14, 94, 644, 4414}), m4_ * v4_);
-  EXPECT_EQ(UnboundedVector<double>({1536, 2484, 4020, 6504}),
-            TransposedView{m4_} * v4_);  // NOLINT
-  EXPECT_EQ(UnboundedVector<double>({-1.5, -1.5, 0.5, 2.0}), v4_ / 2.0);
-  EXPECT_EQ(UnboundedMatrix<double>(
-                {  2067,    3345,   5412,     8757,
-                  14085,   22794,  36879,    59673,
-                  96528,  156213,  252741,  408954,
-                 661611, 1070697, 1732308, 2803005}), m4_ * m4_);
-}
-
 TEST_F(UnboundedArraysTest, Algebra) {
-  EXPECT_EQ(3270, TransposedView{v3_} * v3_);  // NOLINT
+  EXPECT_EQ(-535, TransposedView{u3_} * v3_);  // NOLINT
+  EXPECT_EQ((UnboundedMatrix<double>(3, 4,
+                                     { -30, -30,  10,   40,
+                                       -93, -93,  31,  124,
+                                       141, 141, -47, -188})),
+             v3_ * TransposedView{v4_});
+  EXPECT_EQ((UnboundedMatrix<double>(2, 4,
+                                     { 0,  14, -22,   3,
+                                      14, -63,   5, -92})),
+            m23_ * m34_);
+  EXPECT_EQ(v3_, m34_ * v4_);
+  EXPECT_EQ((UnboundedVector<double>({-486, -229, 333, 198})),
+            TransposedView{m34_} * v3_);  // NOLINT
+  UnboundedMatrix<double> m43(TransposedView{m34_});
+  EXPECT_EQ((UnboundedVector<double>({-486, -229, 333, 198})),
+            m43 * v3_);
 }
 
 TEST_F(UnboundedArraysTest, VectorIndexing) {

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -17,8 +17,19 @@ using namespace principia::testing_utilities::_almost_equals;
 class UnboundedArraysTest : public ::testing::Test {
  protected:
   UnboundedArraysTest()
-    : v3_({10, 31, -47}),
+    : u3_({6, -1, 12}),
+      v3_({10, 31, -47}),
       v4_({-3, -3, 1, 4}),
+      m34_(3, 4,
+           {-8,  -6, -4, -7,
+            -4, -10,  9, -5,
+             6,  -3, -2, -9}),
+      m23_(2, 3,
+           {1, -2,  0,
+            2,  3,  7}),
+      n23_(2, 3,
+           { 5,  -1,  3,
+            12, 13, -4}),
       m4_({  1,   2,   3,    5,
              8,  13,  21,   34,
             55,  89, 144,  233,
@@ -32,9 +43,13 @@ class UnboundedArraysTest : public ::testing::Test {
                  34, 55,
                      89}) {}
 
+  UnboundedVector<double> u3_;
   UnboundedVector<double> v3_;
   UnboundedVector<double> v4_;
-  UnboundedMatrix<double> m4_;
+  UnboundedMatrix<double> m34_;
+  UnboundedMatrix<double> m23_;
+  UnboundedMatrix<double> n23_;
+  UnboundedMatrix<double> m4_;//????
   UnboundedLowerTriangularMatrix<double> l4_;
   UnboundedUpperTriangularMatrix<double> u4_;
 };
@@ -49,12 +64,22 @@ TEST_F(UnboundedArraysTest, Assignment) {
     EXPECT_EQ(u2, w2);
   }
   {
-    UnboundedMatrix<double> u2({1, 2, 3, 4});
-    UnboundedMatrix<double> v2 = {{1, 2, 3, 4}};
-    UnboundedMatrix<double> w2(2, 2);
-    w2 = {{1, 2, 3, 4}};
-    EXPECT_EQ(u2, v2);
-    EXPECT_EQ(u2, w2);
+    UnboundedMatrix<double> l23(2, 3,
+                                {1, 2, 3,
+                                 4, 5, 6 });
+    UnboundedMatrix<double> m23 = {2, 3,
+                                   {1, 2, 3,
+                                    4, 5, 6}};
+    UnboundedMatrix<double> n23 = {2, 3,
+                                   {0, 0, 0,
+                                    0, 0, 0}};
+    // TODO(phl): It would be convenient to have an operator= taking an
+    // initializer list.
+    n23 = UnboundedMatrix<double>(2, 3,
+                                  {1, 2, 3,
+                                   4, 5, 6});
+    EXPECT_EQ(l23, m23);
+    EXPECT_EQ(l23, n23);
   }
   {
     UnboundedLowerTriangularMatrix<double> l3({1,
@@ -97,7 +122,25 @@ TEST_F(UnboundedArraysTest, Assignment) {
 TEST_F(UnboundedArraysTest, Norm) {
   EXPECT_EQ(35, TransposedView{v4_} * v4_);  // NOLINT
   EXPECT_EQ(Sqrt(35.0), v4_.Norm());
-  EXPECT_EQ(Sqrt(4'126'647.0), m4_.FrobeniusNorm());
+  EXPECT_EQ(35, v4_.Norm²());
+  EXPECT_EQ(Sqrt(517.0), m34_.FrobeniusNorm());
+}
+
+TEST_F(UnboundedArraysTest, AdditiveGroups) {
+  EXPECT_EQ((UnboundedVector<double>({-10, -31, 47})), -v3_);
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     {-1,  2,  0,
+                                      -2, -3, -7})), -m23_);
+
+  EXPECT_EQ((UnboundedVector<double>({16, 30, -35})), u3_ + v3_);
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     { 6, -3, 3,
+                                      14, 16, 3})), m23_ + n23_);
+
+  EXPECT_EQ((UnboundedVector<double>({-4, -32, 59})), u3_ - v3_);
+  EXPECT_EQ((UnboundedMatrix<double>(2, 3,
+                                     { -4,  -1, -3,
+                                      -10, -10, 11})), m23_ - n23_);
 }
 
 TEST_F(UnboundedArraysTest, MultiplicationDivision) {


### PR DESCRIPTION
This exercises more code, so of course it uncovered bugs.

Contributes to #3302.