### PR TITLE
Correctly clear manœvre markers when the flight plan disappears

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2243,6 +2243,7 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
         if (main_vessel_guid == null) {
           return;
         }
+        int number_of_rendered_manœuvres = 0;
         if (plugin_.FlightPlanExists(main_vessel_guid)) {
           int number_of_anomalous_manœuvres =
               plugin_.FlightPlanNumberOfAnomalousManoeuvres(main_vessel_guid);
@@ -2250,7 +2251,6 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
               plugin_.FlightPlanNumberOfManoeuvres(main_vessel_guid);
           int number_of_segments =
               plugin_.FlightPlanNumberOfSegments(main_vessel_guid);
-          int number_of_rendered_manœuvres = 0;
           for (int i = 0; i < number_of_segments; ++i) {
             bool is_burn = i % 2 == 1;
             using (DisposableIterator rendered_segments =
@@ -2289,11 +2289,19 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
               }
             }
           }
-          for (int i = number_of_rendered_manœuvres;
-               i < manœuvre_marker_pool_.Count;
-               ++i) {
-            manœuvre_marker_pool_[i].Disable();
+        }
+        // This cleanup must occur even if there is no flight plan. In the
+        // tracking station, one may switch from a vessel with a plan to one
+        // without.
+        for (int i = number_of_rendered_manœuvres;
+             i < manœuvre_marker_pool_.Count;
+             ++i) {
+          // Since markers are used sequentially, all subsequent ones will
+          // be in the disabled state.
+          if (manœuvre_marker_pool_[i].is_disabled) {
+            break;
           }
+          manœuvre_marker_pool_[i].Disable();
         }
       }
     }

--- a/ksp_plugin_adapter/manœuvre_marker.cs
+++ b/ksp_plugin_adapter/manœuvre_marker.cs
@@ -26,6 +26,8 @@ internal class ManœuvreMarker : UnityEngine.MonoBehaviour {
   // during which it is consumed by node markers.
   public static bool has_interacting_marker { get; private set; }
 
+  public bool is_disabled => !gameObject.activeSelf && !caption_.activeSelf;
+
   // Construct the geometry of the marker when instantiated.
   // 1. Build the mesh of the marker (base 'bulb' & one cylinder for each axis).
   // 2. Attach a spherical collider (centred on the bulb) to the gameobject for


### PR DESCRIPTION
In the tracking station, one may switch from a vessel with a flight plan to one without. The stale markers still need to be cleared.

The only reason this ever worked in flight is because one cannot delete a non-empty flight plan.

Fix #4029.