### PR TITLE
Our C++ is too modern for clang

### DIFF
--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -262,8 +262,13 @@ TEST_P(PluginCompatibilityTest, Reach) {
   // Saturn flyby from the video; however, the Saturn flyby seems to be missing
   // from this flight plan even if it is extended further.
   EXPECT_THAT(flybys, SizeIs(Ge(10)));
+#if PRINCIPIA_COMPILER_MSVC
   std::span const first_10_flybys(flybys.begin(), 10);
   std::span const subsequent_flybys(flybys.begin() + 10, flybys.end());
+#else  // TODO(egg): Remove when clang really has C++23.
+  std::vector const first_10_flybys(flybys.begin(), flybys.begin() + 10);
+  std::vector const subsequent_flybys(flybys.begin() + 10, flybys.end());
+#endif
   EXPECT_THAT(
       first_10_flybys,
       ElementsAre(
@@ -284,7 +289,7 @@ TEST_P(PluginCompatibilityTest, Reach) {
     EXPECT_THAT(subsequent_flybys, IsEmpty());
   } else {
     EXPECT_THAT(
-        subsequent_flybys,
+        first_10_flybys,
         ElementsAre(Pair(  // The video has             21:57.
                         ResultOf(&TTSecond, "1978-08-07T21:58:49"_DateTime),
                         "Earth"),


### PR DESCRIPTION
ElementsAre ends up using `std::span::const_iterator` which [is C++23](https://en.cppreference.com/w/cpp/container/span).