### PR TITLE
Rollback the change in #4079

### DIFF
--- a/base/not_null_body.hpp
+++ b/base/not_null_body.hpp
@@ -66,8 +66,10 @@ constexpr not_null<Pointer>& not_null<Pointer>::operator=(
 }
 
 template<typename Pointer>
-constexpr not_null<Pointer>::operator pointer() const {
-  return storage_.pointer;
+constexpr not_null<Pointer>::operator pointer const&&() const& {
+  // This |move| is deceptive: we are not actually moving anything (|*this| is
+  // |const&|), we are simply casting to an rvalue reference.
+  return std::move(storage_.pointer);
 }
 
 template<typename Pointer>

--- a/base/not_null_test.cpp
+++ b/base/not_null_test.cpp
@@ -224,13 +224,30 @@ TEST_F(NotNullTest, RValue) {
   not_null<std::unique_ptr<int>> not_null_owner_int =
       make_not_null_unique<int>(4);
   std::vector<int*> v1;
+  // |v1.push_back| would be ambiguous here if |not_null<pointer>| had an
+  // |operator pointer const&() const&| instead of an
+  // |operator pointer const&&() const&|.
   v1.push_back(not_null_owner_int.get());
+  // |emplace_back| is fine no matter what.
   v1.emplace_back(not_null_owner_int.get());
   EXPECT_EQ(4, *v1[0]);
   EXPECT_EQ(4, *not_null_owner_int);
 
   std::vector<int*> v2;
+  // NOTE(egg): The following fails using clang, I'm not sure where the bug is.
+  // More generally, if functions |foo(int*&&)| and |foo(int* const&)| exist,
+  // |foo(non_rvalue_not_null)| fails to compile with clang ("no viable
+  // conversion"), but without the |foo(int*&&)| overload it compiles.
+  // This is easily circumvented using a temporary (whereas the ambiguity that
+  // would result from having an |operator pointer const&() const&| would
+  // entirely prevent conversion of |not_null<unique_ptr<T>>| to
+  // |unique_ptr<T>|), so we ignore it.
+#if PRINCIPIA_COMPILER_MSVC
   v2.push_back(not_null_int);
+#else
+  int* const temporary = not_null_int;
+  v2.push_back(temporary);
+#endif
   EXPECT_EQ(2, *v2[0]);
   EXPECT_EQ(2, *not_null_int);
 

--- a/ksp_plugin/pile_up.hpp
+++ b/ksp_plugin/pile_up.hpp
@@ -126,7 +126,7 @@ class PileUp {
   void RecomputeFromParts();
 
   using PileUpForSerializationIndex =
-      std::function<not_null<std::shared_ptr<PileUp>> const&(int)>;
+      std::function<not_null<std::shared_ptr<PileUp>>(int)>;
   using SerializationIndexForPileUp =
       std::function<int(not_null<PileUp const*>)>;
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1666,8 +1666,7 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
     shared_pile_ups.emplace_back(check_not_null(pile_up));
   }
   auto const pile_up_for_serialization_index =
-      [&shared_pile_ups](int const serialization_index)
-      -> not_null<std::shared_ptr<PileUp>> const& {
+      [&shared_pile_ups](int const serialization_index) {
     return shared_pile_ups.at(serialization_index);
   };
 


### PR DESCRIPTION
It turns out that it creates endless pain in `not_null` because MSVC blows up left and right whenever we touch that class.