### PR TITLE
More optimizations of Sin and Cos

### DIFF
--- a/functions/functions.vcxproj
+++ b/functions/functions.vcxproj
@@ -5,9 +5,7 @@
     <RootNamespace>functions</RootNamespace>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <AssemblerOutput>AssemblyCode</AssemblerOutput>
-    </ClCompile>
+    <ClCompile />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="accurate_table_generator.hpp" />

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -32,25 +32,6 @@ class SinCosTest : public ::testing::Test {
   double a_ = 1.0;
 };
 
-// Defined in sin_cos.hpp
-#if PRINCIPIA_USE_OSACA
-
-// A convenient skeleton for analysing code with OSACA.  Note that to speed-up
-// analysis, we disable all the other tests when using OSACA.
-TEST_F(SinCosTest, DISABLED_OSACA) {
-  static_assert(PRINCIPIA_INLINE_SIN_COS == 1,
-                "Must force inlining to use OSACA");
-  auto osaca_sin = [](double const a) {
-    return Sin(a);
-  };
-  auto osaca_cos = [](double const a) {
-    return Cos(a);
-  };
-  CHECK_NE(osaca_sin(a_), osaca_cos(a_));
-}
-
-#else
-
 TEST_F(SinCosTest, AccurateTableIndex) {
   static constexpr std::int64_t iterations = 100;
 
@@ -192,8 +173,6 @@ TEST_F(SinCosTest, HardReduction) {
   EXPECT_THAT(Cos(0x16ac5b262ca1ffp797),
               AlmostEquals(-4.687165924254627611122582801963884e-19, 0));
 }
-
-#endif
 
 }  // namespace functions_test
 }  // namespace principia

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -106,7 +106,8 @@ TEST_F(SinCosTest, Random) {
       }
       if (sin_ulps_error > 0.5) {
         ++incorrectly_rounded_sin;
-        LOG(ERROR) << "Sin: " << std::setprecision(25) << principia_argument;
+        LOG(ERROR) << "Sin: " << sin_ulps_error << " ulps at "
+                   << std::setprecision(25) << principia_argument;
       }
     }
     {
@@ -122,7 +123,8 @@ TEST_F(SinCosTest, Random) {
       }
       if (cos_ulps_error > 0.5) {
         ++incorrectly_rounded_cos;
-        LOG(ERROR) << "Cos: " << std::setprecision(25) << principia_argument;
+        LOG(ERROR) << "Cos: " << cos_ulps_error << " ulps at "
+                   << std::setprecision(25) << principia_argument;
       }
     }
   }

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -20,6 +20,7 @@
     constexpr bool UseHardwareFMA = true;                                    \
     constexpr double θ = 3;                                                  \
     /* From argument reduction. */                                           \
+    constexpr double abs_θ = θ > 0 ? θ : -θ;                                 \
     constexpr std::int64_t n = static_cast<std::int64_t>(θ * (2 / π) + 0.5); \
     constexpr double reduction_value = θ - n * π_over_2_high;                \
     constexpr double reduction_error = n * π_over_2_low;                     \

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -184,6 +184,7 @@ static bool OSACA_loop_terminator = false;
     constexpr bool UseHardwareFMA = true;                                  \
     constexpr double θ = 0.1;                                              \
     /* From argument reduction. */                                         \
+    constexpr double abs_θ = θ < 0 ? -θ : θ;                               \
     constexpr double n_double = θ * (2 / π);                               \
     constexpr double reduction_value = θ - n_double * π_over_2_high;       \
     constexpr double reduction_error = n_double * π_over_2_low;            \
@@ -312,12 +313,13 @@ inline double DetectDangerousRounding(double const x, double const Δx) {
 inline void Reduce(Argument const θ,
                    DoublePrecision<Argument>& θ_reduced,
                    std::int64_t& quadrant) {
-  OSACA_IF(θ < π / 4 && θ > -π / 4) {
+  double const abs_θ = std::abs(θ);
+  OSACA_IF(abs_θ < π / 4) {
     θ_reduced.value = θ;
     θ_reduced.error = 0;
     quadrant = 0;
     return;
-  } OSACA_ELSE_IF(θ <= π_over_2_threshold && θ >= -π_over_2_threshold) {
+  } OSACA_ELSE_IF(abs_θ <= π_over_2_threshold) {
     // We are not very sensitive to rounding errors in this expression, because
     // in the worst case it could cause the reduced angle to jump from the
     // vicinity of π / 4 to the vicinity of -π / 4 with appropriate adjustment

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -262,8 +262,8 @@ inline std::int64_t AccurateTableIndex(double const abs_x) {
 
 template<FMAPolicy fma_policy>
 double FusedMultiplyAdd(double const a, double const b, double const c) {
-  OSACA_IF((fma_policy == FMAPolicy::Force && CanEmitFMAInstructions) ||
-            (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
+  static_assert(fma_policy != FMAPolicy::Auto);
+  if constexpr (fma_policy == FMAPolicy::Force) {
     using quantities::_elementary_functions::FusedMultiplyAdd;
     return FusedMultiplyAdd(a, b, c);
   } else {
@@ -273,8 +273,8 @@ double FusedMultiplyAdd(double const a, double const b, double const c) {
 
 template<FMAPolicy fma_policy>
 double FusedNegatedMultiplyAdd(double const a, double const b, double const c) {
-  OSACA_IF((fma_policy == FMAPolicy::Force && CanEmitFMAInstructions) ||
-            (fma_policy == FMAPolicy::Auto && UseHardwareFMA)) {
+  static_assert(fma_policy != FMAPolicy::Auto);
+  if constexpr (fma_policy == FMAPolicy::Force) {
     using quantities::_elementary_functions::FusedNegatedMultiplyAdd;
     return FusedNegatedMultiplyAdd(a, b, c);
   } else {
@@ -372,7 +372,7 @@ Value SinImplementation(DoublePrecision<Argument> const θ_reduced) {
     double const x² = x * x;
     double const x³ = x² * x;
     double const x³_term = FusedMultiplyAdd<fma_policy>(
-                   x³, SinPolynomialNearZero<fma_policy>(x²), e);
+        x³, SinPolynomialNearZero<fma_policy>(x²), e);
     return DetectDangerousRounding(x, x³_term);
   } else {
     __m128d const sign = _mm_and_pd(masks::sign_bit, _mm_set_sd(x));

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -399,9 +399,9 @@ Value SinImplementation(DoublePrecision<Argument> const θ_reduced) {
     double const polynomial_term =
         FusedMultiplyAdd<fma_policy>(
             cos_x₀,
-            FusedMultiplyAdd<fma_policy>(h³, SinPolynomial<fma_policy>(h²), e),
+            h³ * SinPolynomial<fma_policy>(h²),
             sin_x₀ * h² * CosPolynomial<fma_policy>(h²)) +
-        sin_x₀_plus_h_cos_x₀.error;
+        FusedMultiplyAdd<fma_policy>(cos_x₀, e, sin_x₀_plus_h_cos_x₀.error);
     return DetectDangerousRounding(sin_x₀_plus_h_cos_x₀.value, polynomial_term);
   }
 }
@@ -433,10 +433,10 @@ Value CosImplementation(DoublePrecision<Argument> const θ_reduced) {
   double const polynomial_term =
       FusedNegatedMultiplyAdd<fma_policy>(
           sin_x₀,
-          FusedMultiplyAdd<fma_policy>(
-              h³, SinPolynomial<fma_policy>(h²), abs_e),
+          h³ * SinPolynomial<fma_policy>(h²),
           cos_x₀ * h² * CosPolynomial<fma_policy>(h²)) +
-      cos_x₀_minus_h_sin_x₀.error;
+      FusedNegatedMultiplyAdd<fma_policy>(
+          sin_x₀, abs_e, cos_x₀_minus_h_sin_x₀.error);
   return DetectDangerousRounding(cos_x₀_minus_h_sin_x₀.value, polynomial_term);
 }
 


### PR DESCRIPTION
1. Cleanup leftovers from the previous version of OSACA macros.
2. Simplify the FMA wrappers.
3. Change all the algorithms except `Sin` near 0 to operate on the absolute value of their operand and restore the sign at the end if needed.
4. Extract a deeply nested FMA and replace it with a multiplication.  This makes a difference on Zen.

Comparison on Zen 3.  Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.38   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   11.64   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
       principia_cos           52.21   +0.45   +0.90   +0.90   +0.90   +0.90   +1.35
R   sqrtps_xmm0_xmm0      14   13.90   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           30.58   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.00   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
       principia_cos           48.16   +0.90   +0.90   +0.90   +1.35   +1.35   +1.35
R   sqrtps_xmm0_xmm0      14   13.90   +0.00   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           30.58   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
```
Comparison on Golden Cove.  Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            2.40   +0.06   +0.06   +0.08   +0.08   +0.10   +0.10
    sqrtps_xmm0_xmm0            9.62   +0.02   +0.04   +0.06   +0.06   +0.08   +0.10
     mulsd_xmm0_xmm0            5.16   +0.02   +0.02   +0.04   +0.06   +0.76   +0.80
  mulsd_xmm0_xmm0_4x           11.84   +0.04   +0.06   +0.08   +0.08   +0.10   +0.12
Slope: 1.710658 cycle/TSC
Correlation coefficient: 0.999084
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.27   +0.07   +0.07   +0.10   +0.10   +0.14   +0.17
R    mulsd_xmm0_xmm0       4    4.38   +0.07   +0.07   +0.10   +0.10   +0.14   +1.33
R mulsd_xmm0_xmm0_4x      16   15.88   +0.03   +0.07   +0.10   +0.10   +0.14   +0.17
       principia_cos           52.35   +0.48   +0.72   +0.96   +1.13   +1.78   +2.39
R   sqrtps_xmm0_xmm0      12   11.94   +0.14   +0.17   +0.21   +0.21   +0.24   +0.24
             std_cos           31.58   +0.17   +0.24   +0.31   +0.34   +0.41   +0.51
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            2.40   +0.06   +0.06   +0.08   +0.08   +0.10   +0.12
    sqrtps_xmm0_xmm0            9.62   +0.02   +0.04   +0.04   +0.06   +0.08   +0.08
     mulsd_xmm0_xmm0            5.16   +0.02   +0.02   +0.04   +0.04   +0.06   +0.78
  mulsd_xmm0_xmm0_4x           11.86   +0.02   +0.04   +0.06   +0.06   +0.08   +0.10
Slope: 1.707841 cycle/TSC
Correlation coefficient: 0.999116
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.23   +0.03   +0.07   +0.07   +0.07   +0.10   +0.68
R    mulsd_xmm0_xmm0       4    4.41   +0.03   +0.03   +0.07   +0.07   +0.10   +0.14
R mulsd_xmm0_xmm0_4x      16   15.86   +0.03   +0.07   +0.10   +0.14   +0.17   +3.01
       principia_cos           46.05   +0.41   +0.58   +0.72   +0.82   +0.99   +1.26
R   sqrtps_xmm0_xmm0      12   11.96   +0.10   +0.14   +0.17   +0.17   +0.20   +0.24
             std_cos           31.50   +0.17   +0.27   +0.34   +0.38   +0.44   +0.55
```