### PR TITLE
Avoid a race in the construction of PushPullExecutor

### DIFF
--- a/base/push_pull_callback.hpp
+++ b/base/push_pull_callback.hpp
@@ -80,9 +80,11 @@ class PushPullExecutor {
 
  private:
   PushPullCallback<Result, Arguments...> callback_;
-  std::thread thread_;
   mutable absl::Mutex lock_;
   std::optional<T> result_ GUARDED_BY(lock_);
+
+  // This must come last as it references the other member variables, see #4136.
+  std::thread thread_;
 };
 
 }  // namespace internal

--- a/base/push_pull_callback_body.hpp
+++ b/base/push_pull_callback_body.hpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <utility>
 
+#include "glog/logging.h"
+
 namespace principia {
 namespace base {
 namespace _push_pull_callback {
@@ -117,6 +119,7 @@ PushPullExecutor<T, Result, Arguments...>::callback() const {
 template<typename T, typename Result, typename... Arguments>
 T PushPullExecutor<T, Result, Arguments...>::get() {
   absl::MutexLock l(&lock_);
+  CHECK(result_.has_value());
   return std::move(result_.value());
 }
 

--- a/base/push_pull_callback_body.hpp
+++ b/base/push_pull_callback_body.hpp
@@ -105,14 +105,12 @@ PushPullExecutor<T, Result, Arguments...>::~PushPullExecutor() {
 template<typename T, typename Result, typename... Arguments>
 PushPullCallback<Result, Arguments...>&
 PushPullExecutor<T, Result, Arguments...>::callback() {
-  absl::ReaderMutexLock l(&lock_);
   return callback_;
 }
 
 template<typename T, typename Result, typename... Arguments>
 PushPullCallback<Result, Arguments...> const&
 PushPullExecutor<T, Result, Arguments...>::callback() const {
-  absl::ReaderMutexLock l(&lock_);
   return callback_;
 }
 

--- a/base/push_pull_callback_test.cpp
+++ b/base/push_pull_callback_test.cpp
@@ -40,55 +40,25 @@ TEST(PushPullCallback, Test) {
   EXPECT_EQ(8, executor.get());
 }
 
-TEST(PushPullCallback, Repeat) {
-  std::mt19937_64 random(42);
-  std::uniform_real_distribution<> ordinate(-1.0, 1.0);
-
-  double y1;
-  double y2;
-
-  auto f = [&y1, &y2](double const x) {
-    // x = -1.0 -> y1; x = 1.0 -> y2.
-    return (x + 1.0) * (y2 - y1) / 2.0 + y1;
-  };
-
+TEST(PushPullCallback, 4136) {
   auto task =
-      [](std::function<double(double const x, void* const unused)> const& f)
+      [](std::function<double(int const x)> const& f)
       -> std::optional<double> {
-    static constexpr std::int64_t n = 10000;
-    double const f0 = f(0, nullptr);
-    for (std::int64_t i = 1; i <= n; ++i) {
-      double const fi = f(i / static_cast<double>(n), nullptr);
-      if ((f0 > 0 && fi < 0) || (f0 < 0 && fi > 0)) {
-        return i / static_cast<double>(n);
-      }
-    }
     return std::nullopt;
   };
 
-  for (std::int64_t attempt = 0; attempt < 1000; ++ attempt) {
-    y1 = ordinate(random);
-    y2 = ordinate(random);
-
+  for (std::int64_t attempt = 0; attempt < 100'000; ++attempt) {
     auto* const executor =
-        new PushPullExecutor<std::optional<double>, double, double, void*>(
-            task);
+        new PushPullExecutor<std::optional<double>, double, int>(task);
     for (;;) {
-      double x = -2;
-      void* unused;
-      bool const more = executor->callback().Pull(x, unused);
+      int x;
+      bool const more = executor->callback().Pull(x);
       if (!more) {
         auto const result = executor->get();
-        if (result.has_value()) {
-          LOG(ERROR) << attempt << ": " << result.value();
-        } else {
-          LOG(ERROR) << attempt << ": no result";
-        }
         delete executor;
         break;
       }
-      double y = f(x);
-      executor->callback().Push(y);
+      executor->callback().Push(1.0);
     }
   }
 }

--- a/base/push_pull_callback_test.cpp
+++ b/base/push_pull_callback_test.cpp
@@ -1,9 +1,7 @@
 #include "base/push_pull_callback.hpp"
 
-#include <random>
 #include <utility>
 
-#include "glog/logging.h"
 #include "gtest/gtest.h"
 
 namespace principia {

--- a/base/push_pull_callback_test.cpp
+++ b/base/push_pull_callback_test.cpp
@@ -1,7 +1,9 @@
 #include "base/push_pull_callback.hpp"
 
+#include <random>
 #include <utility>
 
+#include "glog/logging.h"
 #include "gtest/gtest.h"
 
 namespace principia {
@@ -36,6 +38,59 @@ TEST(PushPullCallback, Test) {
 
   EXPECT_FALSE(callback.Pull(left, right));
   EXPECT_EQ(8, executor.get());
+}
+
+TEST(PushPullCallback, Repeat) {
+  std::mt19937_64 random(42);
+  std::uniform_real_distribution<> ordinate(-1.0, 1.0);
+
+  double y1;
+  double y2;
+
+  auto f = [&y1, &y2](double const x) {
+    // x = -1.0 -> y1; x = 1.0 -> y2.
+    return (x + 1.0) * (y2 - y1) / 2.0 + y1;
+  };
+
+  auto task =
+      [](std::function<double(double const x, void* const unused)> const& f)
+      -> std::optional<double> {
+    static constexpr std::int64_t n = 10000;
+    double const f0 = f(0, nullptr);
+    for (std::int64_t i = 1; i <= n; ++i) {
+      double const fi = f(i / static_cast<double>(n), nullptr);
+      if ((f0 > 0 && fi < 0) || (f0 < 0 && fi > 0)) {
+        return i / static_cast<double>(n);
+      }
+    }
+    return std::nullopt;
+  };
+
+  for (std::int64_t attempt = 0; attempt < 1000; ++ attempt) {
+    y1 = ordinate(random);
+    y2 = ordinate(random);
+
+    auto* const executor =
+        new PushPullExecutor<std::optional<double>, double, double, void*>(
+            task);
+    for (;;) {
+      double x = -2;
+      void* unused;
+      bool const more = executor->callback().Pull(x, unused);
+      if (!more) {
+        auto const result = executor->get();
+        if (result.has_value()) {
+          LOG(ERROR) << attempt << ": " << result.value();
+        } else {
+          LOG(ERROR) << attempt << ": no result";
+        }
+        delete executor;
+        break;
+      }
+      double y = f(x);
+      executor->callback().Push(y);
+    }
+  }
 }
 
 }  // namespace base


### PR DESCRIPTION
The `thread_` must be declared last because its execution uses the other member variables.

Fix #4136.