### PR TITLE
Detect UB in conversion of floats to integers during orbit analysis

### DIFF
--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -207,7 +207,7 @@ class OrbitAnalysisTest : public ::testing::Test {
         OrbitRecurrence::ClosestRecurrence(elements.nodal_period(),
                                            elements.nodal_precession(),
                                            earth_,
-                                           /*max_abs_Cᴛₒ=*/100);
+                                           /*max_abs_Cᴛₒ=*/100).value();
     // Since our ITRS-to-ICRS conversion disregards the precession of the
     // equinoxes, it is not completely clear which year we should be dealing
     // with here.  Given that the SP3 files have data in the ITRS (whose equator

--- a/astronomy/orbit_recurrence.hpp
+++ b/astronomy/orbit_recurrence.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "absl/status/statusor.h"
 #include "physics/rotating_body.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -49,7 +50,7 @@ class OrbitRecurrence final {
   // The Nᴛₒ / Cᴛₒ of the result is the last convergent of the κ obtained from
   // the given arguments whose denominator is less than `max_abs_Cᴛₒ`.
   template<typename Frame>
-  static OrbitRecurrence ClosestRecurrence(
+  static absl::StatusOr<OrbitRecurrence> ClosestRecurrence(
       Time const& nodal_period,
       AngularFrequency const& nodal_precession,
       RotatingBody<Frame> const& primary,

--- a/astronomy/orbit_recurrence_test.cpp
+++ b/astronomy/orbit_recurrence_test.cpp
@@ -1,5 +1,6 @@
 #include "astronomy/orbit_recurrence.hpp"
 
+#include <limits>
 #include <memory>
 
 #include "astronomy/frames.hpp"

--- a/ksp_plugin/orbit_analyser.cpp
+++ b/ksp_plugin/orbit_analyser.cpp
@@ -148,11 +148,14 @@ absl::Status OrbitAnalyser::AnalyseOrbit(Parameters const& parameters) {
       analysis.elements_ = std::move(elements).value();
       // TODO(egg): max_abs_Cᴛₒ should probably depend on the number of
       // revolutions.
-      analysis.closest_recurrence_ = OrbitRecurrence::ClosestRecurrence(
+      auto status_or_closest_recurrence = OrbitRecurrence::ClosestRecurrence(
           analysis.elements_->nodal_period(),
           analysis.elements_->nodal_precession(),
           *primary,
           /*max_abs_Cᴛₒ=*/100);
+      RETURN_IF_ERROR(status_or_closest_recurrence);
+      analysis.closest_recurrence_ =
+          std::move(status_or_closest_recurrence).value();
       if (analysis.closest_recurrence_->number_of_revolutions() == 0) {
         analysis.closest_recurrence_.reset();
       }

--- a/testing_utilities/matchers.hpp
+++ b/testing_utilities/matchers.hpp
@@ -19,6 +19,8 @@ namespace internal {
 
 // This is not defined in base/status_utilities.hpp to avoid pulling gmock in
 // non-test code.
+#define ASSERT_OK(value) \
+  ASSERT_THAT((value), ::principia::testing_utilities::_matchers::IsOk());
 #define EXPECT_OK(value) \
   EXPECT_THAT((value), ::principia::testing_utilities::_matchers::IsOk());
 


### PR DESCRIPTION
`ClosestRecurrence` now returns an error status if it trips on a floating-point value that cannot be represented as in `int`.

Fix #3831, #4162.