### PR TITLE
A benchmark for our trigonometric functions and a few performance improvements

### DIFF
--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -9,6 +9,7 @@
 #include "benchmarks/metric.hpp"
 #include "functions/cos.hpp"
 #include "functions/sin.hpp"
+#include "numerics/sin_cos.hpp"
 #include "quantities/numbers.hpp"  // 🧙 For π.
 
 namespace principia {
@@ -17,6 +18,7 @@ namespace functions {
 using namespace principia::benchmarks::_metric;
 using namespace principia::functions::_cos;
 using namespace principia::functions::_sin;
+using namespace principia::numerics::_sin_cos;
 
 static constexpr std::int64_t number_of_iterations = 1000;
 
@@ -26,7 +28,7 @@ void BM_EvaluateElementaryFunction(benchmark::State& state) {
   using Argument = double;
 
   std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(-π / 4, π / 4);
+  std::uniform_real_distribution<> uniformly_at(0, π / 4);
 
   Argument a[number_of_iterations];
   for (std::int64_t i = 0; i < number_of_iterations; ++i) {
@@ -79,6 +81,11 @@ BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Latency, cr_sin)
 BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, cr_sin)
     ->Unit(benchmark::kNanosecond);
 
+BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Latency, Sin)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, Sin)
+    ->Unit(benchmark::kNanosecond);
+
 BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Latency, std::cos)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, std::cos)
@@ -87,6 +94,11 @@ BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, std::cos)
 BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Latency, cr_cos)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, cr_cos)
+    ->Unit(benchmark::kNanosecond);
+
+BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Latency, Cos)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(BM_EvaluateElementaryFunction, Metric::Throughput, Cos)
     ->Unit(benchmark::kNanosecond);
 
 }  // namespace functions

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -24,7 +24,7 @@ class SinCosTest : public ::testing::Test {};
 TEST_F(SinCosTest, Random) {
   std::mt19937_64 random(42);
   // TODO(phl): Negative angles.
-  std::uniform_real_distribution<> uniformly_at(0, π / 4);
+  std::uniform_real_distribution<> uniformly_at(-π / 4, π / 4);
 
   cpp_bin_float_50 max_sin_ulps_error = 0;
   cpp_bin_float_50 max_cos_ulps_error = 0;
@@ -69,8 +69,8 @@ TEST_F(SinCosTest, Random) {
   }
 
   // This implementation is not quite correctly rounded, but not far from it.
-  EXPECT_LE(max_sin_ulps_error, 0.500002);
-  EXPECT_LE(max_cos_ulps_error, 0.500002);
+  EXPECT_LE(max_sin_ulps_error, 0.500003);
+  EXPECT_LE(max_cos_ulps_error, 0.500001);
 
   LOG(ERROR) << "Sin error: " << max_sin_ulps_error << std::setprecision(25)
              << " ulps for argument: " << worst_sin_argument

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -34,7 +34,7 @@ TEST_F(SinCosTest, Random) {
 #if _DEBUG
   static constexpr std::int64_t iterations = 100;
 #else
-  static constexpr std::int64_t iterations = 400'000;
+  static constexpr std::int64_t iterations = 300'000;
 #endif
 
   for (std::int64_t i = 0; i < iterations; ++i) {

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "base/not_null.hpp"
+#include "base/tags.hpp"
 #include "numerics/fma.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -14,6 +15,7 @@ namespace _double_precision {
 namespace internal {
 
 using namespace principia::base::_not_null;
+using namespace principia::base::_tags;
 using namespace principia::numerics::_fma;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
@@ -22,8 +24,9 @@ using namespace principia::quantities::_quantities;
 // type of the value must be an affine space.  The notations follow [HLB08].
 template<typename T>
 struct DoublePrecision final {
-  constexpr DoublePrecision() = default;
+  constexpr DoublePrecision();
 
+  explicit constexpr DoublePrecision(uninitialized_t);
   explicit constexpr DoublePrecision(T const& value);
 
   // This is correct assuming that left and right have non-overlapping
@@ -47,8 +50,8 @@ struct DoublePrecision final {
   static DoublePrecision ReadFromMessage(
       serialization::DoublePrecision const& message);
 
-  T value{};
-  Difference<T> error{};
+  T value;
+  Difference<T> error;
 };
 
 // `scale` must be a signed power of two or zero.

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -64,25 +64,29 @@ DoublePrecision<Product<T, U>> Scale(T const& scale,
 template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b);
 
-// Returns the exact value of `a * b + c`.
+// Returns the exact value of `a * b + c` if `|a * b|` is small compared to
+// `|c|`. See [SZ05], section 2.1.
 template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
                                              U const& b,
                                              Product<T, U> const& c);
 
-// Returns the exact value of `a * b - c`.
+// Returns the exact value of `a * b - c` if `|a * b|` is small compared to
+// `|c|`. See [SZ05], section 2.1.
 template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
                                                   U const& b,
                                                   Product<T, U> const& c);
 
-// Returns the exact value of `-a * b + c`.
+// Returns the exact value of `-a * b + c` if `|a * b|` is small compared to
+// `|c|`. See [SZ05], section 2.1.
 template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
                                                     U const& b,
                                                     Product<T, U> const& c);
 
-// Returns the exact value of `-a * b - c`.
+// Returns the exact value of `-a * b - c` if `|a * b|` is small compared to
+// `|c|`. See [SZ05], section 2.1.
 template<FMAPolicy fma_policy = FMAPolicy::Auto, typename T, typename U>
 DoublePrecision<Product<T, U>>
 TwoProductNegatedSubtract(T const& a,

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -108,6 +108,12 @@ struct ComponentwiseComparator<T, U> {
 
 
 template<typename T>
+constexpr DoublePrecision<T>::DoublePrecision() : value{}, error{} {}
+
+template<typename T>
+constexpr DoublePrecision<T>::DoublePrecision(uninitialized_t) {}
+
+template<typename T>
 constexpr DoublePrecision<T>::DoublePrecision(T const& value)
     : value(value),
       error() {}
@@ -199,7 +205,7 @@ DoublePrecision<Product<T, U>> Scale(T const & scale,
     CHECK_EQ(0.5, std::fabs(mantissa)) << scale;
   }
 #endif
-  DoublePrecision<Product<T, U>> result;
+  DoublePrecision<Product<T, U>> result(uninitialized);
   result.value = right.value * scale;
   result.error = right.error * scale;
   return result;
@@ -208,7 +214,7 @@ DoublePrecision<Product<T, U>> Scale(T const & scale,
 template<typename T, typename U>
 constexpr DoublePrecision<Product<T, U>> VeltkampDekkerProduct(T const& a,
                                                                U const& b) {
-  DoublePrecision<Product<T, U>> result;
+  DoublePrecision<Product<T, U>> result(uninitialized);
   auto const& x = a;
   auto const& y = b;
   auto& z = result.value;
@@ -242,7 +248,8 @@ DoublePrecision<Product<T, U>> TwoProduct(T const& a, U const& b) {
   if ((fma_policy == FMAPolicy::Force && CanEmitFMAInstructions) ||
       (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(a * b);
+    DoublePrecision<Product<T, U>> result(uninitialized);
+    result.value = a * b;
     result.error = FusedMultiplySubtract(a, b, result.value);
     return result;
   } else {
@@ -259,8 +266,9 @@ DoublePrecision<Product<T, U>> TwoProductAdd(T const& a,
       (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     using quantities::_elementary_functions::FusedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(FusedMultiplyAdd(a, b, c));
-    result.error = FusedMultiplySubtract(a, b, (result.value - c));
+    DoublePrecision<Product<T, U>> result(uninitialized);
+    result.value = FusedMultiplyAdd(a, b, c);
+    result.error = FusedMultiplySubtract(a, b, result.value - c);
     return result;
   } else {
     auto result = VeltkampDekkerProduct(a, b);
@@ -277,8 +285,9 @@ DoublePrecision<Product<T, U>> TwoProductSubtract(T const& a,
   if ((fma_policy == FMAPolicy::Force && CanEmitFMAInstructions) ||
       (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(FusedMultiplySubtract(a, b, c));
-    result.error = FusedMultiplySubtract(a, b, (result.value + c));
+    DoublePrecision<Product<T, U>> result(uninitialized);
+    result.value = FusedMultiplySubtract(a, b, c);
+    result.error = FusedMultiplySubtract(a, b, result.value + c);
     return result;
   } else {
     auto result = VeltkampDekkerProduct(a, b);
@@ -296,8 +305,9 @@ DoublePrecision<Product<T, U>> TwoProductNegatedAdd(T const& a,
       (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(FusedNegatedMultiplyAdd(a, b, c));
-    result.error = FusedNegatedMultiplySubtract(a, b, (result.value - c));
+    DoublePrecision<Product<T, U>> result(uninitialized);
+    result.value = FusedNegatedMultiplyAdd(a, b, c);
+    result.error = FusedNegatedMultiplySubtract(a, b, result.value - c);
     return result;
   } else {
     auto result = VeltkampDekkerProduct(-a, b);
@@ -315,9 +325,9 @@ TwoProductNegatedSubtract(T const& a,
   if ((fma_policy == FMAPolicy::Force && CanEmitFMAInstructions) ||
       (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
     using quantities::_elementary_functions::FusedNegatedMultiplySubtract;
-    DoublePrecision<Product<T, U>> result(
-        FusedNegatedMultiplySubtract(a, b, c));
-    result.error = FusedNegatedMultiplySubtract(a, b, (result.value + c));
+    DoublePrecision<Product<T, U>> result(uninitialized);
+    result.value = FusedNegatedMultiplySubtract(a, b, c);
+    result.error = FusedNegatedMultiplySubtract(a, b, result.value + c);
     return result;
   } else {
     auto result = VeltkampDekkerProduct(-a, b);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -95,12 +95,12 @@ Value CosImplementation(Argument const x) {
           cos_x₀_minus_h_sin_x₀.error);
 }
 
-Value Sin(Argument const x) {
+Value __cdecl Sin(Argument const x) {
   return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
                         : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
-Value Cos(Argument const x) {
+Value __cdecl Cos(Argument const x) {
   return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
                         : CosImplementation<FMAPolicy::Disallow>(x);
 }

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -2,7 +2,7 @@
 
 #include "numerics/sin_cos.hpp"
 
-#include <cmath>
+#include <pmmintrin.h>
 
 #include "numerics/accurate_tables.mathematica.h"
 #include "numerics/double_precision.hpp"

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -70,16 +70,16 @@ Value SinImplementation(Argument const x) {
   } else {
     auto const i = _mm_cvtsd_si64(_mm_set_sd(abs_x * table_spacing_reciprocal));
     auto const& accurate_values = SinCosAccurateTable[i];
-    double const& x₀ =
-        _mm_cvtsd_f64(_mm_or_pd(_mm_set_sd(accurate_values.x), sign));
+    double const& x₀ = accurate_values.x;
     double const& sin_x₀ =
-        _mm_cvtsd_f64(_mm_or_pd(_mm_set_sd(accurate_values.sin_x), sign));
+        _mm_cvtsd_f64(_mm_xor_pd(_mm_set_sd(accurate_values.sin_x), sign));
     double const& cos_x₀ = accurate_values.cos_x;
-    double const h = x - x₀;
+    double const abs_h = abs_x - x₀;
+    double const h = _mm_cvtsd_f64(_mm_xor_pd(_mm_set_sd(abs_h), sign));
 
     DoublePrecision<double> const sin_x₀_plus_h_cos_x₀ =
         TwoProductAdd<fma_policy>(cos_x₀, h, sin_x₀);
-    double const h² = h * h;
+    double const h² = abs_h * abs_h;
     double const h³ = h² * h;
     return sin_x₀_plus_h_cos_x₀.value +
            ((sin_x₀ * h² * CosPolynomial<fma_policy>(h²) +

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -95,11 +95,17 @@ Value CosImplementation(Argument const x) {
           cos_x₀_minus_h_sin_x₀.error);
 }
 
+#if PRINCIPIA_INLINE_SIN_COS
+inline
+#endif
 Value __cdecl Sin(Argument const x) {
   return UseHardwareFMA ? SinImplementation<FMAPolicy::Force>(x)
                         : SinImplementation<FMAPolicy::Disallow>(x);
 }
 
+#if PRINCIPIA_INLINE_SIN_COS
+inline
+#endif
 Value __cdecl Cos(Argument const x) {
   return UseHardwareFMA ? CosImplementation<FMAPolicy::Force>(x)
                         : CosImplementation<FMAPolicy::Disallow>(x);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "numerics/sin_cos.hpp"
 
 #include <cmath>
@@ -57,7 +59,7 @@ Value SinImplementation(Argument const x) {
     double const x³ = x² * x;
     return x + x³ * SinPolynomialNearZero<fma_policy>(x²);
   } else {
-    std::int64_t const i = std::lround(x * table_spacing_reciprocal);
+    auto const i = _mm_cvtsd_si64(_mm_set_sd(x * table_spacing_reciprocal));
     auto const& accurate_values = SinCosAccurateTable[i];
     double const& x₀ = accurate_values.x;
     double const& sin_x₀ = accurate_values.sin_x;
@@ -78,7 +80,8 @@ Value SinImplementation(Argument const x) {
 template<FMAPolicy fma_policy>
 FORCE_INLINE(inline)
 Value CosImplementation(Argument const x) {
-  std::int64_t const i = std::lround(x * table_spacing_reciprocal);
+  double const abs_x = std::abs(x);
+  auto const i = _mm_cvtsd_si64(_mm_set_sd(abs_x * table_spacing_reciprocal));
   auto const& accurate_values = SinCosAccurateTable[i];
   double const& x₀ = accurate_values.x;
   double const& sin_x₀ = accurate_values.sin_x;

--- a/numerics/sin_cos.hpp
+++ b/numerics/sin_cos.hpp
@@ -5,7 +5,15 @@ namespace numerics {
 namespace _sin_cos {
 namespace internal {
 
+#define PRINCIPIA_INLINE_SIN_COS 0
+
+#if PRINCIPIA_INLINE_SIN_COS
+inline
+#endif
 double __cdecl Sin(double x);
+#if PRINCIPIA_INLINE_SIN_COS
+inline
+#endif
 double __cdecl Cos(double x);
 
 }  // namespace internal
@@ -16,3 +24,7 @@ using internal::Sin;
 }  // namespace _sin_cos
 }  // namespace numerics
 }  // namespace principia
+
+#if PRINCIPIA_INLINE_SIN_COS
+#include "numerics/sin_cos.cpp"
+#endif

--- a/numerics/sin_cos.hpp
+++ b/numerics/sin_cos.hpp
@@ -5,8 +5,8 @@ namespace numerics {
 namespace _sin_cos {
 namespace internal {
 
-double Sin(double x);
-double Cos(double x);
+double __cdecl Sin(double x);
+double __cdecl Cos(double x);
 
 }  // namespace internal
 


### PR DESCRIPTION
* Support for angles in [-π/4, π/4].
* Support for uninitialized `DoublePrecision` objects.
* Improved computation of the table index.

Benchmark:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
------------------------------------------------------------------------------------------------------
Benchmark                                                            Time             CPU   Iterations
------------------------------------------------------------------------------------------------------
BM_EvaluateElementaryFunction<Metric::Latency, std::sin>          7.26 ns         7.25 ns    112000000 cycles: 27.5162
BM_EvaluateElementaryFunction<Metric::Throughput, std::sin>       2.12 ns         2.13 ns    344616000 cycles: 8.00978
BM_EvaluateElementaryFunction<Metric::Latency, cr_sin>            31.9 ns         31.5 ns     21334000 cycles: 120.947
BM_EvaluateElementaryFunction<Metric::Throughput, cr_sin>         20.8 ns         20.9 ns     34462000 cycles: 78.7098
BM_EvaluateElementaryFunction<Metric::Latency, Sin>               11.2 ns         11.2 ns     64000000 cycles: 42.4374
BM_EvaluateElementaryFunction<Metric::Throughput, Sin>            3.59 ns         3.61 ns    194783000 cycles: 13.5883
BM_EvaluateElementaryFunction<Metric::Latency, std::cos>          8.14 ns         8.02 ns     89600000 cycles: 30.8504
BM_EvaluateElementaryFunction<Metric::Throughput, std::cos>       2.12 ns         2.13 ns    344616000 cycles: 8.00876
BM_EvaluateElementaryFunction<Metric::Latency, cr_cos>            35.3 ns         35.3 ns     20364000 cycles: 133.698
BM_EvaluateElementaryFunction<Metric::Throughput, cr_cos>         21.7 ns         21.5 ns     32000000 cycles: 82.2311
BM_EvaluateElementaryFunction<Metric::Latency, Cos>               11.0 ns         11.0 ns     64000000 cycles: 41.5094
BM_EvaluateElementaryFunction<Metric::Throughput, Cos>            3.28 ns         3.30 ns    213334000 cycles: 12.4005
```
#1760.