### PR TITLE
Improve argument reduction

### DIFF
--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -69,7 +69,7 @@ TEST_F(SinCosTest, ReduceIndex) {
   static constexpr double mantissa_reduce_shifter =
       1LL << (std::numeric_limits<double>::digits - 1);
   std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(-1000.0, 1000.0);
+  std::uniform_real_distribution<> uniformly_at(0.0, 1000.0);
 
   for (std::int64_t i = 0; i < iterations; ++i) {
     double const θ = uniformly_at(random);
@@ -79,17 +79,12 @@ TEST_F(SinCosTest, ReduceIndex) {
     double const n_double = _mm_cvtsd_f64(n_128d);
     std::int64_t const n = _mm_cvtsd_si64(n_128d);
 
-    __m128d const sign_128d = _mm_and_pd(sign_bit, _mm_set_sd(θ));
-    double const signed_shifter = _mm_cvtsd_f64(
-        _mm_xor_pd(_mm_set_sd(mantissa_reduce_shifter), sign_128d));
-    double const m_shifted = θ * (2 / π) + signed_shifter;
-    double const m_double = m_shifted - signed_shifter;
-    __m128 const sign_128 = _mm_castpd_ps(sign_128d);
-    std::int64_t const m = _mm_cvtsi128_si32(_mm_sign_epi32(
-        _mm_castpd_si128(
-            _mm_and_pd(mantissa_reduce_bits, _mm_set_sd(m_shifted))),
-        _mm_castps_si128(_mm_or_ps(_mm_shuffle_ps(sign_128, sign_128, 1),
-                                   _mm_castsi128_ps(_mm_cvtsi32_si128(1))))));
+    double const abs_θ = std::abs(θ);
+    __m128d const sign = _mm_and_pd(sign_bit, _mm_set_sd(θ));
+    double const m_shifted = abs_θ * (2 / π) + mantissa_reduce_shifter;
+    double const m_double = _mm_cvtsd_f64(
+        _mm_xor_pd(_mm_set_sd(m_shifted - mantissa_reduce_shifter), sign));
+    std::int64_t const m = _mm_cvtsd_si64(_mm_set_sd(m_double));
 
     EXPECT_EQ(n, m);
     EXPECT_EQ(m, m_double);

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -64,12 +64,10 @@ TEST_F(SinCosTest, ReduceIndex) {
   static constexpr std::int64_t π_over_2_zeroes = 18;
   static const __m128d sign_bit =
       _mm_castsi128_pd(_mm_cvtsi64_si128(0x8000'0000'0000'0000));
-  static const __m128d mantissa_reduce_bits =
-      _mm_castsi128_pd(_mm_cvtsi64_si128((1LL << π_over_2_zeroes) - 1));
   static constexpr double mantissa_reduce_shifter =
       1LL << (std::numeric_limits<double>::digits - 1);
   std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(0.0, 1000.0);
+  std::uniform_real_distribution<> uniformly_at(-1000.0, 1000.0);
 
   for (std::int64_t i = 0; i < iterations; ++i) {
     double const θ = uniformly_at(random);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -83,8 +83,6 @@ static const __m128d mantissa_bits =
     _mm_castsi128_pd(_mm_cvtsi64_si128(0x000f'ffff'ffff'ffff));
 static const __m128d mantissa_index_bits =
     _mm_castsi128_pd(_mm_cvtsi64_si128(0x0000'0000'0000'01ff));
-static const __m128d mantissa_reduce_bits =
-    _mm_castsi128_pd(_mm_cvtsi64_si128((1LL << π_over_2_zeroes) - 1));
 }  // namespace masks
 
 inline std::int64_t AccurateTableIndex(double const abs_x) {


### PR DESCRIPTION
Don't use the `roundsd` instruction but use an addition and a subtraction to drop the fractional part.  This in turn makes it possible to use FMA in two places.

Comparison on Zen 3. Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.38   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
       principia_cos           66.19   +0.00   +0.45   +0.45   +0.45   +0.90   +0.90
       principia_sin           67.09   +0.45   +0.45   +0.45   +0.45   +0.90   +0.90
R   sqrtps_xmm0_xmm0      14   13.90   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           54.47   +0.45   +0.45   +0.45   +0.45   +0.90   +0.90
             std_sin           63.03   +0.00   +0.00   +0.00   +0.00   +0.00   +0.45
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.38   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
       principia_cos           65.73   +0.00   +0.00   +0.45   +0.45   +0.90   +0.90
       principia_sin           64.83   +1.35   +1.80   +1.80   +1.80   +2.25   +2.25
R   sqrtps_xmm0_xmm0      14   13.90   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           55.37   +0.45   +0.90   +0.90   +0.90   +0.90   +0.90
             std_sin           63.03   +0.00   +0.00   +0.00   +0.00   +0.00   +0.45
```
Comparison on Golden Cove. Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            6.82   +0.16   +0.18   +0.20   +0.22   +0.24   +1.72
    sqrtps_xmm0_xmm0           27.04   +0.22   +0.26   +0.26   +0.28   +0.32   +0.36
     mulsd_xmm0_xmm0           14.04   +0.14   +0.18   +0.62   +0.64   +0.66   +0.70
  mulsd_xmm0_xmm0_4x           32.34   +0.12   +0.20   +1.30   +1.32   +1.36   +1.42
Slope: 0.623174 cycle/TSC
Correlation coefficient: 0.998850
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.26   +0.10   +0.11   +0.12   +0.14   +0.15   +0.16
R    mulsd_xmm0_xmm0       4    4.26   +0.34   +0.36   +0.37   +0.39   +0.40   +0.42
R mulsd_xmm0_xmm0_4x      16   15.65   +0.10   +0.79   +0.82   +0.82   +0.85   +0.88
       principia_cos           71.20   +0.90   +1.45   +2.18   +2.58   +3.10   +3.60
       principia_sin           75.37   +0.70   +0.91   +1.11   +1.21   +1.41   +1.65
R   sqrtps_xmm0_xmm0      12   12.39   +0.10   +0.12   +0.14   +0.15   +0.17   +0.20
             std_cos           54.51   +1.10   +1.27   +1.38   +1.43   +1.53   +1.66
             std_sin           64.19   +0.14   +0.20   +0.26   +0.30   +0.37   +0.46
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            6.74   +0.22   +0.24   +0.26   +0.28   +0.30   +0.32
    sqrtps_xmm0_xmm0           26.94   +0.32   +0.34   +0.36   +0.38   +0.42   +0.46
     mulsd_xmm0_xmm0           14.04   +0.14   +0.58   +0.62   +0.64   +0.66   +0.70
  mulsd_xmm0_xmm0_4x           32.36   +0.10   +1.22   +1.28   +1.30   +1.34   +1.40
Slope: 0.622294 cycle/TSC
Correlation coefficient: 0.998924
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.23   +0.11   +0.11   +0.12   +0.14   +0.15   +0.16
R    mulsd_xmm0_xmm0       4    4.30   +0.06   +0.09   +0.36   +0.37   +0.39   +0.41
R mulsd_xmm0_xmm0_4x      16   15.64   +0.10   +0.19   +0.83   +0.85   +0.87   +0.91
       principia_cos           69.40   +0.35   +0.54   +0.71   +0.80   +0.97   +1.17
       principia_sin           70.49   +0.41   +0.58   +0.73   +0.82   +0.97   +1.15
R   sqrtps_xmm0_xmm0      12   12.44   +0.06   +0.09   +0.10   +0.11   +0.12   +0.15
             std_cos           55.23   +0.42   +0.52   +0.62   +0.68   +0.77   +0.88
             std_sin           64.13   +0.12   +0.20   +0.26   +0.30   +0.37   +0.46
```