### PR TITLE
Do not preserve the sign in argument reduction if computing a Cos

### DIFF
--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -64,12 +64,10 @@ TEST_F(SinCosTest, ReduceIndex) {
   static constexpr std::int64_t π_over_2_zeroes = 18;
   static const __m128d sign_bit =
       _mm_castsi128_pd(_mm_cvtsi64_si128(0x8000'0000'0000'0000));
-  static const __m128d mantissa_reduce_bits =
-      _mm_castsi128_pd(_mm_cvtsi64_si128((1LL << π_over_2_zeroes) - 1));
   static constexpr double mantissa_reduce_shifter =
       1LL << (std::numeric_limits<double>::digits - 1);
   std::mt19937_64 random(42);
-  std::uniform_real_distribution<> uniformly_at(0.0, 1000.0);
+  std::uniform_real_distribution<> uniformly_at(-1000.0, 1000.0);
 
   for (std::int64_t i = 0; i < iterations; ++i) {
     double const θ = uniformly_at(random);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -171,8 +171,8 @@ inline void Reduce(Argument const θ,
         FusedMultiplyAdd<fma_policy>(abs_θ, (2 / π), mantissa_reduce_shifter) -
         mantissa_reduce_shifter;
 
-    // Don't move the computation of `n` before the loop, it generates some
-    // extra moves.
+    // Don't move the computation of `n` after the if, it generates some extra
+    // moves.
     Argument value;
     std::int64_t n;
     if constexpr (preserve_sign) {

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -169,9 +169,10 @@ inline void Reduce(Argument const θ,
     __m128d const sign = _mm_and_pd(masks::sign_bit, _mm_set_sd(θ));
     double const n_shifted =
         FusedMultiplyAdd<fma_policy>(abs_θ, (2 / π), mantissa_reduce_shifter);
-    double const n_double = _mm_cvtsd_f64(
-        _mm_xor_pd(_mm_set_sd(n_shifted - mantissa_reduce_shifter), sign));
-    std::int64_t const n = _mm_cvtsd_si64(_mm_set_sd(n_double));
+    __m128d const n_128d =
+        _mm_xor_pd(_mm_set_sd(n_shifted - mantissa_reduce_shifter), sign);
+    double const n_double = _mm_cvtsd_f64(n_128d);
+    std::int64_t const n = _mm_cvtsd_si64(n_128d);
 
     Argument const value =
         FusedNegatedMultiplyAdd<fma_policy>(n_double, π_over_2_high, θ);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -171,14 +171,16 @@ inline void Reduce(Argument const θ,
         FusedMultiplyAdd<fma_policy>(abs_θ, (2 / π), mantissa_reduce_shifter) -
         mantissa_reduce_shifter;
     Argument value;
+    std::int64_t n;
     if constexpr (preserve_sign) {
       n_double = _mm_cvtsd_f64(_mm_xor_pd(_mm_set_sd(n_double), sign));
+      n = _mm_cvtsd_si64(_mm_set_sd(n_double));
       value = FusedNegatedMultiplyAdd<fma_policy>(n_double, π_over_2_high, θ);
     } else {
+      n = _mm_cvtsd_si64(_mm_set_sd(n_double));
       value =
           FusedNegatedMultiplyAdd<fma_policy>(n_double, π_over_2_high, abs_θ);
     }
-    std::int64_t const n = _mm_cvtsd_si64(_mm_set_sd(n_double));
 
     Argument const error = n_double * π_over_2_low;
     θ_reduced = QuickTwoDifference(value, error);

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -170,6 +170,9 @@ inline void Reduce(Argument const θ,
     double n_double =
         FusedMultiplyAdd<fma_policy>(abs_θ, (2 / π), mantissa_reduce_shifter) -
         mantissa_reduce_shifter;
+
+    // Don't move the computation of `n` before the loop, it generates some
+    // extra moves.
     Argument value;
     std::int64_t n;
     if constexpr (preserve_sign) {

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -83,8 +83,6 @@ static const __m128d mantissa_bits =
     _mm_castsi128_pd(_mm_cvtsi64_si128(0x000f'ffff'ffff'ffff));
 static const __m128d mantissa_index_bits =
     _mm_castsi128_pd(_mm_cvtsi64_si128(0x0000'0000'0000'01ff));
-static const __m128d mantissa_reduce_bits =
-    _mm_castsi128_pd(_mm_cvtsi64_si128((1LL << π_over_2_zeroes) - 1));
 }  // namespace masks
 
 inline std::int64_t AccurateTableIndex(double const abs_x) {


### PR DESCRIPTION
Comparison on Zen 3.  Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.00   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
       principia_cos           65.73   +0.00   +0.00   +0.45   +0.45   +0.90   +0.90
       principia_sin           66.19   +0.00   +0.45   +0.45   +0.45   +0.90   +0.90
R   sqrtps_xmm0_xmm0      14   13.90   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           55.37   +0.45   +0.90   +0.90   +0.90   +0.90   +0.90
             std_sin           63.03   +0.00   +0.00   +0.00   +0.00   +0.00   +0.45
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
    sqrtps_xmm0_xmm0           16.72   +0.38   +0.38   +0.38   +0.38   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
Slope: 1.186186 cycle/TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
       principia_cos           63.48   +0.45   +0.45   +0.45   +0.90   +0.90   +0.90
       principia_sin           66.19   +0.45   +0.45   +0.45   +0.90   +0.90   +0.90
R   sqrtps_xmm0_xmm0      14   13.90   +0.45   +0.45   +0.45   +0.45   +0.45   +0.45
             std_cos           54.47   +0.45   +0.45   +0.45   +0.45   +0.90   +0.90
             std_sin           63.03   +0.00   +0.00   +0.00   +0.00   +0.00   +0.45
```
Comparison on Golden Cove.  Before:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            6.76   +0.08   +0.10   +0.14   +0.14   +0.18   +0.20
    sqrtps_xmm0_xmm0           27.10   +0.16   +0.20   +0.22   +0.26   +0.28   +0.34
     mulsd_xmm0_xmm0           14.04   +0.10   +0.16   +0.64   +0.66   +0.70   +0.72
  mulsd_xmm0_xmm0_4x           32.34   +0.12   +0.22   +1.32   +1.34   +1.38   +1.46
Slope: 0.621248 cycle/TSC
Correlation coefficient: 0.998706
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.29   +0.07   +0.09   +0.11   +0.11   +0.14   +0.16
R    mulsd_xmm0_xmm0       4    4.26   +0.05   +0.09   +0.19   +0.41   +0.43   +0.46
R mulsd_xmm0_xmm0_4x      16   15.58   +0.07   +0.14   +0.27   +0.88   +0.92   +0.97
       principia_cos           67.01   +0.48   +0.73   +1.04   +1.29   +1.85   +2.48
       principia_sin           67.93   +0.71   +1.01   +1.33   +1.53   +1.93   +2.70
R   sqrtps_xmm0_xmm0      12   12.40   +0.09   +0.11   +0.14   +0.16   +0.20   +0.29
             std_cos           54.78   +0.75   +0.89   +1.04   +1.12   +1.28   +1.57
             std_sin           64.05   +0.15   +0.24   +0.36   +0.46   +0.82   +1.21
```
After:
```
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            6.72   +0.12   +0.16   +0.18   +0.18   +0.22   +0.28
    sqrtps_xmm0_xmm0           27.08   +0.18   +0.22   +0.26   +0.28   +0.32   +0.36
     mulsd_xmm0_xmm0           13.96   +0.18   +0.26   +0.74   +0.74   +0.78   +0.80
  mulsd_xmm0_xmm0_4x           32.34   +0.10   +0.16   +1.30   +1.34   +1.38   +1.46
Slope: 0.619980 cycle/TSC
Correlation coefficient: 0.998773
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.25   +0.07   +0.10   +0.11   +0.11   +0.14   +0.17
R    mulsd_xmm0_xmm0       4    4.24   +0.11   +0.15   +0.45   +0.46   +0.48   +0.51
R mulsd_xmm0_xmm0_4x      16   15.59   +0.12   +0.22   +0.87   +0.89   +0.92   +0.95
       principia_cos           63.93   +1.46   +1.81   +2.12   +2.29   +2.59   +3.00
       principia_sin           67.92   +0.58   +0.91   +1.22   +1.40   +1.76   +2.42
R   sqrtps_xmm0_xmm0      12   12.39   +0.11   +0.14   +0.16   +0.19   +0.22   +0.31
             std_cos           54.97   +0.47   +0.63   +0.78   +0.86   +1.02   +1.28
             std_sin           63.92   +0.19   +0.27   +0.40   +0.51   +0.88   +1.25
```