### PR TITLE
Avoid the repeated computation of positions in the barycentric reference frame

### DIFF
--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -112,18 +112,18 @@ class BarycentricRotatingReferenceFrame
 
   template<int degree>
   Derivative<Position<InertialFrame>, Instant, degree> PrimaryDerivative(
-      BodiesToPositions const& bodies_to_positions,
+      BodiesToPositions const* bodies_to_positions,
       Instant const& t) const;
   template<int degree>
   Derivative<Position<InertialFrame>, Instant, degree> SecondaryDerivative(
-      BodiesToPositions const& bodies_to_positions,
+      BodiesToPositions const* bodies_to_positions,
       Instant const& t) const;
   template<
       int degree,
       std::vector<not_null<MassiveBody const*>> const
           BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
   Derivative<Position<InertialFrame>, Instant, degree> BarycentreDerivative(
-      BodiesToPositions const& bodies_to_positions,
+      BodiesToPositions const* bodies_to_positions,
       Instant const& t,
       CachedDerivatives& cache) const;
 

--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -96,6 +96,8 @@ class BarycentricRotatingReferenceFrame
 
  private:
   using Base = RigidReferenceFrame<InertialFrame, ThisFrame>;
+  using BodiesToPositions =
+      typename Ephemeris<InertialFrame>::BodiesToPositions;
 
   template<typename SF, typename SB, int o = 0>
   using Trihedron = typename Base::template Trihedron<SF, SB, o>;
@@ -108,11 +110,20 @@ class BarycentricRotatingReferenceFrame
                                     Instant() + NaN<Time>};
   };
 
+  template<int degree>
+  Derivative<Position<InertialFrame>, Instant, degree> PrimaryDerivative(
+      BodiesToPositions const& bodies_to_positions,
+      Instant const& t) const;
+  template<int degree>
+  Derivative<Position<InertialFrame>, Instant, degree> SecondaryDerivative(
+      BodiesToPositions const& bodies_to_positions,
+      Instant const& t) const;
   template<
       int degree,
       std::vector<not_null<MassiveBody const*>> const
           BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
   Derivative<Position<InertialFrame>, Instant, degree> BarycentreDerivative(
+      BodiesToPositions const& bodies_to_positions,
       Instant const& t,
       CachedDerivatives& cache) const;
 

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -247,7 +247,7 @@ BarycentreDerivative(BodiesToPositions const* bodies_to_positions,
     int i = 0;
     for (not_null const body : this->*bodies) {
       if constexpr (degree == 0) {
-        result.Add(ephemeris_->trajectory(body)->EvaluatePosition(t),
+        result.Add(bodies_to_positions->at(body), 
                    body->gravitational_parameter());
       } else if constexpr (degree == 1) {
         result.Add(ephemeris_->trajectory(body)->EvaluateVelocity(t),

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -108,7 +108,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::PrimaryDerivative(
   absl::MutexLock l(&lock_);
   return BarycentreDerivative<degree,
                               &BarycentricRotatingReferenceFrame::primaries_>(
-      t, last_evaluated_primary_derivatives_);
+      ephemeris_->EvaluateAllPositions(t),
+      t,
+      last_evaluated_primary_derivatives_);
 }
 
 template<typename InertialFrame, typename ThisFrame>
@@ -119,7 +121,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
   absl::MutexLock l(&lock_);
   return BarycentreDerivative<degree,
                               &BarycentricRotatingReferenceFrame::secondaries_>(
-      t, last_evaluated_secondary_derivatives_);
+      ephemeris_->EvaluateAllPositions(t),
+      t,
+      last_evaluated_secondary_derivatives_);
 }
 
 template<typename InertialFrame, typename ThisFrame>
@@ -140,12 +144,13 @@ template<typename InertialFrame, typename ThisFrame>
 RigidMotion<InertialFrame, ThisFrame>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
     Instant const& t) const {
-  auto const r₁ = PrimaryDerivative<0>(t);
-  auto const ṙ₁ = PrimaryDerivative<1>(t);
-  auto const r̈₁ = PrimaryDerivative<2>(t);
-  auto const r₂ = SecondaryDerivative<0>(t);
-  auto const ṙ₂ = SecondaryDerivative<1>(t);
-  auto const r̈₂ = SecondaryDerivative<2>(t);
+  auto const bodies_to_positions = ephemeris_->EvaluateAllPositions(t);
+  auto const r₁ = PrimaryDerivative<0>(bodies_to_positions, t);
+  auto const ṙ₁ = PrimaryDerivative<1>(bodies_to_positions, t);
+  auto const r̈₁ = PrimaryDerivative<2>(bodies_to_positions, t);
+  auto const r₂ = SecondaryDerivative<0>(bodies_to_positions, t);
+  auto const ṙ₂ = SecondaryDerivative<1>(bodies_to_positions, t);
+  auto const r̈₂ = SecondaryDerivative<2>(bodies_to_positions, t);
   return ToThisFrame({r₁, ṙ₁, r̈₁}, {r₂, ṙ₂, r̈₂});
 }
 
@@ -185,13 +190,39 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ReadFromMessage(
 }
 
 template<typename InertialFrame, typename ThisFrame>
+template<int degree>
+Derivative<Position<InertialFrame>, Instant, degree>
+BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
+PrimaryDerivative(BodiesToPositions const& bodies_to_positions,
+                  Instant const& t) const {
+  absl::MutexLock l(&lock_);
+  return BarycentreDerivative<degree,
+                              &BarycentricRotatingReferenceFrame::primaries_>(
+      bodies_to_positions, t, last_evaluated_primary_derivatives_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
+template<int degree>
+Derivative<Position<InertialFrame>, Instant, degree>
+BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
+SecondaryDerivative(BodiesToPositions const& bodies_to_positions,
+                    Instant const& t) const {
+  absl::MutexLock l(&lock_);
+  return BarycentreDerivative<degree,
+                              &BarycentricRotatingReferenceFrame::secondaries_>(
+      bodies_to_positions, t, last_evaluated_secondary_derivatives_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
 template<
     int degree,
     std::vector<not_null<MassiveBody const*>> const
         BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::*bodies>
 Derivative<Position<InertialFrame>, Instant, degree>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
-BarycentreDerivative(Instant const& t, CachedDerivatives& cache) const {
+BarycentreDerivative(BodiesToPositions const& bodies_to_positions,
+                     Instant const& t,
+                     CachedDerivatives& cache) const {
   Instant& cache_key = cache.times[degree];
   auto& cached = std::get<degree>(cache.derivatives);
   if (cache_key != t) {
@@ -201,7 +232,7 @@ BarycentreDerivative(Instant const& t, CachedDerivatives& cache) const {
         result;
     if constexpr (degree == 2) {
       all = ephemeris_->ComputeGravitationalAccelerationOnMassiveBodies(
-          this->*bodies, t);
+          this->*bodies, bodies_to_positions, t);
     }
     int i = 0;
     for (not_null const body : this->*bodies) {
@@ -244,14 +275,15 @@ template<typename InertialFrame, typename ThisFrame>
 AcceleratedRigidMotion<InertialFrame, ThisFrame>
 BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::MotionOfThisFrame(
     Instant const& t) const {
-  auto const r₁ = PrimaryDerivative<0>(t);
-  auto const ṙ₁ = PrimaryDerivative<1>(t);
-  auto const r̈₁ = PrimaryDerivative<2>(t);
-  auto const r₁⁽³⁾ = PrimaryDerivative<3>(t);
-  auto const r₂ = SecondaryDerivative<0>(t);
-  auto const ṙ₂ = SecondaryDerivative<1>(t);
-  auto const r̈₂ = SecondaryDerivative<2>(t);
-  auto const r₂⁽³⁾ = SecondaryDerivative<3>(t);
+  auto const bodies_to_positions = ephemeris_->EvaluateAllPositions(t);
+  auto const r₁ = PrimaryDerivative<0>(bodies_to_positions, t);
+  auto const ṙ₁ = PrimaryDerivative<1>(bodies_to_positions, t);
+  auto const r̈₁ = PrimaryDerivative<2>(bodies_to_positions, t);
+  auto const r₁⁽³⁾ = PrimaryDerivative<3>(bodies_to_positions, t);
+  auto const r₂ = SecondaryDerivative<0>(bodies_to_positions, t);
+  auto const ṙ₂ = SecondaryDerivative<1>(bodies_to_positions, t);
+  auto const r̈₂ = SecondaryDerivative<2>(bodies_to_positions, t);
+  auto const r₂⁽³⁾ = SecondaryDerivative<3>(bodies_to_positions, t);
 
   auto const to_this_frame = ToThisFrame({r₁, ṙ₁, r̈₁}, {r₂, ṙ₂, r̈₂});
 

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -247,7 +247,7 @@ BarycentreDerivative(BodiesToPositions const* bodies_to_positions,
     int i = 0;
     for (not_null const body : this->*bodies) {
       if constexpr (degree == 0) {
-        result.Add(bodies_to_positions->at(body), 
+        result.Add(bodies_to_positions->at(body),
                    body->gravitational_parameter());
       } else if constexpr (degree == 1) {
         result.Add(ephemeris_->trajectory(body)->EvaluateVelocity(t),

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -260,10 +260,12 @@ class Ephemeris {
       not_null<MassiveBody const*> body,
       Instant const& t) const EXCLUDES(lock_);
 
-  //TODO(phl):comment
-  virtual std::vector<Vector<Acceleration, Frame>>
-  ComputeGravitationalAccelerationOnMassiveBodies(
-      std::vector<not_null<MassiveBody const*>> const& bodies,
+  // Same as above, but the positions have been precomputed by
+  // `EvaluateAllPositions`.  The client must ensure that the evaluation was for
+  // time `t`.
+  virtual Vector<Acceleration, Frame>
+  ComputeGravitationalAccelerationOnMassiveBody(
+      not_null<MassiveBody const*> body,
       BodiesToPositions const& bodies_to_positions,
       Instant const& t) const;
 
@@ -378,6 +380,15 @@ class Ephemeris {
       std::size_t b2_end,
       std::vector<DegreesOfFreedom<Frame>> const& degrees_of_freedom,
       std::vector<Vector<Jerk, Frame>>& jerks);
+
+  // Returns the gravitational acceleration on the massive `body` at time `t`.
+  // The `positions` must be for all the bodies in this object, in the order of
+  // `bodies_` and must have been evaluated at time `t`.
+  Vector<Acceleration, Frame>
+  ComputeGravitationalAccelerationOnMassiveBody(
+      not_null<MassiveBody const*> const body,
+      std::vector<Position<Frame>> const& positions,
+      Instant const& t) const;
 
   // Computes the accelerations between one body, `body1` (with index `b1` in
   // the `positions` and `accelerations` arrays) and the bodies `bodies2` (with

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -260,12 +260,12 @@ class Ephemeris {
       not_null<MassiveBody const*> body,
       Instant const& t) const EXCLUDES(lock_);
 
-  // Same as above, but the positions have been precomputed by
-  // `EvaluateAllPositions`.  The client must ensure that the evaluation was for
-  // time `t`.
-  virtual Vector<Acceleration, Frame>
-  ComputeGravitationalAccelerationOnMassiveBody(
-      not_null<MassiveBody const*> body,
+  // Same as above, but for multiple bodies.  The positions must have been
+  // precomputed by `EvaluateAllPositions`.  The client must ensure that the
+  // evaluation was for time `t`.
+  virtual std::vector<Vector<Acceleration, Frame>>
+  ComputeGravitationalAccelerationOnMassiveBodies(
+      std::vector<not_null<MassiveBody const*>> const& bodies,
       BodiesToPositions const& bodies_to_positions,
       Instant const& t) const;
 

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -244,6 +244,12 @@ class Ephemeris {
       not_null<MassiveBody const*> body,
       Instant const& t) const EXCLUDES(lock_);
 
+  //TODO(phl):comment
+  virtual std::vector<Vector<Acceleration, Frame>>
+  ComputeGravitationalAccelerationOnMassiveBodies(
+      std::vector<not_null<MassiveBody const*>> const& bodies,
+      Instant const& t) const EXCLUDES(lock_);
+
   // Returns the potential at the given `position` at time `t`.
   SpecificEnergy ComputeGravitationalPotential(
       Position<Frame> const& position,
@@ -456,6 +462,9 @@ class Ephemeris {
   // The oblate bodies precede the spherical bodies in this vector.  The system
   // state is indexed in the same order.
   std::vector<not_null<std::unique_ptr<MassiveBody const>>> bodies_;
+
+  // The indices of bodies in `bodies_`.
+  std::map<not_null<MassiveBody const*>, int> bodies_indices_;
 
   // Only has entries for the oblate bodies, at the same indices as `bodies_`.
   std::vector<Geopotential<Frame>> geopotentials_;

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -78,6 +78,13 @@ class Ephemeris {
   static std::int64_t constexpr unlimited_max_ephemeris_steps =
       std::numeric_limits<std::int64_t>::max();
 
+  using BodiesToPositions =
+      std::map<not_null<MassiveBody const*>, Position<Frame>>;
+  using BodiesToVelocities =
+      std::map<not_null<MassiveBody const*>, Velocity<Frame>>;
+  using BodiesToDegreesOfFreedom =
+      std::map<not_null<MassiveBody const*>, DegreesOfFreedom<Frame>>;
+
   // The equations describing the motion of the `bodies_`.
   using NewtonianMotionEquation =
       SpecialSecondOrderDifferentialEquation<Position<Frame>>;
@@ -137,6 +144,15 @@ class Ephemeris {
   planetary_integrator() const;
 
   virtual absl::Status last_severe_integration_status() const;
+
+  // Convenience methods to evaluate the positions/velocities for all bodies in
+  // this ephemeris.
+  BodiesToPositions EvaluateAllPositions(Instant const& t) const
+      EXCLUDES(lock_);
+  BodiesToVelocities EvaluateAllVelocities(Instant const& t) const
+      EXCLUDES(lock_);
+  BodiesToDegreesOfFreedom EvaluateAllDegreesOfFreedom(Instant const& t) const
+      EXCLUDES(lock_);
 
   // Prolongs the ephemeris up to at least `t`.  Returns an error iff the thread
   // is stopped.  After a successful call with the second parameter defaulted,

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -264,7 +264,8 @@ class Ephemeris {
   virtual std::vector<Vector<Acceleration, Frame>>
   ComputeGravitationalAccelerationOnMassiveBodies(
       std::vector<not_null<MassiveBody const*>> const& bodies,
-      Instant const& t) const EXCLUDES(lock_);
+      BodiesToPositions const& bodies_to_positions,
+      Instant const& t) const;
 
   // Returns the potential at the given `position` at time `t`.
   SpecificEnergy ComputeGravitationalPotential(

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -727,7 +727,6 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
     std::vector<not_null<MassiveBody const*>> const& bodies,
     BodiesToPositions const& bodies_to_positions,
     Instant const& t) const {
-  std::vector<Vector<Acceleration, Frame>> result;
 
   // Put the positions in the order needed by the rest of the computation.
   std::vector<Position<Frame>> positions;
@@ -736,6 +735,8 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
     positions.push_back(bodies_to_positions.at(body.get()));
   }
 
+  std::vector<Vector<Acceleration, Frame>> result;
+  result.reserve(bodies.size());
   for (auto const& body : bodies) {
     std::vector<Vector<Acceleration, Frame>> accelerations(bodies_.size());
     int const b1 = FindOrDie(bodies_indices_, body);

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -640,17 +640,11 @@ Vector<Acceleration, Frame>
 Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBody(
     not_null<MassiveBody const*> const body,
     Instant const& t) const {
-  return ComputeGravitationalAccelerationOnMassiveBodies({body}, t).front();
-}
-
-template<typename Frame>
-std::vector<Vector<Acceleration, Frame>>
-Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
-    std::vector<not_null<MassiveBody const*>> const& bodies,
-    Instant const& t) const {
-  std::vector<Vector<Acceleration, Frame>> result;
+  bool const body_is_oblate = body->is_oblate();
 
   std::vector<Position<Frame>> positions;
+  std::vector<Vector<Acceleration, Frame>> accelerations(bodies_.size());
+  int b1 = -1;
 
   // Evaluate the `positions`.  Locking is necessary to be able to call the
   // "locked" method of each trajectory.
@@ -660,8 +654,86 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
     for (int b = 0; b < bodies_.size(); ++b) {
       auto const& current_body = bodies_[b];
       auto const& current_body_trajectory = trajectories_[b];
+      if (current_body.get() == body) {
+        CHECK_EQ(-1, b1);
+        b1 = b;
+      }
       positions.push_back(current_body_trajectory->EvaluatePositionLocked(t));
     }
+    CHECK_LE(0, b1);
+  }
+
+  if (body_is_oblate) {
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/true,
+        /*body2_is_oblate=*/true>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/0, /*b2_end=*/b1,
+        positions, accelerations, geopotentials_);
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/true,
+        /*body2_is_oblate=*/true>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/b1 + 1, /*b2_end=*/number_of_oblate_bodies_,
+        positions, accelerations, geopotentials_);
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/true,
+        /*body2_is_oblate=*/false>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/number_of_oblate_bodies_,
+        /*b2_end=*/number_of_oblate_bodies_ + number_of_spherical_bodies_,
+        positions, accelerations, geopotentials_);
+  } else {
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/false,
+        /*body2_is_oblate=*/true>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/0, /*b2_end=*/number_of_oblate_bodies_,
+        positions, accelerations, geopotentials_);
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/false,
+        /*body2_is_oblate=*/false>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/number_of_oblate_bodies_,
+        /*b2_end=*/b1,
+        positions, accelerations, geopotentials_);
+    ComputeGravitationalAccelerationByMassiveBodyOnMassiveBodies<
+        /*body1_is_oblate=*/false,
+        /*body2_is_oblate=*/false>(
+        t,
+        /*body1=*/*body, b1,
+        /*bodies2=*/bodies_,
+        /*b2_begin=*/b1 + 1,
+        /*b2_end=*/number_of_oblate_bodies_ + number_of_spherical_bodies_,
+        positions, accelerations, geopotentials_);
+  }
+
+  return accelerations[b1];
+}
+
+template<typename Frame>
+std::vector<Vector<Acceleration, Frame>>
+Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
+    std::vector<not_null<MassiveBody const*>> const& bodies,
+    BodiesToPositions const& bodies_to_positions,
+    Instant const& t) const {
+  std::vector<Vector<Acceleration, Frame>> result;
+
+  // Put the positions in the order needed by the rest of the computation.
+  std::vector<Position<Frame>> positions;
+  positions.reserve(bodies_.size());
+  for (auto const& body : bodies_) {
+    positions.push_back(bodies_to_positions.at(body.get()));
   }
 
   for (auto const& body : bodies) {

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -221,6 +221,42 @@ absl::Status Ephemeris<Frame>::last_severe_integration_status() const {
 }
 
 template<typename Frame>
+Ephemeris<Frame>::BodiesToPositions Ephemeris<Frame>::EvaluateAllPositions(
+    Instant const& t) const {
+  absl::ReaderMutexLock l(&lock_);
+  BodiesToPositions all_positions;
+  for (int i = 0; i < bodies_.size(); ++i) {
+    all_positions.emplace(bodies_[i].get(),
+                          trajectories_[i]->EvaluatePositionLocked(t));
+  }
+  return all_positions;
+}
+
+template<typename Frame>
+Ephemeris<Frame>::BodiesToVelocities Ephemeris<Frame>::EvaluateAllVelocities(
+    Instant const& t) const {
+  absl::ReaderMutexLock l(&lock_);
+  BodiesToVelocities all_velocities;
+  for (int i = 0; i < bodies_.size(); ++i) {
+    all_velocities.emplace(bodies_[i].get(),
+                          trajectories_[i]->EvaluateVelocityLocked(t));
+  }
+  return all_velocities;
+}
+
+template<typename Frame>
+Ephemeris<Frame>::BodiesToDegreesOfFreedom
+Ephemeris<Frame>::EvaluateAllDegreesOfFreedom(Instant const& t) const {
+  absl::ReaderMutexLock l(&lock_);
+  BodiesToDegreesOfFreedom all_degrees_of_freedom;
+  for (int i = 0; i < bodies_.size(); ++i) {
+    all_degrees_of_freedom.emplace(
+        bodies_[i].get(), trajectories_[i]->EvaluateDegreesOfFreedomLocked(t));
+  }
+  return all_degrees_of_freedom;
+}
+
+template<typename Frame>
 void Ephemeris<Frame>::RequestReanimation(Instant const& desired_t_min) {
   reanimator_.Start();
 

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -657,9 +657,9 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBody(
 }
 
 template<typename Frame>
-Vector<Acceleration, Frame>
-Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBody(
-    not_null<MassiveBody const*> const body,
+std::vector<Vector<Acceleration, Frame>>
+Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBodies(
+    std::vector<not_null<MassiveBody const*>> const& bodies,
     BodiesToPositions const& bodies_to_positions,
     Instant const& t) const {
   // Put the positions in the order needed by the computation.
@@ -669,7 +669,13 @@ Ephemeris<Frame>::ComputeGravitationalAccelerationOnMassiveBody(
     positions.push_back(bodies_to_positions.at(body.get()));
   }
 
-  return ComputeGravitationalAccelerationOnMassiveBody(body, positions, t);
+  std::vector<Vector<Acceleration, Frame>> accelerations;
+  accelerations.reserve(bodies.size());
+  for (auto const& body : bodies) {
+    accelerations.push_back(
+        ComputeGravitationalAccelerationOnMassiveBody(body, positions, t));
+  }
+  return accelerations;
 }
 
 template<typename Frame>


### PR DESCRIPTION
For the rotating-pulsating frame it can result in a 2x speedup if there are many bodies in the frame.
Before:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations
------------------------------------------------------------------------------------------
BM_BodyCentredNonRotatingReferenceFrame/1024001        279 ms          281 ms            3
BM_BarycentricRotatingReferenceFrame/1024001          3965 ms         3953 ms            1
BM_RotatingPulsatingReferenceFrame/1024001           51332 ms        51297 ms            1
```
After:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations
------------------------------------------------------------------------------------------
BM_BodyCentredNonRotatingReferenceFrame/1024001        275 ms          281 ms            2
BM_BarycentricRotatingReferenceFrame/1024001          4945 ms         4938 ms            1
BM_RotatingPulsatingReferenceFrame/1024001           24687 ms        24672 ms            1
```