### PR TITLE
Fix a bug in the lattices benchmark and add new instances

### DIFF
--- a/benchmarks/lattices_benchmark.cpp
+++ b/benchmarks/lattices_benchmark.cpp
@@ -16,19 +16,20 @@ using namespace principia::numerics::_lattices;
 
 constexpr std::int64_t number_of_lattices = 1000;
 
-template<typename Element, int max_element>
+template<typename Element, std::int64_t max_element>
 class LatticesBenchmark : public benchmark::Fixture {
  protected:
   using Lattice = FixedMatrix<Element, 5, 4>;
 
   void SetUp(benchmark::State& state) {
     std::mt19937_64 random(42);
-    std::uniform_int_distribution<> uniformly_at(-max_element, max_element);
+    std::uniform_int_distribution<std::int64_t> uniformly_at(-max_element,
+                                                             max_element);
 
     for (std::int64_t l = 0; l < number_of_lattices; ++l) {
       auto& lattice = lattices_[l];
       for (std::int64_t i = 0; i < lattice.rows(); ++i) {
-        for (std::int64_t j = 0; j < lattice.rows(); ++j) {
+        for (std::int64_t j = 0; j < lattice.columns(); ++j) {
           lattice(i, j) = uniformly_at(random);
         }
       }
@@ -47,6 +48,12 @@ class LatticesBenchmark : public benchmark::Fixture {
 };
 
 BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászDouble3,
+                     double, 1'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
                      LenstraLenstraLovászDouble6,
                      double, 1'000'000)(benchmark::State& state) {
   RunLenstraLenstraLovász(state);
@@ -59,6 +66,31 @@ BENCHMARK_TEMPLATE_F(LatticesBenchmark,
 }
 
 BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászDouble12,
+                     double, 1'000'000'000'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászDouble15,
+                     double, 1'000'000'000'000'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászDouble18,
+                     double, 1'000'000'000'000'000'000)(
+                     benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászCppRational3,
+                     cpp_rational, 1'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
                      LenstraLenstraLovászCppRational6,
                      cpp_rational, 1'000'000)(benchmark::State& state) {
   RunLenstraLenstraLovász(state);
@@ -67,6 +99,26 @@ BENCHMARK_TEMPLATE_F(LatticesBenchmark,
 BENCHMARK_TEMPLATE_F(LatticesBenchmark,
                      LenstraLenstraLovászCppRational9,
                      cpp_rational, 1'000'000'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászCppRational12,
+                     cpp_rational, 1'000'000'000'000)(benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászCppRational15,
+                     cpp_rational, 1'000'000'000'000'000)(
+                     benchmark::State& state) {
+  RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     LenstraLenstraLovászCppRational18,
+                     cpp_rational, 1'000'000'000'000'000'000)(
+                     benchmark::State& state) {
   RunLenstraLenstraLovász(state);
 }
 


### PR DESCRIPTION
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
----------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                              Time
CPU   Iterations
----------------------------------------------------------------------------------------------------------------------------------------
LatticesBenchmark<double, 1'000>/LenstraLenstraLov├íszDouble3                                       1659 ns         1629 ns       374000
LatticesBenchmark<double, 1'000'000>/LenstraLenstraLov├íszDouble6                                   1630 ns         1639 ns       448000
LatticesBenchmark<double, 1'000'000'000>/LenstraLenstraLov├íszDouble9                               1524 ns         1537 ns       498000
LatticesBenchmark<double, 1'000'000'000'000>/LenstraLenstraLov├íszDouble12                          1576 ns         1569 ns       448000
LatticesBenchmark<double, 1'000'000'000'000'000>/LenstraLenstraLov├íszDouble15                      1696 ns         1685 ns       408000
LatticesBenchmark<double, 1'000'000'000'000'000'000>/LenstraLenstraLov├íszDouble18                  1594 ns         1569 ns       498000
LatticesBenchmark<cpp_rational, 1'000>/LenstraLenstraLov├íszCppRational3                          712365 ns       718750 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000>/LenstraLenstraLov├íszCppRational6                     1575049 ns      1578125 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000>/LenstraLenstraLov├íszCppRational9                 2283511 ns      2281250 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000>/LenstraLenstraLov├íszCppRational12            3093661 ns      3093750 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000'000>/LenstraLenstraLov├íszCppRational15        3866339 ns      3875000 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000'000'000>/LenstraLenstraLov├íszCppRational18    4269343 ns      4265625 ns         1000
```
#1760.