### PR TITLE
Prerequisites for the implementation of the Stehlé-Zimmermann algorithm

### DIFF
--- a/boost_multiprecision.props
+++ b/boost_multiprecision.props
@@ -6,6 +6,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\Boost\multiprecision\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>BOOST_MP_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/functions/functions.vcxproj
+++ b/functions/functions.vcxproj
@@ -4,11 +4,6 @@
     <ProjectGuid>{7cca653c-2e8f-4ffd-9e9f-bee590f3efab}</ProjectGuid>
     <RootNamespace>functions</RootNamespace>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>BOOST_MP_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="accurate_table_generator.hpp" />
     <ClInclude Include="accurate_table_generator_body.hpp" />

--- a/numerics/polynomial_in_monomial_basis.hpp
+++ b/numerics/polynomial_in_monomial_basis.hpp
@@ -151,6 +151,7 @@ class PolynomialInMonomialBasis : public Polynomial<Value_, Argument_> {
   constexpr int degree() const override;
   bool is_zero() const override;
 
+  Coefficients const& coefficients() const;
   Argument const& origin() const;
 
   // Returns a copy of this polynomial adjusted to the given origin.
@@ -355,10 +356,10 @@ operator-(Value const& left,
 // Application monoid.
 
 template<typename LValue, typename RValue,
-         typename Argument, int ldegree_, int rdegree_>
-constexpr PolynomialInMonomialBasis<LValue, Argument, ldegree_ * rdegree_>
+         typename RArgument, int ldegree_, int rdegree_>
+constexpr PolynomialInMonomialBasis<LValue, RArgument, ldegree_ * rdegree_>
 Compose(PolynomialInMonomialBasis<LValue, RValue, ldegree_> const& left,
-        PolynomialInMonomialBasis<RValue, Argument, rdegree_> const& right);
+        PolynomialInMonomialBasis<RValue, RArgument, rdegree_> const& right);
 
 // Returns a scalar polynomial obtained by pointwise inner product of two
 // vector-valued polynomials.

--- a/numerics/polynomial_in_monomial_basis_body.hpp
+++ b/numerics/polynomial_in_monomial_basis_body.hpp
@@ -12,7 +12,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "base/not_constructible.hpp"
-#include "boost/multiprecision/fwd.hpp"
+#include "boost/multiprecision/number.hpp"
 #include "geometry/cartesian_product.hpp"
 #include "geometry/serialization.hpp"
 #include "numerics/combinatorics.hpp"

--- a/numerics/polynomial_in_monomial_basis_test.cpp
+++ b/numerics/polynomial_in_monomial_basis_test.cpp
@@ -332,7 +332,7 @@ TEST_F(PolynomialInMonomialBasisTest, Monoid) {
   }
   {
     auto const actual = Compose(p1a, p2a)(t0 + 1 * Second);
-    EXPECT_THAT(actual, AlmostEquals(26 * Ampere, 0));
+    EXPECT_THAT(actual, AlmostEquals(30 * Ampere, 0));
   }
 }
 
@@ -452,15 +452,15 @@ TEST_F(PolynomialInMonomialBasisTest, EvaluateLinear) {
 TEST_F(PolynomialInMonomialBasisTest, Boost) {
   using P2i = PolynomialInMonomialBasis<cpp_int, cpp_int, 2>;
   P2i const p2i({1, 3, -8});
-  EXPECT_EQ(p2i(3), -185);
+  EXPECT_EQ(p2i(3), -62);
 
   using P2r = PolynomialInMonomialBasis<cpp_rational, cpp_rational, 2>;
   P2r const p2r({1, 3, -8});
-  EXPECT_EQ(p2r(cpp_rational(1, 3)), cpp_rational(37, 27));
+  EXPECT_EQ(p2r(cpp_rational(1, 3)), cpp_rational(10, 9));
 
   using P2f = PolynomialInMonomialBasis<cpp_bin_float_50, cpp_bin_float_50, 2>;
   P2f const p2f({1, 3, -8});
-  EXPECT_EQ(p2f(cpp_bin_float_50("1.3")), cpp_bin_float_50("-10.206"));
+  EXPECT_EQ(p2f(cpp_bin_float_50("1.25")), cpp_bin_float_50("-7.75"));
 }
 
 // Check that polynomials may be serialized.

--- a/quantities/concepts.hpp
+++ b/quantities/concepts.hpp
@@ -15,6 +15,8 @@ using namespace base::_traits;
 using namespace quantities::_quantities;
 
 // TODO(egg): additive_group should subsume affine, but we use it there.
+// We use |convertible_to| here because we want this concept to work with
+// Boost multiprecision types which heavily use implicit conversions.
 template<typename G>
 concept additive_group = requires(G x, G y, int n) {
   G{};
@@ -34,10 +36,10 @@ concept additive_group = requires(G x, G y, int n) {
 template<typename A>
 concept affine = requires(A x, A y) {
   { x - y } -> additive_group;
-  { y + (x - y) } -> std::convertible_to<A>;
-  { y += (x - y) } -> std::convertible_to<A&>;
-  { y - (x - y) } -> std::convertible_to<A>;
-  { y -= (x - y) } -> std::convertible_to<A&>;
+  { y + (x - y) } -> std::same_as<A>;
+  { y += (x - y) } -> std::same_as<A&>;
+  { y - (x - y) } -> std::same_as<A>;
+  { y -= (x - y) } -> std::same_as<A&>;
 };
 
 // A graded ring restricted to its homogeneous elements; multiplication can
@@ -48,13 +50,13 @@ concept homogeneous_ring =
       // Really, multiplication should return a homogeneous_ring.
       { x * y } -> additive_group;
       { (x * y) * z } -> additive_group;
-      { (x * y) * z } -> std::convertible_to<decltype(x * (y * z))>;
+      { (x * y) * z } -> std::same_as<decltype(x * (y * z))>;
 };
 
 template<typename A>
 concept ring = homogeneous_ring<A> && requires(A x, A y) {
-  { x * y } -> std::convertible_to<A>;
-  { x *= y } -> std::convertible_to<A&>;
+  { x * y } -> std::same_as<A>;
+  { x *= y } -> std::same_as<A&>;
 };
 
 // TODO(egg): field should subsume homogeneous_field, but we use it in
@@ -63,9 +65,9 @@ concept ring = homogeneous_ring<A> && requires(A x, A y) {
 template<typename K>
 concept field = ring<K> && !std::integral<K> && requires(K x, K y, K z) {
   { 1 } -> std::convertible_to<K>;
-  { 1 / y } -> std::convertible_to<K>;
-  { x / y } -> std::convertible_to<K>;
-  { x /= y } -> std::convertible_to<K&>;
+  { 1 / y } -> std::same_as<K>;
+  { x / y } -> std::same_as<K>;
+  { x /= y } -> std::same_as<K&>;
 };
 
 // TODO(egg): vector_space should subsume homogeneous_vector_space, but we use
@@ -73,11 +75,11 @@ concept field = ring<K> && !std::integral<K> && requires(K x, K y, K z) {
 
 template<typename V, typename K>
 concept vector_space = field<K> && requires(K λ, V v) {
-      { λ * v } -> std::convertible_to<V>;
-      { v * λ } -> std::convertible_to<V>;
-      { v / λ } -> std::convertible_to<V>;
-      { v *= λ } -> std::convertible_to<V&>;
-      { v /= λ } -> std::convertible_to<V&>;
+      { λ * v } -> std::same_as<V>;
+      { v * λ } -> std::same_as<V>;
+      { v / λ } -> std::same_as<V>;
+      { v *= λ } -> std::same_as<V&>;
+      { v /= λ } -> std::same_as<V&>;
     };
 
 // A graded field restricted to its homogeneous elements; multiplication and
@@ -88,9 +90,9 @@ concept homogeneous_field = homogeneous_ring<K> && requires(K x, K y, K z) {
   { x / y } -> field;
   requires vector_space<K, decltype(x / y)>;
   { (1 / x) } -> homogeneous_ring;
-  { 1 / (x * y) } -> std::convertible_to<decltype((1 / x) * (1 / y))>;
-  { (x * y) / z } -> std::convertible_to<K>;
-  { (x / y) * z } -> std::convertible_to<K>;
+  { 1 / (x * y) } -> std::same_as<decltype((1 / x) * (1 / y))>;
+  { (x * y) / z } -> std::same_as<K>;
+  { (x / y) * z } -> std::same_as<K>;
 };
 
 template<typename V, typename K>
@@ -99,11 +101,11 @@ concept homogeneous_vector_space =
       // Really, these operations should return a homogeneous_vector_space.
       requires vector_space<V, decltype(λ / μ)>;
       { λ * v } -> additive_group;
-      { v * λ } -> std::convertible_to<decltype(λ * v)>;
+      { v * λ } -> std::same_as<decltype(λ * v)>;
       { v / λ } -> additive_group;
-      { λ * v / λ } -> std::convertible_to<V>;
+      { λ * v / λ } -> std::same_as<V>;
       { (λ * μ) * v } -> additive_group;
-      { λ * (μ * v) } -> std::convertible_to<decltype((λ * μ) * v)>;
+      { λ * (μ * v) } -> std::same_as<decltype((λ * μ) * v)>;
     };
 
 template<typename V>
@@ -118,7 +120,7 @@ template<typename V>
 concept real_affine_space = affine_space<V, double>;
 
 template<typename T>
-concept quantity = instance<T, Quantity> || std::convertible_to<T, double>;
+concept quantity = instance<T, Quantity> || std::same_as<T, double>;
 
 // std::integral || std::floating_point rather than
 // std::convertible_to<double, T> because

--- a/quantities/concepts.hpp
+++ b/quantities/concepts.hpp
@@ -18,26 +18,26 @@ using namespace quantities::_quantities;
 template<typename G>
 concept additive_group = requires(G x, G y, int n) {
   G{};
-  { +x } -> std::same_as<G>;
-  { -x } -> std::same_as<G>;
-  { x + y } -> std::same_as<G>;
-  { x - y } -> std::same_as<G>;
-  { x += y } -> std::same_as<G&>;
-  { x -= y } -> std::same_as<G&>;
+  { +x } -> std::convertible_to<G>;
+  { -x } -> std::convertible_to<G>;
+  { x + y } -> std::convertible_to<G>;
+  { x - y } -> std::convertible_to<G>;
+  { x += y } -> std::convertible_to<G&>;
+  { x -= y } -> std::convertible_to<G&>;
   // An abelian group is a ℤ-module; we require the corresponding operations.
-  { n * x } -> std::same_as<G>;
-  { x * n } -> std::same_as<G>;
-  { x *= n } -> std::same_as<G&>;
+  { n * x } -> std::convertible_to<G>;
+  { x * n } -> std::convertible_to<G>;
+  { x *= n } -> std::convertible_to<G&>;
 };
 
 // A set acted upon simply transitively by an additive group.
 template<typename A>
 concept affine = requires(A x, A y) {
   { x - y } -> additive_group;
-  { y + (x - y) } -> std::same_as<A>;
-  { y += (x - y) } -> std::same_as<A&>;
-  { y - (x - y) } -> std::same_as<A>;
-  { y -= (x - y) } -> std::same_as<A&>;
+  { y + (x - y) } -> std::convertible_to<A>;
+  { y += (x - y) } -> std::convertible_to<A&>;
+  { y - (x - y) } -> std::convertible_to<A>;
+  { y -= (x - y) } -> std::convertible_to<A&>;
 };
 
 // A graded ring restricted to its homogeneous elements; multiplication can
@@ -48,13 +48,13 @@ concept homogeneous_ring =
       // Really, multiplication should return a homogeneous_ring.
       { x * y } -> additive_group;
       { (x * y) * z } -> additive_group;
-      { (x * y) * z } -> std::same_as<decltype(x * (y * z))>;
+      { (x * y) * z } -> std::convertible_to<decltype(x * (y * z))>;
 };
 
 template<typename A>
 concept ring = homogeneous_ring<A> && requires(A x, A y) {
-  { x * y } -> std::same_as<A>;
-  { x *= y } -> std::same_as<A&>;
+  { x * y } -> std::convertible_to<A>;
+  { x *= y } -> std::convertible_to<A&>;
 };
 
 // TODO(egg): field should subsume homogeneous_field, but we use it in
@@ -63,9 +63,9 @@ concept ring = homogeneous_ring<A> && requires(A x, A y) {
 template<typename K>
 concept field = ring<K> && !std::integral<K> && requires(K x, K y, K z) {
   { 1 } -> std::convertible_to<K>;
-  { 1 / y } -> std::same_as<K>;
-  { x / y } -> std::same_as<K>;
-  { x /= y } -> std::same_as<K&>;
+  { 1 / y } -> std::convertible_to<K>;
+  { x / y } -> std::convertible_to<K>;
+  { x /= y } -> std::convertible_to<K&>;
 };
 
 // TODO(egg): vector_space should subsume homogeneous_vector_space, but we use
@@ -73,11 +73,11 @@ concept field = ring<K> && !std::integral<K> && requires(K x, K y, K z) {
 
 template<typename V, typename K>
 concept vector_space = field<K> && requires(K λ, V v) {
-      { λ * v } -> std::same_as<V>;
-      { v * λ } -> std::same_as<V>;
-      { v / λ } -> std::same_as<V>;
-      { v *= λ } -> std::same_as<V&>;
-      { v /= λ } -> std::same_as<V&>;
+      { λ * v } -> std::convertible_to<V>;
+      { v * λ } -> std::convertible_to<V>;
+      { v / λ } -> std::convertible_to<V>;
+      { v *= λ } -> std::convertible_to<V&>;
+      { v /= λ } -> std::convertible_to<V&>;
     };
 
 // A graded field restricted to its homogeneous elements; multiplication and
@@ -88,9 +88,9 @@ concept homogeneous_field = homogeneous_ring<K> && requires(K x, K y, K z) {
   { x / y } -> field;
   requires vector_space<K, decltype(x / y)>;
   { (1 / x) } -> homogeneous_ring;
-  { 1 / (x * y) } -> std::same_as<decltype((1 / x) * (1 / y))>;
-  { (x * y) / z } -> std::same_as<K>;
-  { (x / y) * z } -> std::same_as<K>;
+  { 1 / (x * y) } -> std::convertible_to<decltype((1 / x) * (1 / y))>;
+  { (x * y) / z } -> std::convertible_to<K>;
+  { (x / y) * z } -> std::convertible_to<K>;
 };
 
 template<typename V, typename K>
@@ -99,11 +99,11 @@ concept homogeneous_vector_space =
       // Really, these operations should return a homogeneous_vector_space.
       requires vector_space<V, decltype(λ / μ)>;
       { λ * v } -> additive_group;
-      { v * λ } -> std::same_as<decltype(λ * v)>;
+      { v * λ } -> std::convertible_to<decltype(λ * v)>;
       { v / λ } -> additive_group;
-      { λ * v / λ } -> std::same_as<V>;
+      { λ * v / λ } -> std::convertible_to<V>;
       { (λ * μ) * v } -> additive_group;
-      { λ * (μ * v) } -> std::same_as<decltype((λ * μ) * v)>;
+      { λ * (μ * v) } -> std::convertible_to<decltype((λ * μ) * v)>;
     };
 
 template<typename V>
@@ -118,7 +118,7 @@ template<typename V>
 concept real_affine_space = affine_space<V, double>;
 
 template<typename T>
-concept quantity = instance<T, Quantity> || std::same_as<T, double>;
+concept quantity = instance<T, Quantity> || std::convertible_to<T, double>;
 
 // std::integral || std::floating_point rather than
 // std::convertible_to<double, T> because

--- a/quantities/elementary_functions.hpp
+++ b/quantities/elementary_functions.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <concepts>
+
+#include "boost/multiprecision/fwd.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 
@@ -8,6 +11,7 @@ namespace quantities {
 namespace _elementary_functions {
 namespace internal {
 
+using namespace boost::multiprecision;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 
@@ -84,6 +88,11 @@ Angle ArcTanh(double x);
 // |previous_angle|.
 Angle UnwindFrom(Angle const& previous_angle, Angle const& α);
 
+// Only dimensionless quantities can be rounded.
+template<typename Q>
+  requires is_number<Q>::value || std::floating_point<Q>
+Q Round(Q const& x);
+
 }  // namespace internal
 
 using internal::Abs;
@@ -104,6 +113,7 @@ using internal::Mod;
 using internal::NextDown;
 using internal::NextUp;
 using internal::Pow;
+using internal::Round;
 using internal::Sin;
 using internal::Sinh;
 using internal::Sqrt;

--- a/quantities/elementary_functions.hpp
+++ b/quantities/elementary_functions.hpp
@@ -2,7 +2,7 @@
 
 #include <concepts>
 
-#include "boost/multiprecision/fwd.hpp"
+#include "boost/multiprecision/number.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 

--- a/quantities/elementary_functions.hpp
+++ b/quantities/elementary_functions.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <concepts>
-
 #include "boost/multiprecision/number.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"

--- a/quantities/elementary_functions_body.hpp
+++ b/quantities/elementary_functions_body.hpp
@@ -7,7 +7,6 @@
 #include <cmath>
 
 #include "boost/multiprecision/cpp_int.hpp"
-#include "boost/multiprecision/fwd.hpp"
 #include "numerics/cbrt.hpp"
 #include "numerics/fma.hpp"
 #include "numerics/next.hpp"

--- a/quantities/elementary_functions_body.hpp
+++ b/quantities/elementary_functions_body.hpp
@@ -30,7 +30,14 @@ Product<Q1, Q2> FusedMultiplyAdd(Q1 const& x,
                                  Q2 const& y,
                                  Product<Q1, Q2> const& z) {
   if constexpr (is_number<Q1>::value || is_number<Q2>::value) {
-    return x * y + z;
+    if constexpr ((std::is_same_v<Q1, cpp_int> ||
+                   std::is_same_v<Q1, cpp_rational>) &&
+                  (std::is_same_v<Q2, cpp_int> ||
+                   std::is_same_v<Q2, cpp_rational>)) {
+      return x * y + z;
+    } else {
+      return fma(x, y, z);
+    }
   } else {
     return si::Unit<Product<Q1, Q2>> *
             numerics::_fma::FusedMultiplyAdd(x / si::Unit<Q1>,

--- a/quantities/elementary_functions_body.hpp
+++ b/quantities/elementary_functions_body.hpp
@@ -30,10 +30,10 @@ Product<Q1, Q2> FusedMultiplyAdd(Q1 const& x,
                                  Q2 const& y,
                                  Product<Q1, Q2> const& z) {
   if constexpr (is_number<Q1>::value || is_number<Q2>::value) {
-    if constexpr ((std::is_same_v<Q1, cpp_int> ||
-                   std::is_same_v<Q1, cpp_rational>) &&
-                  (std::is_same_v<Q2, cpp_int> ||
-                   std::is_same_v<Q2, cpp_rational>)) {
+    if constexpr ((number_category<Q1>::value == number_kind_integer ||
+                   number_category<Q1>::value == number_kind_rational) &&
+                  (number_category<Q2>::value == number_kind_integer ||
+                   number_category<Q2>::value == number_kind_rational)) {
       return x * y + z;
     } else {
       return fma(x, y, z);
@@ -163,7 +163,7 @@ inline constexpr double Pow<3>(double x) {
 
 template<int exponent, typename Q>
 constexpr Exponentiation<Q, exponent> Pow(Q const& x) {
-  if constexpr (std::is_same_v<Q, cpp_rational>) {
+  if constexpr (number_category<Q>::value == number_kind_rational) {
     // It seems that Boost does not define |pow| for |cpp_rational|.
     return cpp_rational(pow(numerator(x), exponent),
                         pow(denominator(x), exponent));

--- a/quantities/generators_body.hpp
+++ b/quantities/generators_body.hpp
@@ -5,7 +5,7 @@
 #include <tuple>
 
 #include "base/not_constructible.hpp"
-#include "boost/multiprecision/fwd.hpp"
+#include "boost/multiprecision/number.hpp"
 #include "quantities/dimensions.hpp"
 
 namespace principia {

--- a/quantities/generators_body.hpp
+++ b/quantities/generators_body.hpp
@@ -5,6 +5,7 @@
 #include <tuple>
 
 #include "base/not_constructible.hpp"
+#include "boost/multiprecision/fwd.hpp"
 #include "quantities/dimensions.hpp"
 
 namespace principia {
@@ -12,6 +13,7 @@ namespace quantities {
 namespace _generators {
 namespace internal {
 
+using namespace boost::multiprecision;
 using namespace principia::base::_not_constructible;
 using namespace principia::quantities::_dimensions;
 
@@ -42,6 +44,12 @@ struct ExponentiationGenerator<double, n> : not_constructible {
 template<int n>
 struct ExponentiationGenerator<int, n> : not_constructible {
   using Type = int;
+};
+
+template<typename Number, int n>
+  requires is_number<Number>::value
+struct ExponentiationGenerator<Number, n> : not_constructible {
+  using Type = Number;
 };
 
 template<template<typename> typename Quantity, typename D, int n>

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -5,12 +5,14 @@
 #include <iostream>
 #include <limits>
 #include <string>
+#include <strstream>
 #include <type_traits>
 
 #include "base/macros.hpp"  // 🧙 For CONSTEXPR_NAN.
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
 #include "base/tags.hpp"
+#include "boost/multiprecision/fwd.hpp"
 #include "quantities/dimensions.hpp"
 #include "quantities/generators.hpp"
 #include "serialization/quantities.pb.h"
@@ -20,6 +22,7 @@ namespace quantities {
 namespace _quantities {
 namespace internal {
 
+using namespace boost::multiprecision;
 using namespace principia::base::_not_constructible;
 using namespace principia::base::_not_null;
 using namespace principia::base::_tags;
@@ -143,6 +146,11 @@ std::string Format();
 
 std::string DebugString(
     double number,
+    int precision = std::numeric_limits<double>::max_digits10);
+template<typename N>
+  requires is_number<N>::value
+std::string DebugString(
+    N const& number,
     int precision = std::numeric_limits<double>::max_digits10);
 template<typename D>
 std::string DebugString(

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <limits>
 #include <string>
-#include <strstream>
 #include <type_traits>
 
 #include "base/macros.hpp"  // 🧙 For CONSTEXPR_NAN.

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -12,7 +12,7 @@
 #include "base/not_constructible.hpp"
 #include "base/not_null.hpp"
 #include "base/tags.hpp"
-#include "boost/multiprecision/fwd.hpp"
+#include "boost/multiprecision/number.hpp"
 #include "quantities/dimensions.hpp"
 #include "quantities/generators.hpp"
 #include "serialization/quantities.pb.h"

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -181,6 +181,12 @@ inline std::string DebugString(double const number, int const precision) {
   return result;
 }
 
+template<typename N>
+  requires is_number<N>::value
+std::string DebugString(N const& number, int const precision) {
+  return number.str();
+}
+
 template<typename D>
 std::string DebugString(Quantity<D> const& quantity, int const precision) {
   return DebugString(quantity / SIUnit<Quantity<D>>(), precision) + " " +


### PR DESCRIPTION
1. Add support for Boost multiprecision types in `quantities`, in particular for elementary functions and tracing.
2. Adjust the concepts so that the Boost multiprecision types are considered to have the appropriate algebraic structure.
3. Fix a bug in the composition of polynomials with nontrivial origins.

#1760.