### PR TITLE
Change the FMA support to make it possible to test for FMA upstream and propagate the decision

### DIFF
--- a/base/macros.hpp
+++ b/base/macros.hpp
@@ -178,6 +178,14 @@ char const* const Architecture = "x86-64";
 // For templates in macro parameters.
 #define TEMPLATE(...) template<__VA_ARGS__>
 
+#define PRINCIPIA_REPEAT8(...) \
+  PRINCIPIA_REPEAT4(__VA_ARGS__) PRINCIPIA_REPEAT4(__VA_ARGS__)
+#define PRINCIPIA_REPEAT4(...) \
+  PRINCIPIA_REPEAT2(__VA_ARGS__) PRINCIPIA_REPEAT2(__VA_ARGS__)
+#define PRINCIPIA_REPEAT2(...) \
+  PRINCIPIA_REPEAT1(__VA_ARGS__) PRINCIPIA_REPEAT1(__VA_ARGS__)
+#define PRINCIPIA_REPEAT1(...) __VA_ARGS__
+
 // The macro magic is inspired from http://jhnet.co.uk/articles/cpp_magic.  Note
 // that we are using __VA_OPT__ to stop the recursion and detect empty argument
 // lists because we are modern.

--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <random>
 
+#include "base/macros.hpp"  // 🧙 For PRINCIPIA_REPEAT.
 #include "benchmark/benchmark.h"
 #include "benchmarks/metric.hpp"
 #include "functions/cos.hpp"
@@ -34,8 +35,8 @@ void BM_EvaluateElementaryFunction(benchmark::State& state) {
   if constexpr (metric == Metric::Throughput) {
     Value v[number_of_iterations];
     while (state.KeepRunningBatch(number_of_iterations)) {
-      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-        v[i] = fn(a[i]);
+      for (std::int64_t i = 0; i < number_of_iterations;) {
+        PRINCIPIA_REPEAT8(v[i] = fn(a[i]); ++i;)
       }
       benchmark::DoNotOptimize(v);
     }

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -29,8 +29,8 @@ using Argument = double;
 // A polynomial is too heavy an object to use in this code, so we call the
 // evaluators directly.
 // TODO(phl): FMA makes things slower :-(
-using Polynomial1 = Horner<Value, Argument, 1>;
-using Polynomial2 = Horner<Value, Argument, 2>;
+using Polynomial1 = HornerForceFMA<Value, Argument, 1>;
+using Polynomial2 = HornerForceFMA<Value, Argument, 2>;
 
 constexpr Argument x_min = π / 6;  // The sinus is greater than 1/2.
 constexpr Argument x_max = π / 4;  // Upper bound after argument reduction.

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -6,6 +6,7 @@
 #include <random>
 #include <utility>
 
+#include "base/macros.hpp"  // 🧙 For PRINCIPIA_REPEAT.
 #include "benchmark/benchmark.h"
 #include "benchmarks/metric.hpp"
 #include "numerics/double_precision.hpp"
@@ -820,16 +821,18 @@ void BaseSinBenchmark(Argument const& min_argument,
   if constexpr (metric == Metric::Throughput) {
     Value v[number_of_iterations];
     while (state.KeepRunningBatch(number_of_iterations)) {
-      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-        v[i] = implementation.Sin(a[i]);
-#if _DEBUG
-        // The implementation is not accurate, but let's check that it's not
-        // broken.
-        auto const absolute_error = Abs(v[i] - std::sin(a[i]));
-        CHECK_LT(absolute_error, max_absolute_error);
-#endif
+      for (std::int64_t i = 0; i < number_of_iterations;) {
+        PRINCIPIA_REPEAT8(v[i] = implementation.Sin(a[i]); ++i;)
       }
       benchmark::DoNotOptimize(v);
+#if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        auto const absolute_error = Abs(v[i] - std::sin(a[i]));
+        CHECK_LT(absolute_error, max_absolute_error);
+      }
+#endif
     }
   } else {
     static_assert(metric == Metric::Latency);
@@ -863,16 +866,18 @@ void BaseCosBenchmark(Argument const& min_argument,
   if constexpr (metric == Metric::Throughput) {
     Value v[number_of_iterations];
     while (state.KeepRunningBatch(number_of_iterations)) {
-      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
-        v[i] = implementation.Cos(a[i]);
-#if _DEBUG
-        // The implementation is not accurate, but let's check that it's not
-        // broken.
-        auto const absolute_error = Abs(v[i] - std::cos(a[i]));
-        CHECK_LT(absolute_error, max_absolute_error);
-#endif
+      for (std::int64_t i = 0; i < number_of_iterations;) {
+        PRINCIPIA_REPEAT8(v[i] = implementation.Cos(a[i]); ++i;)
       }
       benchmark::DoNotOptimize(v);
+#if _DEBUG
+      // The implementation is not accurate, but let's check that it's not
+      // broken.
+      for (std::int64_t i = 0; i < number_of_iterations; ++i) {
+        auto const absolute_error = Abs(v[i] - std::cos(a[i]));
+        CHECK_LT(absolute_error, max_absolute_error);
+      }
+#endif
     }
   } else {
     static_assert(metric == Metric::Latency);

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -263,11 +263,8 @@ TableSpacingImplementation<table_spacing>::TableSpacingImplementation() {
 template<Argument table_spacing>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Sin(Argument const x) {
- if (UseHardwareFMA) {
-    return SinImplementation<FMAPolicy::Force>(x);
-  } else {
-    return SinImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
+                        : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<Argument table_spacing>
@@ -295,11 +292,8 @@ Value TableSpacingImplementation<table_spacing>::SinImplementation(
 template<Argument table_spacing>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Cos(Argument const x) {
-  if (UseHardwareFMA) {
-    return CosImplementation<FMAPolicy::Force>(x);
-  } else {
-    return CosImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
+                        : CosImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<Argument table_spacing>
@@ -374,11 +368,8 @@ MultiTableImplementation::MultiTableImplementation() {
 
 FORCE_INLINE(inline)
 Value MultiTableImplementation::Sin(Argument const x) {
-  if (UseHardwareFMA) {
-    return SinImplementation<FMAPolicy::Force>(x);
-  } else {
-    return SinImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
+                        : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>
@@ -408,11 +399,8 @@ Value MultiTableImplementation::SinImplementation(Argument const x) {
 
 FORCE_INLINE(inline)
 Value MultiTableImplementation::Cos(Argument const x) {
-  if (UseHardwareFMA) {
-    return CosImplementation<FMAPolicy::Force>(x);
-  } else {
-    return CosImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
+                        : CosImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>
@@ -504,11 +492,8 @@ SingleTableImplementation::SingleTableImplementation() {
 
 FORCE_INLINE(inline)
 Value SingleTableImplementation::Sin(Argument const x) {
- if (UseHardwareFMA) {
-    return SinImplementation<FMAPolicy::Force>(x);
-  } else {
-    return SinImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
+                        : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>
@@ -546,11 +531,8 @@ Value SingleTableImplementation::SinImplementation(Argument const x) {
 
 FORCE_INLINE(inline)
 Value SingleTableImplementation::Cos(Argument const x) {
-  if (UseHardwareFMA) {
-    return CosImplementation<FMAPolicy::Force>(x);
-  } else {
-    return CosImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
+                        : CosImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>
@@ -607,11 +589,8 @@ NearZeroImplementation::NearZeroImplementation() {
 
 FORCE_INLINE(inline)
 Value NearZeroImplementation::Sin(Argument const x) {
-  if (UseHardwareFMA) {
-    return SinImplementation<FMAPolicy::Force>(x);
-  } else {
-    return SinImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
+                        : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>
@@ -655,11 +634,8 @@ Value NearZeroImplementation::SinImplementation(Argument const x) {
 
 FORCE_INLINE(inline)
 Value NearZeroImplementation::Cos(Argument const x) {
-  if (UseHardwareFMA) {
-    return CosImplementation<FMAPolicy::Force>(x);
-  } else {
-    return CosImplementation<FMAPolicy::Disallow>(x);
-  }
+  return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
+                        : CosImplementation<FMAPolicy::Disallow>(x);
 }
 
 template<FMAPolicy fma_policy>

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -305,7 +305,7 @@ template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Sin(
     Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
@@ -329,7 +329,7 @@ template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Cos(
     Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
@@ -399,7 +399,7 @@ MultiTableImplementation::MultiTableImplementation() {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value MultiTableImplementation::Sin(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   std::int64_t i;
   Argument cutoff;
@@ -426,7 +426,7 @@ Value MultiTableImplementation::Sin(Argument const x) {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value MultiTableImplementation::Cos(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   std::int64_t i;
   Argument cutoff;
@@ -515,7 +515,7 @@ SingleTableImplementation::SingleTableImplementation() {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value SingleTableImplementation::Sin(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
@@ -550,7 +550,7 @@ Value SingleTableImplementation::Sin(Argument const x) {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value SingleTableImplementation::Cos(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
@@ -604,7 +604,7 @@ NearZeroImplementation::NearZeroImplementation() {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value NearZeroImplementation::Sin(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   if (x < near_zero_cutoff) {
     auto const x² = x * x;
@@ -645,7 +645,7 @@ Value NearZeroImplementation::Sin(Argument const x) {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value NearZeroImplementation::Cos(Argument const x) {
-  DCHECK(UseHardwareFMA);
+  DCHECK(CanEmitFMAInstructions);
 
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
@@ -892,7 +892,7 @@ template<Metric metric, Argument table_spacing>
 void BM_ExperimentSinTableSpacing(benchmark::State& state) {
   BaseSinBenchmark<metric, TableSpacingImplementation<table_spacing>>(
       x_min, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -900,7 +900,7 @@ template<Metric metric, Argument table_spacing>
 void BM_ExperimentCosTableSpacing(benchmark::State& state) {
   BaseCosBenchmark<metric, TableSpacingImplementation<table_spacing>>(
       x_min, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -909,7 +909,7 @@ void BM_ExperimentSinMultiTable(benchmark::State& state) {
   BaseSinBenchmark<metric, MultiTableImplementation>(
       MultiTableImplementation::cutoffs
           [MultiTableImplementation::number_of_tables - 1], x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -918,7 +918,7 @@ void BM_ExperimentCosMultiTable(benchmark::State& state) {
   BaseCosBenchmark<metric, MultiTableImplementation>(
       MultiTableImplementation::cutoffs
           [MultiTableImplementation::number_of_tables - 1], x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -926,7 +926,7 @@ template<Metric metric>
 void BM_ExperimentSinSingleTable(benchmark::State& state) {
   BaseSinBenchmark<metric, SingleTableImplementation>(
       SingleTableImplementation::min_argument, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -934,7 +934,7 @@ template<Metric metric>
 void BM_ExperimentCosSingleTable(benchmark::State& state) {
   BaseCosBenchmark<metric, SingleTableImplementation>(
       SingleTableImplementation::min_argument, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -942,7 +942,7 @@ template<Metric metric>
 void BM_ExperimentSinNearZero(benchmark::State& state) {
   BaseSinBenchmark<metric, NearZeroImplementation>(
       0.0, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 
@@ -950,7 +950,7 @@ template<Metric metric>
 void BM_ExperimentCosNearZero(benchmark::State& state) {
   BaseCosBenchmark<metric, NearZeroImplementation>(
       0.0, x_max,
-      1.2e-16,
+      2.3e-16,
       state);
 }
 

--- a/benchmarks/elementary_functions_experiments_benchmark.cpp
+++ b/benchmarks/elementary_functions_experiments_benchmark.cpp
@@ -30,7 +30,6 @@ using Argument = double;
 
 // A polynomial is too heavy an object to use in this code, so we call the
 // evaluators directly.
-// TODO(phl): FMA makes things slower :-(
 template<FMAPolicy fma_policy>
 using Polynomial1 = HornerEvaluator<Value, Argument, 1, fma_policy>;
 template<FMAPolicy fma_policy>
@@ -244,8 +243,6 @@ TableSpacingImplementation<table_spacing>::TableSpacingImplementation() {
 template<Argument table_spacing>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Sin(Argument const x) {
-  using enum FMAPolicy;
-
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
   auto const& x₀ = accurate_values.x;
@@ -275,8 +272,6 @@ Value TableSpacingImplementation<table_spacing>::Sin(Argument const x) {
 template<Argument table_spacing>
 FORCE_INLINE(inline)
 Value TableSpacingImplementation<table_spacing>::Cos(Argument const x) {
-  using enum FMAPolicy;
-
   auto const i = static_cast<std::int64_t>(x * (1.0 / table_spacing));
   auto const& accurate_values = accurate_values_[i];
   auto const& x₀ = accurate_values.x;
@@ -355,8 +350,6 @@ MultiTableImplementation::MultiTableImplementation() {
 
 FORCE_INLINE(inline)
 Value MultiTableImplementation::Sin(Argument const x) {
-  using enum FMAPolicy;
-
   std::int64_t i;
   Argument cutoff;
   SelectCutoff(x, i, cutoff);

--- a/mathematica/floating_point.wl
+++ b/mathematica/floating_point.wl
@@ -65,20 +65,20 @@ TowardNegativeInfinity=Floor;
 mantissaExponent12[x_]:={#[[1]]*2,#[[2]]-1}&[MantissaExponent[x,2]];
 Representation[x_]:=Block[
 {sign,magnitude,\[Mu],e},
-sign=Sign[x];
+sign=If[x<0,2^(exponentBits+significandBits-1),0];
 magnitude=Abs[x];
 If[magnitude==\[Infinity],
-sign(2^exponentBits-1)2^(significandBits-1),
+sign+(2^exponentBits-1)2^(significandBits-1),
 If[x==0,0,
 {\[Mu],e}=mantissaExponent12[magnitude];
 If[e<=-bias,
 2^(significandBits-1) 2^(e+bias-1) \[Mu],
-sign(2^(significandBits-1) (\[Mu]-1)+2^(significandBits-1) (e+bias))
+sign+(2^(significandBits-1) (\[Mu]-1)+2^(significandBits-1) (e+bias))
 ]]]];
 FromRepresentation[n_]:=Block[
 {sign,magnitude,\[Mu],e},
-sign=Sign[n];
-magnitude=Abs[n];
+sign=If[n>=2^(exponentBits+significandBits-1),-1,1];
+magnitude=Mod[n,2^(exponentBits+significandBits-1)];
 \[Mu]=Mod[magnitude,2^(significandBits-1)];
 e=IntegerPart[magnitude/2^(significandBits-1)];
 If[e==0,

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "base/not_null.hpp"
+#include "numerics/fma.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 #include "serialization/numerics.pb.h"
@@ -13,6 +14,7 @@ namespace _double_precision {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::numerics::_fma;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 
@@ -59,29 +61,29 @@ DoublePrecision<Product<T, U>> Scale(T const& scale,
 // from context, it may be preferable to either:
 // — use VeltkampDekkerProduct(a, b) below;
 // — directly compute value = a * b, error = FusedMultiplySubtract(a, b, value).
-template<bool force_fma = false, typename T, typename U>
+template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b);
 
 // Returns the exact value of |a * b + c|.
-template<bool force_fma = false, typename T, typename U>
+template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c);
 
 // Returns the exact value of |a * b - c|.
-template<bool force_fma = false, typename T, typename U>
+template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c);
 
 // Returns the exact value of |-a * b + c|.
-template<bool force_fma = false, typename T, typename U>
+template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c);
 
 // Returns the exact value of |-a * b - c|.
-template<bool force_fma = false, typename T, typename U>
+template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>>
 TwoProductNegatedSubtract(T const& a,
                           U const& b,

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -59,29 +59,29 @@ DoublePrecision<Product<T, U>> Scale(T const& scale,
 // from context, it may be preferable to either:
 // — use VeltkampDekkerProduct(a, b) below;
 // — directly compute value = a * b, error = FusedMultiplySubtract(a, b, value).
-template<typename T, typename U>
+template<bool force_fma = false, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b);
 
 // Returns the exact value of |a * b + c|.
-template<typename T, typename U>
+template<bool force_fma = false, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c);
 
 // Returns the exact value of |a * b - c|.
-template<typename T, typename U>
+template<bool force_fma = false, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c);
 
 // Returns the exact value of |-a * b + c|.
-template<typename T, typename U>
+template<bool force_fma = false, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c);
 
 // Returns the exact value of |-a * b - c|.
-template<typename T, typename U>
+template<bool force_fma = false, typename T, typename U>
 DoublePrecision<Product<T, U>>
 TwoProductNegatedSubtract(T const& a,
                           U const& b,

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -237,10 +237,11 @@ constexpr DoublePrecision<Product<T, U>> VeltkampDekkerProduct(T const& a,
   return result;
 }
 
-template<bool force_fma, typename T, typename U>
+template<FMAPolicy fma_policy, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
-  if (force_fma || UseHardwareFMA) {
+  if (fma_policy == FMAPolicy::Force ||
+      (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
     DoublePrecision<Product<T, U>> result(a * b);
     result.error = FusedMultiplySubtract(a, b, result.value);
@@ -250,12 +251,13 @@ DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
   }
 }
 
-template<bool force_fma, typename T, typename U>
+template<FMAPolicy fma_policy, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c) {
-  if (force_fma || UseHardwareFMA) {
+  if (fma_policy == FMAPolicy::Force ||
+      (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedMultiplyAdd(a, b, c));
@@ -268,12 +270,13 @@ DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
   }
 }
 
-template<bool force_fma, typename T, typename U>
+template<FMAPolicy fma_policy, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c) {
-  if (force_fma || UseHardwareFMA) {
+  if (fma_policy == FMAPolicy::Force ||
+      (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedMultiplySubtract(a, b, c));
@@ -286,12 +289,13 @@ DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
   }
 }
 
-template<bool force_fma, typename T, typename U>
+template<FMAPolicy fma_policy, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c) {
-  if (force_fma || UseHardwareFMA) {
+  if (fma_policy == FMAPolicy::Force ||
+      (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedNegatedMultiplyAdd(a, b, c));
@@ -304,13 +308,14 @@ DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
   }
 }
 
-template<bool force_fma, typename T, typename U>
+template<FMAPolicy fma_policy, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>>
 TwoProductNegatedSubtract(T const& a,
                           U const& b,
                           Product<T, U> const& c) {
-  if (force_fma || UseHardwareFMA) {
+  if (fma_policy == FMAPolicy::Force ||
+      (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
     DoublePrecision<Product<T, U>> result(

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -237,10 +237,10 @@ constexpr DoublePrecision<Product<T, U>> VeltkampDekkerProduct(T const& a,
   return result;
 }
 
-template<typename T, typename U>
+template<bool force_fma, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
-  if (UseHardwareFMA) {
+  if (force_fma || UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
     DoublePrecision<Product<T, U>> result(a * b);
     result.error = FusedMultiplySubtract(a, b, result.value);
@@ -250,12 +250,12 @@ DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
   }
 }
 
-template<typename T, typename U>
+template<bool force_fma, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c) {
-  if (UseHardwareFMA) {
+  if (force_fma || UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedMultiplyAdd(a, b, c));
@@ -268,12 +268,12 @@ DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
   }
 }
 
-template<typename T, typename U>
+template<bool force_fma, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c) {
-  if (UseHardwareFMA) {
+  if (force_fma || UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedMultiplySubtract(a, b, c));
@@ -286,12 +286,12 @@ DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
   }
 }
 
-template<typename T, typename U>
+template<bool force_fma, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c) {
-  if (UseHardwareFMA) {
+  if (force_fma || UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     DoublePrecision<Product<T, U>> result(FusedNegatedMultiplyAdd(a, b, c));
@@ -304,13 +304,13 @@ DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
   }
 }
 
-template<typename T, typename U>
+template<bool force_fma, typename T, typename U>
 FORCE_INLINE(inline)
 DoublePrecision<Product<T, U>>
 TwoProductNegatedSubtract(T const& a,
                           U const& b,
                           Product<T, U> const& c) {
-  if (UseHardwareFMA) {
+  if (force_fma || UseHardwareFMA) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
     DoublePrecision<Product<T, U>> result(

--- a/numerics/fma.hpp
+++ b/numerics/fma.hpp
@@ -26,6 +26,21 @@ inline bool const UseHardwareFMA =
 inline bool const UseHardwareFMA = false;
 #endif
 
+// The policy used for emitting FMA instructions:
+// * |Auto|: FMA is used if supported by the processor, the decision must be
+//   made dynamically by calling |UseHardwareFMA|.
+// * |Disallow|: FMA is never used.
+// * |Force|: FMA is always used.  The caller is expected to determine upstream
+//   if FMA is supported by the processor by calling |UseHardwareFMA|.  Note
+//   that |Force| is equivalent to |Disallow| on clang.
+// This type is not used by this file, but is declared here for the convenience
+// of the clients.
+enum class FMAPolicy {
+  Auto = 0,
+  Disallow = 1,
+  Force = CanEmitFMAInstructions ? 2 : 1,
+};
+
 // The functions in this file unconditionally wrap the appropriate intrinsics.
 // The caller may only use them if |UseHardwareFMA| is true.
 
@@ -44,6 +59,7 @@ inline double FusedNegatedMultiplySubtract(double a, double b, double c);
 }  // namespace internal
 
 using internal::CanEmitFMAInstructions;
+using internal::FMAPolicy;
 using internal::FusedMultiplyAdd;
 using internal::FusedMultiplySubtract;
 using internal::FusedNegatedMultiplyAdd;

--- a/numerics/fma.hpp
+++ b/numerics/fma.hpp
@@ -26,15 +26,15 @@ inline bool const UseHardwareFMA =
 inline bool const UseHardwareFMA = false;
 #endif
 
-// The policy used for emitting FMA instructions:
+// The policy used for emitting FMA instructions.  This type is not used by this
+// file, but is declared here for the convenience of the clients.  The intended
+// semantics are:
 // * |Auto|: FMA is used if supported by the processor, the decision must be
 //   made dynamically by calling |UseHardwareFMA|.
 // * |Disallow|: FMA is never used.
 // * |Force|: FMA is always used.  The caller is expected to determine upstream
 //   if FMA is supported by the processor by calling |UseHardwareFMA|.  Note
 //   that |Force| is equivalent to |Disallow| on clang.
-// This type is not used by this file, but is declared here for the convenience
-// of the clients.
 enum class FMAPolicy {
   Auto = 0,
   Disallow = 1,

--- a/numerics/polynomial_evaluators.hpp
+++ b/numerics/polynomial_evaluators.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base/not_null.hpp"
+#include "numerics/fma.hpp"
 #include "quantities/concepts.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/tuples.hpp"
@@ -12,6 +13,7 @@ namespace _polynomial_evaluators {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::numerics::_fma;
 using namespace principia::quantities::_concepts;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_tuples;
@@ -47,13 +49,6 @@ struct Evaluator {
       serialization::PolynomialInMonomialBasis::Evaluator const& message);
 };
 
-//TODO(phl)comment
-enum class FMAPolicy {
-  Auto,
-  Disallow,
-  Force,
-};
-
 template<typename Value, typename Argument, int degree, FMAPolicy fma_policy>
 class EstrinEvaluator;
 template<typename Value, typename Argument, int degree, FMAPolicy fma_policy>
@@ -68,19 +63,15 @@ template<typename Value, typename Argument, int degree>
 using EstrinWithoutFMA = internal::
     EstrinEvaluator<Value, Argument, degree, internal::FMAPolicy::Disallow>;
 template<typename Value, typename Argument, int degree>
-using EstrinForceFMA = internal::
-    EstrinEvaluator<Value, Argument, degree, internal::FMAPolicy::Force>;
-template<typename Value, typename Argument, int degree>
 using Horner = internal::
     HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Auto>;
 template<typename Value, typename Argument, int degree>
 using HornerWithoutFMA = internal::
     HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Disallow>;
-template<typename Value, typename Argument, int degree>
-using HornerForceFMA = internal::
-    HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Force>;
 
+using internal::EstrinEvaluator;
 using internal::Evaluator;
+using internal::HornerEvaluator;
 using internal::with_evaluator;
 using internal::with_evaluator_t;
 

--- a/numerics/polynomial_evaluators.hpp
+++ b/numerics/polynomial_evaluators.hpp
@@ -47,25 +47,38 @@ struct Evaluator {
       serialization::PolynomialInMonomialBasis::Evaluator const& message);
 };
 
-template<typename Value, typename Argument, int degree, bool allow_fma>
+//TODO(phl)comment
+enum class FMAPolicy {
+  Auto,
+  Disallow,
+  Force,
+};
+
+template<typename Value, typename Argument, int degree, FMAPolicy fma_policy>
 class EstrinEvaluator;
-template<typename Value, typename Argument, int degree, bool allow_fma>
+template<typename Value, typename Argument, int degree, FMAPolicy fma_policy>
 class HornerEvaluator;
 
 }  // namespace internal
 
 template<typename Value, typename Argument, int degree>
 using Estrin = internal::
-    EstrinEvaluator<Value, Argument, degree, /*allow_fma=*/true>;
+    EstrinEvaluator<Value, Argument, degree, internal::FMAPolicy::Auto>;
 template<typename Value, typename Argument, int degree>
 using EstrinWithoutFMA = internal::
-    EstrinEvaluator<Value, Argument, degree, /*allow_fma=*/false>;
+    EstrinEvaluator<Value, Argument, degree, internal::FMAPolicy::Disallow>;
+template<typename Value, typename Argument, int degree>
+using EstrinForceFMA = internal::
+    EstrinEvaluator<Value, Argument, degree, internal::FMAPolicy::Force>;
 template<typename Value, typename Argument, int degree>
 using Horner = internal::
-    HornerEvaluator<Value, Argument, degree, /*allow_fma=*/true>;
+    HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Auto>;
 template<typename Value, typename Argument, int degree>
 using HornerWithoutFMA = internal::
-    HornerEvaluator<Value, Argument, degree, /*allow_fma=*/false>;
+    HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Disallow>;
+template<typename Value, typename Argument, int degree>
+using HornerForceFMA = internal::
+    HornerEvaluator<Value, Argument, degree, internal::FMAPolicy::Force>;
 
 using internal::Evaluator;
 using internal::with_evaluator;


### PR DESCRIPTION
I am changing the existing benchmarks to force FMA, as that makes their results cleaner, and I am adding a benchmark to evaluate the cost of the FMA decision.

I also noticed that loop unrolling was creating noise (if the code in the benchmark loop was getting too big unrolling would stop and it would loop like we took a big performance hit).  So I am unrolling by hand.
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
---------------------------------------------------------------------------------------------------------
Benchmark                                                               Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------
BM_EvaluateElementaryFunction<Metric::Latency, std::sin>             7.25 ns         7.15 ns     89600000
BM_EvaluateElementaryFunction<Metric::Throughput, std::sin>          2.11 ns         2.10 ns    320000000
BM_EvaluateElementaryFunction<Metric::Latency, cr_sin>               31.9 ns         31.5 ns     21334000
BM_EvaluateElementaryFunction<Metric::Throughput, cr_sin>            20.9 ns         20.9 ns     34462000
BM_EvaluateElementaryFunction<Metric::Latency, std::cos>             8.13 ns         8.20 ns     89600000
BM_EvaluateElementaryFunction<Metric::Throughput, std::cos>          2.33 ns         2.35 ns    298667000
BM_EvaluateElementaryFunction<Metric::Latency, cr_cos>               34.9 ns         34.5 ns     19479000
BM_EvaluateElementaryFunction<Metric::Throughput, cr_cos>            21.9 ns         21.5 ns     32000000
BM_ExperimentSinTableSpacing<Metric::Latency, 2.0 / 256.0>           11.9 ns         12.0 ns     56000000
BM_ExperimentSinTableSpacing<Metric::Throughput, 2.0 / 256.0>        2.24 ns         2.20 ns    298667000
BM_ExperimentSinTableSpacing<Metric::Latency, 2.0 / 1024.0>          11.6 ns         11.4 ns     56000000
BM_ExperimentSinTableSpacing<Metric::Throughput, 2.0 / 1024.0>       1.99 ns         1.99 ns    344616000
BM_ExperimentCosTableSpacing<Metric::Latency, 2.0 / 256.0>           11.7 ns         11.7 ns     64000000
BM_ExperimentCosTableSpacing<Metric::Throughput, 2.0 / 256.0>        2.23 ns         2.25 ns    320000000
BM_ExperimentCosTableSpacing<Metric::Latency, 2.0 / 1024.0>          10.9 ns         11.0 ns     64000000
BM_ExperimentCosTableSpacing<Metric::Throughput, 2.0 / 1024.0>       1.95 ns         1.95 ns    344616000
BM_ExperimentSinMultiTable<Metric::Latency>                          12.2 ns         12.0 ns     56000000
BM_ExperimentSinMultiTable<Metric::Throughput>                       3.38 ns         3.44 ns    213334000
BM_ExperimentCosMultiTable<Metric::Latency>                          12.2 ns         12.2 ns     64000000
BM_ExperimentCosMultiTable<Metric::Throughput>                       3.43 ns         3.44 ns    213334000
BM_ExperimentSinSingleTable<Metric::Latency>                         11.5 ns         11.7 ns     64000000
BM_ExperimentSinSingleTable<Metric::Throughput>                      2.58 ns         2.57 ns    280000000
BM_ExperimentCosSingleTable<Metric::Latency>                         11.0 ns         11.0 ns     64000000
BM_ExperimentCosSingleTable<Metric::Throughput>                      1.96 ns         1.95 ns    344616000
BM_ExperimentSinNearZero<Metric::Latency>                            11.4 ns         11.5 ns     64000000
BM_ExperimentSinNearZero<Metric::Throughput>                         2.71 ns         2.73 ns    263530000
BM_ExperimentCosNearZero<Metric::Latency>                            11.0 ns         11.0 ns     64000000
BM_ExperimentCosNearZero<Metric::Throughput>                         1.95 ns         1.97 ns    373334000
BM_ExperimentSinFMA<Metric::Latency>                                 11.4 ns         11.4 ns     56000000
BM_ExperimentSinFMA<Metric::Throughput>                              3.46 ns         3.53 ns    203637000
BM_ExperimentCosFMA<Metric::Latency>                                 11.4 ns         11.4 ns     56000000
BM_ExperimentCosFMA<Metric::Throughput>                              2.27 ns         2.25 ns    298667000
```
#1760.