### PR TITLE
Fix a few TODOs

### DIFF
--- a/numerics/fit_hermite_spline.hpp
+++ b/numerics/fit_hermite_spline.hpp
@@ -25,7 +25,7 @@ using namespace principia::quantities::_named_quantities;
 // not all of |samples| is fitted maximally.  This function further guarantees
 // that the |Hermite3| interpolation of (*itᵣ, *(samples.end() - 1)) fits
 // |samples| within |tolerance|.
-template<typename Argument, typename Value, typename Samples>
+template<typename Value, typename Argument, typename Samples>
 absl::StatusOr<std::list<typename Samples::const_iterator>> FitHermiteSpline(
     Samples const& samples,
     std::function<Argument const&(typename Samples::value_type const&)> const&

--- a/numerics/fit_hermite_spline_body.hpp
+++ b/numerics/fit_hermite_spline_body.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "numerics/fit_hermite_spline.hpp"
+
 #include <list>
 #include <type_traits>
 
@@ -15,7 +17,7 @@ namespace internal {
 using namespace principia::base::_ranges;
 using namespace principia::numerics::_hermite3;
 
-template<typename Argument, typename Value, typename Samples>
+template<typename Value, typename Argument, typename Samples>
 absl::StatusOr<std::list<typename Samples::const_iterator>> FitHermiteSpline(
     Samples const& samples,
     std::function<Argument const&(typename Samples::value_type const&)> const&
@@ -30,7 +32,7 @@ absl::StatusOr<std::list<typename Samples::const_iterator>> FitHermiteSpline(
   auto interpolation_error_is_within_tolerance =
       [get_argument, get_derivative, get_value, tolerance](
           Iterator const begin, Iterator const last) {
-        return Hermite3<Argument, Value>(
+        return Hermite3<Value, Argument>(
                    {get_argument(*begin), get_argument(*last)},
                    {get_value(*begin), get_value(*last)},
                    {get_derivative(*begin), get_derivative(*last)})

--- a/numerics/fit_hermite_spline_test.cpp
+++ b/numerics/fit_hermite_spline_test.cpp
@@ -65,7 +65,7 @@ TEST_F(FitHermiteSplineTest, Sinusoid) {
     }
   }
   std::list<std::vector<Sample>::const_iterator> const interpolation_points =
-      FitHermiteSpline<Instant, Length>(
+      FitHermiteSpline<Length, Instant>(
           samples,
           [](auto&& sample) -> auto&& { return sample.t; },
           [](auto&& sample) -> auto&& { return sample.x; },
@@ -83,7 +83,7 @@ TEST_F(FitHermiteSplineTest, Sinusoid) {
 
   auto lower_bound = samples.cbegin();
   auto upper_bound = interpolation_points.front();
-  Hermite3<Instant, Length> first_polynomial({lower_bound->t, upper_bound->t},
+  Hermite3<Length, Instant> first_polynomial({lower_bound->t, upper_bound->t},
                                              {lower_bound->x, upper_bound->x},
                                              {lower_bound->v, upper_bound->v});
   EXPECT_THAT(first_polynomial.LInfinityError(
@@ -93,7 +93,7 @@ TEST_F(FitHermiteSplineTest, Sinusoid) {
               IsNear(9.3_(1) * Milli(Metre)));
   lower_bound = upper_bound;
   upper_bound = interpolation_points.back();
-  Hermite3<Instant, Length> second_polynomial({lower_bound->t, upper_bound->t},
+  Hermite3<Length, Instant> second_polynomial({lower_bound->t, upper_bound->t},
                                               {lower_bound->x, upper_bound->x},
                                               {lower_bound->v, upper_bound->v});
   EXPECT_THAT(second_polynomial.LInfinityError(
@@ -103,7 +103,7 @@ TEST_F(FitHermiteSplineTest, Sinusoid) {
               IsNear(1.0_(1) * Centi(Metre)));
   lower_bound = upper_bound;
   upper_bound = samples.cend() - 1;
-  Hermite3<Instant, Length> tail_polynomial({lower_bound->t, upper_bound->t},
+  Hermite3<Length, Instant> tail_polynomial({lower_bound->t, upper_bound->t},
                                             {lower_bound->x, upper_bound->x},
                                             {lower_bound->v, upper_bound->v});
   EXPECT_THAT(tail_polynomial.LInfinityError(
@@ -133,7 +133,7 @@ TEST_F(FitHermiteSplineDeathTest, NoDownsampling) {
     }
   }
   auto fit_hermite_spline = [&samples]() {
-    return FitHermiteSpline<Instant, Length>(
+    return FitHermiteSpline<Length, Instant>(
         samples,
         [](auto&& sample) -> auto&& { return sample.t; },
         [](auto&& sample) -> auto&& { return sample.x; },

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -33,8 +33,6 @@ class FixedVector final {
   constexpr FixedVector();
   explicit FixedVector(uninitialized_t);
 
-  // TODO(egg): Figure out why we have a move-conversion for |FixedVector| but
-  // not the matrices.
   constexpr FixedVector(
       std::array<Scalar, size_> const& data);  // NOLINT(runtime/explicit)
   constexpr FixedVector(
@@ -105,6 +103,8 @@ class FixedMatrix final {
   // The |data| must be in row-major format.
   constexpr FixedMatrix(
       std::array<Scalar, size()> const& data);  // NOLINT(runtime/explicit)
+  constexpr FixedMatrix(
+      std::array<Scalar, size()>&& data);  // NOLINT(runtime/explicit)
 
   constexpr explicit FixedMatrix(
       TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view);

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -91,20 +91,21 @@ class FixedVector final {
 
 template<typename Scalar_, int rows_, int columns_>
 class FixedMatrix final {
+  static constexpr int size_ = rows_ * columns_;
+
  public:
   using Scalar = Scalar_;
   static constexpr int rows() { return rows_; }
   static constexpr int columns() { return columns_; }
-  static constexpr int size() { return rows_ * columns_; }
 
   constexpr FixedMatrix();
   explicit FixedMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
   constexpr FixedMatrix(
-      std::array<Scalar, size()> const& data);  // NOLINT(runtime/explicit)
+      std::array<Scalar, size_> const& data);  // NOLINT(runtime/explicit)
   constexpr FixedMatrix(
-      std::array<Scalar, size()>&& data);  // NOLINT(runtime/explicit)
+      std::array<Scalar, size_>&& data);  // NOLINT(runtime/explicit)
 
   constexpr explicit FixedMatrix(
       TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view);
@@ -144,7 +145,7 @@ class FixedMatrix final {
   static FixedMatrix Identity();
 
  private:
-  std::array<Scalar, size()> data_;
+  std::array<Scalar, size_> data_;
 
   template<typename L, typename R, int r, int c>
   friend constexpr FixedVector<Product<L, R>, r> operator*(
@@ -154,18 +155,19 @@ class FixedMatrix final {
 
 template<typename Scalar_, int rows_>
 class FixedStrictlyLowerTriangularMatrix final {
+  static constexpr int size_ = rows_ * (rows_ - 1) / 2;
+
  public:
   using Scalar = Scalar_;
   static constexpr int rows() { return rows_; }
   static constexpr int columns() { return rows_; }
-  static constexpr int size() { return rows_ * (rows_ - 1) / 2; }
 
   constexpr FixedStrictlyLowerTriangularMatrix();
   explicit FixedStrictlyLowerTriangularMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
   constexpr FixedStrictlyLowerTriangularMatrix(
-      std::array<Scalar, size()> const& data);
+      std::array<Scalar, size_> const& data);
 
   friend bool operator==(FixedStrictlyLowerTriangularMatrix const& left,
                          FixedStrictlyLowerTriangularMatrix const& right) =
@@ -184,23 +186,24 @@ class FixedStrictlyLowerTriangularMatrix final {
   Scalar const* row() const;
 
  private:
-  std::array<Scalar, size()> data_;
+  std::array<Scalar, size_> data_;
 };
 
 template<typename Scalar_, int rows_>
 class FixedLowerTriangularMatrix final {
+  static constexpr int size_ = rows_ * (rows_ + 1) / 2;
+
  public:
   using Scalar = Scalar_;
   static constexpr int rows() { return rows_; }
   static constexpr int columns() { return rows_; }
-  static constexpr int size() { return rows_ * (rows_ + 1) / 2; }
 
   constexpr FixedLowerTriangularMatrix();
   explicit FixedLowerTriangularMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
   constexpr FixedLowerTriangularMatrix(
-      std::array<Scalar, size()> const& data);
+      std::array<Scalar, size_> const& data);
 
   explicit FixedLowerTriangularMatrix(
       TransposedView<FixedUpperTriangularMatrix<Scalar, rows_>> const& view);
@@ -217,23 +220,24 @@ class FixedLowerTriangularMatrix final {
   constexpr Scalar const& operator()(int row, int column) const;
 
  private:
-  std::array<Scalar, size()> data_;
+  std::array<Scalar, size_> data_;
 };
 
 template<typename Scalar_, int columns_>
 class FixedUpperTriangularMatrix final {
+  static constexpr int size_ = columns_ * (columns_ + 1) / 2;
+
  public:
   using Scalar = Scalar_;
   static constexpr int rows() { return columns_; }
   static constexpr int columns() { return columns_; }
-  static constexpr int size() { return columns_ * (columns_ + 1) / 2; }
 
   constexpr FixedUpperTriangularMatrix();
   explicit FixedUpperTriangularMatrix(uninitialized_t);
 
   // The |data| must be in row-major format.
   constexpr FixedUpperTriangularMatrix(
-      std::array<Scalar, size()> const& data);
+      std::array<Scalar, size_> const& data);
 
   explicit FixedUpperTriangularMatrix(
       TransposedView<FixedLowerTriangularMatrix<Scalar, columns_>> const& view);
@@ -252,10 +256,10 @@ class FixedUpperTriangularMatrix final {
  private:
   // For ease of writing matrices in tests, the input data is received in row-
   // major format.  This transposes a trapezoidal slice to make it column-major.
-  static std::array<Scalar, size()> Transpose(
-      std::array<Scalar, size()> const& data);
+  static std::array<Scalar, size_> Transpose(
+      std::array<Scalar, size_> const& data);
 
-  std::array<Scalar, size()> data_;
+  std::array<Scalar, size_> data_;
 };
 
 // Prefer using the operator* that takes a TransposedView.

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -49,6 +49,8 @@ class FixedVector final {
   constexpr Scalar& operator[](int index);
   constexpr Scalar const& operator[](int index) const;
 
+  constexpr FixedVector& operator=(Scalar const (&right)[size_]);
+
   constexpr FixedVector& operator+=(FixedVector const& right);
   constexpr FixedVector& operator-=(FixedVector const& right);
   constexpr FixedVector& operator*=(double right);
@@ -121,6 +123,8 @@ class FixedMatrix final {
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
 
+  constexpr FixedMatrix& operator=(Scalar const (&right)[size_]);
+
   constexpr FixedMatrix& operator+=(FixedMatrix const& right);
   constexpr FixedMatrix& operator-=(FixedMatrix const& right);
   constexpr FixedMatrix& operator*=(double right);
@@ -182,6 +186,9 @@ class FixedStrictlyLowerTriangularMatrix final {
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
 
+  constexpr FixedStrictlyLowerTriangularMatrix& operator=(
+      Scalar const (&right)[size_]);
+
   template<int r>
   Scalar const* row() const;
 
@@ -219,6 +226,9 @@ class FixedLowerTriangularMatrix final {
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
 
+  constexpr FixedLowerTriangularMatrix& operator=(
+      Scalar const (&right)[size_]);
+
  private:
   std::array<Scalar, size_> data_;
 };
@@ -252,6 +262,9 @@ class FixedUpperTriangularMatrix final {
   // implies undefined behaviour.
   constexpr Scalar& operator()(int row, int column);
   constexpr Scalar const& operator()(int row, int column) const;
+
+  constexpr FixedUpperTriangularMatrix& operator=(
+      Scalar const (&right)[size_]);
 
  private:
   // For ease of writing matrices in tests, the input data is received in row-

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -3,7 +3,6 @@
 #include "numerics/fixed_arrays.hpp"
 
 #include <algorithm>
-#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -85,7 +84,6 @@ constexpr Scalar_ const& FixedVector<Scalar_, size_>::operator[](
 template<typename Scalar_, int size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator=(
     Scalar const (&right)[size_]) {
-  //std::ranges::copy(right, data_);
   std::copy(right, right + size_, data_.data());
   return *this;
 }

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -163,6 +163,11 @@ constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
 
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
+    std::array<Scalar, size()>&& data)
+    : data_(std::move(data)) {}
+
+template<typename Scalar_, int rows_, int columns_>
+constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
     TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view)
     : FixedMatrix(uninitialized) {
   for (int i = 0; i < rows_; ++i) {

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -3,6 +3,7 @@
 #include "numerics/fixed_arrays.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -79,6 +80,14 @@ constexpr Scalar_ const& FixedVector<Scalar_, size_>::operator[](
   CONSTEXPR_DCHECK(0 <= index);
   CONSTEXPR_DCHECK(index < size());
   return data_[index];
+}
+
+template<typename Scalar_, int size_>
+constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator=(
+    Scalar const (&right)[size_]) {
+  //std::ranges::copy(right, data_);
+  std::copy(right, right + size_, data_.data());
+  return *this;
 }
 
 template<typename Scalar_, int size_>
@@ -199,6 +208,14 @@ constexpr Scalar_ const& FixedMatrix<Scalar_, rows_, columns_>::operator()(
 
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
+FixedMatrix<Scalar_, rows_, columns_>::operator=(
+    Scalar const (&right)[size_]) {
+  std::copy(right, right + size_, data_.data());
+  return *this;
+}
+
+template<typename Scalar_, int rows_, int columns_>
+constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator+=(FixedMatrix const& right) {
   for (int i = 0; i < size_; ++i) {
     data_[i] += right.data_[i];
@@ -312,6 +329,14 @@ operator()(int const row, int const column) const {
 }
 
 template<typename Scalar_, int rows_>
+constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>&
+FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::operator=(
+    Scalar const (&right)[size_]) {
+  std::copy(right, right + size_, data_.data());
+  return *this;
+}
+
+template<typename Scalar_, int rows_>
 template<int r>
 Scalar_ const* FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::row() const {
   static_assert(r < rows_);
@@ -361,6 +386,14 @@ operator()(int const row, int const column) const {
   return data_[row * (row + 1) / 2 + column];
 }
 
+template<typename Scalar_, int rows_>
+constexpr FixedLowerTriangularMatrix<Scalar_, rows_>&
+FixedLowerTriangularMatrix<Scalar_, rows_>::operator=(
+    Scalar const (&right)[size_]) {
+  std::copy(right, right + size_, data_.data());
+  return *this;
+}
+
 template<typename Scalar_, int columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
 FixedUpperTriangularMatrix()
@@ -402,6 +435,15 @@ operator()(int const row, int const column) const {
   CONSTEXPR_DCHECK(row <= column);
   CONSTEXPR_DCHECK(column < columns());
   return data_[column * (column + 1) / 2 + row];
+}
+
+template<typename Scalar_, int columns_>
+constexpr FixedUpperTriangularMatrix<Scalar_, columns_>&
+FixedUpperTriangularMatrix<Scalar_, columns_>::operator=(
+    Scalar const (&right)[size_]) {
+  std::copy(right, right + size_, data_.data());
+  data_ = Transpose(data_);
+  return *this;
 }
 
 template<typename Scalar_, int columns_>

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -158,12 +158,12 @@ FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(uninitialized_t) {}
 
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
-    std::array<Scalar, size()> const& data)
+    std::array<Scalar, size_> const& data)
     : data_(data) {}
 
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
-    std::array<Scalar, size()>&& data)
+    std::array<Scalar, size_>&& data)
     : data_(std::move(data)) {}
 
 template<typename Scalar_, int rows_, int columns_>
@@ -200,7 +200,7 @@ constexpr Scalar_ const& FixedMatrix<Scalar_, rows_, columns_>::operator()(
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator+=(FixedMatrix const& right) {
-  for (int i = 0; i < size(); ++i) {
+  for (int i = 0; i < size_; ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
@@ -209,7 +209,7 @@ FixedMatrix<Scalar_, rows_, columns_>::operator+=(FixedMatrix const& right) {
 template<typename Scalar_, int rows_, int columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator-=(FixedMatrix const& right) {
-  for (int i = 0; i < size(); ++i) {
+  for (int i = 0; i < size_; ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
@@ -290,7 +290,7 @@ FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
 
 template<typename Scalar_, int rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
-FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size()> const& data)
+FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(data) {}
 
 template<typename Scalar_, int rows_>
@@ -329,7 +329,7 @@ FixedLowerTriangularMatrix(uninitialized_t) {}
 
 template<typename Scalar_, int rows_>
 constexpr FixedLowerTriangularMatrix<Scalar_, rows_>::
-FixedLowerTriangularMatrix(std::array<Scalar, size()> const& data)
+FixedLowerTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(data) {}
 
 template<typename Scalar_, int rows_>
@@ -372,7 +372,7 @@ FixedUpperTriangularMatrix<Scalar_, columns_>::FixedUpperTriangularMatrix(
 
 template<typename Scalar_, int columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
-FixedUpperTriangularMatrix(std::array<Scalar, size()> const& data)
+FixedUpperTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(Transpose(data)) {}
 
 template<typename Scalar_, int columns_>
@@ -406,8 +406,8 @@ operator()(int const row, int const column) const {
 
 template<typename Scalar_, int columns_>
 auto FixedUpperTriangularMatrix<Scalar_, columns_>::Transpose(
-    std::array<Scalar, size()> const& data)
-    -> std::array<Scalar, size()> {
+    std::array<Scalar, size_> const& data)
+    -> std::array<Scalar, size_> {
   std::array<Scalar, rows() * columns()> full;
   int index = 0;
   for (int row = 0; row < rows(); ++row) {
@@ -417,7 +417,7 @@ auto FixedUpperTriangularMatrix<Scalar_, columns_>::Transpose(
     }
   }
 
-  std::array<Scalar, size()> result;
+  std::array<Scalar, size_> result;
   index = 0;
   for (int column = 0; column < columns(); ++column) {
     for (int row = 0; row <= column; ++row) {

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -55,7 +55,7 @@ TEST_F(FixedArraysTest, Assignment) {
     FixedVector<double, 2> u2({1, 2});
     FixedVector<double, 2> v2 = {{1, 2}};
     FixedVector<double, 2> w2;
-    w2 = {{1, 2}};
+    w2 = {1, 2};
     EXPECT_EQ(u2, v2);
     EXPECT_EQ(u2, w2);
   }
@@ -67,8 +67,8 @@ TEST_F(FixedArraysTest, Assignment) {
                                       4, 5, 6}};
     FixedMatrix<double, 2, 3> n23 = {{0, 0, 0,
                                       0, 0, 0}};
-    n23 = {{1, 2, 3,
-            4, 5, 6}};
+    n23 = {1, 2, 3,
+           4, 5, 6};
     EXPECT_EQ(l23, m23);
     EXPECT_EQ(l23, n23);
   }
@@ -84,9 +84,9 @@ TEST_F(FixedArraysTest, Assignment) {
                                                          0, 0}};
     FixedStrictlyLowerTriangularMatrix<double, 3> o3;
     EXPECT_EQ(o3, n3);
-    n3 = {{
-           1,
-           2, 3}};
+    n3 = {
+          1,
+          2, 3};
     EXPECT_EQ(l3, m3);
     EXPECT_EQ(l3, n3);
   }
@@ -102,9 +102,9 @@ TEST_F(FixedArraysTest, Assignment) {
                                                  0, 0, 0}};
     FixedLowerTriangularMatrix<double, 3> o3;
     EXPECT_EQ(o3, n3);
-    n3 = {{1,
-           2, 3,
-           4, 5, 6}};
+    n3 = {1,
+          2, 3,
+          4, 5, 6};
     EXPECT_EQ(l3, m3);
     EXPECT_EQ(l3, n3);
   }
@@ -120,9 +120,9 @@ TEST_F(FixedArraysTest, Assignment) {
                                                        0}};
     FixedUpperTriangularMatrix<double, 3> o3;
     EXPECT_EQ(o3, n3);
-    n3 = {{1, 2, 3,
-              4, 5,
-                 6}};
+    n3 = {1, 2, 3,
+             4, 5,
+                6};
     EXPECT_EQ(l3, m3);
     EXPECT_EQ(l3, n3);
   }

--- a/numerics/fixed_arrays_test.cpp
+++ b/numerics/fixed_arrays_test.cpp
@@ -201,7 +201,6 @@ TEST_F(FixedArraysTest, MatrixIndexing) {
 }
 
 TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
-  EXPECT_EQ(6, (FixedStrictlyLowerTriangularMatrix<double, 4>::size()));
   EXPECT_EQ(1, sl4_(1, 0));
   EXPECT_EQ(2, sl4_(2, 0));
   EXPECT_EQ(3, sl4_(2, 1));
@@ -216,7 +215,6 @@ TEST_F(FixedArraysTest, StrictlyLowerTriangularMatrixIndexing) {
 }
 
 TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {
-  EXPECT_EQ(10, (FixedLowerTriangularMatrix<double, 4>::size()));
   EXPECT_EQ(1, l4_(0, 0));
   EXPECT_EQ(2, l4_(1, 0));
   EXPECT_EQ(3, l4_(1, 1));
@@ -235,7 +233,6 @@ TEST_F(FixedArraysTest, LowerTriangularMatrixIndexing) {
 }
 
 TEST_F(FixedArraysTest, UpperTriangularMatrixIndexing) {
-  EXPECT_EQ(10, (FixedUpperTriangularMatrix<double, 4>::size()));
   EXPECT_EQ(1, u4_(0, 0));
   EXPECT_EQ(2, u4_(0, 1));
   EXPECT_EQ(3, u4_(0, 2));

--- a/numerics/hermite3.hpp
+++ b/numerics/hermite3.hpp
@@ -21,7 +21,7 @@ using namespace principia::quantities::_named_quantities;
 // bounds of some interval.
 template<typename Value_, typename Argument_>
 class Hermite3 final {
-  using NormType = typename Hilbert<Difference<Value>>::NormType;
+  using NormType = typename Hilbert<Difference<Value_>>::NormType;
 
  public:
   using Argument = Argument_;

--- a/numerics/hermite3.hpp
+++ b/numerics/hermite3.hpp
@@ -19,12 +19,13 @@ using namespace principia::quantities::_named_quantities;
 
 // A 3rd degree Hermite polynomial defined by its values and derivatives at the
 // bounds of some interval.
-// TODO(phl): Invert the two template arguments for consistency with Derivative.
-template<typename Argument, typename Value>
+template<typename Value_, typename Argument_>
 class Hermite3 final {
   using NormType = typename Hilbert<Difference<Value>>::NormType;
 
  public:
+  using Argument = Argument_;
+  using Value = Value_;
   using Derivative1 = Derivative<Value, Argument>;
 
   Hermite3(std::pair<Argument, Argument> arguments,

--- a/numerics/hermite3_body.hpp
+++ b/numerics/hermite3_body.hpp
@@ -16,7 +16,7 @@ namespace internal {
 using namespace principia::numerics::_root_finders;
 
 template<typename Value_, typename Argument_>
-Hermite3<Argument_, Value_>::Hermite3(
+Hermite3<Value_, Argument_>::Hermite3(
     std::pair<Argument, Argument> arguments,
     std::pair<Value, Value> const& values,
     std::pair<Derivative1, Derivative1> const& derivatives)
@@ -46,28 +46,28 @@ Hermite3<Argument_, Value_>::Hermite3(
 }
 
 template<typename Value_, typename Argument_>
-Value_ Hermite3<Argument_, Value_>::Evaluate(Argument const& argument) const {
+Value_ Hermite3<Value_, Argument_>::Evaluate(Argument const& argument) const {
   Difference<Argument> const Δargument = argument - arguments_.first;
   return (((a3_ * Δargument + a2_) * Δargument) + a1_) * Δargument + a0_;
 }
 
 template<typename Value_, typename Argument_>
-typename Hermite3<Argument_, Value_>::Derivative1
-Hermite3<Argument_, Value_>::
+typename Hermite3<Value_, Argument_>::Derivative1
+Hermite3<Value_, Argument_>::
 EvaluateDerivative(Argument const& argument) const {
   Difference<Argument> const Δargument = argument - arguments_.first;
   return ((3.0 * a3_ * Δargument + 2.0 * a2_) * Δargument) + a1_;
 }
 
 template<typename Value_, typename Argument_>
-BoundedArray<Argument_, 2> Hermite3<Argument_, Value_>::FindExtrema() const {
+BoundedArray<Argument_, 2> Hermite3<Value_, Argument_>::FindExtrema() const {
   return SolveQuadraticEquation<Argument, Derivative1>(
       arguments_.first, a1_, 2.0 * a2_, 3.0 * a3_);
 }
 
 template<typename Value_, typename Argument_>
 template<typename Samples>
-auto Hermite3<Argument_, Value_>::LInfinityError(
+auto Hermite3<Value_, Argument_>::LInfinityError(
     Samples const& samples,
     std::function<Argument const&(typename Samples::value_type const&)> const&
         get_argument,
@@ -82,9 +82,9 @@ auto Hermite3<Argument_, Value_>::LInfinityError(
   return result;
 }
 
-template<typename Argument, typename Value>
+template<typename Value_, typename Argument_>
 template<typename Samples>
-bool Hermite3<Argument, Value>::LInfinityErrorIsWithin(
+bool Hermite3<Value_, Argument_>::LInfinityErrorIsWithin(
     Samples const& samples,
     std::function<Argument const&(typename Samples::value_type const&)> const&
         get_argument,

--- a/numerics/hermite3_body.hpp
+++ b/numerics/hermite3_body.hpp
@@ -15,8 +15,8 @@ namespace internal {
 
 using namespace principia::numerics::_root_finders;
 
-template<typename Argument, typename Value>
-Hermite3<Argument, Value>::Hermite3(
+template<typename Value_, typename Argument_>
+Hermite3<Argument_, Value_>::Hermite3(
     std::pair<Argument, Argument> arguments,
     std::pair<Value, Value> const& values,
     std::pair<Derivative1, Derivative1> const& derivatives)
@@ -45,28 +45,29 @@ Hermite3<Argument, Value>::Hermite3(
             (derivatives.first + derivatives.second) * one_over_Δargument²;
 }
 
-template<typename Argument, typename Value>
-Value Hermite3<Argument, Value>::Evaluate(Argument const& argument) const {
+template<typename Value_, typename Argument_>
+Value_ Hermite3<Argument_, Value_>::Evaluate(Argument const& argument) const {
   Difference<Argument> const Δargument = argument - arguments_.first;
   return (((a3_ * Δargument + a2_) * Δargument) + a1_) * Δargument + a0_;
 }
 
-template<typename Argument, typename Value>
-typename Hermite3<Argument, Value>::Derivative1
-Hermite3<Argument, Value>::EvaluateDerivative(Argument const& argument) const {
+template<typename Value_, typename Argument_>
+typename Hermite3<Argument_, Value_>::Derivative1
+Hermite3<Argument_, Value_>::
+EvaluateDerivative(Argument const& argument) const {
   Difference<Argument> const Δargument = argument - arguments_.first;
   return ((3.0 * a3_ * Δargument + 2.0 * a2_) * Δargument) + a1_;
 }
 
-template<typename Argument, typename Value>
-BoundedArray<Argument, 2> Hermite3<Argument, Value>::FindExtrema() const {
+template<typename Value_, typename Argument_>
+BoundedArray<Argument_, 2> Hermite3<Argument_, Value_>::FindExtrema() const {
   return SolveQuadraticEquation<Argument, Derivative1>(
       arguments_.first, a1_, 2.0 * a2_, 3.0 * a3_);
 }
 
-template<typename Argument, typename Value>
+template<typename Value_, typename Argument_>
 template<typename Samples>
-auto Hermite3<Argument, Value>::LInfinityError(
+auto Hermite3<Argument_, Value_>::LInfinityError(
     Samples const& samples,
     std::function<Argument const&(typename Samples::value_type const&)> const&
         get_argument,

--- a/numerics/hermite3_test.cpp
+++ b/numerics/hermite3_test.cpp
@@ -42,7 +42,7 @@ class Hermite3Test : public ::testing::Test {
 };
 
 TEST_F(Hermite3Test, Precomputed) {
-  Hermite3<Instant, Length> h({t0_ + 1 * Second, t0_ + 2 * Second},
+  Hermite3<Length, Instant> h({t0_ + 1 * Second, t0_ + 2 * Second},
                               {33 * Metre, 40 * Metre},
                               {-5 * Metre / Second, 6 * Metre / Second});
 
@@ -66,7 +66,7 @@ TEST_F(Hermite3Test, Precomputed) {
 
 TEST_F(Hermite3Test, Typed) {
   // Just here to check that the types work in the presence of affine spaces.
-  Hermite3<Instant, Position<World>> h({t0_ + 1 * Second, t0_ + 2 * Second},
+  Hermite3<Position<World>, Instant> h({t0_ + 1 * Second, t0_ + 2 * Second},
                                        {World::origin, World::origin},
                                        {World::unmoving, World::unmoving});
 
@@ -78,7 +78,7 @@ TEST_F(Hermite3Test, Typed) {
 // the end of the interpolation interval is different from the expected one.
 // In particular, the computed position is negative at both ends.
 TEST_F(Hermite3Test, Conditioning) {
-  Hermite3<Instant, Length> h(
+  Hermite3<Length, Instant> h(
       {t0_ + 19418861.806896236 * Second, t0_ + 19418869.842261545 * Second},
       {-2.1383610158805017e-12 * Metre, 0 * Metre},
       {2.3308208035605881e-12 * Metre / Second,
@@ -129,7 +129,7 @@ TEST_F(Hermite3Test, ThreeDimensionalInterpolationError) {
                                                  Sin(ω * (t - t0_)) * Metre,
                                                  0 * Metre})});
   }
-  const auto not_a_circle = Hermite3<Instant, Position<World>>(
+  const auto not_a_circle = Hermite3<Position<World>, Instant>(
       /*arguments=*/{t0_, tmax},
       /*values=*/
       {World::origin + Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre}),

--- a/numerics/poisson_series.hpp
+++ b/numerics/poisson_series.hpp
@@ -67,8 +67,6 @@ class PoissonSeries {
   using PeriodicPolynomial =
       PolynomialInMonomialBasis<Value, Instant, periodic_degree_>;
 
-  // TODO(phl): Use designated initializers for this struct once this project
-  // can be compiled using c++latest.
   // TODO(phl): If we wanted to have Poisson series returning affine values,
   // these polynomials should be changed to return Difference<Value>.
   struct Polynomials {

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -145,8 +145,6 @@ class UnboundedMatrix final {
 
   int rows() const;
   int columns() const;
-  // TODO(phl): The meaning of |size| for matrices is unclear.
-  int size() const;
 
   Scalar FrobeniusNorm() const;
 
@@ -191,7 +189,6 @@ class UnboundedLowerTriangularMatrix final {
 
   int rows() const;
   int columns() const;
-  int size() const;
 
   // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
   // If i and j do not satisfy these conditions, the expression |a(i, j)|
@@ -244,7 +241,6 @@ class UnboundedUpperTriangularMatrix final {
 
   int rows() const;
   int columns() const;
-  int size() const;
 
  private:
   // For ease of writing matrices in tests, the input data is received in row-

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -28,8 +28,6 @@ using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_si;
 
-// TODO(phl): The tests should be more similar to those for fixed arrays.
-
 // An allocator that does not initialize the allocated objects.
 template<class T>
 class uninitialized_allocator : public std::allocator<T> {

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -70,6 +70,8 @@ class UnboundedVector final {
   Scalar& operator[](int index);
   Scalar const& operator[](int index) const;
 
+  UnboundedVector& operator=(std::initializer_list<Scalar> right);
+
   UnboundedVector& operator+=(UnboundedVector const& right);
   UnboundedVector& operator-=(UnboundedVector const& right);
   UnboundedVector& operator*=(double right);
@@ -136,6 +138,8 @@ class UnboundedMatrix final {
       operator()(UnboundedVector<LScalar> const& left,
                  UnboundedVector<RScalar> const& right) const;
 
+  UnboundedMatrix& operator=(std::initializer_list<Scalar> right);
+
   UnboundedMatrix& operator+=(UnboundedMatrix const& right);
   UnboundedMatrix& operator-=(UnboundedMatrix const& right);
   UnboundedMatrix& operator*=(double right);
@@ -179,6 +183,15 @@ class UnboundedLowerTriangularMatrix final {
   friend bool operator!=(UnboundedLowerTriangularMatrix const& left,
                          UnboundedLowerTriangularMatrix const& right) = default;
 
+  // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
+  // If i and j do not satisfy these conditions, the expression |a(i, j)|
+  // implies undefined behaviour.
+  Scalar& operator()(int row, int column);
+  Scalar const& operator()(int row, int column) const;
+
+  UnboundedLowerTriangularMatrix& operator=(
+      std::initializer_list<Scalar> right);
+
   void Extend(int extra_rows);
   void Extend(int extra_rows, uninitialized_t);
 
@@ -189,12 +202,6 @@ class UnboundedLowerTriangularMatrix final {
 
   int rows() const;
   int columns() const;
-
-  // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
-  // If i and j do not satisfy these conditions, the expression |a(i, j)|
-  // implies undefined behaviour.
-  Scalar& operator()(int row, int column);
-  Scalar const& operator()(int row, int column) const;
 
  private:
   int rows_;
@@ -230,6 +237,9 @@ class UnboundedUpperTriangularMatrix final {
   // implies undefined behaviour.
   Scalar& operator()(int row, int column);
   Scalar const& operator()(int row, int column) const;
+
+  UnboundedUpperTriangularMatrix& operator=(
+      std::initializer_list<Scalar> right);
 
   void Extend(int extra_columns);
   void Extend(int extra_columns, uninitialized_t);

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -67,7 +67,7 @@ template<typename Scalar_>
 UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator=(
     std::initializer_list<Scalar> right) {
   DCHECK_EQ(data_.size(), right.size());
-  data_ = right;
+  data_ = std::move(right);
   return *this;
 }
 
@@ -240,9 +240,9 @@ UnboundedMatrix<Scalar_>::operator()(
 
 template<typename Scalar_>
 UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator=(
-    std::initializer_list<Scalar> const right) {
+    std::initializer_list<Scalar> right) {
   DCHECK_EQ(data_.size(), right.size());
-  data_ = right;
+  data_ = std::move(right);
   return *this;
 }
 
@@ -378,7 +378,7 @@ UnboundedLowerTriangularMatrix<Scalar_>&
 UnboundedLowerTriangularMatrix<Scalar_>::operator=(
     std::initializer_list<Scalar> right) {
   DCHECK_EQ(data_.size(), right.size());
-  data_ = right;
+  data_ = std::move(right);
   return *this;
 }
 
@@ -479,7 +479,7 @@ UnboundedUpperTriangularMatrix<Scalar_>&
 UnboundedUpperTriangularMatrix<Scalar_>::operator=(
     std::initializer_list<Scalar> right) {
   DCHECK_EQ(data_.size(), right.size());
-  data_ = Transpose(right,
+  data_ = Transpose(std::move(right),
                     /*current_columns=*/0,
                     /*extra_columns=*/columns_);
 return *this;

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -235,7 +235,7 @@ UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator+=(
     UnboundedMatrix const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < size(); ++i) {
+  for (int i = 0; i < data_.size(); ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
@@ -246,7 +246,7 @@ UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator-=(
     UnboundedMatrix const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < size(); ++i) {
+  for (int i = 0; i < data_.size(); ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
@@ -284,11 +284,6 @@ int UnboundedMatrix<Scalar_>::rows() const {
 template<typename Scalar_>
 int UnboundedMatrix<Scalar_>::columns() const {
   return columns_;
-}
-
-template<typename Scalar_>
-int UnboundedMatrix<Scalar_>::size() const {
-  return rows_ * columns_;
 }
 
 template<typename Scalar_>
@@ -381,11 +376,6 @@ int UnboundedLowerTriangularMatrix<Scalar_>::rows() const {
 template<typename Scalar_>
 int UnboundedLowerTriangularMatrix<Scalar_>::columns() const {
   return rows_;
-}
-
-template<typename Scalar_>
-int UnboundedLowerTriangularMatrix<Scalar_>::size() const {
-  return data_.size();
 }
 
 template<typename Scalar_>
@@ -503,11 +493,6 @@ int UnboundedUpperTriangularMatrix<Scalar_>::rows() const {
 template<typename Scalar_>
 int UnboundedUpperTriangularMatrix<Scalar_>::columns() const {
   return columns_;
-}
-
-template<typename Scalar_>
-int UnboundedUpperTriangularMatrix<Scalar_>::size() const {
-  return data_.size();
 }
 
 template<typename Scalar_>

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -64,6 +64,14 @@ Scalar_ const& UnboundedVector<Scalar_>::operator[](int const index) const {
 }
 
 template<typename Scalar_>
+UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator=(
+    std::initializer_list<Scalar> right) {
+  DCHECK_EQ(data_.size(), right.size());
+  data_ = right;
+  return *this;
+}
+
+template<typename Scalar_>
 UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator+=(
     UnboundedVector const& right) {
   DCHECK_EQ(size(), right.size());
@@ -231,6 +239,14 @@ UnboundedMatrix<Scalar_>::operator()(
 }
 
 template<typename Scalar_>
+UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator=(
+    std::initializer_list<Scalar> const right) {
+  DCHECK_EQ(data_.size(), right.size());
+  data_ = right;
+  return *this;
+}
+
+template<typename Scalar_>
 UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator+=(
     UnboundedMatrix const& right) {
   DCHECK_EQ(rows(), right.rows());
@@ -340,6 +356,33 @@ UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
 }
 
 template<typename Scalar_>
+Scalar_& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
+    int const row, int const column) {
+  DCHECK_LE(0, column);
+  DCHECK_LE(column, row);
+  DCHECK_LT(row, rows_);
+  return data_[row * (row + 1) / 2 + column];
+}
+
+template<typename Scalar_>
+Scalar_ const& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
+    int const row, int const column) const {
+  DCHECK_LE(0, column);
+  DCHECK_LE(column, row);
+  DCHECK_LT(row, rows_);
+  return data_[row * (row + 1) / 2 + column];
+}
+
+template<typename Scalar_>
+UnboundedLowerTriangularMatrix<Scalar_>&
+UnboundedLowerTriangularMatrix<Scalar_>::operator=(
+    std::initializer_list<Scalar> right) {
+  DCHECK_EQ(data_.size(), right.size());
+  data_ = right;
+  return *this;
+}
+
+template<typename Scalar_>
 void UnboundedLowerTriangularMatrix<Scalar_>::Extend(int const extra_rows) {
   rows_ += extra_rows;
   data_.resize(rows_ * (rows_ + 1) / 2, Scalar{});
@@ -376,24 +419,6 @@ int UnboundedLowerTriangularMatrix<Scalar_>::rows() const {
 template<typename Scalar_>
 int UnboundedLowerTriangularMatrix<Scalar_>::columns() const {
   return rows_;
-}
-
-template<typename Scalar_>
-Scalar_& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) {
-  DCHECK_LE(0, column);
-  DCHECK_LE(column, row);
-  DCHECK_LT(row, rows_);
-  return data_[row * (row + 1) / 2 + column];
-}
-
-template<typename Scalar_>
-Scalar_ const& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) const {
-  DCHECK_LE(0, column);
-  DCHECK_LE(column, row);
-  DCHECK_LT(row, rows_);
-  return data_[row * (row + 1) / 2 + column];
 }
 
 template<typename Scalar_>
@@ -447,6 +472,17 @@ Scalar_ const& UnboundedUpperTriangularMatrix<Scalar_>::operator()(
   DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
   return data_[column * (column + 1) / 2 + row];
+}
+
+template<typename Scalar_>
+UnboundedUpperTriangularMatrix<Scalar_>&
+UnboundedUpperTriangularMatrix<Scalar_>::operator=(
+    std::initializer_list<Scalar> right) {
+  DCHECK_EQ(data_.size(), right.size());
+  data_ = Transpose(right,
+                    /*current_columns=*/0,
+                    /*extra_columns=*/columns_);
+return *this;
 }
 
 template<typename Scalar_>

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -196,7 +196,6 @@ TEST_F(UnboundedArraysTest, MatrixIndexing) {
 }
 
 TEST_F(UnboundedArraysTest, LowerTriangularMatrixIndexing) {
-  EXPECT_EQ(10, l4_.size());
   EXPECT_EQ(1, l4_(0, 0));
   EXPECT_EQ(2, l4_(1, 0));
   EXPECT_EQ(3, l4_(1, 1));
@@ -215,7 +214,6 @@ TEST_F(UnboundedArraysTest, LowerTriangularMatrixIndexing) {
 }
 
 TEST_F(UnboundedArraysTest, UpperTriangularMatrixIndexing) {
-  EXPECT_EQ(10, u4_.size());
   EXPECT_EQ(1, u4_(0, 0));
   EXPECT_EQ(2, u4_(0, 1));
   EXPECT_EQ(3, u4_(0, 2));

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -55,7 +55,7 @@ TEST_F(UnboundedArraysTest, Assignment) {
     UnboundedVector<double> u2({1, 2});
     UnboundedVector<double> v2 = {{1, 2}};
     UnboundedVector<double> w2(2);
-    w2 = {{1, 2}};
+    w2 = {1, 2};
     EXPECT_EQ(u2, v2);
     EXPECT_EQ(u2, w2);
   }
@@ -69,8 +69,8 @@ TEST_F(UnboundedArraysTest, Assignment) {
     UnboundedMatrix<double> n23 = {2, 3,
                                    {0, 0, 0,
                                     0, 0, 0}};
-    n23 = {{1, 2, 3,
-            4, 5, 6}};
+    n23 = {1, 2, 3,
+           4, 5, 6};
     EXPECT_EQ(l23, m23);
     EXPECT_EQ(l23, n23);
   }
@@ -86,9 +86,9 @@ TEST_F(UnboundedArraysTest, Assignment) {
                                                   0, 0, 0}};
     UnboundedLowerTriangularMatrix<double> o3(3);
     EXPECT_EQ(o3, n3);
-    n3 = {{1,
-           2, 3,
-           4, 5, 6}};
+    n3 = {1,
+          2, 3,
+          4, 5, 6};
     EXPECT_EQ(l3, m3);
     EXPECT_EQ(l3, n3);
   }
@@ -104,9 +104,9 @@ TEST_F(UnboundedArraysTest, Assignment) {
                                                         0}};
     UnboundedUpperTriangularMatrix<double> o3(3);
     EXPECT_EQ(o3, n3);
-    n3 = {{1, 2, 3,
-              4, 5,
-                 6}};
+    n3 = {1, 2, 3,
+             4, 5,
+                6};
     EXPECT_EQ(l3, m3);
     EXPECT_EQ(l3, n3);
   }

--- a/numerics/unbounded_arrays_test.cpp
+++ b/numerics/unbounded_arrays_test.cpp
@@ -69,11 +69,8 @@ TEST_F(UnboundedArraysTest, Assignment) {
     UnboundedMatrix<double> n23 = {2, 3,
                                    {0, 0, 0,
                                     0, 0, 0}};
-    // TODO(phl): It would be convenient to have an operator= taking an
-    // initializer list.
-    n23 = UnboundedMatrix<double>(2, 3,
-                                  {1, 2, 3,
-                                   4, 5, 6});
+    n23 = {{1, 2, 3,
+            4, 5, 6}};
     EXPECT_EQ(l23, m23);
     EXPECT_EQ(l23, n23);
   }

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -93,7 +93,7 @@ void ComputeApsides(Trajectory<Frame> const& reference,
 
       // The derivative of |squared_distance| changed sign.  Construct a Hermite
       // approximation of |squared_distance| and find its extrema.
-      Hermite3<Instant, Square<Length>> const
+      Hermite3<Square<Length>, Instant> const
           squared_distance_approximation(
               {*previous_time, time},
               {*previous_squared_distance, squared_distance},
@@ -440,7 +440,7 @@ absl::Status ComputeNodes(
 
       // |z| changed sign.  Construct a Hermite approximation of |z| and find
       // its zeros.
-      Hermite3<Instant, Length> const z_approximation(
+      Hermite3<Length, Instant> const z_approximation(
           {*previous_time, time},
           {*previous_z, z},
           {*previous_z_speed, z_speed});

--- a/physics/discrete_trajectory_segment.hpp
+++ b/physics/discrete_trajectory_segment.hpp
@@ -195,7 +195,7 @@ class DiscreteTrajectorySegment : public Trajectory<Frame> {
 
   // Returns the Hermite interpolation for the left-open, right-closed
   // trajectory segment bounded above by |upper|.
-  Hermite3<Instant, Position<Frame>> GetInterpolation(
+  Hermite3<Position<Frame>, Instant> GetInterpolation(
       typename Timeline::const_iterator upper) const;
 
   typename Timeline::const_iterator timeline_begin() const;

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -529,7 +529,7 @@ absl::Status DiscreteTrajectorySegment<Frame>::DownsampleIfNeeded() {
     }
 
     absl::StatusOr<std::list<typename ConstIterators::const_iterator>>
-        right_endpoints = FitHermiteSpline<Instant, Position<Frame>>(
+        right_endpoints = FitHermiteSpline<Position<Frame>, Instant>(
             dense_iterators,
             [](auto&& it) -> auto&& { return it->time; },
             [](auto&& it) -> auto&& {
@@ -573,14 +573,14 @@ absl::Status DiscreteTrajectorySegment<Frame>::DownsampleIfNeeded() {
 }
 
 template<typename Frame>
-Hermite3<Instant, Position<Frame>>
+Hermite3<Position<Frame>, Instant>
 DiscreteTrajectorySegment<Frame>::GetInterpolation(
     typename Timeline::const_iterator const upper) const {
   CHECK(upper != timeline_.cbegin());
   auto const lower = std::prev(upper);
   auto const& [lower_time, lower_degrees_of_freedom] = *lower;
   auto const& [upper_time, upper_degrees_of_freedom] = *upper;
-  return Hermite3<Instant, Position<Frame>>{
+  return Hermite3<Position<Frame>, Instant>{
       {lower_time, upper_time},
       {lower_degrees_of_freedom.position(),
        upper_degrees_of_freedom.position()},


### PR DESCRIPTION
1. Reorder the template parameters of `Hermite3`.
2. Move construction for matrices.
3. No `size` for matrices.
4. Remove a few obsolote TODOs.