### PR TITLE
Fix the flight optimizer test

### DIFF
--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -232,7 +232,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      IsNear(7.51_(1) * Micro(Second)));
+      IsNear(7.39_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
       IsNear(1.054_(1) * Metre / Second));
@@ -247,11 +247,12 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
               StatusIs(termination_condition::VanishingStepSize));
 
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
-  EXPECT_EQ(manœuvre6.initial_time(),
-            flight_plan_->GetManœuvre(6).initial_time());
+  EXPECT_THAT(
+      manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
+      IsNear(12.1_(1) * Micro(Second)));
   EXPECT_THAT((manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
-              IsNear(1.283_(1) * Metre / Second));
-  EXPECT_EQ(91, number_of_evaluations);
+              IsNear(1.292_(1) * Metre / Second));
+  EXPECT_EQ(124, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
@@ -264,11 +265,11 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      IsNear(103_(1) * Milli(Second)));
+      IsNear(-77_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
-      IsNear(61.6_(1) * Metre / Second));
-  EXPECT_EQ(106, number_of_evaluations);
+      IsNear(61.9_(1) * Metre / Second));
+  EXPECT_EQ(102, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));
@@ -299,7 +300,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      IsNear(34.2_(1) * Micro(Second)));
+      IsNear(43.8_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
       IsNear(1.116_(1) * Metre / Second));
@@ -336,15 +337,15 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      IsNear(3.3_(1) * Milli(Second)));
+      IsNear(2.1_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
-      IsNear(62.3_(1) * Metre / Second));
+      IsNear(59.3_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:15:12"_DateTime));
-  EXPECT_THAT(flyby_distance, IsNear(1999.6_(1) * Kilo(Metre)));
-  EXPECT_EQ(75, number_of_evaluations);
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:14:59"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2000.2_(1) * Kilo(Metre)));
+  EXPECT_EQ(86, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));
@@ -440,7 +441,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      IsNear(0.61_(1) * Milli(Second)));
+      IsNear(0.46_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       IsNear(12.7_(1) * Metre / Second));
@@ -448,7 +449,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:08:39"_DateTime));
   EXPECT_THAT(flyby_inclination, IsNear(90.00_(1) * Degree));
-  EXPECT_EQ(60, number_of_evaluations);
+  EXPECT_EQ(54, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));
@@ -481,14 +482,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      IsNear(20.0_(1) * Micro(Second)));
+      IsNear(16.8_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
       IsNear(1.011_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:22:33"_DateTime));
-  EXPECT_THAT(flyby_distance, IsNear(3339.92_(1) * Kilo(Metre)));
+  EXPECT_THAT(flyby_distance, IsNear(3339.88_(1) * Kilo(Metre)));
   EXPECT_EQ(146, number_of_evaluations);
 }
 


### PR DESCRIPTION
Now that Reach's save is (correctly) deserialized to not use FMA, the tolerances change a bit.