### PR TITLE
Get rid of Barycentre of std::pair and simplify its callers

### DIFF
--- a/benchmarks/discrete_trajectory_benchmark.cpp
+++ b/benchmarks/discrete_trajectory_benchmark.cpp
@@ -54,8 +54,7 @@ DiscreteTrajectory<World> MakeTrajectory(Timeline<World> const& timeline,
         double const split = *it_split;
         CHECK_LE(0, split);
         CHECK_LE(split, 1);
-        t_split = Barycentre<Instant, double>({t_min, t_max},
-                                              {1 - split, split});
+        t_split = Barycentre({t_min, t_max}, {1 - split, split});
       }
     }
     if (t >= t_split) {

--- a/geometry/barycentre_calculator.hpp
+++ b/geometry/barycentre_calculator.hpp
@@ -41,11 +41,12 @@ class BarycentreCalculator final {
       reference_;
 };
 
-template<affine Point, typename Weight, std::size_t size>
-  requires(std::is_convertible_v<Weight, double> &&
-           real_vector_space<Difference<Point>>) ||
-          homogeneous_vector_space<Difference<Point>, Weight>
+template<affine Point, homogeneous_field Weight, std::size_t size>
+  requires homogeneous_vector_space<Difference<Point>, Weight>
 Point Barycentre(Point const (&points)[size], Weight const (&weights)[size]);
+template<real_affine_space Point, std::size_t size>
+Point Barycentre(Point const (&points)[size], double const (&weights)[size]);
+
 template<typename T, typename Weight, template<typename...> class Container>
 T Barycentre(Container<T> const& ts, Container<Weight> const& weights);
 

--- a/geometry/barycentre_calculator.hpp
+++ b/geometry/barycentre_calculator.hpp
@@ -41,9 +41,11 @@ class BarycentreCalculator final {
       reference_;
 };
 
-template<typename T, typename Weight>
-T Barycentre(std::pair<T, T> const& ts,
-             std::pair<Weight, Weight> const& weights);
+template<affine Point, typename Weight, std::size_t size>
+  requires(std::is_convertible_v<Weight, double> &&
+           real_vector_space<Difference<Point>>) ||
+          homogeneous_vector_space<Difference<Point>, Weight>
+Point Barycentre(Point const (&points)[size], Weight const (&weights)[size]);
 template<typename T, typename Weight, template<typename...> class Container>
 T Barycentre(Container<T> const& ts, Container<Weight> const& weights);
 

--- a/geometry/barycentre_calculator_body.hpp
+++ b/geometry/barycentre_calculator_body.hpp
@@ -59,8 +59,7 @@ template<affine Point, homogeneous_field Weight, std::size_t size>
   requires homogeneous_vector_space<Difference<Point>, Weight>
 Point Barycentre(Point const (&points)[size], Weight const (&weights)[size]) {
   static_assert(size != 0);
-  BarycentreCalculator<Point, Weight>
-      calculator;
+  BarycentreCalculator<Point, Weight> calculator;
   for (int i = 0; i < size; ++i) {
     calculator.Add(points[i], weights[i]);
   }

--- a/geometry/barycentre_calculator_body.hpp
+++ b/geometry/barycentre_calculator_body.hpp
@@ -55,21 +55,21 @@ template<affine Point, homogeneous_field Weight>
 std::conditional_t<additive_group<Point>, std::nullopt_t, Point> const
     BarycentreCalculator<Point, Weight>::reference_;
 
-
-template<affine Point, typename Weight, std::size_t size>
-  requires(std::is_convertible_v<Weight, double> &&
-           real_vector_space<Difference<Point>>) ||
-          homogeneous_vector_space<Difference<Point>, Weight>
+template<affine Point, homogeneous_field Weight, std::size_t size>
+  requires homogeneous_vector_space<Difference<Point>, Weight>
 Point Barycentre(Point const (&points)[size], Weight const (&weights)[size]) {
   static_assert(size != 0);
-  BarycentreCalculator<
-      Point,
-      std::conditional_t<std::is_convertible_v<Weight, double>, double, Weight>>
+  BarycentreCalculator<Point, Weight>
       calculator;
   for (int i = 0; i < size; ++i) {
     calculator.Add(points[i], weights[i]);
   }
   return calculator.Get();
+}
+
+template<real_affine_space Point, std::size_t size>
+Point Barycentre(Point const (&points)[size], double const (&weights)[size]) {
+  return Barycentre<Point, double>(points, weights);
 }
 
 template<typename T, typename Scalar, template<typename...> class Container>

--- a/geometry/barycentre_calculator_body.hpp
+++ b/geometry/barycentre_calculator_body.hpp
@@ -55,12 +55,20 @@ template<affine Point, homogeneous_field Weight>
 std::conditional_t<additive_group<Point>, std::nullopt_t, Point> const
     BarycentreCalculator<Point, Weight>::reference_;
 
-template<typename T, typename Scalar>
-T Barycentre(std::pair<T, T> const& ts,
-             std::pair<Scalar, Scalar> const& weights) {
-  BarycentreCalculator<T, Scalar> calculator;
-  calculator.Add(ts.first, weights.first);
-  calculator.Add(ts.second, weights.second);
+
+template<typename Point, typename Weight, std::size_t size>
+  requires(std::is_convertible_v<Weight, double> &&
+           real_vector_space<Difference<Point>>) ||
+          homogeneous_vector_space<Difference<Point>, Weight>
+Point Barycentre(Point const (&points)[size], Weight const (&weights)[size]) {
+  static_assert(size != 0);
+  BarycentreCalculator<
+      Point,
+      std::conditional_t<std::is_convertible_v<Weight, double>, double, Weight>>
+      calculator;
+  for (int i = 0; i < size; ++i) {
+    calculator.Add(points[i], weights[i]);
+  }
   return calculator.Get();
 }
 

--- a/geometry/barycentre_calculator_body.hpp
+++ b/geometry/barycentre_calculator_body.hpp
@@ -56,7 +56,7 @@ std::conditional_t<additive_group<Point>, std::nullopt_t, Point> const
     BarycentreCalculator<Point, Weight>::reference_;
 
 
-template<typename Point, typename Weight, std::size_t size>
+template<affine Point, typename Weight, std::size_t size>
   requires(std::is_convertible_v<Weight, double> &&
            real_vector_space<Difference<Point>>) ||
           homogeneous_vector_space<Difference<Point>, Weight>

--- a/geometry/barycentre_calculator_test.cpp
+++ b/geometry/barycentre_calculator_test.cpp
@@ -81,9 +81,9 @@ TEST_F(BarycentreCalculatorTest, Function) {
   EXPECT_THAT(Barycentre({World::origin, q}, {2, 3}),
               Eq(World::origin + 3 * r / 5));
   EXPECT_THAT(Barycentre({World::origin, q}, {0.5, 0.75}),
-              Eq(World::origin + 3 * r / 4));
+              Eq(World::origin + 3 * r / 5));
   EXPECT_THAT(Barycentre({World::origin, q}, {1, 1.5}),
-              Eq(World::origin + 3 * r / 4));
+              Eq(World::origin + 3 * r / 5));
 }
 
 }  // namespace geometry

--- a/geometry/barycentre_calculator_test.cpp
+++ b/geometry/barycentre_calculator_test.cpp
@@ -4,6 +4,7 @@
 
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
+#include "geometry/space.hpp"
 #include "gtest/gtest.h"
 #include "quantities/named_quantities.hpp"
 #include "quantities/si.hpp"
@@ -15,9 +16,11 @@ namespace geometry {
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::geometry::_frame;
 using namespace principia::geometry::_grassmann;
+using namespace principia::geometry::_space;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_si;
 using namespace principia::testing_utilities::_almost_equals;
+using ::testing::Eq;
 
 class BarycentreCalculatorTest : public testing::Test {
  protected:
@@ -68,6 +71,19 @@ TEST_F(BarycentreCalculatorTest, Scalar) {
   barycentre_calculator.Add(k2_, 7);
   EXPECT_THAT(barycentre_calculator.Get(),
               AlmostEquals((23.0 / 4.0) * si::Unit<KinematicViscosity>, 0));
+}
+
+TEST_F(BarycentreCalculatorTest, Function) {
+  Displacement<World> r({1 * Metre, 2 * Metre, 5 * Metre});
+  Position<World> q = World::origin + r;
+  EXPECT_THAT(Barycentre({World::origin, q}, {2 * Kilogram, 3 * Kilogram}),
+              Eq(World::origin + 3 * r / 5));
+  EXPECT_THAT(Barycentre({World::origin, q}, {2, 3}),
+              Eq(World::origin + 3 * r / 5));
+  EXPECT_THAT(Barycentre({World::origin, q}, {0.5, 0.75}),
+              Eq(World::origin + 3 * r / 4));
+  EXPECT_THAT(Barycentre({World::origin, q}, {1, 1.5}),
+              Eq(World::origin + 3 * r / 4));
 }
 
 }  // namespace geometry

--- a/geometry/perspective_body.hpp
+++ b/geometry/perspective_body.hpp
@@ -79,8 +79,7 @@ Perspective<FromFrame, ToFrame>::SegmentBehindFocalPlane(
     // λ determines where the segment intersects the focal plane.
     double const λ = (focal_ - z2) / (z1 - z2);
     auto const intercept =
-        Barycentre<Position<FromFrame>, double>(segment,
-                                                {λ, 1.0 - λ});
+        Barycentre({segment.first, segment.second}, {λ, 1.0 - λ});
     if (first_is_visible) {
       return std::make_optional<Segment<FromFrame>>(segment.first, intercept);
     } else {

--- a/geometry/point_test.cpp
+++ b/geometry/point_test.cpp
@@ -184,9 +184,8 @@ TEST_F(PointDeathTest, BarycentreError) {
 TEST_F(PointTest, Barycentres) {
   Instant const t1 = mjd0 + 1 * Day;
   Instant const t2 = mjd0 - 3 * Day;
-  Instant const b1 = Barycentre<Instant, Volume>({t1, t2},
-                                                 {3 * Litre, 1 * Litre});
-  Instant const b2 = Barycentre<Instant, double>({t2, t1}, {1, 1});
+  Instant const b1 = Barycentre({t1, t2}, {3 * Litre, 1 * Litre});
+  Instant const b2 = Barycentre({t2, t1}, {1, 1});
   EXPECT_THAT(b1, AlmostEquals(mjd0, 1));
   EXPECT_THAT(b2, Eq(mjd0 - 1 * Day));
 }

--- a/ksp_plugin/flight_plan_optimizer.cpp
+++ b/ksp_plugin/flight_plan_optimizer.cpp
@@ -598,7 +598,7 @@ FlightPlanOptimizer::EvaluateClosestPeriapsis(
     // Try to nudge the desired final time.  This may not succeed, in which case
     // we give up.
     auto const previous_actual_final_time = flight_plan_->actual_final_time();
-    auto const new_desired_final_time = Barycentre<Instant, double>(
+    auto const new_desired_final_time = Barycentre(
         {flight_plan_->initial_time(), flight_plan_->desired_final_time()},
         {1 - flight_plan_extension_factor, flight_plan_extension_factor});
     flight_plan_->SetDesiredFinalTime(new_desired_final_time).IgnoreError();

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -533,8 +533,7 @@ class MetricTest
     EXPECT_OK(ephemeris_->Prolong(desired_final_time));
     auto const earth_dof = solar_system_1950_.degrees_of_freedom("Earth");
     auto const mars_dof = solar_system_1950_.degrees_of_freedom("Mars");
-    auto const midway = Barycentre<DegreesOfFreedom<Barycentric>, double>(
-        {earth_dof, mars_dof}, {1, 1});
+    auto const midway = Barycentre({earth_dof, mars_dof}, {1, 1});
     EXPECT_OK(root_.Append(epoch_, midway));
     flight_plan_ = std::make_unique<FlightPlan>(
         /*initial_mass=*/1 * Kilogram,

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -206,8 +206,7 @@ TEST_F(VesselTest, PrepareHistory) {
       .Times(AnyNumber());
   vessel_.CreateTrajectoryIfNeeded(t0_ + 1 * Second);
 
-  auto const expected_dof = Barycentre<DegreesOfFreedom<Barycentric>, Mass>(
-      {p1_dof_, p2_dof_}, {mass1_, mass2_});
+  auto const expected_dof = Barycentre({p1_dof_, p2_dof_}, {mass1_, mass2_});
 
   EXPECT_EQ(1, vessel_.psychohistory()->size());
   EXPECT_EQ(t0_ + 1 * Second,
@@ -253,8 +252,7 @@ TEST_F(VesselTest, AdvanceTime) {
   vessel_.AdvanceTime();
 
   auto const expected_vessel_psychohistory = NewLinearTrajectoryTimeline(
-      Barycentre<DegreesOfFreedom<Barycentric>, Mass>({p1_dof_, p2_dof_},
-                                                      {mass1_, mass2_}),
+      Barycentre({p1_dof_, p2_dof_}, {mass1_, mass2_}),
       /*Δt=*/0.5 * Second,
       /*t1=*/t0_,
       /*t2=*/t0_ + 1.1 * Second);
@@ -282,8 +280,7 @@ TEST_F(VesselTest, Prediction) {
 
   // The call to fill the prognostication until t_max.
   auto const expected_vessel_prediction = NewLinearTrajectoryTimeline(
-      Barycentre<DegreesOfFreedom<Barycentric>, Mass>({p1_dof_, p2_dof_},
-                                                      {mass1_, mass2_}),
+      Barycentre({p1_dof_, p2_dof_}, {mass1_, mass2_}),
       /*Δt=*/0.5 * Second,
       /*t1=*/t0_,
       /*t2=*/t0_ + 2 * Second);
@@ -332,8 +329,7 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
 
   // The call to fill the prognostication until t_max.
   auto const expected_vessel_prediction1 = NewLinearTrajectoryTimeline(
-      Barycentre<DegreesOfFreedom<Barycentric>, Mass>({p1_dof_, p2_dof_},
-                                                      {mass1_, mass2_}),
+      Barycentre({p1_dof_, p2_dof_}, {mass1_, mass2_}),
       /*Δt=*/0.5 * Second,
       /*t1=*/t0_,
       /*t2=*/t0_ + 5.5 * Second);
@@ -346,8 +342,7 @@ TEST_F(VesselTest, PredictBeyondTheInfinite) {
 
   // The call to extend the exphemeris by many points.
   auto const expected_vessel_prediction2 = NewLinearTrajectoryTimeline(
-      Barycentre<DegreesOfFreedom<Barycentric>, Mass>({p1_dof_, p2_dof_},
-                                                      {mass1_, mass2_}),
+      Barycentre({p1_dof_, p2_dof_}, {mass1_, mass2_}),
       /*Δt=*/0.5 * Second,
       /*t1=*/t0_ + 5.5 * Second,
       /*t2=*/t0_ + FlightPlan::max_ephemeris_steps_per_frame * Second);

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -126,7 +126,7 @@ std::string ToMathematicaBody(
     OptionalExpressIn express_in) {
   auto const& a = polynomial.lower_bound();
   auto const& b = polynomial.upper_bound();
-  auto const midpoint = Barycentre(std::pair{a, b}, std::pair{0.5, 0.5});
+  auto const midpoint = Barycentre({a, b}, {0.5, 0.5});
   std::string const argument = RawApply(
       "Divide",
       {RawApply("Subtract", {"#", ToMathematica(midpoint, express_in)}),

--- a/numerics/apodization_body.hpp
+++ b/numerics/apodization_body.hpp
@@ -29,7 +29,7 @@ PoissonSeries<double, 0, 0, Evaluator> Dirichlet(Instant const& t_min,
                                                  Instant const& t_max) {
   using Result = PoissonSeries<double, 0, 0, Evaluator>;
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({1}, t_mid), {});
 }
 
@@ -40,7 +40,7 @@ PoissonSeries<double, 0, 0, Evaluator> Sine(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -54,7 +54,7 @@ PoissonSeries<double, 0, 0, Evaluator> Hann(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0.5}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -68,7 +68,7 @@ PoissonSeries<double, 0, 0, Evaluator> Hamming(Instant const& t_min,
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({25.0 / 46.0}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -82,7 +82,7 @@ PoissonSeries<double, 0, 0, Evaluator> Blackman(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0.42}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -99,7 +99,7 @@ PoissonSeries<double, 0, 0, Evaluator> ExactBlackman(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({3969.0 / 9304.0}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -116,7 +116,7 @@ PoissonSeries<double, 0, 0, Evaluator> Nuttall(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0.355768}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -136,7 +136,7 @@ PoissonSeries<double, 0, 0, Evaluator> BlackmanNuttall(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0.3635819}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -156,7 +156,7 @@ PoissonSeries<double, 0, 0, Evaluator> BlackmanHarris(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({0.35875}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),
@@ -176,7 +176,7 @@ PoissonSeries<double, 0, 0, Evaluator> ISO18431_2(Instant const& t_min,
   using AperiodicPolynomial = typename Result::AperiodicPolynomial;
   using PeriodicPolynomial = typename Result::PeriodicPolynomial;
   AngularFrequency const ω = 2 * π * Radian / (t_max - t_min);
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return Result(AperiodicPolynomial({1.0 / 4.63867187}, t_mid),
                 {{ω,
                   {.sin = PeriodicPolynomial({0}, t_mid),

--- a/numerics/approximation_body.hpp
+++ b/numerics/approximation_body.hpp
@@ -56,7 +56,7 @@ not_null<std::unique_ptr<
     FixedVector<Value<Argument, Function>, N / 2 + 1> const& previous_aⱼ,
     Difference<Value<Argument, Function>>* const error_estimate) {
   // This implementation follows [Boy13], section 4 and appendix A.
-  auto const midpoint = Barycentre(std::pair{a, b}, std::pair{0.5, 0.5});
+  auto const midpoint = Barycentre({a, b}, {0.5, 0.5});
 
   auto чебышёв_lobato_point =
       [&a, &b, &midpoint](std::int64_t const k) -> Argument {
@@ -149,8 +149,7 @@ bool StreamingAdaptiveЧебышёвPolynomialInterpolantImplementation(
             << full_error_estimate;
     Difference<Value<Argument, Function>> upper_error_estimate;
     Difference<Value<Argument, Function>> lower_error_estimate;
-    auto const midpoint =
-        Barycentre(std::pair(lower_bound, upper_bound), std::pair(1.0, 1.0));
+    auto const midpoint = Barycentre({lower_bound, upper_bound}, {1, 1});
     bool const lower_interpolants_stop =
         StreamingAdaptiveЧебышёвPolynomialInterpolantImplementation<max_degree>(
             f,

--- a/numerics/nearest_neighbour_body.hpp
+++ b/numerics/nearest_neighbour_body.hpp
@@ -157,7 +157,7 @@ PrincipalComponentPartitioningTree<Value_>::BuildTree(
   // halfway between these points.  Cost: 0.25 * N.
   auto const mid_lower = std::max_element(begin, mid_upper, projection_less);
 
-  auto const anchor = Barycentre<Displacement, double>(
+  auto const anchor = Barycentre(
       {displacements_[mid_lower->index], displacements_[mid_upper->index]},
       {1, 1});
 

--- a/numerics/newhall_body.hpp
+++ b/numerics/newhall_body.hpp
@@ -321,7 +321,7 @@ NewhallApproximationInMonomialBasis(std::vector<Value> const& q,
     qv[j + 1] = v[i] * duration_over_two;
   }
 
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return origin +
          Dehomogeneize<Difference<Value>, degree, Evaluator>(
              NewhallMonomialApproximator<Difference<Value>, degree, Evaluator>::

--- a/numerics/poisson_series_basis_body.hpp
+++ b/numerics/poisson_series_basis_body.hpp
@@ -173,7 +173,7 @@ std::array<Series, sizeof...(indices)> AperiodicSeriesGenerator<
     degree, dimension,
     std::index_sequence<indices...>>::BasisElements(Instant const& t_min,
                                                     Instant const& t_max) {
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   return {(Series(
       PolynomialGenerator<typename Series::AperiodicPolynomial,
                           dimension>::template UnitPolynomial<indices>(t_min,
@@ -221,7 +221,7 @@ std::array<Series, sizeof...(indices)> PeriodicSeriesGenerator<
     std::index_sequence<indices...>>::BasisElements(AngularFrequency const& ω,
                                                     Instant const& t_min,
                                                     Instant const& t_max) {
-  Instant const t_mid = Barycentre<Instant, double>({t_min, t_max}, {1, 1});
+  Instant const t_mid = Barycentre({t_min, t_max}, {1, 1});
   typename Series::AperiodicPolynomial const aperiodic_zero{{}, t_mid};
   return {Series(
       aperiodic_zero,

--- a/numerics/polynomial_in_чебышёв_basis_body.hpp
+++ b/numerics/polynomial_in_чебышёв_basis_body.hpp
@@ -341,8 +341,7 @@ RealRootsOrDie(double const ε) const {
 
     // Rescale from [-1, 1] to [lower_bound_, upper_bound_].
     absl::btree_set<Argument> real_roots;
-    auto const midpoint =
-        Barycentre(std::pair{lower_bound_, upper_bound_}, std::pair{1.0, 1.0});
+    auto const midpoint = Barycentre({lower_bound_, upper_bound_}, {1, 1});
     auto const half_width = 0.5 * (upper_bound_ - lower_bound_);
     for (auto const& scaled_real_root : scaled_real_roots) {
       // Чебышёв polynomials don't make sense outside of [-1, 1] but they may

--- a/numerics/root_finders_body.hpp
+++ b/numerics/root_finders_body.hpp
@@ -43,8 +43,7 @@ Argument Bisect(Function f,
   Argument lower = lower_bound;
   Argument upper = upper_bound;
   for (;;) {
-    Argument const middle =
-        Barycentre<Argument, double>({lower, upper}, {1, 1});
+    Argument const middle = Barycentre({lower, upper}, {1, 1});
     // The size of the interval has reached one ULP.
     if (middle == lower || middle == upper) {
       return middle;
@@ -170,12 +169,12 @@ Argument GoldenSectionSearch(Function f,
   Argument lower = lower_bound;
   Value f_lower = f(lower);
 
-  Argument lower_interior = Barycentre<Argument, double>(
-      {lower, upper}, {upper_interior_ratio, lower_interior_ratio});
+  Argument lower_interior =
+      Barycentre({lower, upper}, {upper_interior_ratio, lower_interior_ratio});
   Value f_lower_interior = f(lower_interior);
 
-  Argument upper_interior = Barycentre<Argument, double>(
-      {lower, upper}, {lower_interior_ratio, upper_interior_ratio});
+  Argument upper_interior =
+      Barycentre({lower, upper}, {lower_interior_ratio, upper_interior_ratio});
   Value f_upper_interior = f(upper_interior);
 
   while (lower < lower_interior &&
@@ -206,7 +205,7 @@ Argument GoldenSectionSearch(Function f,
       f_upper_interior = f(upper_interior);
     }
   }
-  return Barycentre<Argument, double>({lower, upper}, {1, 1});
+  return Barycentre({lower, upper}, {1, 1});
 }
 
 // The implementation is translated from the ALGOL 60 in [Bre73], chapter 5,
@@ -267,7 +266,7 @@ Argument Brent(Function f,
     Difference<Argument> e{};
     f_v = f_w = f_x = f(x);
     for (;;) {
-      Argument const m = Barycentre<Argument, double>({a, b}, {1, 1});
+      Argument const m = Barycentre({a, b}, {1, 1});
       Difference<Argument> const tol = eps * Abs(x - Argument{}) + t;
       Difference<Argument> const t2 = 2 * tol;
       // Check stopping criterion.

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -117,10 +117,9 @@ void ComputeApsides(Trajectory<Frame> const& reference,
         // Something went wrong when finding the extrema of
         // |squared_distance_approximation|. Use a linear interpolation of
         // |squared_distance_derivative| instead.
-        apsis_time = Barycentre<Instant, Variation<Square<Length>>>(
-            {time, *previous_time},
-            {*previous_squared_distance_derivative,
-             -squared_distance_derivative});
+        apsis_time = Barycentre({time, *previous_time},
+                                {*previous_squared_distance_derivative,
+                                 -squared_distance_derivative});
       }
 
       // This can happen for instance if the square distance is stationary.
@@ -451,8 +450,7 @@ absl::Status ComputeNodes(
           Sign(z_approximation.Evaluate(time))) {
         // The Hermite approximation is poorly conditioned, let's use a linear
         // approximation
-        node_time = Barycentre<Instant, Length>({*previous_time, time},
-                                                {z, -*previous_z});
+        node_time = Barycentre({*previous_time, time}, {z, -*previous_z});
       } else {
         // The normal case, find the intersection with z = 0 using Brent's
         // method.

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -277,9 +277,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::MotionOfThisFrame(
           orthonormal, 𝛛orthonormal, 𝛛²orthonormal);
 
   Vector<Acceleration, InertialFrame> const acceleration_of_to_frame_origin =
-      Barycentre(std::pair{r̈₁, r̈₂},
-                 std::pair{primary_gravitational_parameter_,
-                           secondary_gravitational_parameter_});
+      Barycentre({r̈₁, r̈₂},
+                 {primary_gravitational_parameter_,
+                  secondary_gravitational_parameter_});
   return AcceleratedRigidMotion<InertialFrame, ThisFrame>(
              to_this_frame,
              angular_acceleration_of_to_frame,
@@ -308,10 +308,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ToThisFrame(
       angular_velocity);
 
   DegreesOfFreedom<InertialFrame> const barycentre_degrees_of_freedom =
-      Barycentre(
-          std::pair{primary_degrees_of_freedom, secondary_degrees_of_freedom},
-          std::pair{primary_gravitational_parameter_,
-                    secondary_gravitational_parameter_});
+      Barycentre({primary_degrees_of_freedom, secondary_degrees_of_freedom},
+                 {primary_gravitational_parameter_,
+                  secondary_gravitational_parameter_});
   RigidTransformation<InertialFrame, ThisFrame> const rigid_transformation(
       barycentre_degrees_of_freedom.position(),
       ThisFrame::origin,

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -94,11 +94,9 @@ class BarycentricRotatingReferenceFrameTest : public ::testing::Test {
         small_initial_state_(solar_system_.degrees_of_freedom(small)),
         small_gravitational_parameter_(
             solar_system_.gravitational_parameter(small)),
-        centre_of_mass_initial_state_(
-            Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
-                {big_initial_state_, small_initial_state_},
-                {big_gravitational_parameter_,
-                 small_gravitational_parameter_})) {
+        centre_of_mass_initial_state_(Barycentre(
+            {big_initial_state_, small_initial_state_},
+            {big_gravitational_parameter_, small_gravitational_parameter_})) {
     EXPECT_OK(ephemeris_->Prolong(t0_ + 2 * period_));
     big_small_frame_ = std::make_unique<
         BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(

--- a/physics/body_centred_body_direction_reference_frame_test.cpp
+++ b/physics/body_centred_body_direction_reference_frame_test.cpp
@@ -234,11 +234,9 @@ TEST_F(BodyCentredBodyDirectionReferenceFrameTest, ConstructFromOneBody) {
         ephemeris_->trajectory(big_)->EvaluateDegreesOfFreedom(t0_ + t);
     auto const small_dof =
         ephemeris_->trajectory(small_)->EvaluateDegreesOfFreedom(t0_ + t);
-    auto const barycentre =
-        Barycentre<DegreesOfFreedom<ICRS>, GravitationalParameter>(
-            {big_dof, small_dof},
-            {big_->gravitational_parameter(),
-             small_->gravitational_parameter()});
+    auto const barycentre = Barycentre(
+        {big_dof, small_dof},
+        {big_->gravitational_parameter(), small_->gravitational_parameter()});
     EXPECT_THAT(barycentre.velocity().Norm(),
                 VanishesBefore(1 * Kilo(Metre) / Second, 0, 50));
     EXPECT_OK(barycentre_trajectory.Append(t0_ + t, barycentre));

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -151,8 +151,7 @@ class EphemerisTest : public testing::TestWithParam<FixedStepSizeIntegrator<
     period = 2 * π *
              Sqrt(Pow<3>(semi_major_axis) / (earth->gravitational_parameter() +
                                              moon->gravitational_parameter()));
-    centre_of_mass = Barycentre<Position<ICRS>, Mass>(
-        {q1, q2}, {earth->mass(), moon->mass()});
+    centre_of_mass = Barycentre({q1, q2}, {earth->mass(), moon->mass()});
     Velocity<ICRS> const v1({-2 * π * (q1 - centre_of_mass).Norm() / period,
                              0 * si::Unit<Speed>,
                              0 * si::Unit<Speed>});
@@ -199,8 +198,7 @@ TEST_P(EphemerisTest, ProlongSpecialCases) {
   EXPECT_OK(ephemeris.Prolong(t0_ + period / 2));
   EXPECT_EQ(t_max, ephemeris.t_max());
 
-  Instant const last_t =
-      Barycentre<Instant, double>({t0_ + period, t_max}, {0.5, 0.5});
+  Instant const last_t = Barycentre({t0_ + period, t_max}, {0.5, 0.5});
   ephemeris.Prolong(last_t).IgnoreError();
   EXPECT_EQ(t_max, ephemeris.t_max());
 }

--- a/physics/equipotential_body.hpp
+++ b/physics/equipotential_body.hpp
@@ -140,8 +140,8 @@ auto Equipotential<InertialFrame, Frame>::ComputeLines(
         Length const r = (peak - well.position).Norm();
         if (reference_frame_->GeometricPotential(
                 t,
-                Barycentre(std::pair(peak, well.position),
-                           std::pair(well.radius, r - well.radius))) >=
+                Barycentre({peak, well.position},
+                           {well.radius, r - well.radius})) >=
             energy) {
           // The point at the edge of the well in the direction of the peak is
           // above the energy; this should not happen (the edge of the well
@@ -159,15 +159,13 @@ auto Equipotential<InertialFrame, Frame>::ComputeLines(
         Length const x = Brent(
             [&](Length const& x) {
               return reference_frame_->GeometricPotential(
-                         t,
-                         Barycentre(std::pair(peak, well.position),
-                                    std::pair(x, r - x))) -
+                         t, Barycentre({peak, well.position}, {x, r - x})) -
                      energy;
             },
             well.radius,
             r);
         Position<Frame> const equipotential_position =
-            Barycentre(std::pair(peak, well.position), std::pair(x, r - x));
+            Barycentre({peak, well.position}, {x, r - x});
         lines.push_back(ComputeLine(plane, t, equipotential_position));
       } else {
         // Try to delineate |peak| from the well at infinity; this works as for
@@ -186,15 +184,13 @@ auto Equipotential<InertialFrame, Frame>::ComputeLines(
         double const x = Brent(
             [&](double const& x) {
               return reference_frame_->GeometricPotential(
-                         t,
-                         Barycentre(std::pair(peak, far_away),
-                                    std::pair(x, 1 - x))) -
+                         t, Barycentre({peak, far_away}, {x, 1 - x})) -
                      energy;
             },
             0.0,
             1.0);
         Position<Frame> const equipotential_position =
-            Barycentre(std::pair(peak, far_away), std::pair(x, 1 - x));
+            Barycentre({peak, far_away}, {x, 1 - x});
         lines.push_back(ComputeLine(plane, t, equipotential_position));
       }
       std::vector<Position<Frame>> positions;

--- a/physics/equipotential_test.cpp
+++ b/physics/equipotential_test.cpp
@@ -259,8 +259,8 @@ TEST_F(EquipotentialTest, BodyCentredBodyDirection_EquidistantPoints) {
       [](Position<World> const& l4, Position<World> const& l5) {
         std::vector<Position<World>> positions;
         for (int i = 0; i <= 10; ++i) {
-          positions.push_back(Barycentre(
-              std::pair{l4, l5}, std::pair{i / 10.0, (10.0 - i) / 10.0}));
+          positions.push_back(
+              Barycentre({l4, l5}, {i / 10.0, (10.0 - i) / 10.0}));
         }
         return positions;
       });

--- a/physics/lagrange_equipotentials_body.hpp
+++ b/physics/lagrange_equipotentials_body.hpp
@@ -183,8 +183,7 @@ LagrangeEquipotentials<Inertial, RotatingPulsating>::ComputeLines(
   // maximum of the potential.
   auto const potential_on_primary_secondary_segment = [&](double const x) {
     return potential(
-        Barycentre(std::pair(secondary_position, primary_position),
-                    std::pair(x, 1 - x)));
+        Barycentre({secondary_position, primary_position}, {x, 1 - x}));
   };
   double const arg_approx_l1 = Brent(
       potential_on_primary_secondary_segment,
@@ -195,11 +194,11 @@ LagrangeEquipotentials<Inertial, RotatingPulsating>::ComputeLines(
   // the barycentre.  We look for it between the smaller body and a point as far
   // from the second body as the barycentre, but in the other direction.
   auto const potential_on_secondary_outward_segment = [&](double x) {
-    return potential(Barycentre(
-        std::pair(secondary_position,
-                  RotatingPulsating::origin +
-                      2 * (secondary_position - RotatingPulsating::origin)),
-        std::pair(x, 1 - x)));
+    return potential(
+        Barycentre({secondary_position,
+                    RotatingPulsating::origin +
+                        2 * (secondary_position - RotatingPulsating::origin)},
+                   {x, 1 - x}));
   };
   double const arg_approx_l2 = Brent(
       potential_on_secondary_outward_segment,

--- a/physics/lagrange_equipotentials_test.cpp
+++ b/physics/lagrange_equipotentials_test.cpp
@@ -128,7 +128,7 @@ TEST_F(LagrangeEquipotentialsTest,
   Velocity<World> const v_earth = earth_world_dof.velocity();
   Velocity<World> const v_moon = moon_world_dof.velocity();
   Position<World> const initial_earth_moon_l5 =
-      Barycentre(std::pair(q_earth, q_moon), std::pair(1.0, 1.0)) +
+      Barycentre({q_earth, q_moon}, {1.0, 1.0}) +
       (q_earth - q_moon).Norm() *
           Vector<double, World>({0, quantities::Sqrt(3) / 2, 0});
   using MEO = Frame<struct MEOTag, Arbitrary>;


### PR DESCRIPTION
Not touching the container one for now, so those callers are still ugly.
Also we probably want a 1-parameter overload for equal weights, but I will do that in a subsequent change.