### PR TITLE
Latency benchmark for the elementary functions

### DIFF
--- a/benchmarks/benchmarks.vcxproj
+++ b/benchmarks/benchmarks.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="thread_pool_benchmark.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="metric.hpp" />
     <ClInclude Include="quantities.hpp" />
     <ClInclude Include="quantities_body.hpp" />
   </ItemGroup>

--- a/benchmarks/benchmarks.vcxproj.filters
+++ b/benchmarks/benchmarks.vcxproj.filters
@@ -100,5 +100,8 @@
     <ClInclude Include="quantities_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="metric.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -4,6 +4,7 @@
 #include <random>
 
 #include "benchmark/benchmark.h"
+#include "benchmarks/metric.hpp"
 #include "functions/cos.hpp"
 #include "functions/sin.hpp"
 #include "quantities/numbers.hpp"  // 🧙 For π.
@@ -11,12 +12,11 @@
 namespace principia {
 namespace functions {
 
+using namespace principia::benchmarks::_metric;
 using namespace principia::functions::_cos;
 using namespace principia::functions::_sin;
 
 static constexpr std::int64_t number_of_iterations = 1000;
-
-enum class Metric { Latency, Throughput };
 
 template<Metric metric, double (__cdecl *fn)(double)>
 void BM_EvaluateElementaryFunction(benchmark::State& state) {

--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -43,7 +43,7 @@ void BM_EvaluateElementaryFunction(benchmark::State& state) {
     static_assert(metric == Metric::Latency);
     Value v;
     while (state.KeepRunningBatch(number_of_iterations)) {
-      Argument argument = a[0];
+      Argument argument = a[number_of_iterations - 1];
       for (std::int64_t i = 0; i < number_of_iterations; ++i) {
         v = fn(argument);
         argument = (v + a[i]) - v;

--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -46,9 +46,7 @@ void BM_EvaluateElementaryFunction(benchmark::State& state) {
       Argument argument = a[0];
       for (std::int64_t i = 0; i < number_of_iterations; ++i) {
         v = fn(argument);
-        // Here v < 1 / √2 < π / 4.  The quantity being added is less than
-        // π / 64 < π / 4 - 1 / √2, thus the argument remains less than π / 4.
-        argument = v + 0.0625 * a[i];
+        argument = (v + a[i]) - v;
       }
     }
   }

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "benchmark/benchmark.h"
+#include "benchmarks/metric.hpp"
 #include "numerics/double_precision.hpp"
 #include "numerics/scale_b.hpp"
 #include "quantities/elementary_functions.hpp"
@@ -20,6 +21,7 @@ namespace functions {
 // TODO(phl): Study the effect of rounding the polynomial coefficients to
 // machine numbers.
 
+using namespace principia::benchmarks::_metric;
 using namespace principia::numerics::_double_precision;
 using namespace principia::numerics::_scale_b;
 using namespace principia::quantities::_elementary_functions;
@@ -426,192 +428,142 @@ Value SingleTableImplementation::CosPolynomial2(Argument const x) {
   return x * (0x1.5555555555555p-5 - 0x1.6C16C10C09C11p-10 * x);
 }
 
-template<Argument table_spacing>
+template<Metric metric, typename Implementation>
+void BaseSinBenchmark(Argument const& min_argument,
+                      Argument const& max_argument,
+                      Value const& max_absolute_error,
+                      benchmark::State& state) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> uniformly_at(min_argument, max_argument);
+
+  Implementation implementation;
+  implementation.Initialize();
+
+  Argument a[number_of_iterations];
+  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+    a[i] = uniformly_at(random);
+  }
+
+  Value v[number_of_iterations];
+  while (state.KeepRunningBatch(number_of_iterations)) {
+    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+      v[i] = implementation.Sin(a[i]);
+#if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
+      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
+      CHECK_LT(absolute_error, max_absolute_error);
+#endif
+    }
+    benchmark::DoNotOptimize(v);
+  }
+}
+
+template<Metric metric, typename Implementation>
+void BaseCosBenchmark(Argument const& min_argument,
+                      Argument const& max_argument,
+                      Value const& max_absolute_error,
+                      benchmark::State& state) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> uniformly_at(min_argument, max_argument);
+
+  Implementation implementation;
+  implementation.Initialize();
+
+  Argument a[number_of_iterations];
+  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+    a[i] = uniformly_at(random);
+  }
+
+  Value v[number_of_iterations];
+  while (state.KeepRunningBatch(number_of_iterations)) {
+    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+      v[i] = implementation.Cos(a[i]);
+#if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
+      auto const absolute_error = Abs(v[i] - std::cos(a[i]));
+      CHECK_LT(absolute_error, max_absolute_error);
+#endif
+    }
+    benchmark::DoNotOptimize(v);
+  }
+}
+
+template<Metric metric, Argument table_spacing>
 void BM_ExperimentSinTableSpacing(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(x_min, x_max);
-
-  TableSpacingImplementation<table_spacing> implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Sin(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+  BaseSinBenchmark<metric, TableSpacingImplementation<table_spacing>>(
+      x_min, x_max,
+      1.2e-16,
+      state);
 }
 
-template<Argument table_spacing>
+template<Metric metric,Argument table_spacing>
 void BM_ExperimentCosTableSpacing(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(x_min, x_max);
-
-  TableSpacingImplementation<table_spacing> implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Cos(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+  BaseCosBenchmark<metric, TableSpacingImplementation<table_spacing>>(
+      x_min, x_max,
+      1.2e-16,
+      state);
 }
 
+template<Metric metric>
 void BM_ExperimentSinMultiTable(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(
+  BaseSinBenchmark<metric, MultiTableImplementation>(
       MultiTableImplementation::cutoffs
-          [MultiTableImplementation::number_of_tables - 1],
-      x_max);
-
-  MultiTableImplementation implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Sin(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+          [MultiTableImplementation::number_of_tables - 1], x_max,
+      1.2e-16,
+      state);
 }
 
+template<Metric metric>
 void BM_ExperimentCosMultiTable(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(
+  BaseCosBenchmark<metric, MultiTableImplementation>(
       MultiTableImplementation::cutoffs
-          [MultiTableImplementation::number_of_tables - 1],
-      x_max);
-
-  MultiTableImplementation implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Cos(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+          [MultiTableImplementation::number_of_tables - 1], x_max,
+      1.2e-16,
+      state);
 }
 
+template<Metric metric>
 void BM_ExperimentSinSingleTable(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(
-      SingleTableImplementation::min_argument,
-      x_max);
-
-  SingleTableImplementation implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Sin(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+  BaseSinBenchmark<metric, SingleTableImplementation>(
+      SingleTableImplementation::min_argument, x_max,
+      1.2e-16,
+      state);
 }
 
+template<Metric metric>
 void BM_ExperimentCosSingleTable(benchmark::State& state) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(
-      SingleTableImplementation::min_argument,
-      x_max);
-
-  SingleTableImplementation implementation;
-  implementation.Initialize();
-
-  Argument a[number_of_iterations];
-  for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-    a[i] = uniformly_at(random);
-  }
-
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Cos(a[i]);
-#if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-      CHECK_LT(absolute_error, 1.2e-16);
-#endif
-    }
-    benchmark::DoNotOptimize(v);
-  }
+  BaseCosBenchmark<metric, SingleTableImplementation>(
+      SingleTableImplementation::min_argument, x_max,
+      1.2e-16,
+      state);
 }
 
-BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing, 2.0 / 256.0)
+BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
+                   Metric::Throughput,
+                   2.0 / 256.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing, 2.0 / 1024.0)
+BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
+                   Metric::Throughput,
+                   2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing, 2.0 / 256.0)
+BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
+                   Metric::Throughput,
+                   2.0 / 256.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing, 2.0 / 1024.0)
+BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
+                   Metric::Throughput,
+                   2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
-BENCHMARK(BM_ExperimentSinMultiTable)->Unit(benchmark::kNanosecond);
-BENCHMARK(BM_ExperimentCosMultiTable)->Unit(benchmark::kNanosecond);
-BENCHMARK(BM_ExperimentSinSingleTable)->Unit(benchmark::kNanosecond);
-BENCHMARK(BM_ExperimentCosSingleTable)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinMultiTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosMultiTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinSingleTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosSingleTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
 
 }  // namespace functions
 }  // namespace principia

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -18,8 +18,6 @@ namespace functions {
 
 // TODO(phl): The polynomials in this file should use class
 // |PolynomialInMonomialBasis|.
-// TODO(phl): Study the effect of rounding the polynomial coefficients to
-// machine numbers.
 
 using namespace principia::benchmarks::_metric;
 using namespace principia::numerics::_double_precision;
@@ -465,7 +463,7 @@ void BaseSinBenchmark(Argument const& min_argument,
     static_assert(metric == Metric::Latency);
     Value v;
     while (state.KeepRunningBatch(number_of_iterations)) {
-      Argument argument = a[0];
+      Argument argument = a[number_of_iterations - 1];
       for (std::int64_t i = 0; i < number_of_iterations; ++i) {
         v = implementation.Sin(argument);
         argument = (v + a[i]) - v;
@@ -509,7 +507,7 @@ void BaseCosBenchmark(Argument const& min_argument,
     static_assert(metric == Metric::Latency);
     Value v;
     while (state.KeepRunningBatch(number_of_iterations)) {
-      Argument argument = a[0];
+      Argument argument = a[number_of_iterations - 1];
       for (std::int64_t i = 0; i < number_of_iterations; ++i) {
         v = implementation.Cos(argument);
         argument = (v + a[i]) - v;

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -525,7 +525,7 @@ void BM_ExperimentSinTableSpacing(benchmark::State& state) {
       state);
 }
 
-template<Metric metric,Argument table_spacing>
+template<Metric metric, Argument table_spacing>
 void BM_ExperimentCosTableSpacing(benchmark::State& state) {
   BaseCosBenchmark<metric, TableSpacingImplementation<table_spacing>>(
       x_min, x_max,

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -117,7 +117,8 @@ class MultiTableImplementation {
   // Because the interval [π / 6, π / 4] is shorter than the next one below, the
   // maximum value is reached between the first two cutoffs.
   static constexpr std::int64_t table_size =
-      static_cast<std::int64_t>((cutoffs[0] - cutoffs[1]) / table_spacings[1]);
+      static_cast<std::int64_t>((cutoffs[0] - cutoffs[1]) / table_spacings[1]) +
+      1;
 
   std::array<std::int64_t, number_of_tables> one_over_table_spacings_;
   std::array<std::array<AccurateValues, table_size>, number_of_tables>
@@ -244,7 +245,9 @@ void MultiTableImplementation::Initialize() {
     current_x_min = cutoffs[i];
     one_over_table_spacings_[i] = 1.0 / table_spacings[i];
     Argument x = current_x_min + table_spacings[i] / 2;
-    for (std::int64_t j = 0; j < table_size && x < current_x_max; ++j) {
+    for (std::int64_t j = 0;
+         j < table_size && x < current_x_max + table_spacings[i] / 2;
+         ++j) {
       accurate_values_[i][j] = {.x = x,
                                 .sin_x = std::sin(x),
                                 .cos_x = std::cos(x)};
@@ -541,26 +544,50 @@ void BM_ExperimentCosSingleTable(benchmark::State& state) {
 }
 
 BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
+                   Metric::Latency,
+                   2.0 / 256.0)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
                    Metric::Throughput,
                    2.0 / 256.0)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
+                   Metric::Latency,
+                   2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentSinTableSpacing,
                    Metric::Throughput,
                    2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
+                   Metric::Latency,
+                   2.0 / 256.0)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
                    Metric::Throughput,
                    2.0 / 256.0)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
+                   Metric::Latency,
+                   2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentCosTableSpacing,
                    Metric::Throughput,
                    2.0 / 1024.0)
     ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinMultiTable, Metric::Latency)
+    ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentSinMultiTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosMultiTable, Metric::Latency)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentCosMultiTable, Metric::Throughput)
     ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentSinSingleTable, Metric::Latency)
+    ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentSinSingleTable, Metric::Throughput)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_ExperimentCosSingleTable, Metric::Latency)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_ExperimentCosSingleTable, Metric::Throughput)
     ->Unit(benchmark::kNanosecond);

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -447,16 +447,29 @@ void BaseSinBenchmark(Argument const& min_argument,
     a[i] = uniformly_at(random);
   }
 
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Sin(a[i]);
+  if constexpr (metric == Metric::Throughput) {
+    Value v[number_of_iterations];
+    while (state.KeepRunningBatch(number_of_iterations)) {
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        v[i] = implementation.Sin(a[i]);
 #if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-      CHECK_LT(absolute_error, max_absolute_error);
+        // The implementation is not accurate, but let's check that it's not
+        // broken.
+        auto const absolute_error = Abs(v[i] - std::sin(a[i]));
+        CHECK_LT(absolute_error, max_absolute_error);
 #endif
+      }
+      benchmark::DoNotOptimize(v);
+    }
+  } else {
+    static_assert(metric == Metric::Latency);
+    Value v;
+    while (state.KeepRunningBatch(number_of_iterations)) {
+      Argument argument = a[0];
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        v = implementation.Sin(argument);
+        argument = (v + a[i]) - v;
+      }
     }
     benchmark::DoNotOptimize(v);
   }
@@ -478,16 +491,29 @@ void BaseCosBenchmark(Argument const& min_argument,
     a[i] = uniformly_at(random);
   }
 
-  Value v[number_of_iterations];
-  while (state.KeepRunningBatch(number_of_iterations)) {
-    for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-      v[i] = implementation.Cos(a[i]);
+  if constexpr (metric == Metric::Throughput) {
+    Value v[number_of_iterations];
+    while (state.KeepRunningBatch(number_of_iterations)) {
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        v[i] = implementation.Cos(a[i]);
 #if _DEBUG
-      // The implementation is not accurate, but let's check that it's not
-      // broken.
-      auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-      CHECK_LT(absolute_error, max_absolute_error);
+        // The implementation is not accurate, but let's check that it's not
+        // broken.
+        auto const absolute_error = Abs(v[i] - std::cos(a[i]));
+        CHECK_LT(absolute_error, max_absolute_error);
 #endif
+      }
+      benchmark::DoNotOptimize(v);
+    }
+  } else {
+    static_assert(metric == Metric::Latency);
+    Value v;
+    while (state.KeepRunningBatch(number_of_iterations)) {
+      Argument argument = a[0];
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        v = implementation.Cos(argument);
+        argument = (v + a[i]) - v;
+      }
     }
     benchmark::DoNotOptimize(v);
   }

--- a/benchmarks/metric.hpp
+++ b/benchmarks/metric.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace principia {
+namespace benchmarks {
+namespace _metric {
+namespace internal {
+
+enum class Metric {
+  Latency,
+  Throughput
+};
+
+}  // namespace internal
+
+using internal::Metric;
+
+}  // namespace _metric
+}  // namespace benchmarks
+}  // namespace principia

--- a/benchmarks/polynomial_in_monomial_basis_benchmark.cpp
+++ b/benchmarks/polynomial_in_monomial_basis_benchmark.cpp
@@ -5,6 +5,7 @@
 
 #include "astronomy/frames.hpp"
 #include "benchmark/benchmark.h"
+#include "benchmarks/metric.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/r3_element.hpp"
 #include "geometry/space.hpp"
@@ -19,6 +20,7 @@ namespace principia {
 namespace numerics {
 
 using namespace principia::astronomy::_frames;
+using namespace principia::benchmarks::_metric;
 using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_r3_element;
 using namespace principia::geometry::_space;
@@ -29,11 +31,6 @@ using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;
 
 static constexpr std::int64_t number_of_iterations = 100;
-
-enum class Metric {
-  Latency,
-  Throughput
-};
 
 template<typename T>
 struct ValueGenerator;


### PR DESCRIPTION
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
---------------------------------------------------------------------------------------------------------
Benchmark                                                               Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------
BM_EvaluateElementaryFunction<Metric::Latency, std::sin>             7.25 ns         7.15 ns     89600000
BM_EvaluateElementaryFunction<Metric::Throughput, std::sin>          2.22 ns         2.25 ns    320000000
BM_EvaluateElementaryFunction<Metric::Latency, cr_sin>               31.8 ns         31.5 ns     21334000
BM_EvaluateElementaryFunction<Metric::Throughput, cr_sin>            21.4 ns         21.3 ns     34462000
BM_EvaluateElementaryFunction<Metric::Latency, std::cos>             8.13 ns         8.20 ns     89600000
BM_EvaluateElementaryFunction<Metric::Throughput, std::cos>          2.70 ns         2.67 ns    263530000
BM_EvaluateElementaryFunction<Metric::Latency, cr_cos>               35.2 ns         35.3 ns     20364000
BM_EvaluateElementaryFunction<Metric::Throughput, cr_cos>            22.0 ns         22.0 ns     32000000
BM_ExperimentSinTableSpacing<Metric::Latency, 2.0 / 256.0>           12.5 ns         12.6 ns     56000000
BM_ExperimentSinTableSpacing<Metric::Throughput, 2.0 / 256.0>        2.54 ns         2.55 ns    263530000
BM_ExperimentSinTableSpacing<Metric::Latency, 2.0 / 1024.0>          11.3 ns         11.2 ns     56000000
BM_ExperimentSinTableSpacing<Metric::Throughput, 2.0 / 1024.0>       2.24 ns         2.25 ns    320000000
BM_ExperimentCosTableSpacing<Metric::Latency, 2.0 / 256.0>           12.3 ns         12.3 ns     56000000
BM_ExperimentCosTableSpacing<Metric::Throughput, 2.0 / 256.0>        2.54 ns         2.57 ns    280000000
BM_ExperimentCosTableSpacing<Metric::Latency, 2.0 / 1024.0>          11.1 ns         11.2 ns     64000000
BM_ExperimentCosTableSpacing<Metric::Throughput, 2.0 / 1024.0>       2.25 ns         2.25 ns    320000000
BM_ExperimentSinMultiTable<Metric::Latency>                          12.3 ns         12.3 ns     56000000
BM_ExperimentSinMultiTable<Metric::Throughput>                       3.28 ns         3.30 ns    213334000
BM_ExperimentCosMultiTable<Metric::Latency>                          12.1 ns         12.2 ns     64000000
BM_ExperimentCosMultiTable<Metric::Throughput>                       3.25 ns         3.22 ns    213334000
BM_ExperimentSinSingleTable<Metric::Latency>                         11.8 ns         11.7 ns     56000000
BM_ExperimentSinSingleTable<Metric::Throughput>                      2.85 ns         2.85 ns    235790000
BM_ExperimentCosSingleTable<Metric::Latency>                         11.7 ns         11.7 ns     56000000
BM_ExperimentCosSingleTable<Metric::Throughput>                      2.86 ns         2.83 ns    248889000
```
#1760.