### PR TITLE
Process intervals with predictible bounds in the Stehlé-Zimmermann search

### DIFF
--- a/base/bits.hpp
+++ b/base/bits.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
+#include <cstdint>
+
 namespace principia {
 namespace base {
 namespace _bits {
 namespace internal {
 
 // Floor log2 of n, or 0 for n = 0.  8 ↦ 3, 7 ↦ 2.
-constexpr int FloorLog2(int n);
+constexpr std::int64_t FloorLog2(std::int64_t n);
 
 // Greatest power of 2 less than or equal to n.  8 ↦ 8, 7 ↦ 4.
-constexpr int PowerOf2Le(int n);
+constexpr std::int64_t PowerOf2Le(std::int64_t n);
 
 // Computes bitreversed(bitreversed(n) + 1) assuming that n is represented on
 // the given number of bits.  For 4 bits:
 //   0 ↦ 8 ↦ 4 ↦ C ↦ 2 ↦ A ↦ 6 ↦ E ↦ 1 ↦ 9 ↦ 5 ↦ D ↦ 3 ↦ B ↦ 7 ↦ F
-constexpr int BitReversedIncrement(int n, int bits);
+constexpr std::int64_t BitReversedIncrement(std::int64_t n, std::int64_t bits);
 
 }  // namespace internal
 

--- a/base/bits_body.hpp
+++ b/base/bits_body.hpp
@@ -2,8 +2,6 @@
 
 #include "base/bits.hpp"
 
-#include <cstdint>
-
 #include "base/macros.hpp"  // 🧙 For CONSTEXPR_DCHECK.
 #include "glog/logging.h"
 
@@ -12,20 +10,21 @@ namespace base {
 namespace _bits {
 namespace internal {
 
-constexpr int FloorLog2(int const n) {
+constexpr std::int64_t FloorLog2(std::int64_t const n) {
   return n == 0 ? 0 : n == 1 ? 0 : FloorLog2(n >> 1) + 1;
 }
 
-constexpr int PowerOf2Le(int const n) {
+constexpr std::int64_t PowerOf2Le(std::int64_t const n) {
   return n == 0 ? 0 : n == 1 ? 1 : PowerOf2Le(n >> 1) << 1;
 }
 
-constexpr int BitReversedIncrement(int const n, int const bits) {
+constexpr std::int64_t BitReversedIncrement(std::int64_t const n,
+                                            std::int64_t const bits) {
   if (bits == 0) {
     CONSTEXPR_DCHECK(n == 0);
     return 0;
   }
-  CONSTEXPR_DCHECK(n >= 0 && n < 1 << bits);
+  CONSTEXPR_DCHECK(n >= 0 && n < 1LL << bits);
   CONSTEXPR_DCHECK(bits > 0 && bits < 32);
   // [War03], chapter 7.1 page 105.
   std::uint32_t mask = 0x8000'0000;

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -464,7 +464,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
           auto const status_or_solution =
               StehléZimmermannSimultaneousSearch<zeroes>(
                   scaled_functions,
-                  scaled_polynomials, 
+                  scaled_polynomials,
                   scaled_remainders,
                   high_interval.midpoint(),
                   N,

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -41,6 +41,7 @@ using namespace principia::quantities::_elementary_functions;
 using namespace principia::quantities::_quantities;
 
 constexpr std::int64_t T_max = 16;
+static_assert(T_max >= 1);
 
 template<std::int64_t rows, std::int64_t columns>
 FixedMatrix<cpp_int, rows, columns> ToInt(
@@ -435,7 +436,9 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
   for (;;) {
     {
       auto T = T₀;
-      do {
+      // This loop exits (breaks or returns) when |T <= T_max| because
+      // exhaustive search always gives an answer.
+      for (;;) {
         VLOG(2) << "T = " << T << ", high_interval = " << high_interval;
         auto const status_or_solution =
             StehléZimmermannSimultaneousSearch<zeroes>(scaled_functions,
@@ -461,18 +464,13 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
             return status;
           }
         }
-      } while (T > 0);
-
-      // The Stehlé-Zimmermann algorithm doesn't work for T = 0 because the
-      // lattice becomes singular.
-      if (T == 0 && AllFunctionValuesHaveDesiredZeroes<zeroes>(
-                        scaled_functions, high_interval.max)) {
-        return high_interval.max;
       }
     }
     {
       auto T = T₀;
-      do {
+      // This loop exits (breaks or returns) when |T <= T_max| because
+      // exhaustive search always gives an answer.
+      for (;;) {
         VLOG(2) << "T = " << T << ", low_interval = " << low_interval;
         auto const status_or_solution =
             StehléZimmermannSimultaneousSearch<zeroes>(scaled_functions,
@@ -498,13 +496,6 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
             return status;
           }
         }
-      } while (T > 0);
-
-      // The Stehlé-Zimmermann algorithm doesn't work for T = 0 because the
-      // lattice becomes singular.
-      if (T == 0 && AllFunctionValuesHaveDesiredZeroes<zeroes>(
-                        scaled_functions, low_interval.min)) {
-        return low_interval.min;
       }
     }
     VLOG_EVERY_N(1, 10) << "high = "

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -378,7 +378,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
 
   // [SZ05], section 3.2, proves that T³ = O(M * N).  We use a fudge factor of 8
   // to avoid starting with too small a value.
-  auto const T₀ =
+  std::int64_t const T₀ =
       PowerOf2Le(8 * Cbrt(static_cast<double>(M) * static_cast<double>(N)));
 
   // Scale the argument, functions, and polynomials to lie within [1/2, 1[.
@@ -443,8 +443,10 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
     Interval<cpp_rational> high_interval = initial_high_interval;
     Interval<cpp_rational> low_interval = initial_low_interval;
 
-    auto high_T_to_cover = T₀;
-    auto low_T_to_cover = T₀;
+    // The measure of the intervals remaining to cover above and below the
+    // `scaled_argument`.
+    std::int64_t high_T_to_cover = 2 * T₀;
+    std::int64_t low_T_to_cover = 2 * T₀;
 
     // When exiting this loop, we have completely processed
     // |initial_high_interval| and |initial_low_interval|.
@@ -456,7 +458,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
       }
 
       if (!high_interval_empty) {
-        auto T = high_T_to_cover;
+        std::int64_t T = high_T_to_cover;
         // This loop exits (breaks or returns) when |T <= T_max| because
         // exhaustive search always gives an answer.
         for (;;) {
@@ -481,7 +483,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
               high_interval.max = high_interval.min + cpp_rational(2 * T, N);
             } else if (absl::IsNotFound(status)) {
               // No solutions here, go to the next interval.
-              high_T_to_cover -= T;
+              high_T_to_cover -= 2 * T;
               break;
             } else {
               return status;
@@ -490,7 +492,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
         }
       }
       if (!low_interval_empty) {
-        auto T = low_T_to_cover;
+        std::int64_t T = low_T_to_cover;
         // This loop exits (breaks or returns) when |T <= T_max| because
         // exhaustive search always gives an answer.
         for (;;) {
@@ -515,7 +517,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
               low_interval.min = low_interval.max - cpp_rational(2 * T, N);
             } else if (absl::IsNotFound(status)) {
               // No solutions here, go to the next interval.
-              low_T_to_cover -= T;
+              low_T_to_cover -= 2 * T;
               break;
             } else {
               return status;

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -446,8 +446,8 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
     auto high_T_to_cover = T₀;
     auto low_T_to_cover = T₀;
 
-    // When exiting this loop, we have completely processed the intervals
-    // corresponding to |index|.
+    // When exiting this loop, we have completely processed
+    // |initial_high_interval| and |initial_low_interval|.
     for (;;) {
       bool const high_interval_empty = high_interval.empty();
       bool const low_interval_empty = low_interval.empty();

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -427,7 +427,9 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
       build_scaled_polynomial(function_scales[1], polynomials[1])};
 
   // We construct intervals above and below |scaled_argument| and search for
-  // solutions on each side alternatively.
+  // solutions on each side alternatively.  The intervals all have the same
+  // measure, 2 * T₀, and are progressively farther from the
+  // |starting_argument|.
   for (std::int64_t index = 0;; ++index) {
     auto const start = std::chrono::system_clock::now();
 

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -443,10 +443,10 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
     Interval<cpp_rational> high_interval = initial_high_interval;
     Interval<cpp_rational> low_interval = initial_low_interval;
 
-    // The measure of the intervals remaining to cover above and below the
+    // The radii of the intervals remaining to cover above and below the
     // `scaled_argument`.
-    std::int64_t high_T_to_cover = 2 * T₀;
-    std::int64_t low_T_to_cover = 2 * T₀;
+    std::int64_t high_T_to_cover = T₀;
+    std::int64_t low_T_to_cover = T₀;
 
     // When exiting this loop, we have completely processed
     // |initial_high_interval| and |initial_low_interval|.
@@ -483,7 +483,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
               high_interval.max = high_interval.min + cpp_rational(2 * T, N);
             } else if (absl::IsNotFound(status)) {
               // No solutions here, go to the next interval.
-              high_T_to_cover -= 2 * T;
+              high_T_to_cover -= T;
               break;
             } else {
               return status;
@@ -517,7 +517,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
               low_interval.min = low_interval.max - cpp_rational(2 * T, N);
             } else if (absl::IsNotFound(status)) {
               // No solutions here, go to the next interval.
-              low_T_to_cover -= 2 * T;
+              low_T_to_cover -= T;
               break;
             } else {
               return status;

--- a/functions/accurate_table_generator_test.cpp
+++ b/functions/accurate_table_generator_test.cpp
@@ -42,7 +42,7 @@ using namespace principia::testing_utilities::_numerics_matchers;
 class AccurateTableGeneratorTest : public ::testing::Test {
  protected:
   AccurateTableGeneratorTest() {
-    FLAGS_v = 1;
+    FLAGS_v = 0;
     google::LogToStderr();
   }
 };

--- a/functions/accurate_table_generator_test.cpp
+++ b/functions/accurate_table_generator_test.cpp
@@ -42,7 +42,7 @@ using namespace principia::testing_utilities::_numerics_matchers;
 class AccurateTableGeneratorTest : public ::testing::Test {
  protected:
   AccurateTableGeneratorTest() {
-    FLAGS_v = 0;
+    FLAGS_v = 1;
     google::LogToStderr();
   }
 };
@@ -167,6 +167,7 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannSinCos15) {
       /*T=*/1ll << 21);
   EXPECT_THAT(u,
               IsOkAndHolds(cpp_rational(4785074575333183, 9007199254740992)));
+  EXPECT_EQ(*u, cpp_rational(static_cast<double>(*u)));
   EXPECT_THAT(static_cast<double>(*u),
               RelativeErrorFrom(u₀, Lt(1.3e-10)));
   {
@@ -225,7 +226,8 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannFullSinCos5NoScaling) {
       {remainder_sin_taylor2, remainder_cos_taylor2},
       u₀);
   EXPECT_THAT(u,
-              IsOkAndHolds(cpp_rational(4785074604080979, 9007199254740992)));
+              IsOkAndHolds(cpp_rational(1196268651020245, 2251799813685248)));
+  EXPECT_EQ(*u, cpp_rational(static_cast<double>(*u)));
   EXPECT_THAT(static_cast<double>(*u),
               RelativeErrorFrom(u₀, Lt(3.7e-14)));
   {
@@ -242,7 +244,7 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannFullSinCos5NoScaling) {
                                                   /*base=*/2);
     std::string_view mantissa = mathematica;
     CHECK(absl::ConsumePrefix(&mantissa, "Times[2^^"));
-    EXPECT_THAT(mantissa.substr(53, 5), Eq("00000"));
+    EXPECT_THAT(mantissa.substr(53, 5), Eq("11111"));
   }
 }
 
@@ -285,6 +287,7 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannFullSinCos15NoScaling) {
       u₀);
   EXPECT_THAT(u,
               IsOkAndHolds(cpp_rational(4785074575333183, 9007199254740992)));
+  EXPECT_EQ(*u, cpp_rational(static_cast<double>(*u)));
   EXPECT_THAT(static_cast<double>(*u),
               RelativeErrorFrom(u₀, Lt(6.1e-9)));
   {
@@ -336,6 +339,7 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannFullSinCos15WithScaling) {
       x₀);
   EXPECT_THAT(x,
               IsOkAndHolds(cpp_rational(4785074575333183, 36028797018963968)));
+  EXPECT_EQ(*x, cpp_rational(static_cast<double>(*x)));
   EXPECT_THAT(static_cast<double>(*x),
               RelativeErrorFrom(x₀, Lt(6.1e-9)));
   {
@@ -398,6 +402,7 @@ TEST_F(AccurateTableGeneratorTest, StehléZimmermannMultisearchSinCos15) {
   for (std::int64_t i = 0; i < xs.size(); ++i) {
     CHECK_OK(xs[i].status());
     auto const& x = *xs[i];
+    EXPECT_EQ(x, cpp_rational(static_cast<double>(x)));
     EXPECT_THAT(static_cast<double>(x),
                 RelativeErrorFrom((i + index_begin) / 128.0, Lt(1.3e-7)));
     {

--- a/geometry/interval.hpp
+++ b/geometry/interval.hpp
@@ -22,6 +22,10 @@ struct Interval {
 
   // The Lebesgue measure of this interval.
   Difference<T> measure() const;
+
+  // Return true iff |measure| would return zero, but more efficient.
+  bool empty() const;
+
   // The midpoint of this interval; NaN if the interval is empty (min > max).
   T midpoint() const;
 

--- a/geometry/interval.hpp
+++ b/geometry/interval.hpp
@@ -23,7 +23,7 @@ struct Interval {
   // The Lebesgue measure of this interval.
   Difference<T> measure() const;
 
-  // Return true iff |measure| would return zero, but more efficiently.
+  // Returns true iff |measure| would return zero, but more efficiently.
   bool empty() const;
 
   // The midpoint of this interval; NaN if the interval is empty (min > max).

--- a/geometry/interval.hpp
+++ b/geometry/interval.hpp
@@ -23,7 +23,7 @@ struct Interval {
   // The Lebesgue measure of this interval.
   Difference<T> measure() const;
 
-  // Return true iff |measure| would return zero, but more efficient.
+  // Return true iff |measure| would return zero, but more efficiently.
   bool empty() const;
 
   // The midpoint of this interval; NaN if the interval is empty (min > max).

--- a/geometry/interval_body.hpp
+++ b/geometry/interval_body.hpp
@@ -20,6 +20,11 @@ Difference<T> Interval<T>::measure() const {
 }
 
 template<typename T>
+bool Interval<T>::empty() const {
+  return max <= min;
+}
+
+template<typename T>
 T Interval<T>::midpoint() const {
   if constexpr (is_number<T>::value) {
     DCHECK_GE(max, min);


### PR DESCRIPTION
Intervals of measure 2 T₀ (after rescaling) on each side of the starting argument are processed sequentially and there is no "bleeding" of an interval onto the next one.  The search for each interval takes 10-50 ms, and is therefore suitable for parallelization.  This is preparatory work for speculatively searching in distant intervals when we have free cores.

Note that changing the intervals means that the heuristic can find different solutions.  It's the case in one of the tests.

#1760.