### PR TITLE
Round the polynomial coefficients using Mathematica and take advantage of powers of two

### DIFF
--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -411,22 +411,19 @@ Value SingleTableImplementation::Cos(Argument const x) {
   }
 }
 
-Value SingleTableImplementation::SinPolynomial(
-    Argument const x) {
+Value SingleTableImplementation::SinPolynomial(Argument const x) {
   // 84 bits.  Works for all binades.
   return -0x1.5555555555555p-3 + 0x1.111110B24ACB5p-7 * x;
 }
 
-Value SingleTableImplementation::CosPolynomial1(
-    Argument const x) {
-    // 72 bits.
-    return cos_polynomial_0 + 0x1.555554B290E6Ap-5 * x;
+Value SingleTableImplementation::CosPolynomial1(Argument const x) {
+  // 72 bits.
+  return cos_polynomial_0 + 0x1.555554B290E6Ap-5 * x;
 }
 
-Value SingleTableImplementation::CosPolynomial2(
-    Argument const x) {
+Value SingleTableImplementation::CosPolynomial2(Argument const x) {
   // 97 bits.
-    return x * (0x1.5555555555555p-5 - 0x1.6C16C10C09C11p-10 * x);
+  return x * (0x1.5555555555555p-5 - 0x1.6C16C10C09C11p-10 * x);
 }
 
 template<Argument table_spacing>

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -372,8 +372,7 @@ Value SingleTableImplementation::Sin(Argument const x) {
     // TODO(phl): Error analysis of this computation.
     auto const h² = TwoProduct(h, h);
     auto const h³ = h².value * h;
-    auto const h²_sin_x₀_cos_polynomial_0 =
-        h² * TwoProduct(sin_x₀, cos_polynomial_0);
+    auto const h²_sin_x₀_cos_polynomial_0 = h² * (sin_x₀ * cos_polynomial_0);
     auto const terms_up_to_h² = QuickTwoSum(sin_x₀_plus_h_cos_x₀.value,
                                             h²_sin_x₀_cos_polynomial_0.value);
     return terms_up_to_h².value +
@@ -402,8 +401,7 @@ Value SingleTableImplementation::Cos(Argument const x) {
     // TODO(phl): Error analysis of this computation.
     auto const h² = TwoProduct(h, h);
     auto const h³ = h².value * h;
-    auto const h²_cos_x₀_cos_polynomial_0 =
-        h² * TwoProduct(cos_x₀, cos_polynomial_0);
+    auto const h²_cos_x₀_cos_polynomial_0 = h² * (cos_x₀ * cos_polynomial_0);
     auto const terms_up_to_h² = QuickTwoSum(cos_x₀_minus_h_sin_x₀.value,
                                             h²_cos_x₀_cos_polynomial_0.value);
     return terms_up_to_h².value +

--- a/mathematica/floating_point.wl
+++ b/mathematica/floating_point.wl
@@ -36,9 +36,11 @@ Bits;
 
 
 HexLiteral;
+Attributes[HexLiteral]={Listable}
 
 
 CorrectlyRound;
+Attributes[CorrectlyRound]={Listable};
 
 
 Begin["`Private`"]
@@ -82,7 +84,7 @@ e=IntegerPart[magnitude/2^(significandBits-1)];
 If[e==0,
 \[Mu]/2^(significandBits-1) 2^(1-bias),
 sign(1+\[Mu]/2^(significandBits-1))2^(e-bias)]];
-CorrectlyRound[x_]:=If[x==\[Infinity]||x==-\[Infinity],x,If[Abs[#]>=2^(bias+1),Sign[x]\[Infinity],#]&@FromRepresentation[correctlyRoundRepresentation[Representation[x]]]];
+CorrectlyRound[x_?NumberQ]:=If[x==\[Infinity]||x==-\[Infinity],x,If[Abs[#]>=2^(bias+1),Sign[x]\[Infinity],#]&@FromRepresentation[correctlyRoundRepresentation[Representation[x]]]];
 UlpDistance[x_,y_]:=Abs[Representation[x]-Representation[y]]
 
 

--- a/mathematica/floating_point.wl
+++ b/mathematica/floating_point.wl
@@ -103,7 +103,7 @@ leastFullHexDigitValue:=2^(significandBits-1)/16^fullHexDigits
 leastHexDigitValue:=If[leastFullHexDigitValue>1,leastFullHexDigitValue/16,leastFullHexDigitValue]
 
 
-HexLiteral[n_]:=If[n<0,"-",""]<>
+HexLiteral[n_]:=If[n==0,"0.0",If[n<0,"-",""]<>
 "0x1."<>ToUpperCase[
 IntegerString[
 Mod[IntegerPart[Representation[Abs[n]]/leastFullHexDigitValue],16^fullHexDigits],16,fullHexDigits]<>
@@ -122,7 +122,7 @@ Switch[
 binary32,"f",
 binary64,"",
 x87extended,"l",
-_,"_"<>ToString[significandBits]<>"_sigbits"]
+_,"_"<>ToString[significandBits]<>"_sigbits"]]
 
 
 smol=-12;

--- a/mathematica/floating_point.wl
+++ b/mathematica/floating_point.wl
@@ -84,7 +84,7 @@ e=IntegerPart[magnitude/2^(significandBits-1)];
 If[e==0,
 \[Mu]/2^(significandBits-1) 2^(1-bias),
 sign(1+\[Mu]/2^(significandBits-1))2^(e-bias)]];
-CorrectlyRound[x_?NumberQ]:=If[x==\[Infinity]||x==-\[Infinity],x,If[Abs[#]>=2^(bias+1),Sign[x]\[Infinity],#]&@FromRepresentation[correctlyRoundRepresentation[Representation[x]]]];
+CorrectlyRound[x_]:=If[x==\[Infinity]||x==-\[Infinity],x,If[Abs[#]>=2^(bias+1),Sign[x]\[Infinity],#]&@FromRepresentation[correctlyRoundRepresentation[Representation[x]]]];
 UlpDistance[x_,y_]:=Abs[Representation[x]-Representation[y]]
 
 

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -127,8 +127,24 @@ template<typename T>
 DoublePrecision<Difference<T>> operator-(DoublePrecision<T> const& left);
 
 template<typename T, typename U>
+DoublePrecision<Sum<T, U>> operator+(T const& left,
+                                     DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Sum<T, U>> operator+(DoublePrecision<T> const& left,
+                                     U const& right);
+
+template<typename T, typename U>
 DoublePrecision<Sum<T, U>> operator+(DoublePrecision<T> const& left,
                                      DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Difference<T, U>> operator-(T const& left,
+                                            DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Difference<T, U>> operator-(DoublePrecision<T> const& left,
+                                            U const& right);
 
 template<typename T, typename U>
 DoublePrecision<Difference<T, U>> operator-(DoublePrecision<T> const& left,
@@ -145,6 +161,14 @@ DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
 template<typename T, typename U>
 DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
                                          DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Quotient<T, U>> operator/(T const& left,
+                                          DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Quotient<T, U>> operator/(DoublePrecision<T> const& left,
+                                          U const& right);
 
 template<typename T, typename U>
 DoublePrecision<Quotient<T, U>> operator/(DoublePrecision<T> const& left,

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -135,6 +135,14 @@ DoublePrecision<Difference<T, U>> operator-(DoublePrecision<T> const& left,
                                             DoublePrecision<U> const& right);
 
 template<typename T, typename U>
+DoublePrecision<Product<T, U>> operator*(T const& left,
+                                         DoublePrecision<U> const& right);
+
+template<typename T, typename U>
+DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
+                                         U const& right);
+
+template<typename T, typename U>
 DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
                                          DoublePrecision<U> const& right);
 

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -414,6 +414,26 @@ DoublePrecision<Difference<T, U>> operator-(DoublePrecision<T> const& left,
 
 template<typename T, typename U>
 FORCE_INLINE(inline)
+DoublePrecision<Product<T, U>> operator*(T const& left,
+                                         DoublePrecision<U> const& right) {
+  // [Lin81], algorithm longmul.
+  auto product = TwoProduct(left, right.value);
+  product.error += left.value * right.error;
+  return QuickTwoSum(product.value, product.error);
+}
+
+template<typename T, typename U>
+FORCE_INLINE(inline)
+DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
+                                         U const& right) {
+  // [Lin81], algorithm longmul.
+  auto product = TwoProduct(left.value, right);
+  product.error += +left.error * right;
+  return QuickTwoSum(product.value, product.error);
+}
+
+template<typename T, typename U>
+FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
                                          DoublePrecision<U> const& right) {
   // [Lin81], algorithm longmul.

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -397,11 +397,43 @@ DoublePrecision<Difference<T>> operator-(DoublePrecision<T> const& left) {
 }
 
 template<typename T, typename U>
+DoublePrecision<Sum<T, U>> operator+(T const& left,
+                                     DoublePrecision<U> const& right) {
+  // [Lin81], algorithm longadd.
+  auto const sum = TwoSum(left, right.value);
+  return QuickTwoSum(sum.value, sum.error + right.error);
+}
+
+template<typename T, typename U>
+DoublePrecision<Sum<T, U>> operator+(DoublePrecision<T> const& left,
+                                     U const& right) {
+  // [Lin81], algorithm longadd.
+  auto const sum = TwoSum(left.value, right);
+  return QuickTwoSum(sum.value, sum.error + left.error);
+}
+
+template<typename T, typename U>
 DoublePrecision<Sum<T, U>> operator+(DoublePrecision<T> const& left,
                                      DoublePrecision<U> const& right) {
   // [Lin81], algorithm longadd.
   auto const sum = TwoSum(left.value, right.value);
   return QuickTwoSum(sum.value, (sum.error + left.error) + right.error);
+}
+
+template<typename T, typename U>
+DoublePrecision<Difference<T, U>> operator-(T const& left,
+                                            DoublePrecision<U> const& right) {
+  // [Lin81], algorithm longadd.
+  auto const sum = TwoDifference(left, right.value);
+  return QuickTwoSum(sum.value, sum.error - right.error);
+}
+
+template<typename T, typename U>
+DoublePrecision<Difference<T, U>> operator-(DoublePrecision<T> const& left,
+                                            U const& right) {
+  // [Lin81], algorithm longadd.
+  auto const sum = TwoDifference(left.value, right);
+  return QuickTwoSum(sum.value, sum.error + left.error);
 }
 
 template<typename T, typename U>
@@ -441,6 +473,28 @@ DoublePrecision<Product<T, U>> operator*(DoublePrecision<T> const& left,
   product.error +=
       (left.value + left.error) * right.error + left.error * right.value;
   return QuickTwoSum(product.value, product.error);
+}
+
+template<typename T, typename U>
+DoublePrecision<Quotient<T, U>> operator/(T const& left,
+                                          DoublePrecision<U> const& right) {
+  // [Lin81], algorithm longdiv.
+  auto const z = left / right.value;
+  auto const product = TwoProduct(right.value, z);
+  auto const zz = (((left - product.value) - product.error) - z * right.error) /
+                  (right.value + right.error);
+  return QuickTwoSum(z, zz);
+}
+
+template<typename T, typename U>
+DoublePrecision<Quotient<T, U>> operator/(DoublePrecision<T> const& left,
+                                          U const& right) {
+  // [Lin81], algorithm longdiv.
+  auto const z = left.value / right;
+  auto const product = TwoProduct(right, z);
+  auto const zz =
+      (((left.value - product.value) - product.error) + left.error) / right;
+  return QuickTwoSum(z, zz);
 }
 
 template<typename T, typename U>


### PR DESCRIPTION
A bit faster:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
BM_ExperimentSinSingleTable       2.89 ns         2.85 ns    235790000
BM_ExperimentCosSingleTable       2.84 ns         2.83 ns    248889000
```
#1760.