### PR TITLE
A benchmark for the Nguyễn-Stehlé algorithm

### DIFF
--- a/benchmarks/lattices_benchmark.cpp
+++ b/benchmarks/lattices_benchmark.cpp
@@ -44,6 +44,14 @@ class LatticesBenchmark : public benchmark::Fixture {
     }
   }
 
+  void RunNguyễnStehlé(benchmark::State& state) {
+    while (state.KeepRunningBatch(number_of_lattices)) {
+      for (auto const& lattice : lattices_) {
+        benchmark::DoNotOptimize(NguyễnStehlé(lattice));
+      }
+    }
+  }
+
   std::array<Lattice, number_of_lattices> lattices_;
 };
 
@@ -120,6 +128,81 @@ BENCHMARK_TEMPLATE_F(LatticesBenchmark,
                      cpp_rational, 1'000'000'000'000'000'000)(
                      benchmark::State& state) {
   RunLenstraLenstraLovász(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble3,
+                     double, 1'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble6,
+                     double, 1'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble9,
+                     double, 1'000'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble12,
+                     double, 1'000'000'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble15,
+                     double, 1'000'000'000'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléDouble18,
+                     double, 1'000'000'000'000'000'000)(
+                     benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt3,
+                     cpp_int, 1'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt6,
+                     cpp_int, 1'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt9,
+                     cpp_int, 1'000'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt12,
+                     cpp_int, 1'000'000'000'000)(benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt15,
+                     cpp_int, 1'000'000'000'000'000)(
+                     benchmark::State& state) {
+  RunNguyễnStehlé(state);
+}
+
+BENCHMARK_TEMPLATE_F(LatticesBenchmark,
+                     NguyễnStehléCppInt18,
+                     cpp_int, 1'000'000'000'000'000'000)(
+                     benchmark::State& state) {
+  RunNguyễnStehlé(state);
 }
 
 }  // namespace numerics


### PR DESCRIPTION
TL;DR: It is 200-300× faster than LLL.
```
Running C:\Users\phl\Projects\GitHub\Principia\Principia\Release\x64\benchmarks.exe
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
----------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------------------------
LatticesBenchmark<double, 1'000>/LenstraLenstraLovászDouble3                                        894 ns          899 ns       747000
LatticesBenchmark<double, 1'000'000>/LenstraLenstraLovászDouble6                                    898 ns          907 ns       896000
LatticesBenchmark<double, 1'000'000'000>/LenstraLenstraLovászDouble9                                897 ns          879 ns       747000
LatticesBenchmark<double, 1'000'000'000'000>/LenstraLenstraLovászDouble12                           897 ns          899 ns       747000
LatticesBenchmark<double, 1'000'000'000'000'000>/LenstraLenstraLovászDouble15                       895 ns          899 ns       747000
LatticesBenchmark<double, 1'000'000'000'000'000'000>/LenstraLenstraLovászDouble18                   866 ns          872 ns       896000
LatticesBenchmark<cpp_rational, 1'000>/LenstraLenstraLovászCppRational3                          507334 ns       500000 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000>/LenstraLenstraLovászCppRational6                     1165508 ns      1156250 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000>/LenstraLenstraLovászCppRational9                 1552135 ns      1546875 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000>/LenstraLenstraLovászCppRational12            2197723 ns      2187500 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000'000>/LenstraLenstraLovászCppRational15        2685649 ns      2687500 ns         1000
LatticesBenchmark<cpp_rational, 1'000'000'000'000'000'000>/LenstraLenstraLovászCppRational18    2960975 ns      2968750 ns         1000
LatticesBenchmark<double, 1'000>/NguyễnStehléDouble3                                             661 ns          670 ns      1120000
LatticesBenchmark<double, 1'000'000>/NguyễnStehléDouble6                                         661 ns          645 ns       896000
LatticesBenchmark<double, 1'000'000'000>/NguyễnStehléDouble9                                     660 ns          670 ns      1120000
LatticesBenchmark<double, 1'000'000'000'000>/NguyễnStehléDouble12                                659 ns          656 ns      1120000
LatticesBenchmark<double, 1'000'000'000'000'000>/NguyễnStehléDouble15                            659 ns          656 ns      1120000
LatticesBenchmark<double, 1'000'000'000'000'000'000>/NguyễnStehléDouble18                        645 ns          642 ns      1120000
LatticesBenchmark<cpp_int, 1'000>/NguyễnStehléCppInt3                                           4947 ns         5065 ns       145000
LatticesBenchmark<cpp_int, 1'000'000>/NguyễnStehléCppInt6                                       6644 ns         6597 ns        90000
LatticesBenchmark<cpp_int, 1'000'000'000>/NguyễnStehléCppInt9                                   8124 ns         8160 ns        90000
LatticesBenchmark<cpp_int, 1'000'000'000'000>/NguyễnStehléCppInt12                             10036 ns        10010 ns        64000
LatticesBenchmark<cpp_int, 1'000'000'000'000'000>/NguyễnStehléCppInt15                         10209 ns        10208 ns        75000
LatticesBenchmark<cpp_int, 1'000'000'000'000'000'000>/NguyễnStehléCppInt18                      8585 ns         8681 ns        90000
```