### PR TITLE
Fix a race between the code and the test for Vessel

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -623,7 +623,10 @@ void Vessel::RefreshPrediction() {
     prognostication = prognosticator_.Get();
   }
   if (prognostication.has_value()) {
+    LOG(ERROR) << "Prognostication ends at " << prognostication->back().time;
     AttachPrediction(std::move(prognostication).value());
+  } else {
+    LOG(ERROR) << "No prognostication";
   }
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -1122,7 +1122,7 @@ absl::StatusOr<DiscreteTrajectory<Barycentric>> Vessel::FlowPrognostication(
         prognosticator_parameters.adaptive_step_parameters,
         FlightPlan::max_ephemeris_steps_per_frame);
   }
-  LOG_IF_EVERY_N(ERROR, !status.ok(), 50)
+  LOG_IF_EVERY_N(INFO, !status.ok(), 50)
       << "Prognostication from " << prognosticator_parameters.first_time
       << " finished at " << prognostication.back().time << " with "
       << status.ToString() << " for " << ShortDebugString();

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -623,10 +623,7 @@ void Vessel::RefreshPrediction() {
     prognostication = prognosticator_.Get();
   }
   if (prognostication.has_value()) {
-    LOG(ERROR) << "Prognostication ends at " << prognostication->back().time;
     AttachPrediction(std::move(prognostication).value());
-  } else {
-    LOG(ERROR) << "No prognostication";
   }
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -1122,7 +1122,7 @@ absl::StatusOr<DiscreteTrajectory<Barycentric>> Vessel::FlowPrognostication(
         prognosticator_parameters.adaptive_step_parameters,
         FlightPlan::max_ephemeris_steps_per_frame);
   }
-  LOG_IF_EVERY_N(INFO, !status.ok(), 50)
+  LOG_IF_EVERY_N(ERROR, !status.ok(), 50)
       << "Prognostication from " << prognosticator_parameters.first_time
       << " finished at " << prognostication.back().time << " with "
       << status.ToString() << " for " << ShortDebugString();

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -286,10 +286,9 @@ TEST_F(VesselTest, Prediction) {
       /*t2=*/t0_ + 2 * Second);
   EXPECT_CALL(ephemeris_,
               FlowWithAdaptiveStep(_, _, t0_ + 2 * Second, _, _))
-      .WillOnce(DoAll(
+      .WillRepeatedly(DoAll(
           AppendPointsToDiscreteTrajectory(&expected_vessel_prediction),
-          Return(absl::OkStatus())))
-      .WillRepeatedly(Return(absl::OkStatus()));
+          Return(absl::OkStatus())));
 
   // The call to extend the exphemeris.  Irrelevant since we won't be looking at
   // these points.
@@ -303,6 +302,8 @@ TEST_F(VesselTest, Prediction) {
   int count = 0;
   do {
     vessel_.RefreshPrediction(t0_ + 1 * Second);
+    LOG(ERROR) << "Iteration " << count << " back is "
+               << vessel_.prediction()->back().time;
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
     ++count;

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -305,6 +305,8 @@ TEST_F(VesselTest, Prediction) {
     vessel_.RefreshPrediction(t0_ + 1 * Second);
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
+    LOG(ERROR) << "Iteration " << count << " back is "
+               << vessel_.prediction()->back().time;
     ++count;
     CHECK_LT(count, 1000);
   } while (vessel_.prediction()->back().time == t0_);

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -305,8 +305,6 @@ TEST_F(VesselTest, Prediction) {
     vessel_.RefreshPrediction(t0_ + 1 * Second);
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(100ms);
-    LOG(ERROR) << "Iteration " << count << " back is "
-               << vessel_.prediction()->back().time;
     ++count;
     CHECK_LT(count, 1000);
   } while (vessel_.prediction()->back().time == t0_);


### PR DESCRIPTION
The scenario is this:
1. The test thread calls `RefreshPrediction` [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin_test/vessel_test.cpp#L305).
2. It gets suspended after calling `Start` [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin/vessel.cpp#L622) but before calling `Get`.
3. The prognosticator thread executes `FlowPrognostication` [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin/vessel.cpp#L1102), and consumes the `WillOnce` expectation [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin_test/vessel_test.cpp#L289).  This results in a proper prognostication, but that one is not picked up because the test thread is still suspended.
4. The prognosticator thread re-executes `FlowPrognostication`, but it now consumes the `WillRepeatedly` expectation [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin_test/vessel_test.cpp#L292).
5. The test thread finally wakes up and calls `Get` [here](https://github.com/mockingbirdnest/Principia/blob/b860ba6c0ccd137aa967b6bf75c2e135c55c0204/ksp_plugin/vessel.cpp#L623).  It now picks a prognostication to which nothing was appended, and is unable to make progress.  It loops forever.

Fix #4010.