### PR TITLE
Fix a bug in the deserialization of integrators

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -89,19 +89,6 @@ char const* const Architecture = "x86-64";
 #  endif
 #endif
 
-// A function for use on control paths that don't return a value, typically
-// because they end with a |LOG(FATAL)|.
-#if PRINCIPIA_COMPILER_CLANG || PRINCIPIA_COMPILER_CLANG_CL
-[[noreturn]]
-#elif PRINCIPIA_COMPILER_MSVC
-__declspec(noreturn)
-#elif PRINCIPIA_COMPILER_ICC
-__attribute__((noreturn))
-#else
-#error "What compiler is this?"
-#endif
-inline void noreturn() { std::exit(0); }
-
 // Used to force inlining.
 #if PRINCIPIA_COMPILER_CLANG    ||  \
     PRINCIPIA_COMPILER_CLANG_CL ||  \

--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -61,7 +61,7 @@ Scalar& R3Element<Scalar>::operator[](int const index) {
       return z;
     default:
       DLOG(FATAL) << FUNCTION_SIGNATURE << ": index = " << index;
-      base::noreturn();
+      std::abort();
   }
 }
 
@@ -77,7 +77,7 @@ Scalar const& R3Element<Scalar>::operator[](
       return z;
     default:
       DLOG(FATAL) << FUNCTION_SIGNATURE << ": index = " << index;
-      base::noreturn();
+      std::abort();
   }
 }
 

--- a/geometry/r3x3_matrix_body.hpp
+++ b/geometry/r3x3_matrix_body.hpp
@@ -36,7 +36,7 @@ FORCE_INLINE(inline) Scalar R3x3Matrix<Scalar>::operator()(
     default:
       DLOG(FATAL) << FUNCTION_SIGNATURE
                   << " indices = {" << r << ", " << c << "}";
-      base::noreturn();
+      std::abort();
   }
 }
 
@@ -50,7 +50,7 @@ Scalar& R3x3Matrix<Scalar>::operator()(int r, int c) {
     default:
       DLOG(FATAL) << FUNCTION_SIGNATURE
                   << " indices = {" << r << ", " << c << "}";
-      base::noreturn();
+      std::abort();
   }
 }
 

--- a/ksp_plugin/interface_body.hpp
+++ b/ksp_plugin/interface_body.hpp
@@ -567,7 +567,7 @@ inline not_null<std::unique_ptr<NavigationFrame>> NewNavigationFrame(
       return plugin.NewBodySurfaceNavigationFrame(parameters.centre_index);
     default:
       LOG(FATAL) << "Unexpected extension " << parameters.extension;
-      base::noreturn();
+      std::abort();
   }
 }
 

--- a/ksp_plugin_test/pile_up_test.cpp
+++ b/ksp_plugin_test/pile_up_test.cpp
@@ -686,7 +686,7 @@ TEST_F(PileUpTest, Serialization) {
       return &p2_;
     }
     LOG(FATAL) << "Unexpected part id " << part_id;
-    base::noreturn();
+    std::abort();
   };
   auto const p = PileUp::ReadFromMessage(message,
                                          part_id_to_part,
@@ -728,7 +728,7 @@ TEST_F(PileUpTest, SerializationCompatibility) {
       return &p2_;
     }
     LOG(FATAL) << "Unexpected part id " << part_id;
-    base::noreturn();
+    std::abort();
   };
   auto const p = PileUp::ReadFromMessage(message,
                                          part_id_to_part,

--- a/numerics/global_optimization_body.hpp
+++ b/numerics/global_optimization_body.hpp
@@ -19,7 +19,7 @@ namespace numerics {
 namespace _global_optimization {
 namespace internal {
 
-using base::noreturn;
+using std::abort;
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::geometry::_grassmann;
 using namespace principia::numerics::_gradient_descent;

--- a/numerics/global_optimization_body.hpp
+++ b/numerics/global_optimization_body.hpp
@@ -19,7 +19,6 @@ namespace numerics {
 namespace _global_optimization {
 namespace internal {
 
-using std::abort;
 using namespace principia::geometry::_barycentre_calculator;
 using namespace principia::geometry::_grassmann;
 using namespace principia::numerics::_gradient_descent;
@@ -40,7 +39,7 @@ MultiLevelSingleLinkage<Scalar, Argument, dimensions>::Box::measure() const {
   } else if constexpr (dimensions == 3) {
     return 8 * Wedge(vertices[0], Wedge(vertices[1], vertices[2])).Norm();
   }
-  noreturn();
+  std::abort();
 }
 
 template<typename Scalar, typename Argument, int dimensions>
@@ -315,7 +314,7 @@ MultiLevelSingleLinkage<Scalar, Argument, dimensions>::CriticalRadius²(
   } else if constexpr (dimensions == 3) {
     return Cbrt(Pow<2>(3.0 * box_measure_ * σ * std::log(kN) / (4.0 * π * kN)));
   }
-  noreturn();
+  std::abort();
 }
 
 }  // namespace internal

--- a/numerics/polynomial_in_чебышёв_basis_body.hpp
+++ b/numerics/polynomial_in_чебышёв_basis_body.hpp
@@ -114,7 +114,7 @@ PolynomialInЧебышёвBasis<Value_, Argument_, std::nullopt>::ReadFromMessag
                  << pre_канторович_message.DebugString();
 #if PRINCIPIA_COMPILER_MSVC && \
     _MSC_FULL_VER == 193'933'523
-      base::noreturn();
+      std::abort();
 #endif
   }
 }

--- a/numerics/polynomial_in_чебышёв_basis_body.hpp
+++ b/numerics/polynomial_in_чебышёв_basis_body.hpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <utility>
 
-#include "base/macros.hpp"  // 🧙 For noreturn.
 #include "base/not_constructible.hpp"
 #include "base/tags.hpp"
 #include "base/traits.hpp"

--- a/physics/body_body.hpp
+++ b/physics/body_body.hpp
@@ -31,7 +31,7 @@ inline not_null<std::unique_ptr<Body>> Body::ReadFromMessage(
     return MassiveBody::ReadFromMessage(message.massive_body());
   } else {
     LOG(FATAL) << "Body is neither massive nor massless";
-    base::noreturn();
+    std::abort();
   }
 }
 

--- a/physics/euler_solver_body.hpp
+++ b/physics/euler_solver_body.hpp
@@ -385,7 +385,7 @@ EulerSolver<InertialFrame, PrincipalAxesFrame>::AttitudeAt(
       LOG(FATAL) << "Unexpected region " << static_cast<int>(region_);
 #if PRINCIPIA_COMPILER_MSVC && \
     _MSC_FULL_VER == 193'933'523
-      base::noreturn();
+      std::abort();
 #endif
   }
 }

--- a/physics/euler_solver_body.hpp
+++ b/physics/euler_solver_body.hpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 
-#include "base/macros.hpp"  // 🧙 For noreturn.
 #include "geometry/orthogonal_map.hpp"
 #include "geometry/quaternion.hpp"
 #include "geometry/sign.hpp"

--- a/physics/geopotential_body.hpp
+++ b/physics/geopotential_body.hpp
@@ -808,7 +808,7 @@ Geopotential<Frame>::GeneralSphericalHarmonicsAcceleration(
       return Vector<ReducedAcceleration, Frame>{};
     default:
       LOG(FATAL) << "Unexpected degree " << max_degree << " " << body_->name();
-      base::noreturn();
+      std::abort();
   }
 }
 
@@ -890,7 +890,7 @@ Geopotential<Frame>::GeneralSphericalHarmonicsPotential(
       return ReducedPotential{};
     default:
       LOG(FATAL) << "Unexpected degree " << max_degree << " " << body_->name();
-      base::noreturn();
+      std::abort();
   }
 }
 

--- a/physics/hierarchical_system_body.hpp
+++ b/physics/hierarchical_system_body.hpp
@@ -96,7 +96,7 @@ HierarchicalSystem<Frame>::ToBarycentric(System& system) {
              right->jacobi_osculating_elements.period;
     }
     LOG(FATAL) << "improperly initialized elements";
-    base::noreturn();
+    std::abort();
   };
 
   std::sort(system.satellites.begin(),

--- a/physics/massive_body_body.hpp
+++ b/physics/massive_body_body.hpp
@@ -200,7 +200,7 @@ inline not_null<std::unique_ptr<MassiveBody>> MassiveBody::ReadFromMessage(
       }
     }
     LOG(FATAL) << enum_descriptor->name();
-    base::noreturn();
+    std::abort();
   } else {
     return std::make_unique<MassiveBody>(parameters);
   }

--- a/physics/oblate_body_body.hpp
+++ b/physics/oblate_body_body.hpp
@@ -221,7 +221,7 @@ not_null<std::unique_ptr<OblateBody<Frame>>> OblateBody<Frame>::ReadFromMessage(
       break;
     case serialization::OblateBody::OblatenessCase::OBLATENESS_NOT_SET:
       LOG(FATAL) << message.DebugString();
-      base::noreturn();
+      std::abort();
   }
   return std::make_unique<OblateBody<Frame>>(massive_body_parameters,
                                              rotating_body_parameters,

--- a/physics/solar_system_body.hpp
+++ b/physics/solar_system_body.hpp
@@ -633,7 +633,7 @@ SolarSystem<Frame>::MakeOblateBodyParameters(
     case serialization::GravityModel::Body::OblatenessCase::OBLATENESS_NOT_SET:
     default:
       LOG(FATAL) << body.DebugString();
-      base::noreturn();
+      std::abort();
   }
 }
 

--- a/quantities/parser_body.hpp
+++ b/quantities/parser_body.hpp
@@ -157,7 +157,7 @@ inline Unit ParseUnit(std::string const& s) {
     return Unit(si::Steradian);
   } else {
     LOG(FATAL) << "Unsupported unit " << s;
-    base::noreturn();
+    std::abort();
   }
 }
 

--- a/testing_utilities/solar_system_factory_body.hpp
+++ b/testing_utilities/solar_system_factory_body.hpp
@@ -108,7 +108,7 @@ SolarSystemFactory::MakeAccuracyParameters(Length const& fitting_tolerance,
           /*geopotential_tolerance=*/0.0);
   }
   LOG(FATAL) << "Bad accuracy";
-  base::noreturn();
+  std::abort();
 }
 
 inline not_null<std::unique_ptr<SolarSystem<ICRS>>>
@@ -135,7 +135,7 @@ inline int SolarSystemFactory::parent(int const index) {
   switch (index) {
     case Sun:
       LOG(FATAL) << FUNCTION_SIGNATURE << "The Sun has no parent";
-      base::noreturn();
+      std::abort();
     case Jupiter:
     case Saturn:
     case Neptune:
@@ -179,7 +179,7 @@ inline int SolarSystemFactory::parent(int const index) {
       return Pluto;
     default:
       LOG(FATAL) << FUNCTION_SIGNATURE << "Undefined index";
-      base::noreturn();
+      std::abort();
   }
 }
 
@@ -222,7 +222,7 @@ inline std::string SolarSystemFactory::name(int const index) {
     BODY_NAME(Deimos);
     default:
       LOG(FATAL) << FUNCTION_SIGNATURE << "Undefined index";
-      base::noreturn();
+      std::abort();
   }
 #undef BODY_NAME
 }

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.hpp"  // 🧙 For noreturn.
 #include "base/map_util.hpp"
 #include "glog/logging.h"
 #include "serialization/journal.pb.h"

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1948,7 +1948,7 @@ std::string JournalProtoProcessor::MarshalAs(
   LOG(FATAL) << "Bad marshaler for " << descriptor->name();
 #if PRINCIPIA_COMPILER_MSVC && \
     _MSC_FULL_VER == 193'933'523
-  base::noreturn();
+  std::abort();
 #endif
 }
 


### PR DESCRIPTION
An SPRK can be viewed as an SRKN, so we need to check for both kinds of ODE at deserialization time.

Also remove `base::noreturn`, which hid the bug for a year, and use `std::abort` instead.