### PR TITLE
Restructure the code of Stehlé-Zimmermann search

### DIFF
--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -177,9 +177,10 @@ absl::StatusOr<std::int64_t> StehléZimmermannExhaustiveSearch(
 
 // Searches in a "slice", which is a set of two intervals of measure |2 * T₀| on
 // either side of |scaled.argument|.  Consecutive values of |slice_index|
-// correspond to consecutive intervals farther away from |scaled.argument|.
-// Returns |NotFound| if no solution was found in the slice.  Slices may be
-// processed independently of one another.
+// correspond to contiguous intervals farther away from |scaled.argument|.
+// Slices may be processed independently of one another.
+// Returns a *scaled* argument, or |NotFound| if no solution was found in the
+// slice.
 template<std::int64_t zeroes>
 absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousSliceSearch(
     StehléZimmermannSpecification const& scaled,
@@ -556,7 +557,7 @@ absl::StatusOr<cpp_rational> StehléZimmermannSimultaneousFullSearch(
     absl::Status const& status = status_or_scaled_solution.status();
     if (status.ok()) {
       // The argument returned by the slice search is scaled, so we must adjust
-      // it before returning it.
+      // it before returning.
       return status_or_scaled_solution.value() / argument_scale;
     } else if (absl::IsNotFound(status)) {
       // No solution found in this slice, go to the next one.

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -45,32 +45,6 @@ using namespace principia::quantities::_quantities;
 constexpr std::int64_t T_max = 16;
 static_assert(T_max >= 1);
 
-template<std::int64_t rows, std::int64_t columns>
-FixedMatrix<cpp_int, rows, columns> ToInt(
-    FixedMatrix<cpp_rational, rows, columns> const& m) {
-  FixedMatrix<cpp_int, rows, columns> result(uninitialized);
-  for (std::int64_t i = 0; i < rows; ++i) {
-    for (std::int64_t j = 0; j < columns; ++j) {
-      auto const& mᵢⱼ = m(i, j);
-      DCHECK_EQ(1, denominator(mᵢⱼ));
-      result(i, j) = numerator(m(i, j));
-    }
-  }
-  return result;
-}
-
-template<std::int64_t rows, std::int64_t columns>
-FixedMatrix<cpp_rational, rows, columns> ToRational(
-    FixedMatrix<cpp_int, rows, columns> const& m) {
-  FixedMatrix<cpp_rational, rows, columns> result(uninitialized);
-  for (std::int64_t i = 0; i < rows; ++i) {
-    for (std::int64_t j = 0; j < columns; ++j) {
-      result(i, j) = m(i, j);
-    }
-  }
-  return result;
-}
-
 template<std::int64_t zeroes>
 bool HasDesiredZeroes(cpp_bin_float_50 const& y) {
   std::int64_t y_exponent;

--- a/functions/accurate_table_generator_body.hpp
+++ b/functions/accurate_table_generator_body.hpp
@@ -68,50 +68,6 @@ bool AllFunctionValuesHaveDesiredZeroes(
                      });
 }
 
-// This is essentially the same as Gal's exhaustive search, but with the
-// normalization done for [SZ05].
-absl::StatusOr<std::int64_t> StehléZimmermannExhaustiveSearch(
-    std::array<AccurateFunction, 2> const& F,
-    std::int64_t const M,
-    std::int64_t const T) {
-  VLOG(2) << "Exhaustive search with T = " << T;
-  for (std::int64_t t = 0; t <= T; ++t) {
-    {
-      bool found = true;
-      for (auto const& Fᵢ : F) {
-        auto const Fᵢ_t = Fᵢ(t);
-        auto const Fᵢ_t_cmod_1 = Fᵢ_t - round(Fᵢ_t);
-        VLOG(2) << "Fi(t) cmod 1 = " << Fᵢ_t_cmod_1;
-        if (M * abs(Fᵢ_t_cmod_1) >= 1) {
-          found = false;
-          break;
-        }
-      }
-      if (found) {
-        VLOG(2) << "t = " << t;
-        return t;
-      }
-    }
-    if (t > 0) {
-      bool found = true;
-      for (auto const& Fᵢ : F) {
-        auto const Fᵢ_minus_t = Fᵢ(-t);
-        auto const Fᵢ_minus_t_cmod_1 = Fᵢ_minus_t - round(Fᵢ_minus_t);
-        VLOG(2) << "Fi(-t) cmod 1 = " << Fᵢ_minus_t_cmod_1;
-        if (M * abs(Fᵢ_minus_t_cmod_1) >= 1) {
-          found = false;
-          break;
-        }
-      }
-      if (found) {
-        VLOG(2) << "t = " << -t;
-        return -t;
-      }
-    }
-  }
-  return absl::NotFoundError("Not enough zeroes");
-}
-
 struct StehléZimmermannSpecification {
   std::array<AccurateFunction, 2> functions;
   std::array<AccuratePolynomial<cpp_rational, 2>, 2> polynomials;
@@ -175,6 +131,50 @@ StehléZimmermannSpecification ScaleToBinade0(
                                                   polynomials[1])},
           .remainders = scaled_remainders,
           .argument = scaled_argument};
+}
+
+// This is essentially the same as Gal's exhaustive search, but with the
+// scaling to binade 0.
+absl::StatusOr<std::int64_t> StehléZimmermannExhaustiveSearch(
+    std::array<AccurateFunction, 2> const& F,
+    std::int64_t const M,
+    std::int64_t const T) {
+  VLOG(2) << "Exhaustive search with T = " << T;
+  for (std::int64_t t = 0; t <= T; ++t) {
+    {
+      bool found = true;
+      for (auto const& Fᵢ : F) {
+        auto const Fᵢ_t = Fᵢ(t);
+        auto const Fᵢ_t_cmod_1 = Fᵢ_t - round(Fᵢ_t);
+        VLOG(2) << "Fi(t) cmod 1 = " << Fᵢ_t_cmod_1;
+        if (M * abs(Fᵢ_t_cmod_1) >= 1) {
+          found = false;
+          break;
+        }
+      }
+      if (found) {
+        VLOG(2) << "t = " << t;
+        return t;
+      }
+    }
+    if (t > 0) {
+      bool found = true;
+      for (auto const& Fᵢ : F) {
+        auto const Fᵢ_minus_t = Fᵢ(-t);
+        auto const Fᵢ_minus_t_cmod_1 = Fᵢ_minus_t - round(Fᵢ_minus_t);
+        VLOG(2) << "Fi(-t) cmod 1 = " << Fᵢ_minus_t_cmod_1;
+        if (M * abs(Fᵢ_minus_t_cmod_1) >= 1) {
+          found = false;
+          break;
+        }
+      }
+      if (found) {
+        VLOG(2) << "t = " << -t;
+        return -t;
+      }
+    }
+  }
+  return absl::NotFoundError("Not enough zeroes");
 }
 
 //TODO(phl)comment


### PR DESCRIPTION
This is a semantics-preserving change in preparation for speculative execution:
1. Move the rescaling code to a separate function, `ScaleToBinade0`.
2. Extract the code that searches in a "slice" of two intervals of measure 2 T₀.
3. Remove dead code related to the LLL algorithm (which we don't use anymore).

#1760.