### PR TITLE
Avoid double-to-int64_t overflows in the lattice reduction

### DIFF
--- a/numerics/lattices_body.hpp
+++ b/numerics/lattices_body.hpp
@@ -33,6 +33,11 @@ using namespace principia::quantities::_concepts;
 using namespace principia::quantities::_elementary_functions;
 using namespace principia::quantities::_named_quantities;
 
+// The largest `int64_t` that can be converted to and from `double` without loss
+// of accuracy.
+constexpr std::int64_t largest_convertible_integer =
+    2LL << std::numeric_limits<double>::digits;
+
 // In the terminology of [NS09], our vectors are in columns, so `d` is `columns`
 // and `n` is `rows`.
 template<typename Matrix>
@@ -378,14 +383,26 @@ void SizeReduce(std::int64_t const κ,
     }
 
     std::vector<std::int64_t> X(κ);
+    bool making_progress = false;
     for (std::int64_t i = κ - 1; i >= 0; --i) {
-      // Step 4.
-      X[i] = std::llround(μ(i, κ));
+      // Step 4.  A large `double` value may overflow `int64_t`, and cause
+      // `llround` to return junk.  To avoid this, we make the conversion
+      // saturating and trust that the reduction will iterate.
+      double const μ_iκ = μ(i, κ);
+      if (μ_iκ > largest_convertible_integer) {
+        X[i] = largest_convertible_integer;
+      } else if (μ_iκ < -largest_convertible_integer) {
+        X[i] = -largest_convertible_integer;
+      } else {
+        X[i] = std::llround(μ_iκ);
+      }
+      making_progress |= X[i] != 0;
       // Step 5.
       for (std::int64_t j = 0; j <= i - 1; ++j) {
         μ(j, κ) -= X[i] * μ(j, i);
       }
     }
+    CHECK(making_progress) << b;
     // Step 6.
     auto b_κ = ColumnView{.matrix = b,
                           .first_row = 0,

--- a/numerics/lattices_body.hpp
+++ b/numerics/lattices_body.hpp
@@ -3,6 +3,7 @@
 #include "numerics/lattices.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 #include <vector>
 

--- a/numerics/lattices_test.cpp
+++ b/numerics/lattices_test.cpp
@@ -47,10 +47,11 @@ TEST_F(LatticesTest, LLL_Rational) {
 
   auto const reduced = LenstraLenstraLovász(l);
   EXPECT_EQ(reduced,
-            (FixedMatrix<cpp_rational, 5, 4>({  45,     6, -18,   15,    0,
-                                                45, -1200, 348,    0,    0,
-                                                 0,     0,   0, 1083,  336,
-                                              -660,     0, 165, -180, 1263})));
+            (FixedMatrix<cpp_rational, 5, 4>({ 45,    6,   -18,   15,
+                                                0,   45, -1200,  348,
+                                                0,    0,     0,    0,
+                                                0, 1083,   336, -660,
+                                                0,  165,  -180, 1263})));
 }
 
 TEST_F(LatticesTest, NS_Example_7_75) {
@@ -87,10 +88,27 @@ TEST_F(LatticesTest, NS_Int) {
 
   auto const reduced = NguyễnStehlé(l);
   EXPECT_EQ(reduced,
-            (FixedMatrix<cpp_int, 5, 4>({  45,     6, -18,   15,    0,
-                                           45, -1200, 348,    0,    0,
-                                            0,     0,   0, 1083,  336,
-                                         -660,     0, 165, -180, 1263})));
+            (FixedMatrix<cpp_int, 5, 4>({ 45,    6,   -18,   15,
+                                           0,   45, -1200,  348,
+                                           0,    0,     0,    0,
+                                           0, 1083,   336, -660,
+                                           0,  165,  -180, 1263})));
+}
+
+TEST_F(LatticesTest, NoProgress) {
+  FixedMatrix<cpp_int, 5, 4> l(
+      { 212,  74278, -24016,  cpp_int("2236050964407517784120"),
+       -116, 135836, -23372, cpp_int("-1223499584298453127159"),
+          0,      0,      0,                                  0,
+          3,  -3513, 784686,    cpp_int("31642230628408270524"),
+          0,      0,      0,                                  3});
+  auto const reduced = NguyễnStehlé(l);
+  EXPECT_EQ(reduced,
+            (FixedMatrix<cpp_int, 5, 4>({ 0,  212,  72582,  26440,
+                                          1, -113, 133330,  52572,
+                                          0,    0,      0,      0,
+                                         -6,  -15,  17067, 164088,
+                                          3,    9, -10302, 310656})));
 }
 
 }  // namespace _lattices


### PR DESCRIPTION
#1760.