### PR TITLE
Use std::int64_t in matrices

### DIFF
--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -285,13 +285,11 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousSearch(
   // the columns according to the L₂ norm.
   std::array<std::unique_ptr<ColumnView<Lattice const>>, V.columns()> v;
   for (std::int64_t i = 0; i < v.size(); ++i) {
-    // TODO(phl): Switch the matrices to use std::int64_t instead of int, and
-    // the cast below will go away.
     v[i] = std::make_unique<ColumnView<Lattice const>>(
         ColumnView<Lattice const>{.matrix = V,
                                   .first_row = 0,
                                   .last_row = V.rows() - 1,
-                                  .column = static_cast<int>(i)});
+                                  .column = i});
   }
   std::sort(v.begin(),
             v.end(),

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -21,16 +21,16 @@ using namespace principia::numerics::_transposed_view;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_si;
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 class FixedMatrix;
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 class FixedUpperTriangularMatrix;
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 class FixedVector final {
  public:
   using Scalar = Scalar_;
-  static constexpr int dimension = size_;
+  static constexpr std::int64_t dimension = size_;
 
   constexpr FixedVector();
   explicit FixedVector(uninitialized_t);
@@ -54,8 +54,8 @@ class FixedVector final {
   friend bool operator!=(FixedVector const& left,
                          FixedVector const& right) = default;
 
-  constexpr Scalar& operator[](int index);
-  constexpr Scalar const& operator[](int index) const;
+  constexpr Scalar& operator[](std::int64_t index);
+  constexpr Scalar const& operator[](std::int64_t index) const;
 
   constexpr FixedVector& operator=(Scalar const (&right)[size_]);
 
@@ -69,14 +69,14 @@ class FixedVector final {
 
   FixedVector<double, size_> Normalize() const;
 
-  static constexpr int size() { return size_; }
+  static constexpr std::int64_t size() { return size_; }
 
   typename std::array<Scalar, size_>::const_iterator begin() const;
   typename std::array<Scalar, size_>::const_iterator end() const;
 
   template<typename H>
   friend H AbslHashValue(H h, FixedVector const& vector) {
-    for (int index = 0; index < size_; ++index) {
+    for (std::int64_t index = 0; index < size_; ++index) {
       h = H::combine(std::move(h), vector.data_[index] / si::Unit<Scalar>);
     }
     return h;
@@ -85,28 +85,28 @@ class FixedVector final {
  private:
   std::array<Scalar, size_> data_;
 
-  template<typename L, typename R, int s>
+  template<typename L, typename R, std::int64_t s>
   friend constexpr Product<L, R> operator*(
       L* const left,
       FixedVector<R, s> const& right);
-  template<typename L, typename R, int s>
+  template<typename L, typename R, std::int64_t s>
   friend constexpr Product<L, R> operator*(
       TransposedView<FixedVector<L, s>> const& left,
       FixedVector<R, s> const& right);
-  template<typename L, typename R, int r, int c>
+  template<typename L, typename R, std::int64_t r, std::int64_t c>
   friend constexpr FixedVector<Product<L, R>, r> operator*(
       FixedMatrix<L, r, c> const& left,
       FixedVector<R, c> const& right);
 };
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 class FixedMatrix final {
-  static constexpr int size_ = rows_ * columns_;
+  static constexpr std::int64_t size_ = rows_ * columns_;
 
  public:
   using Scalar = Scalar_;
-  static constexpr int rows() { return rows_; }
-  static constexpr int columns() { return columns_; }
+  static constexpr std::int64_t rows() { return rows_; }
+  static constexpr std::int64_t columns() { return columns_; }
 
   constexpr FixedMatrix();
   explicit FixedMatrix(uninitialized_t);
@@ -128,8 +128,9 @@ class FixedMatrix final {
   // For  0 < i < rows and 0 < j < columns, the entry a_ij is accessed as
   // |a(i, j)|.  if i and j do not satisfy these conditions, the expression
   // |a(i, j)| implies undefined behaviour.
-  constexpr Scalar& operator()(int row, int column);
-  constexpr Scalar const& operator()(int row, int column) const;
+  constexpr Scalar& operator()(std::int64_t row, std::int64_t column);
+  constexpr Scalar const& operator()(std::int64_t row,
+                                     std::int64_t column) const;
 
   constexpr FixedMatrix& operator=(Scalar const (&right)[size_]);
 
@@ -142,7 +143,7 @@ class FixedMatrix final {
       FixedMatrix<double, rows_, columns_> const& right)
     requires(rows_ == columns_);
 
-  template<int r>
+  template<std::int64_t r>
   Scalar const* row() const;
 
   Scalar FrobeniusNorm() const;
@@ -159,20 +160,20 @@ class FixedMatrix final {
  private:
   std::array<Scalar, size_> data_;
 
-  template<typename L, typename R, int r, int c>
+  template<typename L, typename R, std::int64_t r, std::int64_t c>
   friend constexpr FixedVector<Product<L, R>, r> operator*(
       FixedMatrix<L, r, c> const& left,
       FixedVector<R, c> const& right);
 };
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 class FixedStrictlyLowerTriangularMatrix final {
-  static constexpr int size_ = rows_ * (rows_ - 1) / 2;
+  static constexpr std::int64_t size_ = rows_ * (rows_ - 1) / 2;
 
  public:
   using Scalar = Scalar_;
-  static constexpr int rows() { return rows_; }
-  static constexpr int columns() { return rows_; }
+  static constexpr std::int64_t rows() { return rows_; }
+  static constexpr std::int64_t columns() { return rows_; }
 
   constexpr FixedStrictlyLowerTriangularMatrix();
   explicit FixedStrictlyLowerTriangularMatrix(uninitialized_t);
@@ -193,27 +194,28 @@ class FixedStrictlyLowerTriangularMatrix final {
   // For  0 ≤ j < i < rows, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
-  constexpr Scalar& operator()(int row, int column);
-  constexpr Scalar const& operator()(int row, int column) const;
+  constexpr Scalar& operator()(std::int64_t row, std::int64_t column);
+  constexpr Scalar const& operator()(std::int64_t row,
+                                     std::int64_t column) const;
 
   constexpr FixedStrictlyLowerTriangularMatrix& operator=(
       Scalar const (&right)[size_]);
 
-  template<int r>
+  template<std::int64_t r>
   Scalar const* row() const;
 
  private:
   std::array<Scalar, size_> data_;
 };
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 class FixedLowerTriangularMatrix final {
-  static constexpr int size_ = rows_ * (rows_ + 1) / 2;
+  static constexpr std::int64_t size_ = rows_ * (rows_ + 1) / 2;
 
  public:
   using Scalar = Scalar_;
-  static constexpr int rows() { return rows_; }
-  static constexpr int columns() { return rows_; }
+  static constexpr std::int64_t rows() { return rows_; }
+  static constexpr std::int64_t columns() { return rows_; }
 
   constexpr FixedLowerTriangularMatrix();
   explicit FixedLowerTriangularMatrix(uninitialized_t);
@@ -235,8 +237,9 @@ class FixedLowerTriangularMatrix final {
   // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
-  constexpr Scalar& operator()(int row, int column);
-  constexpr Scalar const& operator()(int row, int column) const;
+  constexpr Scalar& operator()(std::int64_t row, std::int64_t column);
+  constexpr Scalar const& operator()(std::int64_t row,
+                                     std::int64_t column) const;
 
   constexpr FixedLowerTriangularMatrix& operator=(
       Scalar const (&right)[size_]);
@@ -245,14 +248,14 @@ class FixedLowerTriangularMatrix final {
   std::array<Scalar, size_> data_;
 };
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 class FixedUpperTriangularMatrix final {
-  static constexpr int size_ = columns_ * (columns_ + 1) / 2;
+  static constexpr std::int64_t size_ = columns_ * (columns_ + 1) / 2;
 
  public:
   using Scalar = Scalar_;
-  static constexpr int rows() { return columns_; }
-  static constexpr int columns() { return columns_; }
+  static constexpr std::int64_t rows() { return columns_; }
+  static constexpr std::int64_t columns() { return columns_; }
 
   constexpr FixedUpperTriangularMatrix();
   explicit FixedUpperTriangularMatrix(uninitialized_t);
@@ -274,8 +277,9 @@ class FixedUpperTriangularMatrix final {
   // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a(i, j)|.
   // if i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
-  constexpr Scalar& operator()(int row, int column);
-  constexpr Scalar const& operator()(int row, int column) const;
+  constexpr Scalar& operator()(std::int64_t row, std::int64_t column);
+  constexpr Scalar const& operator()(std::int64_t row,
+                                     std::int64_t column) const;
 
   constexpr FixedUpperTriangularMatrix& operator=(
       Scalar const (&right)[size_]);
@@ -290,90 +294,94 @@ class FixedUpperTriangularMatrix final {
 };
 
 // Prefer using the operator* that takes a TransposedView.
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> InnerProduct(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<double, size> Normalize(
     FixedVector<Scalar, size> const& vector);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedMatrix<Product<LScalar, RScalar>, size, size> SymmetricProduct(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedMatrix<Square<Scalar>, size, size> SymmetricSquare(
     FixedVector<Scalar, size> const& vector);
 
 // Additive groups.
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<Scalar, size> operator+(
     FixedVector<Scalar, size> const& right);
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Scalar, rows, columns> operator+(
     FixedMatrix<Scalar, rows, columns> const& right);
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<Scalar, size> operator-(
     FixedVector<Scalar, size> const& right);
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Scalar, rows, columns> operator-(
     FixedMatrix<Scalar, rows, columns> const& right);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Sum<LScalar, RScalar>, size> operator+(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar, std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Sum<LScalar, RScalar>, rows, columns> operator+(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedMatrix<RScalar, rows, columns> const& right);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Difference<LScalar, RScalar>, size> operator-(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Difference<LScalar, RScalar>, rows, columns> operator-(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedMatrix<RScalar, rows, columns> const& right);
 
 // Vector spaces.
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Product<LScalar, RScalar>, size> operator*(
     LScalar const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Product<LScalar, RScalar>, size> operator*(
     FixedVector<LScalar, size> const& left,
     RScalar const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns>
 operator*(LScalar const& left,
           FixedMatrix<RScalar, rows, columns> const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns>
 operator*(FixedMatrix<LScalar, rows, columns> const& left,
           RScalar const& right);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Quotient<LScalar, RScalar>, size> operator/(
     FixedVector<LScalar, size> const& left,
     RScalar const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Quotient<LScalar, RScalar>, rows, columns>
 operator/(FixedMatrix<LScalar, rows, columns> const& left,
           RScalar const& right);
@@ -381,60 +389,63 @@ operator/(FixedMatrix<LScalar, rows, columns> const& left,
 // Hilbert space and algebra.
 
 // TODO(phl): We should have a RowView.
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> operator*(
     LScalar* const left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> operator*(
     TransposedView<FixedVector<LScalar, size>> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, int lsize, int rsize>
+template<typename LScalar, typename RScalar,
+         std::int64_t lsize, std::int64_t rsize>
 constexpr FixedMatrix<Product<LScalar, RScalar>, lsize, rsize> operator*(
     FixedVector<LScalar, lsize> const& left,
     TransposedView<FixedVector<RScalar, rsize>> const& right);
 
 template<typename LScalar, typename RScalar,
-         int rows, int dimension, int columns>
+         std::int64_t rows, std::int64_t dimension, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns>
 operator*(FixedMatrix<LScalar, rows, dimension> const& left,
           FixedMatrix<RScalar, dimension, columns> const& right);
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedVector<Product<LScalar, RScalar>, rows> operator*(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedVector<RScalar, columns> const& right);
 
 // Use this operator to multiply a row vector with a matrix.  We don't have an
 // operator returning a TransposedView as that would cause dangling references.
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedVector<Product<LScalar, RScalar>, columns> operator*(
     TransposedView<FixedMatrix<LScalar, rows, columns>> const& left,
     FixedVector<RScalar, rows> const& right);
 
 // Ouput.
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 std::ostream& operator<<(std::ostream& out,
                          FixedVector<Scalar, size> const& vector);
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 std::ostream& operator<<(std::ostream& out,
                          FixedMatrix<Scalar, rows, columns> const& matrix);
 
-template<typename Scalar, int rows>
+template<typename Scalar, std::int64_t rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix);
 
-template<typename Scalar, int rows>
+template<typename Scalar, std::int64_t rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedLowerTriangularMatrix<Scalar, rows> const& matrix);
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 std::ostream& operator<<(
     std::ostream& out,
     FixedUpperTriangularMatrix<Scalar, columns> const& matrix);

--- a/numerics/fixed_arrays.hpp
+++ b/numerics/fixed_arrays.hpp
@@ -335,7 +335,8 @@ constexpr FixedVector<Sum<LScalar, RScalar>, size> operator+(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right);
 
-template<typename LScalar, typename RScalar, std::int64_t rows, std::int64_t columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Sum<LScalar, RScalar>, rows, columns> operator+(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedMatrix<RScalar, rows, columns> const& right);

--- a/numerics/fixed_arrays_body.hpp
+++ b/numerics/fixed_arrays_body.hpp
@@ -23,7 +23,7 @@ using namespace principia::quantities::_elementary_functions;
 template<typename LScalar, typename RScalar, typename>
 struct DotProduct;
 
-template<typename LScalar, typename RScalar, int... i>
+template<typename LScalar, typename RScalar, std::int64_t... i>
 struct DotProduct<LScalar, RScalar, std::index_sequence<i...>> {
   template<typename Left, typename Right>
   static Product<LScalar, RScalar> Compute(Left const& left,
@@ -31,7 +31,7 @@ struct DotProduct<LScalar, RScalar, std::index_sequence<i...>> {
 };
 
 
-template<typename LScalar, typename RScalar, int... i>
+template<typename LScalar, typename RScalar, std::int64_t... i>
 template<typename Left, typename Right>
 Product<LScalar, RScalar>
 DotProduct<LScalar, RScalar, std::index_sequence<i...>>::Compute(
@@ -44,80 +44,81 @@ DotProduct<LScalar, RScalar, std::index_sequence<i...>>::Compute(
 // which performs value initialization on the components.  For quantities this
 // calls the default constructor, for non-class types this does
 // zero-initialization.
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>::FixedVector() : data_{} {}
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 FixedVector<Scalar_, size_>::FixedVector(uninitialized_t) {}
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>::FixedVector(
     std::array<Scalar, size_> const& data)
     : data_(data) {}
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>::FixedVector(
     std::array<Scalar, size_>&& data)
     : data_(std::move(data)) {}
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 template<typename T>
   requires std::same_as<typename T::Scalar, Scalar_>
 constexpr FixedVector<Scalar_, size_>::FixedVector(
     ColumnView<T> const& view) : FixedVector(uninitialized) {
   CONSTEXPR_DCHECK(view.size() == size_);
-  for (int i = 0; i < size_; ++i) {
+  for (std::int64_t i = 0; i < size_; ++i) {
     (*this)[i] = view[i];
   }
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>::operator std::array<Scalar_, size_>()
     const {
   return data_;
 }
 
-template<typename Scalar_, int size_>
-constexpr Scalar_& FixedVector<Scalar_, size_>::operator[](int const index) {
+template<typename Scalar_, std::int64_t size_>
+constexpr Scalar_& FixedVector<Scalar_, size_>::operator[](
+    std::int64_t const index) {
   CONSTEXPR_DCHECK(0 <= index);
   CONSTEXPR_DCHECK(index < size());
   return data_[index];
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr Scalar_ const& FixedVector<Scalar_, size_>::operator[](
-    int const index) const {
+    std::int64_t const index) const {
   CONSTEXPR_DCHECK(0 <= index);
   CONSTEXPR_DCHECK(index < size());
   return data_[index];
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator=(
     Scalar const (&right)[size_]) {
   std::copy(right, right + size_, data_.data());
   return *this;
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator+=(
     FixedVector const& right) {
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator-=(
     FixedVector const& right) {
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator*=(
     double const right) {
   for (auto& d : data_) {
@@ -126,7 +127,7 @@ constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator*=(
   return *this;
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator/=(
     double const right) {
   for (auto& d : data_) {
@@ -135,69 +136,69 @@ constexpr FixedVector<Scalar_, size_>& FixedVector<Scalar_, size_>::operator/=(
   return *this;
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 Scalar_ FixedVector<Scalar_, size_>::Norm() const {
   return Sqrt(Norm²());
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 Square<Scalar_> FixedVector<Scalar_, size_>::Norm²() const {
   return DotProduct<Scalar, Scalar, std::make_index_sequence<size_>>::Compute(
       data_, data_);
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 FixedVector<double, size_> FixedVector<Scalar_, size_>::Normalize() const {
   return *this / Norm();
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 typename std::array<Scalar_, size_>::const_iterator
 FixedVector<Scalar_, size_>::begin() const {
   return data_.cbegin();
 }
 
-template<typename Scalar_, int size_>
+template<typename Scalar_, std::int64_t size_>
 typename std::array<Scalar_, size_>::const_iterator
 FixedVector<Scalar_, size_>::end() const {
   return data_.cend();
 }
 
-template<typename H, typename Scalar_, int size_>
+template<typename H, typename Scalar_, std::int64_t size_>
 H AbslHashValue(H h, FixedVector<Scalar_, size_> const& vector) {
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix()
     : data_{} {}
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(uninitialized_t) {}
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
     std::array<Scalar, size_> const& data)
     : data_(data) {}
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
     std::array<Scalar, size_>&& data)
     : data_(std::move(data)) {}
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>::FixedMatrix(
     TransposedView<FixedMatrix<Scalar, columns_, rows_>> const& view)
     : FixedMatrix(uninitialized) {
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j < columns_; ++j) {
+  for (std::int64_t i = 0; i < rows_; ++i) {
+    for (std::int64_t j = 0; j < columns_; ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr Scalar_& FixedMatrix<Scalar_, rows_, columns_>::operator()(
-    int const row, int const column) {
+    std::int64_t const row, std::int64_t const column) {
   CONSTEXPR_DCHECK(0 <= row);
   CONSTEXPR_DCHECK(row < rows());
   CONSTEXPR_DCHECK(0 <= column);
@@ -205,9 +206,9 @@ constexpr Scalar_& FixedMatrix<Scalar_, rows_, columns_>::operator()(
   return data_[row * columns() + column];
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr Scalar_ const& FixedMatrix<Scalar_, rows_, columns_>::operator()(
-    int const row, int const column) const {
+    std::int64_t const row, std::int64_t const column) const {
   CONSTEXPR_DCHECK(0 <= row);
   CONSTEXPR_DCHECK(row < rows());
   CONSTEXPR_DCHECK(0 <= column);
@@ -215,7 +216,7 @@ constexpr Scalar_ const& FixedMatrix<Scalar_, rows_, columns_>::operator()(
   return data_[row * columns() + column];
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator=(
     Scalar const (&right)[size_]) {
@@ -223,25 +224,25 @@ FixedMatrix<Scalar_, rows_, columns_>::operator=(
   return *this;
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator+=(FixedMatrix const& right) {
-  for (int i = 0; i < size_; ++i) {
+  for (std::int64_t i = 0; i < size_; ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator-=(FixedMatrix const& right) {
-  for (int i = 0; i < size_; ++i) {
+  for (std::int64_t i = 0; i < size_; ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator*=(double const right) {
   for (auto& d : data_) {
@@ -250,7 +251,7 @@ FixedMatrix<Scalar_, rows_, columns_>::operator*=(double const right) {
   return *this;
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator/=(double const right) {
   for (auto& d : data_) {
@@ -259,7 +260,7 @@ FixedMatrix<Scalar_, rows_, columns_>::operator/=(double const right) {
   return *this;
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 constexpr FixedMatrix<Scalar_, rows_, columns_>&
 FixedMatrix<Scalar_, rows_, columns_>::operator*=(
     FixedMatrix<double, rows_, columns_> const& right)
@@ -268,25 +269,25 @@ FixedMatrix<Scalar_, rows_, columns_>::operator*=(
   return *this = *this * right;
 }
 
-template<typename Scalar_, int rows_, int columns_>
-template<int r>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
+template<std::int64_t r>
 Scalar_ const* FixedMatrix<Scalar_, rows_, columns_>::row() const {
   static_assert(r < rows_);
   return &data_[r * columns()];
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 Scalar_ FixedMatrix<Scalar_, rows_, columns_>::FrobeniusNorm() const {
   Square<Scalar> Σᵢⱼaᵢⱼ²{};
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       Σᵢⱼaᵢⱼ² += Pow<2>((*this)(i, j));
     }
   }
   return Sqrt(Σᵢⱼaᵢⱼ²);
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 template<typename LScalar, typename RScalar>
 Product<Scalar_, Product<LScalar, RScalar>>
 FixedMatrix<Scalar_, rows_, columns_>::operator()(
@@ -295,61 +296,61 @@ FixedMatrix<Scalar_, rows_, columns_>::operator()(
   return TransposedView{left} * (*this * right);  // NOLINT
 }
 
-template<typename Scalar_, int rows_, int columns_>
+template<typename Scalar_, std::int64_t rows_, std::int64_t columns_>
 FixedMatrix<Scalar_, rows_, columns_>
 FixedMatrix<Scalar_, rows_, columns_>::Identity() {
   FixedMatrix<Scalar, rows(), columns()> m;
-  for (int i = 0; i < rows(); ++i) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
     m(i, i) = 1;
   }
   return m;
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
     FixedStrictlyLowerTriangularMatrix()
     : data_{} {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
     FixedStrictlyLowerTriangularMatrix(uninitialized_t) {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
 FixedStrictlyLowerTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(data) {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
 operator FixedMatrix<Scalar_, rows_, rows_>() const {
   FixedMatrix<Scalar, rows_, rows_> result;  // Initialized.
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (std::int64_t i = 0; i < rows_; ++i) {
+    for (std::int64_t j = 0; j < i; ++j) {
       result(i, j) = (*this)(i, j);
     }
   }
   return result;
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr Scalar_& FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
-operator()(int const row, int const column) {
+operator()(std::int64_t const row, std::int64_t const column) {
   CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row - 1) / 2 + column];
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr Scalar_ const& FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::
-operator()(int const row, int const column) const {
+operator()(std::int64_t const row, std::int64_t const column) const {
   CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column < row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row - 1) / 2 + column];
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>&
 FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::operator=(
     Scalar const (&right)[size_]) {
@@ -357,69 +358,69 @@ FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::operator=(
   return *this;
 }
 
-template<typename Scalar_, int rows_>
-template<int r>
+template<typename Scalar_, std::int64_t rows_>
+template<std::int64_t r>
 Scalar_ const* FixedStrictlyLowerTriangularMatrix<Scalar_, rows_>::row() const {
   static_assert(r < rows_);
   return &data_[r * (r - 1) / 2];
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedLowerTriangularMatrix<Scalar_, rows_>::
 FixedLowerTriangularMatrix()
     : data_{} {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 FixedLowerTriangularMatrix<Scalar_, rows_>::
 FixedLowerTriangularMatrix(uninitialized_t) {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedLowerTriangularMatrix<Scalar_, rows_>::
 FixedLowerTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(data) {}
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 FixedLowerTriangularMatrix<Scalar_, rows_>::FixedLowerTriangularMatrix(
     TransposedView<FixedUpperTriangularMatrix<Scalar, rows_>> const& view)
     : FixedLowerTriangularMatrix(uninitialized) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedLowerTriangularMatrix<Scalar_, rows_>::
 operator FixedMatrix<Scalar_, rows_, rows_>() const {
   FixedMatrix<Scalar, rows_, rows_> result;  // Initialized.
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (std::int64_t i = 0; i < rows_; ++i) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       result(i, j) = (*this)(i, j);
     }
   }
   return result;
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr Scalar_& FixedLowerTriangularMatrix<Scalar_, rows_>::
-operator()(int const row, int const column) {
+operator()(std::int64_t const row, std::int64_t const column) {
   CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column <= row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row + 1) / 2 + column];
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr Scalar_ const& FixedLowerTriangularMatrix<Scalar_, rows_>::
-operator()(int const row, int const column) const {
+operator()(std::int64_t const row, std::int64_t const column) const {
   CONSTEXPR_DCHECK(0 <= column);
   CONSTEXPR_DCHECK(column <= row);
   CONSTEXPR_DCHECK(row < rows());
   return data_[row * (row + 1) / 2 + column];
 }
 
-template<typename Scalar_, int rows_>
+template<typename Scalar_, std::int64_t rows_>
 constexpr FixedLowerTriangularMatrix<Scalar_, rows_>&
 FixedLowerTriangularMatrix<Scalar_, rows_>::operator=(
     Scalar const (&right)[size_]) {
@@ -427,62 +428,62 @@ FixedLowerTriangularMatrix<Scalar_, rows_>::operator=(
   return *this;
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
 FixedUpperTriangularMatrix()
     : data_{} {}
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 FixedUpperTriangularMatrix<Scalar_, columns_>::FixedUpperTriangularMatrix(
     uninitialized_t) {}
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
 FixedUpperTriangularMatrix(std::array<Scalar, size_> const& data)
     : data_(Transpose(data)) {}
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 FixedUpperTriangularMatrix<Scalar_, columns_>::FixedUpperTriangularMatrix(
     TransposedView<FixedLowerTriangularMatrix<Scalar, columns_>> const& view)
     : FixedUpperTriangularMatrix(uninitialized) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = i; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = i; j < columns(); ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>::
 operator FixedMatrix<Scalar_, columns_, columns_>() const {
   FixedMatrix<Scalar, columns_, columns_> result;  // Initialized.
-  for (int j = 0; j < columns_; ++j) {
-    for (int i = 0; i <= j; ++i) {
+  for (std::int64_t j = 0; j < columns_; ++j) {
+    for (std::int64_t i = 0; i <= j; ++i) {
       result(i, j) = (*this)(i, j);
     }
   }
   return result;
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr Scalar_& FixedUpperTriangularMatrix<Scalar_, columns_>::
-operator()(int const row, int const column) {
+operator()(std::int64_t const row, std::int64_t const column) {
   CONSTEXPR_DCHECK(0 <= row);
   CONSTEXPR_DCHECK(row <= column);
   CONSTEXPR_DCHECK(column < columns());
   return data_[column * (column + 1) / 2 + row];
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr Scalar_ const& FixedUpperTriangularMatrix<Scalar_, columns_>::
-operator()(int const row, int const column) const {
+operator()(std::int64_t const row, std::int64_t const column) const {
   CONSTEXPR_DCHECK(0 <= row);
   CONSTEXPR_DCHECK(row <= column);
   CONSTEXPR_DCHECK(column < columns());
   return data_[column * (column + 1) / 2 + row];
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 constexpr FixedUpperTriangularMatrix<Scalar_, columns_>&
 FixedUpperTriangularMatrix<Scalar_, columns_>::operator=(
     Scalar const (&right)[size_]) {
@@ -491,14 +492,14 @@ FixedUpperTriangularMatrix<Scalar_, columns_>::operator=(
   return *this;
 }
 
-template<typename Scalar_, int columns_>
+template<typename Scalar_, std::int64_t columns_>
 auto FixedUpperTriangularMatrix<Scalar_, columns_>::Transpose(
     std::array<Scalar, size_> const& data)
     -> std::array<Scalar, size_> {
   std::array<Scalar, rows() * columns()> full;
-  int index = 0;
-  for (int row = 0; row < rows(); ++row) {
-    for (int column = row; column < columns(); ++column) {
+  std::int64_t index = 0;
+  for (std::int64_t row = 0; row < rows(); ++row) {
+    for (std::int64_t column = row; column < columns(); ++column) {
       full[row * columns() + column] = data[index];
       ++index;
     }
@@ -506,8 +507,8 @@ auto FixedUpperTriangularMatrix<Scalar_, columns_>::Transpose(
 
   std::array<Scalar, size_> result;
   index = 0;
-  for (int column = 0; column < columns(); ++column) {
-    for (int row = 0; row <= column; ++row) {
+  for (std::int64_t column = 0; column < columns(); ++column) {
+    for (std::int64_t row = 0; row <= column; ++row) {
       result[index] = full[row * columns() + column];
       ++index;
     }
@@ -515,7 +516,7 @@ auto FixedUpperTriangularMatrix<Scalar_, columns_>::Transpose(
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> InnerProduct(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right) {
@@ -523,19 +524,19 @@ constexpr Product<LScalar, RScalar> InnerProduct(
       left, right);
 }
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<double, size> Normalize(
     FixedVector<Scalar, size> const& vector) {
   return vector / vector.Norm();
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedMatrix<Product<LScalar, RScalar>, size, size> SymmetricProduct(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right) {
   FixedMatrix<Product<LScalar, RScalar>, size, size> result(uninitialized);
-  for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (std::int64_t i = 0; i < size; ++i) {
+    for (std::int64_t j = 0; j < i; ++j) {
       auto const r = 0.5 * (left[i] * right[j] + left[j] * right[i]);
       result(i, j) = r;
       result(j, i) = r;
@@ -545,12 +546,12 @@ constexpr FixedMatrix<Product<LScalar, RScalar>, size, size> SymmetricProduct(
   return result;
 }
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedMatrix<Square<Scalar>, size, size> SymmetricSquare(
     FixedVector<Scalar, size> const& vector) {
   FixedMatrix<Square<Scalar>, size, size> result(uninitialized);
-  for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (std::int64_t i = 0; i < size; ++i) {
+    for (std::int64_t j = 0; j < i; ++j) {
       auto const r =  vector[i] * vector[j];
       result(i, j) = r;
       result(j, i) = r;
@@ -560,165 +561,170 @@ constexpr FixedMatrix<Square<Scalar>, size, size> SymmetricSquare(
   return result;
 }
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<Scalar, size> operator+(
     FixedVector<Scalar, size> const& right) {
   return right;
 }
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Scalar, rows, columns> operator+(
     FixedMatrix<Scalar, rows, columns> const& right) {
   return right;
 }
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 constexpr FixedVector<Scalar, size> operator-(
     FixedVector<Scalar, size> const& right) {
   std::array<Scalar, size> result;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     result[i] = -right[i];
   }
   return FixedVector<Scalar, size>(std::move(result));
 }
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Scalar, rows, columns> operator-(
     FixedMatrix<Scalar, rows, columns> const& right) {
   FixedMatrix<Scalar, rows, columns> result(uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = -right(i, j);
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Sum<LScalar, RScalar>, size> operator+(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right) {
   std::array<Sum<LScalar, RScalar>, size> result;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     result[i] = left[i] + right[i];
   }
   return FixedVector<Sum<LScalar, RScalar>, size>(std::move(result));
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Sum<LScalar, RScalar>, rows, columns> operator+(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedMatrix<RScalar, rows, columns> const& right) {
   FixedMatrix<Sum<LScalar, RScalar>, rows, columns> result(uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = left(i, j) + right(i, j);
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Difference<LScalar, RScalar>, size> operator-(
     FixedVector<LScalar, size> const& left,
     FixedVector<RScalar, size> const& right) {
   std::array<Difference<LScalar, RScalar>, size> result;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     result[i] = left[i] - right[i];
   }
   return FixedVector<Difference<LScalar, RScalar>, size>(std::move(result));
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Difference<LScalar, RScalar>, rows, columns> operator-(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedMatrix<RScalar, rows, columns> const& right) {
   FixedMatrix<Difference<LScalar, RScalar>, rows, columns> result(
       uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = left(i, j) - right(i, j);
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Product<LScalar, RScalar>, size> operator*(
     LScalar const& left,
     FixedVector<RScalar, size> const& right) {
   std::array<Product<LScalar, RScalar>, size> result;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     result[i] = left * right[i];
   }
   return FixedVector<Product<LScalar, RScalar>, size>(std::move(result));
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Product<LScalar, RScalar>, size> operator*(
     FixedVector<LScalar, size> const& left,
     RScalar const& right) {
   std::array<Product<LScalar, RScalar>, size> result;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     result[i] = left[i] * right;
   }
   return FixedVector<Product<LScalar, RScalar>, size>(std::move(result));
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns> operator*(
     LScalar const& left,
     FixedMatrix<RScalar, rows, columns> const& right) {
   FixedMatrix<Product<LScalar, RScalar>, rows, columns> result(
       uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = left * right(i, j);
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns> operator*(
     FixedMatrix<LScalar, rows, columns> const& left,
     RScalar const& right) {
   FixedMatrix<Product<LScalar, RScalar>, rows, columns> result(
       uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = left(i, j) * right;
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr FixedVector<Quotient<LScalar, RScalar>, size> operator/(
     FixedVector<LScalar, size> const& left,
     RScalar const& right) {
   FixedVector<Quotient<LScalar, RScalar>, size> result(uninitialized);
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     result[i] = left[i] / right;
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedMatrix<Quotient<LScalar, RScalar>, rows, columns> operator/(
     FixedMatrix<LScalar, rows, columns> const& left,
     RScalar const& right) {
   FixedMatrix<Quotient<LScalar, RScalar>, rows, columns> result(
       uninitialized);
-  for (int i = 0; i < rows; ++i) {
-    for (int j = 0; j < columns; ++j) {
+  for (std::int64_t i = 0; i < rows; ++i) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       result(i, j) = left(i, j) / right;
     }
   }
   return result;
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> operator*(
     LScalar* const left,
     FixedVector<RScalar, size> const& right) {
@@ -726,7 +732,7 @@ constexpr Product<LScalar, RScalar> operator*(
       left, right.data_);
 }
 
-template<typename LScalar, typename RScalar, int size>
+template<typename LScalar, typename RScalar, std::int64_t size>
 constexpr Product<LScalar, RScalar> operator*(
     TransposedView<FixedVector<LScalar, size>> const& left,
     FixedVector<RScalar, size> const& right) {
@@ -734,13 +740,14 @@ constexpr Product<LScalar, RScalar> operator*(
       left.transpose.data_, right.data_);
 }
 
-template<typename LScalar, typename RScalar, int lsize, int rsize>
+template<typename LScalar, typename RScalar,
+         std::int64_t lsize, std::int64_t rsize>
 constexpr FixedMatrix<Product<LScalar, RScalar>, lsize, rsize> operator*(
     FixedVector<LScalar, lsize> const& left,
     TransposedView<FixedVector<RScalar, rsize>> const& right) {
   FixedMatrix<Product<LScalar, RScalar>, lsize, rsize> result(uninitialized);
-  for (int i = 0; i < lsize; ++i) {
-    for (int j = 0; j < rsize; ++j) {
+  for (std::int64_t i = 0; i < lsize; ++i) {
+    for (std::int64_t j = 0; j < rsize; ++j) {
       result(i, j) = left[i] * right[j];
     }
   }
@@ -748,14 +755,14 @@ constexpr FixedMatrix<Product<LScalar, RScalar>, lsize, rsize> operator*(
 }
 
 template<typename LScalar, typename RScalar,
-         int rows, int dimension, int columns>
+         std::int64_t rows, std::int64_t dimension, std::int64_t columns>
 constexpr FixedMatrix<Product<LScalar, RScalar>, rows, columns>
 operator*(FixedMatrix<LScalar, rows, dimension> const& left,
           FixedMatrix<RScalar, dimension, columns> const& right) {
   FixedMatrix<Product<LScalar, RScalar>, rows, columns> result{};
-  for (int i = 0; i < left.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
-      for (int k = 0; k < left.columns(); ++k) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
+      for (std::int64_t k = 0; k < left.columns(); ++k) {
         result(i, j) += left(i, k) * right(k, j);
       }
     }
@@ -763,13 +770,14 @@ operator*(FixedMatrix<LScalar, rows, dimension> const& left,
   return result;
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedVector<Product<LScalar, RScalar>, rows> operator*(
     FixedMatrix<LScalar, rows, columns> const& left,
     FixedVector<RScalar, columns> const& right) {
   std::array<Product<LScalar, RScalar>, rows> result;
   auto const* row = left.data_.data();
-  for (int i = 0; i < rows; ++i) {
+  for (std::int64_t i = 0; i < rows; ++i) {
     result[i] =
         DotProduct<LScalar, RScalar, std::make_index_sequence<columns>>::
             Compute(row, right.data_);
@@ -778,25 +786,26 @@ constexpr FixedVector<Product<LScalar, RScalar>, rows> operator*(
   return FixedVector<Product<LScalar, RScalar>, rows>(std::move(result));
 }
 
-template<typename LScalar, typename RScalar, int rows, int columns>
+template<typename LScalar, typename RScalar,
+         std::int64_t rows, std::int64_t columns>
 constexpr FixedVector<Product<LScalar, RScalar>, columns> operator*(
     TransposedView<FixedMatrix<LScalar, rows, columns>> const& left,
     FixedVector<RScalar, rows> const& right) {
   std::array<Product<LScalar, RScalar>, columns> result{};
-  for (int i = 0; i < columns; ++i) {
+  for (std::int64_t i = 0; i < columns; ++i) {
     auto& result_i = result[i];
-    for (int j = 0; j < rows; ++j) {
+    for (std::int64_t j = 0; j < rows; ++j) {
       result_i += left(i, j) * right[j];
     }
   }
   return FixedVector<Product<LScalar, RScalar>, columns>(std::move(result));
 }
 
-template<typename Scalar, int size>
+template<typename Scalar, std::int64_t size>
 std::ostream& operator<<(std::ostream& out,
                          FixedVector<Scalar, size> const& vector) {
   std::stringstream s;
-  for (int i = 0; i < size; ++i) {
+  for (std::int64_t i = 0; i < size; ++i) {
     s << (i == 0 ? "{" : "") << vector[i]
       << (i == size - 1 ? "}" : ", ");
   }
@@ -804,13 +813,13 @@ std::ostream& operator<<(std::ostream& out,
   return out;
 }
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 std::ostream& operator<<(std::ostream& out,
                          FixedMatrix<Scalar, rows, columns> const& matrix) {
   out << "rows: " << rows << " columns: " << columns << "\n";
-  for (int i = 0; i < rows; ++i) {
+  for (std::int64_t i = 0; i < rows; ++i) {
     out << "{";
-    for (int j = 0; j < columns; ++j) {
+    for (std::int64_t j = 0; j < columns; ++j) {
       out << matrix(i, j);
       if (j < columns - 1) {
         out << ", ";
@@ -821,14 +830,14 @@ std::ostream& operator<<(std::ostream& out,
   return out;
 }
 
-template<typename Scalar, int rows>
+template<typename Scalar, std::int64_t rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedStrictlyLowerTriangularMatrix<Scalar, rows> const& matrix) {
   out << "rows: " << matrix.rows() << "\n";
-  for (int i = 0; i < matrix.rows(); ++i) {
+  for (std::int64_t i = 0; i < matrix.rows(); ++i) {
     out << "{";
-    for (int j = 0; j < i; ++j) {
+    for (std::int64_t j = 0; j < i; ++j) {
       out << matrix(i, j);
       if (j < i - 1) {
         out << ", ";
@@ -839,14 +848,14 @@ std::ostream& operator<<(
   return out;
 }
 
-template<typename Scalar, int rows>
+template<typename Scalar, std::int64_t rows>
 std::ostream& operator<<(
     std::ostream& out,
     FixedLowerTriangularMatrix<Scalar, rows> const& matrix) {
   out << "rows: " << matrix.rows() << "\n";
-  for (int i = 0; i < matrix.rows(); ++i) {
+  for (std::int64_t i = 0; i < matrix.rows(); ++i) {
     out << "{";
-    for (int j = 0; j <= i; ++j) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       out << matrix(i, j);
       if (j < i) {
         out << ", ";
@@ -857,14 +866,14 @@ std::ostream& operator<<(
   return out;
 }
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 std::ostream& operator<<(
     std::ostream& out,
     FixedUpperTriangularMatrix<Scalar, columns> const& matrix) {
   out << "columns: " << matrix.columns() << "\n";
-  for (int i = 0; i < matrix.columns(); ++i) {
+  for (std::int64_t i = 0; i < matrix.columns(); ++i) {
     out << "{";
-    for (int j = i; j < matrix.columns(); ++j) {
+    for (std::int64_t j = i; j < matrix.columns(); ++j) {
       if (j > i) {
         out << ", ";
       }

--- a/numerics/matrix_computations.hpp
+++ b/numerics/matrix_computations.hpp
@@ -146,7 +146,7 @@ RealSchurDecomposition(Matrix const& A, double ε);
 template<typename Matrix>
 typename ClassicalJacobiGenerator<Matrix>::Result ClassicalJacobi(
     Matrix const& A,
-    int max_iterations = 16,
+    std::int64_t max_iterations = 16,
     double ε = std::numeric_limits<double>::epsilon() / 128);
 
 // Returns the Rayleigh quotient r(x) = ᵗx A x / ᵗx x.

--- a/numerics/matrix_computations_body.hpp
+++ b/numerics/matrix_computations_body.hpp
@@ -98,15 +98,15 @@ void PostMultiply(Matrix& A, HouseholderReflection const& P) {
 struct JacobiRotation {
   double cos;
   double sin;
-  int p;
-  int q;
+  std::int64_t p;
+  std::int64_t q;
 };
 
 // See [GV13] section 8.5.2, algorithm 8.5.1.
 template<typename Scalar, typename Matrix>
 JacobiRotation SymmetricSchurDecomposition2By2(Matrix const& A,
-                                               int const p,
-                                               int const q) {
+                                               std::int64_t const p,
+                                               std::int64_t const q) {
   DCHECK_LE(0, p);
   DCHECK_LT(p, q);
   DCHECK_LT(q, A.rows());
@@ -137,7 +137,7 @@ JacobiRotation SymmetricSchurDecomposition2By2(Matrix const& A,
 template<typename Matrix>
 void PremultiplyByTranspose(JacobiRotation const& J, Matrix& A) {
   auto const& [c, s, p, q] = J;
-  for (int j = 0; j < A.columns(); ++j) {
+  for (std::int64_t j = 0; j < A.columns(); ++j) {
     auto const τ₁ = A(p, j);
     auto const τ₂ = A(q, j);
     A(p, j) = c * τ₁ - s * τ₂;
@@ -149,7 +149,7 @@ void PremultiplyByTranspose(JacobiRotation const& J, Matrix& A) {
 template<typename Matrix>
 void PostMultiply(Matrix& A, JacobiRotation const& J) {
   auto const& [c, s, p, q] = J;
-  for (int j = 0; j < A.rows(); ++j) {
+  for (std::int64_t j = 0; j < A.rows(); ++j) {
     auto const τ₁ = A(j, p);
     auto const τ₂ = A(j, q);
     A(j, p) = c * τ₁ - s * τ₂;
@@ -175,8 +175,8 @@ absl::btree_set<typename Matrix::Scalar> Compute2By2Eigenvalues(
 // [GV13] algorithm 7.5.1.
 template<typename Scalar, typename Matrix>
 void FrancisQRStep(Matrix& H) {
-  int const n = H.rows();
-  int const m = n - 1;
+  std::int64_t const n = H.rows();
+  std::int64_t const m = n - 1;
   auto const s = H(m - 1, m - 1) + H(n - 1, n - 1);
   auto const t = H(m - 1, m - 1) * H(n - 1, n - 1) -
                  H(m - 1, n - 1) * H(n - 1, m - 1);
@@ -187,9 +187,9 @@ void FrancisQRStep(Matrix& H) {
   x = Pow<2>(H(0, 0)) + H(0, 1) * H(1, 0) - s * H(0, 0) + t;
   y = H(1, 0) * (H(0, 0) + H(1, 1) - s);
   z = H(1, 0) * H(2, 1);
-  for (int k = 0; k < n - 2; ++k) {
+  for (std::int64_t k = 0; k < n - 2; ++k) {
     auto const P = ComputeHouseholderReflection(xyz);
-    int const q = std::max(1, k);
+    std::int64_t const q = std::max(1LL, k);
     {
       auto block = BlockView<Matrix>{.matrix = H,
                                      .first_row = k,
@@ -198,7 +198,7 @@ void FrancisQRStep(Matrix& H) {
                                      .last_column = n - 1};
       Premultiply(P, block);
     }
-    int const r = std::min(k + 4, n);
+    std::int64_t const r = std::min(k + 4, n);
     {
       auto block = BlockView<Matrix>{.matrix = H,
                                      .first_row = 0,
@@ -241,7 +241,7 @@ struct CholeskyDecompositionGenerator<UnboundedUpperTriangularMatrix<Scalar>> {
   static Result Uninitialized(UnboundedUpperTriangularMatrix<Scalar> const& u);
 };
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 struct CholeskyDecompositionGenerator<
     FixedUpperTriangularMatrix<Scalar, columns>> {
   using Result = FixedUpperTriangularMatrix<SquareRoot<Scalar>, columns>;
@@ -259,7 +259,7 @@ struct ᵗRDRDecompositionGenerator<UnboundedVector<Scalar>,
   static Result Uninitialized(UnboundedUpperTriangularMatrix<Scalar> const& u);
 };
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 struct ᵗRDRDecompositionGenerator<
     FixedVector<Scalar, columns>,
     FixedUpperTriangularMatrix<Scalar, columns>> {
@@ -279,8 +279,8 @@ struct SubstitutionGenerator<TriangularMatrix<LScalar>,
   static Result Uninitialized(TriangularMatrix<LScalar> const& m);
 };
 
-template<typename LScalar, typename RScalar, int dimension,
-         template<typename S, int d> typename TriangularMatrix>
+template<typename LScalar, typename RScalar, std::int64_t dimension,
+         template<typename S, std::int64_t d> typename TriangularMatrix>
 struct SubstitutionGenerator<TriangularMatrix<LScalar, dimension>,
                              FixedVector<RScalar, dimension>> {
   using Result = FixedVector<Quotient<RScalar, LScalar>, dimension>;
@@ -298,7 +298,7 @@ struct GramSchmidtGenerator<UnboundedMatrix<Scalar>> {
   static Result Uninitialized(UnboundedMatrix<Scalar> const& m);
 };
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 struct GramSchmidtGenerator<FixedMatrix<Scalar, dimension, dimension>> {
   struct Result {
     FixedMatrix<double, dimension, dimension> Q;
@@ -321,7 +321,7 @@ struct UnitriangularGramSchmidtGenerator<UnboundedMatrix<Scalar>> {
   static Result Uninitialized(UnboundedMatrix<Scalar> const& m);
 };
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 struct UnitriangularGramSchmidtGenerator<FixedMatrix<Scalar, rows, columns>> {
   struct Result {
     FixedMatrix<Scalar, rows, columns> Q;
@@ -334,7 +334,7 @@ struct UnitriangularGramSchmidtGenerator<FixedMatrix<Scalar, rows, columns>> {
 
 // A specialization for |cpp_rational|, which is used for lattice reduction.
 // |double| is not appropriate for the element of |R| in this case.
-template<int rows, int columns>
+template<std::int64_t rows, std::int64_t columns>
 struct UnitriangularGramSchmidtGenerator<
     FixedMatrix<cpp_rational, rows, columns>> {
   struct Result {
@@ -354,7 +354,7 @@ struct HessenbergDecompositionGenerator<UnboundedMatrix<Scalar>> {
   };
 };
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 struct HessenbergDecompositionGenerator<
     FixedMatrix<Scalar, dimension, dimension>> {
   struct Result {
@@ -370,7 +370,7 @@ struct RealSchurDecompositionGenerator<UnboundedMatrix<Scalar>> {
   };
 };
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 struct RealSchurDecompositionGenerator<
     FixedMatrix<Scalar, dimension, dimension>> {
   struct Result {
@@ -390,7 +390,7 @@ struct ClassicalJacobiGenerator<UnboundedMatrix<Scalar>> {
   static Result Uninitialized(UnboundedMatrix<Scalar> const& m);
 };
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 struct ClassicalJacobiGenerator<FixedMatrix<Scalar, dimension, dimension>> {
   using Rotation = FixedMatrix<double, dimension, dimension>;
   struct Result {
@@ -408,7 +408,7 @@ struct RayleighQuotientGenerator<UnboundedMatrix<MScalar>,
   using Result = MScalar;
 };
 
-template<typename MScalar, typename VScalar, int dimension>
+template<typename MScalar, typename VScalar, std::int64_t dimension>
 struct RayleighQuotientGenerator<FixedMatrix<MScalar, dimension, dimension>,
                                  FixedVector<VScalar, dimension>> {
   using Result = MScalar;
@@ -425,7 +425,7 @@ struct RayleighQuotientIterationGenerator<
   static Result Uninitialized(UnboundedVector<VScalar> const& v);
 };
 
-template<typename MScalar, typename VScalar, int dimension>
+template<typename MScalar, typename VScalar, std::int64_t dimension>
 struct RayleighQuotientIterationGenerator<
     FixedMatrix<MScalar, dimension, dimension>,
     FixedVector<VScalar, dimension>> {
@@ -446,7 +446,8 @@ struct SolveGenerator<UnboundedMatrix<MScalar>, UnboundedVector<VScalar>> {
   UninitializedU(UnboundedMatrix<MScalar> const& m);
 };
 
-template<typename MScalar, typename VScalar, int rows, int columns>
+template<typename MScalar, typename VScalar,
+         std::int64_t rows, std::int64_t columns>
 struct SolveGenerator<FixedMatrix<MScalar, rows, columns>,
                       FixedVector<VScalar, rows>> {
   using Scalar = MScalar;
@@ -465,7 +466,7 @@ Uninitialized(UnboundedUpperTriangularMatrix<Scalar> const& u) -> Result {
   return Result(u.columns(), uninitialized);
 }
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 auto CholeskyDecompositionGenerator<
     FixedUpperTriangularMatrix<Scalar, columns>>::
 Uninitialized(FixedUpperTriangularMatrix<Scalar, columns> const& u) -> Result {
@@ -480,7 +481,7 @@ Uninitialized(UnboundedUpperTriangularMatrix<Scalar> const& u) -> Result {
           UnboundedVector<Scalar>(u.columns(), uninitialized)};
 }
 
-template<typename Scalar, int columns>
+template<typename Scalar, std::int64_t columns>
 auto ᵗRDRDecompositionGenerator<FixedVector<Scalar, columns>,
                                 FixedUpperTriangularMatrix<Scalar, columns>>::
 Uninitialized(FixedUpperTriangularMatrix<Scalar, columns> const& u) -> Result {
@@ -504,7 +505,7 @@ Uninitialized(UnboundedMatrix<Scalar> const& m) -> Result {
       .R = UnboundedUpperTriangularMatrix<Scalar>(m.columns(), uninitialized)};
 }
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 auto GramSchmidtGenerator<FixedMatrix<Scalar, dimension, dimension>>::
 Uninitialized(FixedMatrix<Scalar, dimension, dimension> const& m) -> Result {
   return Result{
@@ -520,7 +521,7 @@ Uninitialized(UnboundedMatrix<Scalar> const& m) -> Result {
       .R = UnboundedUpperTriangularMatrix<double>(m.columns(), uninitialized)};
 }
 
-template<typename Scalar, int rows, int columns>
+template<typename Scalar, std::int64_t rows, std::int64_t columns>
 auto UnitriangularGramSchmidtGenerator<
     FixedMatrix<Scalar, rows, columns>>::
 Uninitialized(FixedMatrix<Scalar, rows, columns> const& m) -> Result {
@@ -529,7 +530,7 @@ Uninitialized(FixedMatrix<Scalar, rows, columns> const& m) -> Result {
       .R = FixedUpperTriangularMatrix<double, columns>(uninitialized)};
 }
 
-template<int rows, int columns>
+template<std::int64_t rows, std::int64_t columns>
 auto UnitriangularGramSchmidtGenerator<
     FixedMatrix<cpp_rational, rows, columns>>::
 Uninitialized(FixedMatrix<cpp_rational, rows, columns> const& m) -> Result {
@@ -551,13 +552,13 @@ Uninitialized(UnboundedMatrix<Scalar> const& m) -> Result {
           .eigenvalues = UnboundedVector<Scalar>(m.columns())};
 }
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 auto ClassicalJacobiGenerator<FixedMatrix<Scalar, dimension, dimension>>::
 Identity(FixedMatrix<Scalar, dimension, dimension> const& m) -> Rotation {
   return Rotation::Identity();
 }
 
-template<typename Scalar, int dimension>
+template<typename Scalar, std::int64_t dimension>
 auto ClassicalJacobiGenerator<FixedMatrix<Scalar, dimension, dimension>>::
 Uninitialized(FixedMatrix<Scalar, dimension, dimension> const& m) -> Result {
   return {.rotation = FixedMatrix<double, dimension, dimension>(),
@@ -572,7 +573,7 @@ Uninitialized(UnboundedVector<VScalar> const& v) -> Result {
   return {UnboundedVector<VScalar>(v.size(), uninitialized), MScalar()};
 }
 
-template<typename MScalar, typename VScalar, int dimension>
+template<typename MScalar, typename VScalar, std::int64_t dimension>
 auto RayleighQuotientIterationGenerator<
     FixedMatrix<MScalar, dimension, dimension>,
     FixedVector<VScalar, dimension>>::
@@ -580,8 +581,8 @@ Uninitialized(FixedVector<VScalar, dimension> const& v) -> Result {
   return {FixedVector<VScalar, dimension>(uninitialized), MScalar()};
 }
 
-template<typename LScalar, typename RScalar, int dimension,
-         template<typename S, int d> typename TriangularMatrix>
+template<typename LScalar, typename RScalar, std::int64_t dimension,
+         template<typename S, std::int64_t d> typename TriangularMatrix>
 auto SubstitutionGenerator<TriangularMatrix<LScalar, dimension>,
                            FixedVector<RScalar, dimension>>::Uninitialized(
     TriangularMatrix<LScalar, dimension> const& m) -> Result {
@@ -603,7 +604,8 @@ UninitializedU(UnboundedMatrix<MScalar> const& m) {
   return UnboundedUpperTriangularMatrix<MScalar>(m.columns(), uninitialized);
 }
 
-template<typename MScalar, typename VScalar, int rows, int columns>
+template<typename MScalar, typename VScalar,
+         std::int64_t rows, std::int64_t columns>
 FixedLowerTriangularMatrix<Quotient<MScalar, MScalar>, rows>
 SolveGenerator<FixedMatrix<MScalar, rows, columns>,
                FixedVector<VScalar, rows>>::
@@ -612,7 +614,8 @@ UninitializedL(FixedMatrix<MScalar, rows, columns> const& m) {
       uninitialized);
 }
 
-template<typename MScalar, typename VScalar, int rows, int columns>
+template<typename MScalar, typename VScalar,
+         std::int64_t rows, std::int64_t columns>
 FixedUpperTriangularMatrix<MScalar, columns>
 SolveGenerator<FixedMatrix<MScalar, rows, columns>,
                FixedVector<VScalar, rows>>::
@@ -627,16 +630,16 @@ CholeskyDecomposition(UpperTriangularMatrix const& A) {
   using G = CholeskyDecompositionGenerator<UpperTriangularMatrix>;
   using Scalar = typename UpperTriangularMatrix::Scalar;
   auto R = G::Uninitialized(A);
-  for (int j = 0; j < A.columns(); ++j) {
-    for (int i = 0; i < j; ++i) {
+  for (std::int64_t j = 0; j < A.columns(); ++j) {
+    for (std::int64_t i = 0; i < j; ++i) {
       Scalar Σrₖᵢrₖⱼ{};
-      for (int k = 0; k < i; ++k) {
+      for (std::int64_t k = 0; k < i; ++k) {
         Σrₖᵢrₖⱼ += R(k, i) * R(k, j);
       }
       R(i, j) = (A(i, j) - Σrₖᵢrₖⱼ) / R(i, i);
     }
     Scalar Σrₖⱼ²{};
-    for (int k = 0; k < j; ++k) {
+    for (std::int64_t k = 0; k < j; ++k) {
       Σrₖⱼ² += Pow<2>(R(k, j));
     }
     // This will produce NaNs if the matrix is not positive definite.
@@ -654,15 +657,15 @@ typename ᵗRDRDecompositionGenerator<Vector, UpperTriangularMatrix>::Result
   auto result = G::Uninitialized(A);
   auto& R = result.R;
   auto& D = result.D;
-  for (int i = 0; i < A.columns(); ++i) {
+  for (std::int64_t i = 0; i < A.columns(); ++i) {
     Scalar Σrₖᵢ²dₖ{};
-    for (int k = 0; k < i; ++k) {
+    for (std::int64_t k = 0; k < i; ++k) {
       Σrₖᵢ²dₖ += Pow<2>(R(k, i)) * D[k];
     }
     D[i] = A(i, i) - Σrₖᵢ²dₖ;
-    for (int j = i + 1; j < A.columns(); ++j) {
+    for (std::int64_t j = i + 1; j < A.columns(); ++j) {
       Scalar Σrₖᵢrₖⱼdₖ{};
-      for (int k = 0; k < i; ++k) {
+      for (std::int64_t k = 0; k < i; ++k) {
         Σrₖᵢrₖⱼdₖ += R(k, i) * R(k, j) * D[k];
       }
       R(i, j) = (A(i, j) - Σrₖᵢrₖⱼdₖ) / D[i];
@@ -679,11 +682,11 @@ BackSubstitution(UpperTriangularMatrix const& U,
                  Vector const& b) {
   using G = SubstitutionGenerator<UpperTriangularMatrix, Vector>;
   auto x = G::Uninitialized(U);
-  int const n = x.size() - 1;
+  std::int64_t const n = x.size() - 1;
   x[n] = b[n] / U(n, n);
-  for (int i = n - 1; i >= 0; --i) {
+  for (std::int64_t i = n - 1; i >= 0; --i) {
     auto s = b[i];
-    for (int j = i + 1; j <= n; ++j) {
+    for (std::int64_t j = i + 1; j <= n; ++j) {
       s -= U(i, j) * x[j];
     }
     x[i] = s / U(i, i);
@@ -701,9 +704,9 @@ ForwardSubstitution(LowerTriangularMatrix const& L,
   using G = SubstitutionGenerator<LowerTriangularMatrix, Vector>;
   auto x = G::Uninitialized(L);
   x[0] = b[0] / L(0, 0);
-  for (int i = 1; i < b.size(); ++i) {
+  for (std::int64_t i = 1; i < b.size(); ++i) {
     auto s = b[i];
-    for (int j = 0; j < i; ++j) {
+    for (std::int64_t j = 0; j < i; ++j) {
       s -= L(i, j) * x[j];
     }
     x[i] = s / L(i, i);
@@ -718,15 +721,15 @@ typename GramSchmidtGenerator<Matrix>::Result ClassicalGramSchmidt(
   auto result = G::Uninitialized(A);
   auto& Q = result.Q;
   auto& R = result.R;
-  int const n = A.rows();
+  std::int64_t const n = A.rows();
 
   // [Hig02], Algorithm 19.11.
-  for (int j = 0; j < n; ++j) {
+  for (std::int64_t j = 0; j < n; ++j) {
     auto const aⱼ = ColumnView<Matrix const>{.matrix = A,
                                              .first_row = 0,
                                              .last_row = n - 1,
                                              .column = j};
-    for (int i = 0; i < j; ++i) {
+    for (std::int64_t i = 0; i < j; ++i) {
       auto const qᵢ = ColumnView{.matrix = Q,
                                  .first_row = 0,
                                  .last_row = n - 1,
@@ -734,7 +737,7 @@ typename GramSchmidtGenerator<Matrix>::Result ClassicalGramSchmidt(
       R(i, j) = TransposedView{.transpose = qᵢ} * aⱼ;  // NOLINT
     }
     typename G::AVector qʹⱼ(aⱼ);
-    for (int k = 0; k < j; ++k) {
+    for (std::int64_t k = 0; k < j; ++k) {
       qʹⱼ -= R(k, j) * typename G::QVector(ColumnView{.matrix = Q,
                                                       .first_row = 0,
                                                       .last_row = n - 1,
@@ -756,8 +759,8 @@ UnitriangularGramSchmidt(Matrix const& A) {
   auto result = G::Uninitialized(A);
   auto& Q = result.Q;
   auto& R = result.R;
-  int const m = A.rows();
-  int const n = A.columns();
+  std::int64_t const m = A.rows();
+  std::int64_t const n = A.columns();
 
   // The algorithm is derived from [HPS14], Theorem 7.13, but we keep the code
   // similar to the one for classical Gram-Schmidt, i.e., adopt the conventions
@@ -767,12 +770,12 @@ UnitriangularGramSchmidt(Matrix const& A) {
   //   v⭑ⱼ ≘ qⱼ
   //   μᵢⱼ ≘ Rⱼᵢ
   auto const zero = Square<typename G::QVector::Scalar>{};
-  for (int j = 0; j < n; ++j) {
+  for (std::int64_t j = 0; j < n; ++j) {
     auto const aⱼ = ColumnView<Matrix const>{.matrix = A,
                                              .first_row = 0,
                                              .last_row = m - 1,
                                              .column = j};
-    for (int i = 0; i < j; ++i) {
+    for (std::int64_t i = 0; i < j; ++i) {
       auto const qᵢ = ColumnView{.matrix = Q,
                                  .first_row = 0,
                                  .last_row = m - 1,
@@ -789,7 +792,7 @@ UnitriangularGramSchmidt(Matrix const& A) {
                          .last_row = m - 1,
                          .column = j};
     qⱼ = aⱼ;
-    for (int k = 0; k < j; ++k) {
+    for (std::int64_t k = 0; k < j; ++k) {
       qⱼ -= R(k, j) * typename G::QVector(ColumnView{.matrix = Q,
                                                      .first_row = 0,
                                                      .last_row = m - 1,
@@ -806,10 +809,10 @@ HessenbergDecomposition(Matrix const& A) {
   using G = HessenbergDecompositionGenerator<Matrix>;
   typename G::Result result{.H = A};
   auto& H = result.H;
-  int const n = A.rows();
+  std::int64_t const n = A.rows();
 
   // [GV13], Algorithm 7.4.2.
-  for (int k = 0; k < n - 2; ++k) {
+  for (std::int64_t k = 0; k < n - 2; ++k) {
     auto const P = ComputeHouseholderReflection(
         ColumnView<Matrix>{.matrix = H,
                            .first_row = k + 1,
@@ -845,9 +848,9 @@ RealSchurDecomposition(Matrix const& A, double const ε) {
   // [GV13] algorithm 7.5.2.
   auto hessenberg = HessenbergDecomposition(A);
   auto& H = hessenberg.H;
-  int const n = H.rows();
+  std::int64_t const n = H.rows();
   for (;;) {
-    for (int i = 1; i < n; ++i) {
+    for (std::int64_t i = 1; i < n; ++i) {
       if (Abs(H(i, i - 1)) <= ε * (Abs(H(i, i)) + Abs(H(i - 1, i - 1)))) {
         H(i, i - 1) = zero;
       }
@@ -856,8 +859,8 @@ RealSchurDecomposition(Matrix const& A, double const ε) {
     // Upper quasi-triangular means that we don't have consecutive nonzero
     // subdiagonal elements, and we end on a zero.
     bool has_subdiagonal_element = false;
-    int q = 0;
-    for (int i = 1; i <= n; ++i) {
+    std::int64_t q = 0;
+    for (std::int64_t i = 1; i <= n; ++i) {
       // The case i == n corresponds to a zero sentinel immediately to the left
       // of the first element of the matrix.
       if (i == n || H(n - i, n - i - 1) == zero) {
@@ -874,7 +877,7 @@ RealSchurDecomposition(Matrix const& A, double const ε) {
       break;
     }
 
-    int p = n - q - 1;
+    std::int64_t p = n - q - 1;
     for (; p > 0; --p) {
       if (H(p, p - 1) == zero) {
         break;
@@ -892,8 +895,8 @@ RealSchurDecomposition(Matrix const& A, double const ε) {
   // Find the real eigenvalues.  Note that they may be part of a 2×2 block which
   // happens to have real roots.
   absl::btree_set<Scalar> real_eigenvalues;
-  for (int i = 0; i < H.rows();) {
-    int first_in_block = 0;
+  for (std::int64_t i = 0; i < H.rows();) {
+    std::int64_t first_in_block = 0;
     if (i == H.rows() - 1) {
       if (i == 0 || H(i, i - 1) == 0) {
         real_eigenvalues.insert(H(i, i));
@@ -926,7 +929,7 @@ RealSchurDecomposition(Matrix const& A, double const ε) {
 
 template<typename Matrix>
 typename ClassicalJacobiGenerator<Matrix>::Result
-ClassicalJacobi(Matrix const& A,  int max_iterations, double const ε) {
+ClassicalJacobi(Matrix const& A,  std::int64_t max_iterations, double const ε) {
   using G = ClassicalJacobiGenerator<Matrix>;
   using Scalar = typename Matrix::Scalar;
   auto result = G::Uninitialized(A);
@@ -937,14 +940,14 @@ ClassicalJacobi(Matrix const& A,  int max_iterations, double const ε) {
   auto const A_frobenius_norm = A.FrobeniusNorm();
   V = identity;
   auto diagonalized_A = A;
-  for (int k = 0; k < max_iterations; ++k) {
+  for (std::int64_t k = 0; k < max_iterations; ++k) {
     Scalar max_Apq{};
-    int max_p = -1;
-    int max_q = -1;
+    std::int64_t max_p = -1;
+    std::int64_t max_q = -1;
 
     // Find the largest off-diagonal element and exit if it's small.
-    for (int p = 0; p < diagonalized_A.rows(); ++p) {
-      for (int q = p + 1; q < diagonalized_A.columns(); ++q) {
+    for (std::int64_t p = 0; p < diagonalized_A.rows(); ++p) {
+      for (std::int64_t q = p + 1; q < diagonalized_A.columns(); ++q) {
         Scalar const abs_Apq = Abs(diagonalized_A(p, q));
         if (abs_Apq >= max_Apq) {
           max_Apq = abs_Apq;
@@ -972,7 +975,7 @@ ClassicalJacobi(Matrix const& A,  int max_iterations, double const ε) {
     }
   }
 
-  for (int i = 0; i < A.rows(); ++i) {
+  for (std::int64_t i = 0; i < A.rows(); ++i) {
     result.eigenvalues[i] = diagonalized_A(i, i);
   }
   return result;
@@ -995,10 +998,10 @@ RayleighQuotientIteration(Matrix const& A, Vector const& x) {
 
   // [GV13], section 8.2.3.
   xₖ = x / x.Norm();
-  for (int iteration = 0; iteration < 10; ++iteration) {
+  for (std::int64_t iteration = 0; iteration < 10; ++iteration) {
     μₖ = RayleighQuotient(A, xₖ);
     auto A_minus_μₖ_I = A;
-    for (int i = 0; i < A.rows(); ++i) {
+    for (std::int64_t i = 0; i < A.rows(); ++i) {
       A_minus_μₖ_I(i, i) -= μₖ;
     }
     auto const residual = (A_minus_μₖ_I * xₖ).Norm();
@@ -1028,11 +1031,11 @@ Solve(Matrix A, Vector b) {
 
   // Doolittle's method: write P * A = L * U where P is an implicit permutation
   // that is also applied to b.  See [Hig02], Algorithm 9.2 p. 162.
-  for (int k = 0; k < A.columns(); ++k) {
+  for (std::int64_t k = 0; k < A.columns(); ++k) {
     // Partial pivoting.
-    int r = -1;
+    std::int64_t r = -1;
     Scalar max{};
-    for (int i = k; i < A.rows(); ++i) {
+    for (std::int64_t i = k; i < A.rows(); ++i) {
       if (Abs(A(i, k)) >= max) {
         r = i;
         max = Abs(A(i, k));
@@ -1042,11 +1045,11 @@ Solve(Matrix A, Vector b) {
     CHECK_LT(r, A.rows()) << A << " cannot pivot";
 
     // Swap the rows of A.
-    for (int i = 0; i < A.columns(); ++i) {
+    for (std::int64_t i = 0; i < A.columns(); ++i) {
       std::swap(A(k, i), A(r, i));
     }
     // Swap the rows of L.
-    for (int i = 0; i < k; ++i) {
+    for (std::int64_t i = 0; i < k; ++i) {
       std::swap(L(k, i), L(r, i));
     }
     // Swap the rows of b.
@@ -1055,16 +1058,16 @@ Solve(Matrix A, Vector b) {
     LOG_IF(WARNING, A(k, k) == Scalar{})
         << A << " does not have a unique LU decomposition";
 
-    for (int j = k; j < A.columns(); ++j) {
+    for (std::int64_t j = k; j < A.columns(); ++j) {
       auto U_kj = A(k, j);
-      for (int i = 0; i < k; ++i) {
+      for (std::int64_t i = 0; i < k; ++i) {
         U_kj -= L(k, i) * U(i, j);
       }
       U(k, j) = U_kj;
     }
-    for (int i = k + 1; i < A.rows(); ++i) {
+    for (std::int64_t i = k + 1; i < A.rows(); ++i) {
       auto L_ik = A(i, k);
-      for (int j = 0; j < k; ++j) {
+      for (std::int64_t j = 0; j < k; ++j) {
         L_ik -= L(i, j) * U(j, k);
       }
       L(i, k) = L_ik / U(k, k);

--- a/numerics/matrix_views.hpp
+++ b/numerics/matrix_views.hpp
@@ -23,13 +23,14 @@ struct BlockView {
   using Scalar = typename Matrix::Scalar;
 
   Matrix& matrix;
-  int first_row;
-  int last_row;
-  int first_column;
-  int last_column;
+  std::int64_t first_row;
+  std::int64_t last_row;
+  std::int64_t first_column;
+  std::int64_t last_column;
 
-  constexpr Scalar& operator()(int row, int column);
-  constexpr Scalar const& operator()(int row, int column) const;
+  constexpr Scalar& operator()(std::int64_t row, std::int64_t column);
+  constexpr Scalar const& operator()(std::int64_t row,
+                                     std::int64_t column) const;
 
   template<typename T>
     requires two_dimensional<T> && same_elements_as<T, Matrix>
@@ -45,8 +46,8 @@ struct BlockView {
   BlockView& operator*=(double right);
   BlockView& operator/=(double right);
 
-  constexpr int rows() const;
-  constexpr int columns() const;
+  constexpr std::int64_t rows() const;
+  constexpr std::int64_t columns() const;
 };
 
 // A view of a column of a matrix.  This view is |one_dimensional|.
@@ -56,12 +57,12 @@ struct ColumnView {
   using Scalar = typename Matrix::Scalar;
 
   Matrix& matrix;
-  int first_row;
-  int last_row;
-  int column;
+  std::int64_t first_row;
+  std::int64_t last_row;
+  std::int64_t column;
 
-  constexpr Scalar& operator[](int index);
-  constexpr Scalar const& operator[](int index) const;
+  constexpr Scalar& operator[](std::int64_t index);
+  constexpr Scalar const& operator[](std::int64_t index) const;
 
   template<typename T>
     requires one_dimensional<T> && same_elements_as<T, Matrix>
@@ -80,7 +81,7 @@ struct ColumnView {
 
   Scalar Norm() const;
   Square<Scalar> Norm²() const;
-  constexpr int size() const;
+  constexpr std::int64_t size() const;
 };
 
 // TODO(phl): This should probably be just |swap|.  The semantics of BlockView

--- a/numerics/matrix_views_body.hpp
+++ b/numerics/matrix_views_body.hpp
@@ -18,7 +18,7 @@ using namespace principia::quantities::_elementary_functions;
 template<typename Matrix>
   requires two_dimensional<Matrix>
 constexpr auto BlockView<Matrix>::operator()(
-    int const row, int const column) -> Scalar& {
+    std::int64_t const row, std::int64_t const column) -> Scalar& {
   CONSTEXPR_DCHECK(row <= last_row - first_row);
   CONSTEXPR_DCHECK(column <= last_column - first_column);
   return matrix(first_row + row, first_column + column);
@@ -27,8 +27,8 @@ constexpr auto BlockView<Matrix>::operator()(
 template<typename Matrix>
   requires two_dimensional<Matrix>
 constexpr auto BlockView<Matrix>::operator()(
-    int const row,
-    int const column) const -> Scalar const& {
+    std::int64_t const row,
+    std::int64_t const column) const -> Scalar const& {
   CONSTEXPR_DCHECK(row <= last_row - first_row);
   CONSTEXPR_DCHECK(column <= last_column - first_column);
   return matrix(first_row + row, first_column + column);
@@ -41,8 +41,8 @@ template<typename T>
 BlockView<Matrix>& BlockView<Matrix>::operator=(T const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       matrix(first_row + i, first_column + j) = right(i, j);
     }
   }
@@ -56,8 +56,8 @@ template<typename T>
 BlockView<Matrix>& BlockView<Matrix>::operator+=(T const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       matrix(first_row + i, first_column + j) += right(i, j);
     }
   }
@@ -71,8 +71,8 @@ template<typename T>
 auto BlockView<Matrix>::operator-=(T const& right) -> BlockView<Matrix>& {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       matrix(first_row + i, first_column + j) -= right(i, j);
     }
   }
@@ -82,8 +82,8 @@ auto BlockView<Matrix>::operator-=(T const& right) -> BlockView<Matrix>& {
 template<typename Matrix>
   requires two_dimensional<Matrix>
 BlockView<Matrix>& BlockView<Matrix>::operator*=(double const right) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       matrix(first_row + i, first_column + j) *= right;
     }
   }
@@ -93,8 +93,8 @@ BlockView<Matrix>& BlockView<Matrix>::operator*=(double const right) {
 template<typename Matrix>
   requires two_dimensional<Matrix>
 BlockView<Matrix>& BlockView<Matrix>::operator/=(double const right) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j < columns(); ++j) {
       matrix(first_row + i, first_column + j) /= right;
     }
   }
@@ -103,20 +103,21 @@ BlockView<Matrix>& BlockView<Matrix>::operator/=(double const right) {
 
 template<typename Matrix>
   requires two_dimensional<Matrix>
-constexpr auto BlockView<Matrix>::rows() const -> int {
+constexpr auto BlockView<Matrix>::rows() const -> std::int64_t {
   return last_row - first_row + 1;
 }
 
 template<typename Matrix>
   requires two_dimensional<Matrix>
-constexpr auto BlockView<Matrix>::columns() const -> int{
+constexpr auto BlockView<Matrix>::columns() const -> std::int64_t{
   return last_column - first_column + 1;
 }
 
 
 template<typename Matrix>
   requires two_dimensional<Matrix>
-constexpr auto ColumnView<Matrix>::operator[](int const index) -> Scalar& {
+constexpr auto ColumnView<Matrix>::operator[](
+    std::int64_t const index) -> Scalar& {
   CONSTEXPR_DCHECK(index <= last_row - first_row);
   return matrix(first_row + index, column);
 }
@@ -124,7 +125,7 @@ constexpr auto ColumnView<Matrix>::operator[](int const index) -> Scalar& {
 template<typename Matrix>
   requires two_dimensional<Matrix>
 constexpr auto ColumnView<Matrix>::operator[](
-    int const index) const -> Scalar const& {
+    std::int64_t const index) const -> Scalar const& {
   CONSTEXPR_DCHECK(index <= last_row - first_row);
   return matrix(first_row + index, column);
 }
@@ -135,7 +136,7 @@ template<typename T>
   requires one_dimensional<T> && same_elements_as<T, Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator=(T const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     matrix(first_row + i, column) = right[i];
   }
   return *this;
@@ -145,7 +146,7 @@ template<typename Matrix>
   requires two_dimensional<Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator=(ColumnView const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     matrix(first_row + i, column) = right[i];
   }
   return *this;
@@ -157,7 +158,7 @@ template<typename T>
   requires one_dimensional<T> && same_elements_as<T, Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator+=(T const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     matrix(first_row + i, column) += right[i];
   }
   return *this;
@@ -169,7 +170,7 @@ template<typename T>
   requires one_dimensional<T> && same_elements_as<T, Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator-=(T const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     matrix(first_row + i, column) -= right[i];
   }
   return *this;
@@ -178,7 +179,7 @@ ColumnView<Matrix>& ColumnView<Matrix>::operator-=(T const& right) {
 template<typename Matrix>
   requires two_dimensional<Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator*=(double const right) {
-  for (int i = first_row; i <= last_row; ++i) {
+  for (std::int64_t i = first_row; i <= last_row; ++i) {
     matrix(i, column) *= right;
   }
   return *this;
@@ -187,7 +188,7 @@ ColumnView<Matrix>& ColumnView<Matrix>::operator*=(double const right) {
 template<typename Matrix>
   requires two_dimensional<Matrix>
 ColumnView<Matrix>& ColumnView<Matrix>::operator/=(double const right) {
-  for (int i = first_row; i <= last_row; ++i) {
+  for (std::int64_t i = first_row; i <= last_row; ++i) {
     matrix(i, column) /= right;
   }
   return *this;
@@ -203,7 +204,7 @@ template<typename Matrix>
   requires two_dimensional<Matrix>
 auto ColumnView<Matrix>::Norm²() const -> Square<Scalar> {
   Square<Scalar> result{};
-  for (int i = first_row; i <= last_row; ++i) {
+  for (std::int64_t i = first_row; i <= last_row; ++i) {
     result += Pow<2>(matrix(i, column));
   }
   return result;
@@ -211,7 +212,7 @@ auto ColumnView<Matrix>::Norm²() const -> Square<Scalar> {
 
 template<typename Matrix>
   requires two_dimensional<Matrix>
-constexpr auto ColumnView<Matrix>::size() const -> int {
+constexpr auto ColumnView<Matrix>::size() const -> std::int64_t {
   return last_row - first_row + 1;
 }
 
@@ -219,7 +220,7 @@ template<typename Matrix>
 void SwapColumns(ColumnView<Matrix>& m1, ColumnView<Matrix>& m2) {
   DCHECK_EQ(m1.first_row, m2.first_row);
   DCHECK_EQ(m1.last_row, m2.last_row);
-  for (int i = 0; i < m1.size(); ++i) {
+  for (std::int64_t i = 0; i < m1.size(); ++i) {
     std::swap(m1[i], m2[i]);
   }
 }
@@ -230,7 +231,7 @@ Product<typename LMatrix::Scalar, typename RMatrix::Scalar> operator*(
     ColumnView<RMatrix> const& right) {
   DCHECK_EQ(left.size(), right.size());
   Product<typename LMatrix::Scalar, typename RMatrix::Scalar> result{};
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     result += left[i] * right[i];
   }
   return result;
@@ -242,8 +243,8 @@ bool operator==(BlockView<Matrix> const& left, T const& right) {
   if (left.rows() != right.rows() || left.columns() != right.columns()) {
     return false;
   }
-  for (int i = 0; i < left.rows(); ++i) {
-    for (int j = 0; j < left.columns(); ++j) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       if (left(i, j) != right(i, j)) {
         return false;
       }
@@ -258,7 +259,7 @@ bool operator==(ColumnView<Matrix> const& left, T const& right) {
   if (left.size() != right.size()) {
     return false;
   }
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     if (left[i] != right[i]) {
       return false;
     }
@@ -269,9 +270,9 @@ bool operator==(ColumnView<Matrix> const& left, T const& right) {
 template<typename Matrix>
 std::ostream& operator<<(std::ostream& out, BlockView<Matrix> const& view) {
   out << "rows: " << view.rows() << " columns: " << view.columns() << "\n";
-  for (int i = 0; i < view.rows(); ++i) {
+  for (std::int64_t i = 0; i < view.rows(); ++i) {
     out << "{";
-    for (int j = 0; j < view.columns(); ++j) {
+    for (std::int64_t j = 0; j < view.columns(); ++j) {
       out << view(i, j);
       if (j < view.columns() - 1) {
         out << ", ";
@@ -286,7 +287,7 @@ template<typename Matrix>
 std::ostream& operator<<(std::ostream& out,
                          ColumnView<Matrix> const& view) {
   std::stringstream s;
-  for (int i = 0; i < view.size(); ++i) {
+  for (std::int64_t i = 0; i < view.size(); ++i) {
     s << (i == 0 ? "{" : "") << view[i]
       << (i == view.size() - 1 ? "}" : ", ");
   }

--- a/numerics/matrix_views_body.hpp
+++ b/numerics/matrix_views_body.hpp
@@ -109,7 +109,7 @@ constexpr auto BlockView<Matrix>::rows() const -> std::int64_t {
 
 template<typename Matrix>
   requires two_dimensional<Matrix>
-constexpr auto BlockView<Matrix>::columns() const -> std::int64_t{
+constexpr auto BlockView<Matrix>::columns() const -> std::int64_t {
   return last_column - first_column + 1;
 }
 

--- a/numerics/unbounded_arrays.hpp
+++ b/numerics/unbounded_arrays.hpp
@@ -49,11 +49,11 @@ class UnboundedVector final {
  public:
   using Scalar = Scalar_;
 
-  explicit UnboundedVector(int size);  // Zero-initialized.
-  UnboundedVector(int size, uninitialized_t);
+  explicit UnboundedVector(std::int64_t size);  // Zero-initialized.
+  UnboundedVector(std::int64_t size, uninitialized_t);
   UnboundedVector(std::initializer_list<Scalar> data);
 
-  template<int size_>
+  template<std::int64_t size_>
   explicit UnboundedVector(FixedVector<Scalar, size_> const& data);
 
   // Constructs an unbounded vector by copying data from the view.  Note that
@@ -67,8 +67,8 @@ class UnboundedVector final {
   friend bool operator!=(UnboundedVector const& left,
                          UnboundedVector const& right) = default;
 
-  Scalar& operator[](int index);
-  Scalar const& operator[](int index) const;
+  Scalar& operator[](std::int64_t index);
+  Scalar const& operator[](std::int64_t index) const;
 
   UnboundedVector& operator=(std::initializer_list<Scalar> right);
 
@@ -77,18 +77,18 @@ class UnboundedVector final {
   UnboundedVector& operator*=(double right);
   UnboundedVector& operator/=(double right);
 
-  void Extend(int extra_size);
-  void Extend(int extra_size, uninitialized_t);
+  void Extend(std::int64_t extra_size);
+  void Extend(std::int64_t extra_size, uninitialized_t);
   void Extend(std::initializer_list<Scalar> data);
 
-  void EraseToEnd(int begin_index);
+  void EraseToEnd(std::int64_t begin_index);
 
   Scalar Norm() const;
   Square<Scalar> Norm²() const;
 
   UnboundedVector<double> Normalize() const;
 
-  int size() const;
+  std::int64_t size() const;
 
   typename std::vector<Scalar>::const_iterator begin() const;
   typename std::vector<Scalar>::const_iterator end() const;
@@ -110,13 +110,14 @@ class UnboundedMatrix final {
  public:
   using Scalar = Scalar_;
 
-  UnboundedMatrix(int rows, int columns);
-  UnboundedMatrix(int rows, int columns, uninitialized_t);
+  UnboundedMatrix(std::int64_t rows, std::int64_t columns);
+  UnboundedMatrix(std::int64_t rows, std::int64_t columns, uninitialized_t);
 
   // The |data| must be in row-major format and must be for a square matrix.
   UnboundedMatrix(std::initializer_list<Scalar> data);
 
-  UnboundedMatrix(int rows, int columns, std::initializer_list<Scalar> data);
+  UnboundedMatrix(std::int64_t rows, std::int64_t columns,
+                  std::initializer_list<Scalar> data);
 
   explicit UnboundedMatrix(TransposedView<UnboundedMatrix<Scalar>> const& view);
 
@@ -128,8 +129,8 @@ class UnboundedMatrix final {
   // For  0 ≤ i < rows and 0 ≤ j < columns, the entry a_ij is accessed as
   // |a(i, j)|.  If i and j do not satisfy these conditions, the expression
   // |a(i, j)| implies undefined behaviour.
-  Scalar& operator()(int row, int column);
-  Scalar const& operator()(int row, int column) const;
+  Scalar& operator()(std::int64_t row, std::int64_t column);
+  Scalar const& operator()(std::int64_t row, std::int64_t column) const;
 
   // Applies the matrix as a bilinear form.  Present for compatibility with
   // |SymmetricBilinearForm|.  Prefer to use |TransposedView| and |operator*|.
@@ -147,16 +148,16 @@ class UnboundedMatrix final {
 
   UnboundedMatrix& operator*=(UnboundedMatrix<double> const& right);
 
-  int rows() const;
-  int columns() const;
+  std::int64_t rows() const;
+  std::int64_t columns() const;
 
   Scalar FrobeniusNorm() const;
 
-  static UnboundedMatrix Identity(int rows, int columns);
+  static UnboundedMatrix Identity(std::int64_t rows, std::int64_t columns);
 
  private:
-  int rows_;
-  int columns_;
+  std::int64_t rows_;
+  std::int64_t columns_;
   std::vector<Scalar, uninitialized_allocator<Scalar>> data_;
 
   template<typename S>
@@ -169,8 +170,8 @@ class UnboundedLowerTriangularMatrix final {
  public:
   using Scalar = Scalar_;
 
-  explicit UnboundedLowerTriangularMatrix(int rows);
-  UnboundedLowerTriangularMatrix(int rows, uninitialized_t);
+  explicit UnboundedLowerTriangularMatrix(std::int64_t rows);
+  UnboundedLowerTriangularMatrix(std::int64_t rows, uninitialized_t);
 
   // The |data| must be in row-major format.
   UnboundedLowerTriangularMatrix(std::initializer_list<Scalar> data);
@@ -188,25 +189,25 @@ class UnboundedLowerTriangularMatrix final {
   // For  0 ≤ j ≤ i < rows, the entry a_ij is accessed as |a(i, j)|.
   // If i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
-  Scalar& operator()(int row, int column);
-  Scalar const& operator()(int row, int column) const;
+  Scalar& operator()(std::int64_t row, std::int64_t column);
+  Scalar const& operator()(std::int64_t row, std::int64_t column) const;
 
   UnboundedLowerTriangularMatrix& operator=(
       std::initializer_list<Scalar> right);
 
-  void Extend(int extra_rows);
-  void Extend(int extra_rows, uninitialized_t);
+  void Extend(std::int64_t extra_rows);
+  void Extend(std::int64_t extra_rows, uninitialized_t);
 
   // The |data| must be in row-major format.
   void Extend(std::initializer_list<Scalar> data);
 
-  void EraseToEnd(int begin_row_index);
+  void EraseToEnd(std::int64_t begin_row_index);
 
-  int rows() const;
-  int columns() const;
+  std::int64_t rows() const;
+  std::int64_t columns() const;
 
  private:
-  int rows_;
+  std::int64_t rows_;
   std::vector<Scalar, uninitialized_allocator<Scalar>> data_;
 
   template<typename S>
@@ -220,8 +221,8 @@ class UnboundedUpperTriangularMatrix final {
  public:
   using Scalar = Scalar_;
 
-  explicit UnboundedUpperTriangularMatrix(int columns);
-  UnboundedUpperTriangularMatrix(int columns, uninitialized_t);
+  explicit UnboundedUpperTriangularMatrix(std::int64_t columns);
+  UnboundedUpperTriangularMatrix(std::int64_t columns, uninitialized_t);
 
   // The |data| must be in row-major format.
   UnboundedUpperTriangularMatrix(std::initializer_list<Scalar> const& data);
@@ -239,32 +240,32 @@ class UnboundedUpperTriangularMatrix final {
   // For  0 ≤ i ≤ j < columns, the entry a_ij is accessed as |a(i, j)|.
   // If i and j do not satisfy these conditions, the expression |a(i, j)|
   // implies undefined behaviour.
-  Scalar& operator()(int row, int column);
-  Scalar const& operator()(int row, int column) const;
+  Scalar& operator()(std::int64_t row, std::int64_t column);
+  Scalar const& operator()(std::int64_t row, std::int64_t column) const;
 
   UnboundedUpperTriangularMatrix& operator=(
       std::initializer_list<Scalar> right);
 
-  void Extend(int extra_columns);
-  void Extend(int extra_columns, uninitialized_t);
+  void Extend(std::int64_t extra_columns);
+  void Extend(std::int64_t extra_columns, uninitialized_t);
 
   // The |data| must be in row-major format.
   void Extend(std::initializer_list<Scalar> const& data);
 
-  void EraseToEnd(int begin_column_index);
+  void EraseToEnd(std::int64_t begin_column_index);
 
-  int rows() const;
-  int columns() const;
+  std::int64_t rows() const;
+  std::int64_t columns() const;
 
  private:
   // For ease of writing matrices in tests, the input data is received in row-
   // major format.  This translates a trapezoidal slice to make it column-major.
   static std::vector<Scalar, uninitialized_allocator<Scalar>> Transpose(
       std::initializer_list<Scalar> const& data,
-      int current_columns,
-      int extra_columns);
+      std::int64_t current_columns,
+      std::int64_t extra_columns);
 
-  int columns_;
+  std::int64_t columns_;
   // Stored in column-major format, so the data passed the public API must be
   // transposed.
   std::vector<Scalar, uninitialized_allocator<Scalar>> data_;

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -346,7 +346,7 @@ UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
 template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
     std::initializer_list<Scalar> data)
-    : rows_(static_cast<std::int64_t>(std::lround((-1 + Sqrt(8 * data.size())) * 0.5))),
+    : rows_(std::llround((-1 + Sqrt(8 * data.size())) * 0.5)),
       data_(std::move(data)) {
   DCHECK_EQ(data_.size(), rows_ * (rows_ + 1) / 2);
 }
@@ -535,8 +535,8 @@ void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
 template<typename Scalar_>
 void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
     std::initializer_list<Scalar> const& data) {
-  std::int64_t const new_columns = static_cast<std::int64_t>(
-      std::lround((-1 + Sqrt(8 * (data_.size() + data.size()))) * 0.5));
+  std::int64_t const new_columns =
+      std::llround((-1 + Sqrt(8 * (data_.size() + data.size()))) * 0.5);
   auto transposed_data = Transpose(data,
                                    /*current_columns=*/columns_,
                                    /*extra_columns=*/new_columns - columns_);

--- a/numerics/unbounded_arrays_body.hpp
+++ b/numerics/unbounded_arrays_body.hpp
@@ -22,11 +22,12 @@ void uninitialized_allocator<T>::construct(U* const p, Args&&... args) {
 }
 
 template<typename Scalar_>
-UnboundedVector<Scalar_>::UnboundedVector(int const size)
+UnboundedVector<Scalar_>::UnboundedVector(std::int64_t const size)
     : data_(size, Scalar{}) {}
 
 template<typename Scalar_>
-UnboundedVector<Scalar_>::UnboundedVector(int const size, uninitialized_t)
+UnboundedVector<Scalar_>::UnboundedVector(std::int64_t const size,
+                                          uninitialized_t)
     : data_(size) {}
 
 template<typename Scalar_>
@@ -34,7 +35,7 @@ UnboundedVector<Scalar_>::UnboundedVector(std::initializer_list<Scalar> data)
     : data_(std::move(data)) {}
 
 template<typename Scalar_>
-template<int size_>
+template<std::int64_t size_>
 UnboundedVector<Scalar_>::UnboundedVector(
     FixedVector<Scalar, size_> const& data)
     : data_(data.begin(), data.end()) {}
@@ -44,20 +45,21 @@ template<typename T>
   requires std::same_as<typename T::Scalar, Scalar_>
 UnboundedVector<Scalar_>::UnboundedVector(ColumnView<T> const& view)
     : UnboundedVector<Scalar_>(view.size(), uninitialized) {
-  for (int i = 0; i < view.size(); ++i) {
+  for (std::int64_t i = 0; i < view.size(); ++i) {
     (*this)[i] = view[i];
   }
 }
 
 template<typename Scalar_>
-Scalar_& UnboundedVector<Scalar_>::operator[](int const index) {
+Scalar_& UnboundedVector<Scalar_>::operator[](std::int64_t const index) {
   DCHECK_LE(0, index);
   DCHECK_LT(index, size());
   return data_[index];
 }
 
 template<typename Scalar_>
-Scalar_ const& UnboundedVector<Scalar_>::operator[](int const index) const {
+Scalar_ const& UnboundedVector<Scalar_>::operator[](
+    std::int64_t const index) const {
   DCHECK_LE(0, index);
   DCHECK_LT(index, size());
   return data_[index];
@@ -75,7 +77,7 @@ template<typename Scalar_>
 UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator+=(
     UnboundedVector const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
@@ -85,7 +87,7 @@ template<typename Scalar_>
 UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator-=(
     UnboundedVector const& right) {
   DCHECK_EQ(size(), right.size());
-  for (int i = 0; i < size(); ++i) {
+  for (std::int64_t i = 0; i < size(); ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
@@ -110,13 +112,14 @@ UnboundedVector<Scalar_>& UnboundedVector<Scalar_>::operator/=(
 }
 
 template<typename Scalar_>
-void UnboundedVector<Scalar_>::Extend(int const extra_size) {
+void UnboundedVector<Scalar_>::Extend(std::int64_t const extra_size) {
   DCHECK_LE(0, extra_size);
   data_.resize(data_.size() + extra_size, Scalar{});
 }
 
 template<typename Scalar_>
-void UnboundedVector<Scalar_>::Extend(int const extra_size, uninitialized_t) {
+void UnboundedVector<Scalar_>::Extend(std::int64_t const extra_size,
+                                      uninitialized_t) {
   DCHECK_LE(0, extra_size);
   data_.resize(data_.size() + extra_size);
 }
@@ -127,7 +130,7 @@ void UnboundedVector<Scalar_>::Extend(std::initializer_list<Scalar> data) {
 }
 
 template<typename Scalar_>
-void UnboundedVector<Scalar_>::EraseToEnd(int const begin_index) {
+void UnboundedVector<Scalar_>::EraseToEnd(std::int64_t const begin_index) {
   data_.erase(data_.begin() + begin_index, data_.end());
 }
 
@@ -151,7 +154,7 @@ UnboundedVector<double> UnboundedVector<Scalar_>::Normalize() const {
 }
 
 template<typename Scalar_>
-int UnboundedVector<Scalar_>::size() const {
+std::int64_t UnboundedVector<Scalar_>::size() const {
   return data_.size();
 }
 
@@ -168,13 +171,15 @@ typename std::vector<Scalar_>::const_iterator UnboundedVector<Scalar_>::end()
 }
 
 template<typename Scalar_>
-UnboundedMatrix<Scalar_>::UnboundedMatrix(int const rows, int const columns)
+UnboundedMatrix<Scalar_>::UnboundedMatrix(std::int64_t const rows,
+                                          std::int64_t const columns)
     : rows_(rows),
       columns_(columns),
       data_(rows_ * columns_, Scalar{}) {}
 
 template<typename Scalar_>
-UnboundedMatrix<Scalar_>::UnboundedMatrix(int const rows, int const columns,
+UnboundedMatrix<Scalar_>::UnboundedMatrix(std::int64_t const rows,
+                                          std::int64_t const columns,
                                           uninitialized_t)
     : rows_(rows),
       columns_(columns),
@@ -190,7 +195,8 @@ UnboundedMatrix<Scalar_>::UnboundedMatrix(std::initializer_list<Scalar_> data)
 }
 
 template<typename Scalar_>
-UnboundedMatrix<Scalar_>::UnboundedMatrix(int const rows, int const columns,
+UnboundedMatrix<Scalar_>::UnboundedMatrix(std::int64_t const rows,
+                                          std::int64_t const columns,
                                           std::initializer_list<Scalar> data)
     : rows_(rows),
       columns_(columns),
@@ -202,8 +208,8 @@ template<typename Scalar_>
 UnboundedMatrix<Scalar_>::UnboundedMatrix(
     TransposedView<UnboundedMatrix<Scalar>> const& view)
     : UnboundedMatrix(view.rows(), view.columns(), uninitialized) {
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j < columns_; ++j) {
+  for (std::int64_t i = 0; i < rows_; ++i) {
+    for (std::int64_t j = 0; j < columns_; ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
@@ -211,7 +217,7 @@ UnboundedMatrix<Scalar_>::UnboundedMatrix(
 
 template<typename Scalar_>
 Scalar_& UnboundedMatrix<Scalar_>::operator()(
-    int const row, int const column) {
+    std::int64_t const row, std::int64_t const column) {
   DCHECK_LE(0, row);
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
@@ -221,7 +227,7 @@ Scalar_& UnboundedMatrix<Scalar_>::operator()(
 
 template<typename Scalar_>
 Scalar_ const& UnboundedMatrix<Scalar_>::operator()(
-    int const row, int const column) const {
+    std::int64_t const row, std::int64_t const column) const {
   DCHECK_LE(0, row);
   DCHECK_LT(row, rows_);
   DCHECK_LE(0, column);
@@ -251,7 +257,7 @@ UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator+=(
     UnboundedMatrix const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < data_.size(); ++i) {
+  for (std::int64_t i = 0; i < data_.size(); ++i) {
     data_[i] += right.data_[i];
   }
   return *this;
@@ -262,7 +268,7 @@ UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator-=(
     UnboundedMatrix const& right) {
   DCHECK_EQ(rows(), right.rows());
   DCHECK_EQ(columns(), right.columns());
-  for (int i = 0; i < data_.size(); ++i) {
+  for (std::int64_t i = 0; i < data_.size(); ++i) {
     data_[i] -= right.data_[i];
   }
   return *this;
@@ -293,20 +299,20 @@ UnboundedMatrix<Scalar_>& UnboundedMatrix<Scalar_>::operator*=(
 }
 
 template<typename Scalar_>
-int UnboundedMatrix<Scalar_>::rows() const {
+std::int64_t UnboundedMatrix<Scalar_>::rows() const {
   return rows_;
 }
 
 template<typename Scalar_>
-int UnboundedMatrix<Scalar_>::columns() const {
+std::int64_t UnboundedMatrix<Scalar_>::columns() const {
   return columns_;
 }
 
 template<typename Scalar_>
 Scalar_ UnboundedMatrix<Scalar_>::FrobeniusNorm() const {
   Square<Scalar> Σᵢⱼaᵢⱼ²{};
-  for (int i = 0; i < rows_; ++i) {
-    for (int j = 0; j < columns_; ++j) {
+  for (std::int64_t i = 0; i < rows_; ++i) {
+    for (std::int64_t j = 0; j < columns_; ++j) {
       Σᵢⱼaᵢⱼ² += Pow<2>((*this)(i, j));
     }
   }
@@ -314,10 +320,11 @@ Scalar_ UnboundedMatrix<Scalar_>::FrobeniusNorm() const {
 }
 
 template<typename Scalar_>
-UnboundedMatrix<Scalar_>
-UnboundedMatrix<Scalar_>::Identity(int const rows, int const columns) {
+UnboundedMatrix<Scalar_> UnboundedMatrix<Scalar_>::Identity(
+    std::int64_t const rows,
+    std::int64_t const columns) {
   UnboundedMatrix<Scalar> m(rows, columns);
-  for (int i = 0; i < rows; ++i) {
+  for (std::int64_t i = 0; i < rows; ++i) {
     m(i, i) = 1;
   }
   return m;
@@ -325,13 +332,13 @@ UnboundedMatrix<Scalar_>::Identity(int const rows, int const columns) {
 
 template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
-    int const rows)
+    std::int64_t const rows)
     : rows_(rows),
       data_(rows_ * (rows_ + 1) / 2, Scalar{}) {}
 
 template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
-    int const rows,
+    std::int64_t const rows,
     uninitialized_t)
     : rows_(rows),
       data_(rows_ * (rows_ + 1) / 2) {}
@@ -339,7 +346,7 @@ UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
 template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
     std::initializer_list<Scalar> data)
-    : rows_(static_cast<int>(std::lround((-1 + Sqrt(8 * data.size())) * 0.5))),
+    : rows_(static_cast<std::int64_t>(std::lround((-1 + Sqrt(8 * data.size())) * 0.5))),
       data_(std::move(data)) {
   DCHECK_EQ(data_.size(), rows_ * (rows_ + 1) / 2);
 }
@@ -348,8 +355,8 @@ template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::UnboundedLowerTriangularMatrix(
     TransposedView<UnboundedUpperTriangularMatrix<Scalar>> const& view)
     : UnboundedLowerTriangularMatrix(view.rows(), uninitialized) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
@@ -359,8 +366,8 @@ template<typename Scalar_>
 UnboundedLowerTriangularMatrix<Scalar_>::operator UnboundedMatrix<
     Scalar_>() const {
   UnboundedMatrix<Scalar> result(rows_, rows_);  // Initialized.
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = 0; j <= i; ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       result(i, j) = (*this)(i, j);
     }
   }
@@ -369,7 +376,7 @@ UnboundedLowerTriangularMatrix<Scalar_>::operator UnboundedMatrix<
 
 template<typename Scalar_>
 Scalar_& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) {
+    std::int64_t const row, std::int64_t const column) {
   DCHECK_LE(0, column);
   DCHECK_LE(column, row);
   DCHECK_LT(row, rows_);
@@ -378,7 +385,7 @@ Scalar_& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
 
 template<typename Scalar_>
 Scalar_ const& UnboundedLowerTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) const {
+    std::int64_t const row, std::int64_t const column) const {
   DCHECK_LE(0, column);
   DCHECK_LE(column, row);
   DCHECK_LT(row, rows_);
@@ -395,14 +402,16 @@ UnboundedLowerTriangularMatrix<Scalar_>::operator=(
 }
 
 template<typename Scalar_>
-void UnboundedLowerTriangularMatrix<Scalar_>::Extend(int const extra_rows) {
+void UnboundedLowerTriangularMatrix<Scalar_>::Extend(
+    std::int64_t const extra_rows) {
   rows_ += extra_rows;
   data_.resize(rows_ * (rows_ + 1) / 2, Scalar{});
 }
 
 template<typename Scalar_>
-void UnboundedLowerTriangularMatrix<Scalar_>::Extend(int const extra_rows,
-                                                     uninitialized_t) {
+void UnboundedLowerTriangularMatrix<Scalar_>::Extend(
+    std::int64_t const extra_rows,
+    uninitialized_t) {
   rows_ += extra_rows;
   data_.resize(rows_ * (rows_ + 1) / 2);
 }
@@ -411,37 +420,37 @@ template<typename Scalar_>
 void UnboundedLowerTriangularMatrix<Scalar_>::Extend(
     std::initializer_list<Scalar> data) {
   std::move(data.begin(), data.end(), std::back_inserter(data_));
-  rows_ = static_cast<int>(std::lround((-1 + Sqrt(8 * data_.size())) * 0.5));
+  rows_ = std::llround((-1 + Sqrt(8 * data_.size())) * 0.5);
   DCHECK_EQ(data_.size(), rows_ * (rows_ + 1) / 2);
 }
 
 template<typename Scalar_>
 void UnboundedLowerTriangularMatrix<Scalar_>::EraseToEnd(
-    int const begin_row_index) {
+    std::int64_t const begin_row_index) {
   rows_ = begin_row_index;
   data_.erase(data_.begin() + begin_row_index * (begin_row_index + 1) / 2,
               data_.end());
 }
 
 template<typename Scalar_>
-int UnboundedLowerTriangularMatrix<Scalar_>::rows() const {
+std::int64_t UnboundedLowerTriangularMatrix<Scalar_>::rows() const {
   return rows_;
 }
 
 template<typename Scalar_>
-int UnboundedLowerTriangularMatrix<Scalar_>::columns() const {
+std::int64_t UnboundedLowerTriangularMatrix<Scalar_>::columns() const {
   return rows_;
 }
 
 template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
-    int const columns)
+    std::int64_t const columns)
     : columns_(columns),
       data_(columns_ * (columns_ + 1) / 2, Scalar{}) {}
 
 template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
-    int const columns,
+    std::int64_t const columns,
     uninitialized_t)
     : columns_(columns),
       data_(columns_ * (columns_ + 1) / 2) {}
@@ -449,8 +458,7 @@ UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
 template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
     std::initializer_list<Scalar> const& data)
-    : columns_(
-          static_cast<int>(std::lround((-1 + Sqrt(8 * data.size())) * 0.5))),
+    : columns_(std::llround((-1 + Sqrt(8 * data.size())) * 0.5)),
       data_(Transpose(data,
                       /*current_columns=*/0,
                       /*extra_columns=*/columns_)) {
@@ -461,8 +469,8 @@ template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::UnboundedUpperTriangularMatrix(
     TransposedView<UnboundedLowerTriangularMatrix<Scalar>> const& view)
     : UnboundedUpperTriangularMatrix<Scalar>(view.columns(), uninitialized) {
-  for (int i = 0; i < rows(); ++i) {
-    for (int j = i; j < columns(); ++j) {
+  for (std::int64_t i = 0; i < rows(); ++i) {
+    for (std::int64_t j = i; j < columns(); ++j) {
       (*this)(i, j) = view(i, j);
     }
   }
@@ -472,8 +480,8 @@ template<typename Scalar_>
 UnboundedUpperTriangularMatrix<Scalar_>::
 operator UnboundedMatrix<Scalar_>() const {
   UnboundedMatrix<Scalar> result(columns_, columns_);  // Initialized.
-  for (int j = 0; j < columns_; ++j) {
-    for (int i = 0; i <= j; ++i) {
+  for (std::int64_t j = 0; j < columns_; ++j) {
+    for (std::int64_t i = 0; i <= j; ++i) {
       result(i, j) = (*this)(i, j);
     }
   }
@@ -482,7 +490,7 @@ operator UnboundedMatrix<Scalar_>() const {
 
 template<typename Scalar_>
 Scalar_& UnboundedUpperTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) {
+    std::int64_t const row, std::int64_t const column) {
   DCHECK_LE(0, row);
   DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
@@ -491,7 +499,7 @@ Scalar_& UnboundedUpperTriangularMatrix<Scalar_>::operator()(
 
 template<typename Scalar_>
 Scalar_ const& UnboundedUpperTriangularMatrix<Scalar_>::operator()(
-    int const row, int const column) const {
+    std::int64_t const row, std::int64_t const column) const {
   DCHECK_LE(0, row);
   DCHECK_LE(row, column);
   DCHECK_LT(column, columns_);
@@ -510,14 +518,16 @@ return *this;
 }
 
 template<typename Scalar_>
-void UnboundedUpperTriangularMatrix<Scalar_>::Extend(int const extra_columns) {
+void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
+    std::int64_t const extra_columns) {
   columns_ += extra_columns;
   data_.resize(columns_ * (columns_ + 1) / 2, Scalar{});
 }
 
 template<typename Scalar_>
-void UnboundedUpperTriangularMatrix<Scalar_>::Extend(int const extra_columns,
-                                                     uninitialized_t) {
+void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
+    std::int64_t const extra_columns,
+    uninitialized_t) {
   columns_ += extra_columns;
   data_.resize(columns_ * (columns_ + 1) / 2);
 }
@@ -525,7 +535,7 @@ void UnboundedUpperTriangularMatrix<Scalar_>::Extend(int const extra_columns,
 template<typename Scalar_>
 void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
     std::initializer_list<Scalar> const& data) {
-  int const new_columns = static_cast<int>(
+  std::int64_t const new_columns = static_cast<std::int64_t>(
       std::lround((-1 + Sqrt(8 * (data_.size() + data.size()))) * 0.5));
   auto transposed_data = Transpose(data,
                                    /*current_columns=*/columns_,
@@ -539,19 +549,19 @@ void UnboundedUpperTriangularMatrix<Scalar_>::Extend(
 
 template<typename Scalar_>
 void UnboundedUpperTriangularMatrix<Scalar_>::EraseToEnd(
-    int const begin_column_index) {
+    std::int64_t const begin_column_index) {
   columns_ = begin_column_index;
   data_.erase(data_.begin() + begin_column_index * (begin_column_index + 1) / 2,
               data_.end());
 }
 
 template<typename Scalar_>
-int UnboundedUpperTriangularMatrix<Scalar_>::rows() const {
+std::int64_t UnboundedUpperTriangularMatrix<Scalar_>::rows() const {
   return columns_;
 }
 
 template<typename Scalar_>
-int UnboundedUpperTriangularMatrix<Scalar_>::columns() const {
+std::int64_t UnboundedUpperTriangularMatrix<Scalar_>::columns() const {
   return columns_;
 }
 
@@ -559,8 +569,8 @@ template<typename Scalar_>
 auto
 UnboundedUpperTriangularMatrix<Scalar_>::Transpose(
     std::initializer_list<Scalar> const& data,
-    int const current_columns,
-    int const extra_columns) ->
+    std::int64_t const current_columns,
+    std::int64_t const extra_columns) ->
   std::vector<Scalar, uninitialized_allocator<Scalar>> {
   // |data| is a trapezoidal slice at the end of the matrix.  This is
   // inconvenient to index, so we start by constructing a rectangular array with
@@ -569,8 +579,8 @@ UnboundedUpperTriangularMatrix<Scalar_>::Transpose(
   std::vector<Scalar, uninitialized_allocator<Scalar>> padded;
   {
     padded.reserve(2 * data.size());  // An overestimate.
-    int row = 0;
-    int column = 0;
+    std::int64_t row = 0;
+    std::int64_t column = 0;
     for (auto it = data.begin(); it != data.end();) {
       if (row <= current_columns + column) {
         padded.push_back(*it);
@@ -590,9 +600,9 @@ UnboundedUpperTriangularMatrix<Scalar_>::Transpose(
   // the result.
   std::vector<Scalar, uninitialized_allocator<Scalar>> result;
   result.reserve(data.size());
-  int const number_of_rows = current_columns + extra_columns;
-  for (int column = 0; column < extra_columns; ++column) {
-    for (int row = 0; row < number_of_rows; ++row) {
+  std::int64_t const number_of_rows = current_columns + extra_columns;
+  for (std::int64_t column = 0; column < extra_columns; ++column) {
+    for (std::int64_t row = 0; row < number_of_rows; ++row) {
       if (row <= current_columns + column) {
         result.push_back(padded[row * extra_columns + column]);
       }
@@ -620,8 +630,8 @@ UnboundedMatrix<Product<LScalar, RScalar>> SymmetricProduct(
   DCHECK_EQ(left.size(), right.size());
   UnboundedMatrix<Product<LScalar, RScalar>> result(
       left.size(), right.size(), uninitialized);
-  for (int i = 0; i < left.size(); ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
+    for (std::int64_t j = 0; j < i; ++j) {
       auto const r = 0.5 * (left[i] * right[j] + left[j] * right[i]);
       result(i, j) = r;
       result(j, i) = r;
@@ -636,8 +646,8 @@ UnboundedMatrix<Square<Scalar>> SymmetricSquare(
     UnboundedVector<Scalar> const& vector) {
   UnboundedMatrix<Square<Scalar>> result(
       vector.size(), vector.size(), uninitialized);
-  for (int i = 0; i < vector.size(); ++i) {
-    for (int j = 0; j < i; ++j) {
+  for (std::int64_t i = 0; i < vector.size(); ++i) {
+    for (std::int64_t j = 0; j < i; ++j) {
       auto const r = vector[i] * vector[j];
       result(i, j) = r;
       result(j, i) = r;
@@ -660,7 +670,7 @@ UnboundedMatrix<Scalar> operator+(UnboundedMatrix<Scalar> const& right) {
 template<typename Scalar>
 UnboundedVector<Scalar> operator-(UnboundedVector<Scalar> const& right) {
   UnboundedVector<Scalar> result(right.size(), uninitialized);
-  for (int i = 0; i < right.size(); ++i) {
+  for (std::int64_t i = 0; i < right.size(); ++i) {
     result[i] = -right[i];
   }
   return result;
@@ -669,8 +679,8 @@ UnboundedVector<Scalar> operator-(UnboundedVector<Scalar> const& right) {
 template<typename Scalar>
 UnboundedMatrix<Scalar> operator-(UnboundedMatrix<Scalar> const& right) {
   UnboundedMatrix<Scalar> result(right.rows(), right.columns(), uninitialized);
-  for (int i = 0; i < right.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
+  for (std::int64_t i = 0; i < right.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
       result(i, j) = -right(i, j);
     }
   }
@@ -683,7 +693,7 @@ UnboundedVector<Sum<LScalar, RScalar>> operator+(
     UnboundedVector<RScalar> const& right) {
   DCHECK_EQ(left.size(), right.size());
   UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
-  for (int i = 0; i < right.size(); ++i) {
+  for (std::int64_t i = 0; i < right.size(); ++i) {
     result[i] = left[i] + right[i];
   }
   return result;
@@ -697,8 +707,8 @@ UnboundedMatrix<Sum<LScalar, RScalar>> operator+(
   DCHECK_EQ(left.columns(), right.columns());
   UnboundedMatrix<Sum<LScalar, RScalar>> result(
       right.rows(), right.columns(), uninitialized);
-  for (int i = 0; i < right.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
+  for (std::int64_t i = 0; i < right.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
       result(i, j) = left(i, j) + right(i, j);
     }
   }
@@ -711,7 +721,7 @@ UnboundedVector<Difference<LScalar, RScalar>> operator-(
     UnboundedVector<RScalar> const& right) {
   DCHECK_EQ(left.size(), right.size());
   UnboundedVector<Sum<LScalar, RScalar>> result(right.size(), uninitialized);
-  for (int i = 0; i < right.size(); ++i) {
+  for (std::int64_t i = 0; i < right.size(); ++i) {
     result[i] = left[i] - right[i];
   }
   return result;
@@ -725,8 +735,8 @@ UnboundedMatrix<Difference<LScalar, RScalar>> operator-(
   DCHECK_EQ(left.columns(), right.columns());
   UnboundedMatrix<Sum<LScalar, RScalar>> result(
       right.rows(), right.columns(), uninitialized);
-  for (int i = 0; i < right.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
+  for (std::int64_t i = 0; i < right.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
       result(i, j) = left(i, j) - right(i, j);
     }
   }
@@ -739,7 +749,7 @@ UnboundedVector<Product<LScalar, RScalar>> operator*(
     UnboundedVector<RScalar> const& right) {
   UnboundedVector<Product<LScalar, RScalar>> result(right.size(),
                                                     uninitialized);
-  for (int i = 0; i < right.size(); ++i) {
+  for (std::int64_t i = 0; i < right.size(); ++i) {
     result[i] = left * right[i];
   }
   return result;
@@ -751,7 +761,7 @@ UnboundedVector<Product<LScalar, RScalar>> operator*(
     RScalar const& right) {
   UnboundedVector<Product<LScalar, RScalar>> result(left.size(),
                                                     uninitialized);
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     result[i] = left[i] * right;
   }
   return result;
@@ -764,8 +774,8 @@ UnboundedMatrix<Product<LScalar, RScalar>> operator*(
   UnboundedMatrix<Product<LScalar, RScalar>> result(right.rows(),
                                                     right.columns(),
                                                     uninitialized);
-  for (int i = 0; i < right.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
+  for (std::int64_t i = 0; i < right.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
       result(i, j) = left * right(i, j);
     }
   }
@@ -779,8 +789,8 @@ UnboundedMatrix<Product<LScalar, RScalar>> operator*(
   UnboundedMatrix<Product<LScalar, RScalar>> result(left.rows(),
                                                     left.columns(),
                                                     uninitialized);
-  for (int i = 0; i < left.rows(); ++i) {
-    for (int j = 0; j < left.columns(); ++j) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result(i, j) = left(i, j) * right;
     }
   }
@@ -793,7 +803,7 @@ UnboundedVector<Quotient<LScalar, RScalar>> operator/(
     RScalar const& right) {
   UnboundedVector<Quotient<LScalar, RScalar>> result(left.size(),
                                                      uninitialized);
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     result[i] = left[i] / right;
   }
   return result;
@@ -806,8 +816,8 @@ UnboundedMatrix<Quotient<LScalar, RScalar>> operator/(
   UnboundedMatrix<Quotient<LScalar, RScalar>> result(left.rows(),
                                                      left.columns(),
                                                      uninitialized);
-  for (int i = 0; i < left.rows(); ++i) {
-    for (int j = 0; j < left.columns(); ++j) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result(i, j) = left(i, j) / right;
     }
   }
@@ -820,7 +830,7 @@ Product<LScalar, RScalar> operator*(
     UnboundedVector<RScalar> const& right) {
   DCHECK_EQ(left.size(), right.size());
   Product<LScalar, RScalar> result{};
-  for (int i = 0; i < left.size(); ++i) {
+  for (std::int64_t i = 0; i < left.size(); ++i) {
     result += left[i] * right[i];
   }
   return result;
@@ -833,8 +843,8 @@ UnboundedMatrix<Product<LScalar, RScalar>> operator*(
   UnboundedMatrix<Product<LScalar, RScalar>> result(left.size(),
                                                     right.size(),
                                                     uninitialized);
-  for (int i = 0; i < result.rows(); ++i) {
-    for (int j = 0; j < result.columns(); ++j) {
+  for (std::int64_t i = 0; i < result.rows(); ++i) {
+    for (std::int64_t j = 0; j < result.columns(); ++j) {
       result(i, j) = left[i] * right[j];
     }
   }
@@ -848,9 +858,9 @@ UnboundedMatrix<Product<LScalar, RScalar>> operator*(
   DCHECK_EQ(left.columns(), right.rows());
   UnboundedMatrix<Product<LScalar, RScalar>> result(left.rows(),
                                                     right.columns());
-  for (int i = 0; i < left.rows(); ++i) {
-    for (int j = 0; j < right.columns(); ++j) {
-      for (int k = 0; k < left.columns(); ++k) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
+    for (std::int64_t j = 0; j < right.columns(); ++j) {
+      for (std::int64_t k = 0; k < left.columns(); ++k) {
         result(i, j) += left(i, k) * right(k, j);
       }
     }
@@ -864,9 +874,9 @@ UnboundedVector<Product<LScalar, RScalar>> operator*(
     UnboundedVector<RScalar> const& right) {
   DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<LScalar, RScalar>> result(left.rows());
-  for (int i = 0; i < left.rows(); ++i) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];
-    for (int j = 0; j < left.columns(); ++j) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result_i += left(i, j) * right[j];
     }
   }
@@ -880,9 +890,9 @@ UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> operator*(
   DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> result(
       left.rows());
-  for (int i = 0; i < left.rows(); ++i) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];
-    for (int j = 0; j < left.columns(); ++j) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result_i += left(i, j) * right[j];
     }
   }
@@ -896,9 +906,9 @@ UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> operator*(
   DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<typename LMatrix::Scalar, RScalar>> result(
       left.rows());
-  for (int i = 0; i < left.rows(); ++i) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];
-    for (int j = 0; j < left.columns(); ++j) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result_i += left(i, j) * right[j];
     }
   }
@@ -911,9 +921,9 @@ UnboundedVector<Product<LScalar, RScalar>> operator*(
     UnboundedVector<RScalar> const& right) {
   DCHECK_EQ(left.columns(), right.size());
   UnboundedVector<Product<LScalar, RScalar>> result(left.rows());
-  for (int i = 0; i < left.rows(); ++i) {
+  for (std::int64_t i = 0; i < left.rows(); ++i) {
     auto& result_i = result[i];
-    for (int j = 0; j < left.columns(); ++j) {
+    for (std::int64_t j = 0; j < left.columns(); ++j) {
       result_i += left(i, j) * right[j];
     }
   }
@@ -924,7 +934,7 @@ template<typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          UnboundedVector<Scalar> const& vector) {
   std::stringstream s;
-  for (int i = 0; i < vector.size(); ++i) {
+  for (std::int64_t i = 0; i < vector.size(); ++i) {
     s << (i == 0 ? "{" : "") << vector[i]
       << (i == vector.size() - 1 ? "}" : ", ");
   }
@@ -936,9 +946,9 @@ template<typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          UnboundedLowerTriangularMatrix<Scalar> const& matrix) {
   out << "rows: " << matrix.rows() << "\n";
-  for (int i = 0; i < matrix.rows(); ++i) {
+  for (std::int64_t i = 0; i < matrix.rows(); ++i) {
     out << "{";
-    for (int j = 0; j <= i; ++j) {
+    for (std::int64_t j = 0; j <= i; ++j) {
       out << matrix(i, j);
       if (j < i) {
         out << ", ";
@@ -953,9 +963,9 @@ template<typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          UnboundedMatrix<Scalar> const& matrix) {
   out << "rows: " << matrix.rows() << " columns: " << matrix.columns() << "\n";
-  for (int i = 0; i < matrix.rows(); ++i) {
+  for (std::int64_t i = 0; i < matrix.rows(); ++i) {
     out << "{";
-    for (int j = 0; j < matrix.columns(); ++j) {
+    for (std::int64_t j = 0; j < matrix.columns(); ++j) {
       out << matrix(i, j);
       if (j < matrix.columns() - 1) {
         out << ", ";
@@ -970,9 +980,9 @@ template<typename Scalar>
 std::ostream& operator<<(std::ostream& out,
                          UnboundedUpperTriangularMatrix<Scalar> const& matrix) {
   out << "columns: " << matrix.columns_ << "\n";
-  for (int i = 0; i < matrix.columns(); ++i) {
+  for (std::int64_t i = 0; i < matrix.columns(); ++i) {
     out << "{";
-    for (int j = i; j < matrix.columns(); ++j) {
+    for (std::int64_t j = i; j < matrix.columns(); ++j) {
       if (j > i) {
         out << ", ";
       }


### PR DESCRIPTION
We were not overly consistent as to whether we preferred `int` or `std::int64_t`, and this led to annoying `static_cast`.

#1760.