### PR TITLE
A benchmark for a multi-table implementation of sin and cos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ unity/
 
 # Visual Studio Code
 .vscode/
+
+# Nuget
+.nuget/

--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -6,6 +6,7 @@
 #include "benchmark/benchmark.h"
 #include "functions/cos.hpp"
 #include "functions/sin.hpp"
+#include "quantities/numbers.hpp"  // 🧙 For π.
 
 namespace principia {
 namespace functions {
@@ -23,7 +24,7 @@ void BM_EvaluateElementaryFunction(benchmark::State& state) {
   using Argument = double;
 
   std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(-1.0, 1.0);
+  std::uniform_real_distribution<> uniformly_at(0.0, π / 4);
   Argument argument = uniformly_at(random);
 
   if constexpr (metric == Metric::Throughput) {

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -321,7 +321,6 @@ void BM_ExperimentSinTableSpacing(benchmark::State& state) {
   Value v[number_of_iterations];
   while (state.KeepRunningBatch(number_of_iterations)) {
     for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      using namespace principia::quantities;
       v[i] = implementation.Sin(a[i]);
 #if _DEBUG
       // The implementation is not accurate, but let's check that it's not
@@ -350,7 +349,6 @@ void BM_ExperimentCosTableSpacing(benchmark::State& state) {
   Value v[number_of_iterations];
   while (state.KeepRunningBatch(number_of_iterations)) {
     for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      using namespace principia::quantities;
       v[i] = implementation.Cos(a[i]);
 #if _DEBUG
       // The implementation is not accurate, but let's check that it's not
@@ -381,13 +379,11 @@ void BM_ExperimentSinMultiTable(benchmark::State& state) {
   Value v[number_of_iterations];
   while (state.KeepRunningBatch(number_of_iterations)) {
     for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      using namespace principia::quantities;
       v[i] = implementation.Sin(a[i]);
 #if _DEBUG
       // The implementation is not accurate, but let's check that it's not
       // broken.
       auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-      //LOG(ERROR)<<absolute_error;
       CHECK_LT(absolute_error, 1.2e-16);
 #endif
     }
@@ -413,13 +409,11 @@ void BM_ExperimentCosMultiTable(benchmark::State& state) {
   Value v[number_of_iterations];
   while (state.KeepRunningBatch(number_of_iterations)) {
     for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      using namespace principia::quantities;
       v[i] = implementation.Cos(a[i]);
 #if _DEBUG
       // The implementation is not accurate, but let's check that it's not
       // broken.
       auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-      //LOG(ERROR)<<absolute_error;
       CHECK_LT(absolute_error, 1.2e-16);
 #endif
     }

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -74,7 +74,7 @@ class MultiTableImplementation {
   Value CosPolynomial(Argument x);
 
   static constexpr std::int64_t table_size =
-      static_cast<std::int64_t>(0.5 / max_table_spacing);
+      static_cast<std::int64_t>((2 * x_min - x_min) / max_table_spacing);
 
   std::array<std::int64_t, number_of_tables> one_over_table_spacings_;
   std::array<std::array<AccurateValues, table_size>, number_of_tables>
@@ -162,7 +162,7 @@ Initialize() {
   Argument current_table_spacing = max_table_spacing;
   for (std::int64_t i = number_of_tables - 1; i >= 0; --i) {
     one_over_table_spacings_[i] = 1.0 / current_table_spacing;
-    std::int64_t j = number_of_tables - 1;
+    std::int64_t j = table_size - 1;
     for (Argument x = current_x_max - current_table_spacing / 2;
          x > current_x_min;
          x -= current_table_spacing, --j) {


### PR DESCRIPTION
Not great, not terrible:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_ExperimentSinMultiTable       3.24 ns         3.22 ns    213334000
BM_ExperimentCosMultiTable       3.21 ns         3.22 ns    213334000
```
For reference, the Windows implementation:
```
BM_EvaluateElementaryFunction<Metric::Throughput, std::sin>       2.22 ns         2.20 ns    298667000
BM_EvaluateElementaryFunction<Metric::Throughput, std::cos>       2.44 ns         2.40 ns    280000000
```
#1760.