### PR TITLE
A benchmark to decide on the spacing of accurate values table

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Include="quantities_benchmark.cpp" />
     <ClCompile Include="symplectic_runge_kutta_nyström_integrator_benchmark.cpp" />
     <ClCompile Include="thread_pool_benchmark.cpp" />
+    <ClCompile Include="tradeoffs_benchmark.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp" />

--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="checkpointer_benchmark.cpp" />
     <ClCompile Include="discrete_trajectory_benchmark.cpp" />
     <ClCompile Include="elementary_functions_benchmark.cpp" />
+    <ClCompile Include="elementary_functions_experiments_benchmark.cpp" />
     <ClCompile Include="lagrange_equipotentials_benchmark.cpp" />
     <ClCompile Include="polynomial_in_monomial_basis_benchmark.cpp" />
     <ClCompile Include="polynomial_in_чебышёв_basis_benchmark.cpp" />
@@ -40,7 +41,6 @@
     <ClCompile Include="quantities_benchmark.cpp" />
     <ClCompile Include="symplectic_runge_kutta_nyström_integrator_benchmark.cpp" />
     <ClCompile Include="thread_pool_benchmark.cpp" />
-    <ClCompile Include="tradeoffs_benchmark.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp" />

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -89,7 +89,7 @@
     <ClCompile Include="elementary_functions_benchmark.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="tradeoffs_benchmark.cpp">
+    <ClCompile Include="elementary_functions_experiments_benchmark.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClCompile Include="elementary_functions_benchmark.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="tradeoffs_benchmark.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="quantities.hpp">

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -21,6 +21,7 @@ constexpr Argument x_min = π / 12;
 constexpr Argument x_max = π / 6;
 static constexpr std::int64_t number_of_iterations = 1000;
 
+// A helper class to benchmark implementations with various table spacings.
 template<Argument table_spacing>
 class Implementation {
  public:
@@ -30,6 +31,8 @@ class Implementation {
   Value Cos(Argument x);
 
  private:
+  // Despite the name these are not accurate values, but for the purposes of
+  // benchmarking it doesn't matter.
   struct AccurateValues {
     Argument x;
     Value sin_x;
@@ -46,7 +49,6 @@ class Implementation {
 
 template<Argument table_spacing>
 void Implementation<table_spacing>::Initialize() {
-  using namespace principia::quantities;
   int i = 0;
   for (Argument x = table_spacing / 2;
        x <= x_max + table_spacing / 2;
@@ -91,7 +93,7 @@ Value Implementation<table_spacing>::Cos(Argument const x) {
           cos_x₀_minus_h_sin_x₀.error);
 }
 
-//TODO(phl):polynomials
+// TODO(phl): This should use polynomials.
 
 template<Argument table_spacing>
 Value Implementation<table_spacing>::SinPolynomial(Argument const x) {
@@ -121,7 +123,7 @@ Value Implementation<table_spacing>::CosPolynomial(Argument const x) {
 }
 
 template<Argument table_spacing>
-void BM_EvaluateSinTradeOffs(benchmark::State& state) {
+void BM_EvaluateSinTableSpacing(benchmark::State& state) {
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> uniformly_at(x_min, x_max);
 
@@ -139,6 +141,8 @@ void BM_EvaluateSinTradeOffs(benchmark::State& state) {
       using namespace principia::quantities;
       v[i] = implementation.Sin(a[i]);
 #if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
       auto const absolute_error = Abs(v[i] - std::sin(a[i]));
       CHECK_LT(absolute_error, 5.6e-17);
 #endif
@@ -148,7 +152,7 @@ void BM_EvaluateSinTradeOffs(benchmark::State& state) {
 }
 
 template<Argument table_spacing>
-void BM_EvaluateCosTradeOffs(benchmark::State& state) {
+void BM_EvaluateCosTableSpacing(benchmark::State& state) {
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> uniformly_at(x_min, x_max);
 
@@ -166,6 +170,8 @@ void BM_EvaluateCosTradeOffs(benchmark::State& state) {
       using namespace principia::quantities;
       v[i] = implementation.Cos(a[i]);
 #if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
       auto const absolute_error = Abs(v[i] - std::cos(a[i]));
       CHECK_LT(absolute_error, 1.2e-16);
 #endif
@@ -174,13 +180,13 @@ void BM_EvaluateCosTradeOffs(benchmark::State& state) {
   }
 }
 
-BENCHMARK_TEMPLATE(BM_EvaluateSinTradeOffs, 1.0 / 128.0)
+BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 1.0 / 128.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateSinTradeOffs, 1.0 / 512.0)
+BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 1.0 / 512.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateCosTradeOffs, 1.0 / 128.0)
+BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 1.0 / 128.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateCosTradeOffs, 1.0 / 512.0)
+BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 1.0 / 512.0)
     ->Unit(benchmark::kNanosecond);
 
 }  // namespace functions

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -110,15 +110,15 @@ Value Implementation<table_spacing>::SinPolynomial(Argument const x) {
 
 template<Argument table_spacing>
 Value Implementation<table_spacing>::CosPolynomial(Argument const x) {
-  if constexpr (table_spacing == 2.0 / 1024.0) {
-    // 72 bits.
-    return -0.499999999999999999999872434553 +
-           0.0416666654823785864634569932662 * x;
-  } else if constexpr (table_spacing == 2.0 / 256.0) {
+  if constexpr (table_spacing == 2.0 / 256.0) {
     // 77 bits.
     return -0.499999999999999999999999974543 +
            x * (0.0416666666666633318024480868405 -
                 0.00138888829905860875255146938745 * x);
+  } else if constexpr (table_spacing == 2.0 / 1024.0) {
+    // 72 bits.
+    return -0.499999999999999999999872434553 +
+           0.0416666654823785864634569932662 * x;
   }
 }
 

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -1,3 +1,5 @@
+// .\Release\x64\benchmarks.exe --benchmark_repetitions=3 --benchmark_filter=BM_Evaluate.*Spacing  // NOLINT(whitespace/line_length)
+
 #include <array>
 #include <cmath>
 #include <cstdint>
@@ -6,7 +8,7 @@
 #include "benchmark/benchmark.h"
 #include "numerics/double_precision.hpp"
 #include "quantities/elementary_functions.hpp"
-#include "quantities/numbers.hpp"
+#include "quantities/numbers.hpp"  // 🧙 For π.
 
 namespace principia {
 namespace functions {

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -180,13 +180,13 @@ void BM_EvaluateCosTableSpacing(benchmark::State& state) {
   }
 }
 
-BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 1.0 / 128.0)
+BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 2.0 / 256.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 1.0 / 512.0)
+BENCHMARK_TEMPLATE(BM_EvaluateSinTableSpacing, 2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 1.0 / 128.0)
+BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 2.0 / 256.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 1.0 / 512.0)
+BENCHMARK_TEMPLATE(BM_EvaluateCosTableSpacing, 2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
 
 }  // namespace functions

--- a/benchmarks/tradeoffs_benchmark.cpp
+++ b/benchmarks/tradeoffs_benchmark.cpp
@@ -1,0 +1,103 @@
+#include <array>
+#include <cstdint>
+
+#include "numerics/double_precision.hpp"
+#include "quantities/elementary_functions.hpp"
+#include "quantities/numbers.hpp"
+
+namespace principia {
+namespace functions {
+
+using namespace principia::numerics::_double_precision;
+
+constexpr double x_min = π / 12;
+constexpr double x_max = π / 6;
+
+template<std::int64_t table_size>
+class Implementation {
+ public:
+  void Initialize();
+
+  double Sin(double x);
+  double Cos(double x);
+
+ private:
+  struct AccurateValues {
+    double x;
+    double sin_x;
+    double cos_x;
+  };
+
+  double SinPolynomial(double x);
+  double CosPolynomial(double x);
+
+  std::array<AccurateValues, table_size> accurate_values_;
+};
+
+template<std::int64_t table_size>
+void Implementation<table_size>::Initialize() {
+  using namespace principia::quantities;
+  for (std::int64_t i = 0; i < table_size; ++i) {
+    double const x = x_min + i * (x_max - x_min) / table_size;
+    accurate_values_[i] = {.x = x,
+                           .sin_x = _elementary_functions::Sin(x),
+                           .cos_x = _elementary_functions::Cos(x)};
+  }
+}
+
+template<std::int64_t table_size>
+double Implementation<table_size>::Sin(double const x) {
+  //TODO(phl)slow
+  auto const i = static_cast<std::int64_t>(std::round(x * one_over_h_));
+  auto const& accurate_values = accurate_values_[i];
+  auto const h = x - accurate_values.x;
+  auto const h2 = h * h;
+  auto const h3 = h2 * h;
+  auto const c0h = TwoProduct(accurate_values.cos_x, h);
+  return accurate_values.sin_x + accurate_values.cos_x * h +
+         accurate_values.sin_x * h2 * CosPolynomial(h2) +
+         accurate_values.cos_x * h3 * SinPolynomial(h2);
+}
+
+template<std::int64_t table_size>
+double Implementation<table_size>::Cos(double const x) {
+  auto const x0 = static_cast<std::int64_t>(std::round(x / h_));
+  //TODO(phl)slow
+  auto const x0 = static_cast<std::int64_t>(std::round(x * one_over_h_));
+}
+
+//TODO(phl):polynomials
+
+template<std::int64_t table_size>
+double Implementation<table_size>::SinPolynomial(double const x) {
+  if constexpr (table_size == 256) {
+    // 71 bits.
+    return 0.166666666666666666666421797625 +
+           0.00833333057503280528178543245797 * x;
+  } else if constexpr (table_size == 1024) {
+    // 85 bits.
+    return -0.166666666666666666666666651721 +
+           0.00833333316093951937646271666739 * x;
+  } else {
+    static_assert(false);
+  }
+}
+
+template<std::int64_t table_size>
+double Implementation<table_size>::CosPolynomial(double const x) {
+  if constexpr (table_size == 1024) {
+    // 72 bits.
+    return -0.499999999999999999999872434553 +
+           0.0416666654823785864634569932662 * x;
+  } else if constexpr (table_size == 256) {
+    // 77 bits.
+    return -0.499999999999999999999999974543 +
+           x * (0.0416666666666633318024480868405 -
+                0.00138888829905860875255146938745 * x);
+  } else {
+    static_assert(false);
+  }
+}
+
+}  // namespace functions
+}  // namespace principia

--- a/benchmarks/tradeoffs_benchmark.cpp
+++ b/benchmarks/tradeoffs_benchmark.cpp
@@ -1,6 +1,9 @@
 #include <array>
+#include <cmath>
 #include <cstdint>
+#include <random>
 
+#include "benchmark/benchmark.h"
 #include "numerics/double_precision.hpp"
 #include "quantities/elementary_functions.hpp"
 #include "quantities/numbers.hpp"
@@ -9,95 +12,140 @@ namespace principia {
 namespace functions {
 
 using namespace principia::numerics::_double_precision;
+using namespace principia::quantities::_elementary_functions;
 
-constexpr double x_min = π / 12;
-constexpr double x_max = π / 6;
+using Value = double;
+using Argument = double;
 
-template<std::int64_t table_size>
+constexpr Argument x_min = π / 12;
+constexpr Argument x_max = π / 6;
+static constexpr std::int64_t number_of_iterations = 1000;
+
+template<Argument table_spacing>
 class Implementation {
  public:
   void Initialize();
 
-  double Sin(double x);
-  double Cos(double x);
+  Value Sin(Argument x);
+  Value Cos(Argument x);
 
  private:
   struct AccurateValues {
-    double x;
-    double sin_x;
-    double cos_x;
+    Argument x;
+    Value sin_x;
+    Value cos_x;
   };
 
-  double SinPolynomial(double x);
-  double CosPolynomial(double x);
+  Value SinPolynomial(Argument x);
+  Value CosPolynomial(Argument x);
 
-  std::array<AccurateValues, table_size> accurate_values_;
+  std::array<AccurateValues,
+             static_cast<std::int64_t>(x_max / table_spacing) + 1>
+      accurate_values_;
 };
 
-template<std::int64_t table_size>
-void Implementation<table_size>::Initialize() {
+template<Argument table_spacing>
+void Implementation<table_spacing>::Initialize() {
   using namespace principia::quantities;
-  for (std::int64_t i = 0; i < table_size; ++i) {
-    double const x = x_min + i * (x_max - x_min) / table_size;
+  int i = 0;
+  for (Argument x = table_spacing / 2;
+       x <= x_max + table_spacing / 2;
+       x += table_spacing, ++i) {
     accurate_values_[i] = {.x = x,
-                           .sin_x = _elementary_functions::Sin(x),
-                           .cos_x = _elementary_functions::Cos(x)};
+                           .sin_x = std::sin(x),
+                           .cos_x = std::cos(x)};
   }
 }
 
-template<std::int64_t table_size>
-double Implementation<table_size>::Sin(double const x) {
-  //TODO(phl)slow
-  auto const i = static_cast<std::int64_t>(std::round(x * one_over_h_));
+template<Argument table_spacing>
+Value Implementation<table_spacing>::Sin(Argument const x) {
+  auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
   auto const h = x - accurate_values.x;
   auto const h2 = h * h;
   auto const h3 = h2 * h;
-  auto const c0h = TwoProduct(accurate_values.cos_x, h);
-  return accurate_values.sin_x + accurate_values.cos_x * h +
-         accurate_values.sin_x * h2 * CosPolynomial(h2) +
-         accurate_values.cos_x * h3 * SinPolynomial(h2);
+  auto const s0_plus_c0h =
+      TwoProductAdd(accurate_values.cos_x, h, accurate_values.sin_x);
+  return s0_plus_c0h.value + ((accurate_values.sin_x * h2 * CosPolynomial(h2) +
+                               accurate_values.cos_x * h3 * SinPolynomial(h2)) +
+                              s0_plus_c0h.error);
 }
 
-template<std::int64_t table_size>
-double Implementation<table_size>::Cos(double const x) {
-  auto const x0 = static_cast<std::int64_t>(std::round(x / h_));
-  //TODO(phl)slow
-  auto const x0 = static_cast<std::int64_t>(std::round(x * one_over_h_));
+template<Argument table_spacing>
+Value Implementation<table_spacing>::Cos(Argument const x) {
+  auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
+  auto const& accurate_values = accurate_values_[i];
+  auto const h = x - accurate_values.x;
+  auto const h2 = h * h;
+  auto const h3 = h2 * h;
+  auto const c0_minus_hs0 =
+      TwoProductAdd(accurate_values.sin_x, -h, accurate_values.cos_x);
+  return c0_minus_hs0.value +
+         ((accurate_values.cos_x * h2 * CosPolynomial(h2) -
+           accurate_values.sin_x * h3 * SinPolynomial(h2)) +
+          c0_minus_hs0.error);
 }
 
 //TODO(phl):polynomials
 
-template<std::int64_t table_size>
-double Implementation<table_size>::SinPolynomial(double const x) {
-  if constexpr (table_size == 256) {
+template<Argument table_spacing>
+Value Implementation<table_spacing>::SinPolynomial(Argument const x) {
+  if constexpr (table_spacing == 2.0 / 256.0) {
     // 71 bits.
-    return 0.166666666666666666666421797625 +
+    return -0.166666666666666666666421797625 +
            0.00833333057503280528178543245797 * x;
-  } else if constexpr (table_size == 1024) {
+  } else if constexpr (table_spacing == 2.0 / 1024.0) {
     // 85 bits.
     return -0.166666666666666666666666651721 +
            0.00833333316093951937646271666739 * x;
-  } else {
-    static_assert(false);
   }
 }
 
-template<std::int64_t table_size>
-double Implementation<table_size>::CosPolynomial(double const x) {
-  if constexpr (table_size == 1024) {
+template<Argument table_spacing>
+Value Implementation<table_spacing>::CosPolynomial(Argument const x) {
+  if constexpr (table_spacing == 2.0 / 1024.0) {
     // 72 bits.
     return -0.499999999999999999999872434553 +
            0.0416666654823785864634569932662 * x;
-  } else if constexpr (table_size == 256) {
+  } else if constexpr (table_spacing == 2.0 / 256.0) {
     // 77 bits.
     return -0.499999999999999999999999974543 +
            x * (0.0416666666666633318024480868405 -
                 0.00138888829905860875255146938745 * x);
-  } else {
-    static_assert(false);
   }
 }
+
+template<Argument table_spacing>
+void BM_EvaluateSinTradeOffs(benchmark::State& state) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> uniformly_at(x_min, x_max);
+
+  Implementation<table_spacing> implementation;
+  implementation.Initialize();
+
+  Argument a[number_of_iterations];
+  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+    a[i] = uniformly_at(random);
+  }
+
+  Value v[number_of_iterations];
+  while (state.KeepRunningBatch(number_of_iterations)) {
+    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+      using namespace principia::quantities;
+      v[i] = implementation.Sin(a[i]);
+#if _DEBUG
+      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
+      CHECK_LT(absolute_error, 6e-17);
+#endif
+    }
+    benchmark::DoNotOptimize(v);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_EvaluateSinTradeOffs, 1.0 / 128.0)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EvaluateSinTradeOffs, 1.0 / 512.0)
+    ->Unit(benchmark::kNanosecond);
 
 }  // namespace functions
 }  // namespace principia

--- a/functions/std_accuracy_test.cpp
+++ b/functions/std_accuracy_test.cpp
@@ -7,7 +7,7 @@
 #include "glog/logging.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "quantities/numbers.hpp"
+#include "quantities/numbers.hpp"  // 🧙 For π.
 #include "quantities/si.hpp"
 #include "testing_utilities/almost_equals.hpp"
 #include "testing_utilities/approximate_quantity.hpp"

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -300,10 +300,13 @@ TEST_F(VesselTest, Prediction) {
 
   vessel_.CreateTrajectoryIfNeeded(t0_);
   // Polling for the integration to happen.
+  int count = 0;
   do {
     vessel_.RefreshPrediction(t0_ + 1 * Second);
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
+    ++count;
+    CHECK_LT(count, 1000);
   } while (vessel_.prediction()->back().time == t0_);
 
   EXPECT_EQ(3, vessel_.prediction()->size());

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -62,6 +62,31 @@ DoublePrecision<Product<T, U>> Scale(T const& scale,
 template<typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b);
 
+// Returns the exact value of |a * b + c|.
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
+                                             U const& b,
+                                             Product<T, U> const& c);
+
+// Returns the exact value of |a * b - c|.
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
+                                                  U const& b,
+                                                  Product<T, U> const& c);
+
+// Returns the exact value of |-a * b + c|.
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
+                                                    U const& b,
+                                                    Product<T, U> const& c);
+
+// Returns the exact value of |-a * b - c|.
+template<typename T, typename U>
+DoublePrecision<Product<T, U>>
+TwoProductNegatedSubtract(T const& a,
+                          U const& b,
+                          Product<T, U> const& c);
+
 // Same as |TwoProduct|, but never uses FMA.
 template<typename T, typename U>
 constexpr DoublePrecision<Product<T, U>> VeltkampDekkerProduct(T const& a,
@@ -129,6 +154,7 @@ std::ostream& operator<<(std::ostream& os,
 using internal::DoublePrecision;
 using internal::TwoDifference;
 using internal::TwoProduct;
+using internal::TwoProductAdd;
 using internal::TwoSum;
 using internal::VeltkampDekkerProduct;
 

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -155,6 +155,9 @@ using internal::DoublePrecision;
 using internal::TwoDifference;
 using internal::TwoProduct;
 using internal::TwoProductAdd;
+using internal::TwoProductNegatedAdd;
+using internal::TwoProductNegatedSubtract;
+using internal::TwoProductSubtract;
 using internal::TwoSum;
 using internal::VeltkampDekkerProduct;
 

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -250,6 +250,7 @@ DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
 }
 
 template<typename T, typename U>
+FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c) {
@@ -267,6 +268,7 @@ DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
 }
 
 template<typename T, typename U>
+FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c) {
@@ -284,6 +286,7 @@ DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
 }
 
 template<typename T, typename U>
+FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c) {
@@ -302,13 +305,15 @@ DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
 
 template<typename T, typename U>
 DoublePrecision<Product<T, U>>
+FORCE_INLINE(inline)
 TwoProductNegatedSubtract(T const& a,
                           U const& b,
                           Product<T, U> const& c) {
   if (UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(FusedNegatedMultiplySubtract(a, b, c));
+    DoublePrecision<Product<T, U>> result(
+        FusedNegatedMultiplySubtract(a, b, c));
     result.error = FusedMultiplyAdd(a, b, (result.value + c));
     return result;
   } else {

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -250,6 +250,75 @@ DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
 }
 
 template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
+                                             U const& b,
+                                             Product<T, U> const& c) {
+  if (UseHardwareFMA) {
+    using quantities::_elementary_functions::FusedMultiplyAdd;
+    using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
+    DoublePrecision<Product<T, U>> result(FusedMultiplyAdd(a, b, c));
+    result.error = FusedNegatedMultiplyAdd(a, b, (result.value - c));
+    return result;
+  } else {
+    auto result = VeltkampDekkerProduct(a, b);
+    result += c;
+    return result;
+  }
+}
+
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
+                                                  U const& b,
+                                                  Product<T, U> const& c) {
+  if (UseHardwareFMA) {
+    using quantities::_elementary_functions::FusedMultiplySubtract;
+    using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
+    DoublePrecision<Product<T, U>> result(FusedMultiplySubtract(a, b, c));
+    result.error = FusedNegatedMultiplyAdd(a, b, (result.value + c));
+    return result;
+  } else {
+    auto result = VeltkampDekkerProduct(a, b);
+    result -= c;
+    return result;
+  }
+}
+
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
+                                                    U const& b,
+                                                    Product<T, U> const& c) {
+  if (UseHardwareFMA) {
+    using quantities::_elementary_functions::FusedMultiplyAdd;
+    using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
+    DoublePrecision<Product<T, U>> result(FusedNegatedMultiplyAdd(a, b, c));
+    result.error = FusedMultiplyAdd(a, b, (result.value - c));
+    return result;
+  } else {
+    auto result = VeltkampDekkerProduct(-a, b);
+    result += c;
+    return result;
+  }
+}
+
+template<typename T, typename U>
+DoublePrecision<Product<T, U>>
+TwoProductNegatedSubtract(T const& a,
+                          U const& b,
+                          Product<T, U> const& c) {
+  if (UseHardwareFMA) {
+    using quantities::_elementary_functions::FuseMultiplyAdd;
+    using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
+    DoublePrecision<Product<T, U>> result(FusedNegatedMultiplySubtract(a, b, c));
+    result.error = FusedMultiplyAdd(a, b, (result.value + c));
+    return result;
+  } else {
+    auto result = VeltkampDekkerProduct(-a, b);
+    result -= c;
+    return result;
+  }
+}
+
+template<typename T, typename U>
 FORCE_INLINE(constexpr)
 DoublePrecision<Sum<T, U>> QuickTwoSum(T const& a, U const& b) {
 #if _DEBUG

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -306,7 +306,7 @@ TwoProductNegatedSubtract(T const& a,
                           U const& b,
                           Product<T, U> const& c) {
   if (UseHardwareFMA) {
-    using quantities::_elementary_functions::FuseMultiplyAdd;
+    using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
     DoublePrecision<Product<T, U>> result(FusedNegatedMultiplySubtract(a, b, c));
     result.error = FusedMultiplyAdd(a, b, (result.value + c));

--- a/numerics/double_precision_test.cpp
+++ b/numerics/double_precision_test.cpp
@@ -282,6 +282,20 @@ TEST_F(DoublePrecisionTest, Product) {
                            0));
 }
 
+TEST_F(DoublePrecisionTest, ProductAndAdd) {
+  Time const a = 3.0 * Second;
+  Speed const b =  7.0 * Metre / Second;
+  Length const c = 5.0 * Metre;
+  auto const add = TwoProductAdd(a, b, c);
+  EXPECT_THAT(add.value, AlmostEquals(26.0 * Metre, 0));
+  auto const subtract = TwoProductSubtract(a, b, c);
+  EXPECT_THAT(subtract.value, AlmostEquals(16.0 * Metre, 0));
+  auto const negated_add = TwoProductNegatedAdd(a, b, c);
+  EXPECT_THAT(negated_add.value, AlmostEquals(-16.0 * Metre, 0));
+  auto const negated_subtract = TwoProductNegatedSubtract(a, b, c);
+  EXPECT_THAT(negated_subtract.value, AlmostEquals(-26.0 * Metre, 0));
+}
+
 TEST_F(DoublePrecisionTest, LongProduct) {
   DoublePrecision<Length> a(3 * Metre);
   a.Increment(474 * ε * Metre);


### PR DESCRIPTION
* With a spacing of 2/256, we need a degree-2 polynomial for cos.
* With a spacing of 2/1024, we can use a degree-1 polynomial for both sin and cos.

The latter wins:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_EvaluateSinTableSpacing<2.0 / 256.0>        2.56 ns         2.55 ns    263530000
BM_EvaluateSinTableSpacing<2.0 / 1024.0>       2.26 ns         2.25 ns    320000000
BM_EvaluateCosTableSpacing<2.0 / 256.0>        2.54 ns         2.57 ns    280000000
BM_EvaluateCosTableSpacing<2.0 / 1024.0>       2.23 ns         2.25 ns    298667000
```
#1760.