### PR TITLE
Use indirect calls for Sin and Cos

### DIFF
--- a/benchmarks/elementary_functions_benchmark.cpp
+++ b/benchmarks/elementary_functions_benchmark.cpp
@@ -17,13 +17,16 @@ namespace functions {
 
 using namespace principia::benchmarks::_metric;
 using namespace principia::numerics::_sin_cos;
+namespace sin_cos = principia::numerics::_sin_cos;
 
-static constexpr std::int64_t number_of_iterations = 1000;
+constexpr std::int64_t number_of_iterations = 1000;
 
 template<Metric metric, double (__cdecl *fn)(double)>
 void BM_EvaluateElementaryFunction(benchmark::State& state) {
   using Value = double;
   using Argument = double;
+
+  sin_cos::StaticInitialization();
 
   std::mt19937_64 random(42);
   std::uniform_real_distribution<> uniformly_at(-2 * π, 2 * π);

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -26,11 +26,12 @@ using namespace principia::functions::_multiprecision;
 using namespace principia::numerics::_next;
 using namespace principia::numerics::_sin_cos;
 using namespace principia::testing_utilities::_almost_equals;
+namespace sin_cos = principia::numerics::_sin_cos;
 
 class SinCosTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    StaticInitialization();
+    sin_cos::StaticInitialization();
   }
 
   double a_ = 1.0;

--- a/functions/sin_cos_test.cpp
+++ b/functions/sin_cos_test.cpp
@@ -29,6 +29,10 @@ using namespace principia::testing_utilities::_almost_equals;
 
 class SinCosTest : public ::testing::Test {
  protected:
+  static void SetUpTestCase() {
+    StaticInitialization();
+  }
+
   double a_ = 1.0;
 };
 

--- a/nanobenchmarks/main.cpp
+++ b/nanobenchmarks/main.cpp
@@ -89,6 +89,7 @@ using namespace principia::nanobenchmarks::_microarchitectures;
 using namespace principia::nanobenchmarks::_performance_settings_controller;
 using namespace principia::numerics::_sin_cos;
 using namespace principia::testing_utilities::_statistics;
+namespace sin_cos = principia::numerics::_sin_cos;
 
 struct LatencyDistributionTable {
   double min;
@@ -211,7 +212,7 @@ std::size_t FormattedWidth(std::string const& s) {
 }
 
 void Main() {
-  StaticInitialization();
+  sin_cos::StaticInitialization();
   std::regex const name_matcher(absl::GetFlag(FLAGS_benchmark_filter));
   auto controller = PerformanceSettingsController::New();
   std::unique_ptr<Logger> logger;

--- a/nanobenchmarks/main.cpp
+++ b/nanobenchmarks/main.cpp
@@ -24,6 +24,7 @@
 #include "nanobenchmarks/function_registry.hpp"
 #include "nanobenchmarks/microarchitectures.hpp"
 #include "nanobenchmarks/performance_settings_controller.hpp"
+#include "numerics/sin_cos.hpp"
 #include "testing_utilities/statistics.hpp"
 
 
@@ -86,6 +87,7 @@ using namespace principia::mathematica::_mathematica;
 using namespace principia::nanobenchmarks::_function_registry;
 using namespace principia::nanobenchmarks::_microarchitectures;
 using namespace principia::nanobenchmarks::_performance_settings_controller;
+using namespace principia::numerics::_sin_cos;
 using namespace principia::testing_utilities::_statistics;
 
 struct LatencyDistributionTable {
@@ -209,6 +211,7 @@ std::size_t FormattedWidth(std::string const& s) {
 }
 
 void Main() {
+  StaticInitialization();
   std::regex const name_matcher(absl::GetFlag(FLAGS_benchmark_filter));
   auto controller = PerformanceSettingsController::New();
   std::unique_ptr<Logger> logger;

--- a/numerics/osaca.hpp
+++ b/numerics/osaca.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PRINCIPIA_USE_OSACA 1
+#define PRINCIPIA_USE_OSACA 0
 
 // The macros OSACA_FUNCTION_BEGIN and OSACA_RETURN are used to analyse the
 // latency of a double -> double function, as measured, e.g., by the

--- a/numerics/osaca.hpp
+++ b/numerics/osaca.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PRINCIPIA_USE_OSACA 0
+#define PRINCIPIA_USE_OSACA 1
 
 // The macros OSACA_FUNCTION_BEGIN and OSACA_RETURN are used to analyse the
 // latency of a double -> double function, as measured, e.g., by the

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -80,9 +80,9 @@ Value (__cdecl *sin)(Argument θ) = nullptr;
 
 // Forward declarations needed by the OSACA macros.
 template<FMAPolicy fma_policy>
-Value __cdecl Sin(Argument const θ);
+Value __cdecl Sin(Argument θ);
 template<FMAPolicy fma_policy>
-Value __cdecl Cos(Argument const θ);
+Value __cdecl Cos(Argument θ);
 
 namespace masks {
 __m128d const sign_bit =

--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -29,7 +29,7 @@ using namespace principia::quantities::_elementary_functions;
 
 #define OSACA_ANALYSED_FUNCTION Cos
 #define OSACA_ANALYSED_FUNCTION_NAMESPACE
-#define OSACA_ANALYSED_FUNCTION_TEMPLATE_PARAMETERS
+#define OSACA_ANALYSED_FUNCTION_TEMPLATE_PARAMETERS <FMAPolicy::Force>
 #define UNDER_OSACA_HYPOTHESES(expression)                                   \
   [&] {                                                                      \
     constexpr bool UseHardwareFMA = true;                                    \

--- a/numerics/sin_cos.hpp
+++ b/numerics/sin_cos.hpp
@@ -7,6 +7,8 @@ namespace numerics {
 namespace _sin_cos {
 namespace internal {
 
+void StaticInitialization();
+
 double __cdecl Sin(double x);
 double __cdecl Cos(double x);
 
@@ -14,6 +16,7 @@ double __cdecl Cos(double x);
 
 using internal::Cos;
 using internal::Sin;
+using internal::StaticInitialization;
 
 }  // namespace _sin_cos
 }  // namespace numerics


### PR DESCRIPTION
It removes some `if` statements, and more importantly gives a way to use the functions from the platform if needed (e.g., when loading a legacy save).  The performance is unaffected.

This requires to call the non-thread-safe `principia::numerics::_sin_cos::StaticInitialization` before calling `Sin` or `Cos`.