### PR TITLE
Statically link the UCRT

### DIFF
--- a/google_glog.props
+++ b/google_glog.props
@@ -5,10 +5,11 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\Google\glog\src\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>GOOGLE_GLOG_DLL_DECL=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SolutionDir)..\Google\glog\msvc\$(PrincipiaDependencyConfiguration)\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>glog.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>glog_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/google_glog.props
+++ b/google_glog.props
@@ -13,9 +13,4 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
-  <Target Name="CopyGlogDll" AfterTargets="Build">
-    <Copy SourceFiles="$(SolutionDir)..\Google\glog\msvc\$(PrincipiaDependencyConfiguration)\$(Platform)\glog.dll"
-          DestinationFolder="$(OutDir)"
-          SkipUnchangedFiles="true"/>
-  </Target>
 </Project>

--- a/google_protobuf.props
+++ b/google_protobuf.props
@@ -5,18 +5,12 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>PROTOBUF_USE_DLLS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\Google\protobuf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SolutionDir)..\Google\protobuf\vsprojects\$(PrincipiaDependencyConfiguration)\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libprotobuf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libprotobuf_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
-  <Target Name="CopyProtobufDll" AfterTargets="Build">
-    <Copy SourceFiles="$(SolutionDir)..\Google\protobuf\vsprojects\$(PrincipiaDependencyConfiguration)\$(Platform)\libprotobuf.dll"
-          DestinationFolder="$(OutDir)"
-          SkipUnchangedFiles="true"/>
-  </Target>
 </Project>

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -260,7 +260,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(
       (manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
       AnyOf(IsNear(1.292_(1) * Metre / Second),
-            IsNear(1.272_(1) * Metre / Second)));
+            IsNear(1.272_(1) * Metre)));
   EXPECT_EQ(124, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -319,7 +319,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
       AnyOf(IsNear(1.116_(1) * Metre / Second),
-            IsNear(1.112_(1) * Metre / Second)));
+            IsNear(1.112_(1) * Metre)));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
   EXPECT_THAT(flyby_time,
@@ -442,7 +442,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
       AnyOf(IsNear(0.715_(1) * Micro(Second)), Eq(0 * Second)));
   EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
               AnyOf(IsNear(1.615_(1) * Centi(Metre) / Second),
-                    IsNear(1.577_(1) * Centi(Metre) / Second)));
+                    IsNear(1.577_(1) * Centi(Metre))));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:09:20"_DateTime));
@@ -486,7 +486,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       AnyOf(IsNear(12.7_(1) * Metre / Second),
-            IsNear(12.3_(1) * Metre / Second)));
+            IsNear(12.3_(1) * Metre)));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
   EXPECT_THAT(flyby_time,

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -213,12 +213,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   Instant flyby_time;
   Length flyby_distance;
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:02:51"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(58591.4_(1) * Kilo(Metre)),
-                    IsNear(58534.2_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(58591.4_(1) * Kilo(Metre)));
 
   std::int64_t number_of_evaluations = 0;
   FlightPlanOptimizer optimizer(
@@ -237,11 +233,10 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      AnyOf(IsNear(7.39_(1) * Micro(Second)),
-            IsNear(14.31_(1) * Micro(Second))));
-  EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
-              AnyOf(IsNear(1.054_(1) * Metre / Second),
-                    IsNear(1.059_(1) * Metre / Second)));
+      IsNear(7.39_(1) * Micro(Second)));
+  EXPECT_THAT(
+      (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
+      IsNear(1.054_(1) * Metre / Second));
   EXPECT_EQ(113, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -255,12 +250,9 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
-      AnyOf(IsNear(12.1_(1) * Micro(Second)),
-            IsNear(-47.7_(1) * Micro(Second))));
-  EXPECT_THAT(
-      (manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
-      AnyOf(IsNear(1.292_(1) * Metre / Second),
-            IsNear(1.272_(1) * Metre)));
+      IsNear(12.1_(1) * Micro(Second)));
+  EXPECT_THAT((manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
+              IsNear(1.292_(1) * Metre / Second));
   EXPECT_EQ(124, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -274,8 +266,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_EQ(8, flight_plan_->number_of_anomalous_manœuvres());
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      AnyOf(IsNear(-77_(1) * Milli(Second)),
-            IsNear(-70_(1) * Milli(Second))));
+      IsNear(-77_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       IsNear(61.9_(1) * Metre / Second));
@@ -295,12 +286,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   Instant flyby_time;
   Length flyby_distance;
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:02:51"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(58591.4_(1) * Kilo(Metre)),
-                    IsNear(58534.2_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(58591.4_(1) * Kilo(Metre)));
 
   std::int64_t number_of_evaluations = 0;
   FlightPlanOptimizer optimizer(
@@ -314,20 +301,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      AnyOf(IsNear(43.8_(1) * Micro(Second)),
-            IsNear(31.4_(1) * Micro(Second))));
+      IsNear(43.8_(1) * Micro(Second)));
   EXPECT_THAT(
       (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
-      AnyOf(IsNear(1.116_(1) * Metre / Second),
-            IsNear(1.112_(1) * Metre)));
+      IsNear(1.116_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:24:00"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:23:44"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(2255.3_(1) * Kilo(Metre)),
-                    IsNear(2100.0_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:24:00"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2255.3_(1) * Kilo(Metre)));
   EXPECT_EQ(79, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -339,19 +320,13 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
-      AnyOf(IsNear(0.954_(1) * Micro(Second)),
-            Eq(0 * Second)));
+      IsNear(0.954_(1) * Micro(Second)));
   EXPECT_THAT((manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
-              AnyOf(IsNear(1.312_(1) * Metre / Second),
-                    IsNear(1.319_(1) * Metre / Second)));
+              IsNear(1.312_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:16:41"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:16:10"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(2001.4_(1) * Kilo(Metre)),
-                    IsNear(2025.7_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:16:41"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2001.4_(1) * Kilo(Metre)));
   EXPECT_EQ(72, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -363,19 +338,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      AnyOf(IsNear(2.1_(1) * Milli(Second)),
-            IsNear(2.9_(1) * Milli(Second))));
+      IsNear(2.1_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       IsNear(59.3_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:14:59"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:14:51"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(2000.2_(1) * Kilo(Metre)),
-                    IsNear(2000.5_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:14:59"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(2000.2_(1) * Kilo(Metre)));
   EXPECT_EQ(86, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -414,11 +384,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   Instant flyby_time;
   Angle flyby_inclination;
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:02:51"_DateTime)));
-  EXPECT_THAT(flyby_inclination,
-              AnyOf(IsNear(76.32_(1) * Degree), IsNear(76.64_(1) * Degree)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
+  EXPECT_THAT(flyby_inclination, IsNear(76.32_(1) * Degree));
 
   std::int64_t number_of_evaluations = 0;
   FlightPlanOptimizer optimizer(
@@ -438,10 +405,10 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      AnyOf(IsNear(0.715_(1) * Micro(Second)), Eq(0 * Second)));
-  EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
-              AnyOf(IsNear(1.615_(1) * Centi(Metre) / Second),
-                    IsNear(1.577_(1) * Centi(Metre))));
+      IsNear(0.715_(1) * Micro(Second)));
+  EXPECT_THAT(
+      (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
+      IsNear(1.615_(1) * Centi(Metre) / Second));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:09:20"_DateTime));
@@ -457,17 +424,13 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
-      AnyOf(Eq(0 * Second), IsNear(-0.119_(1) * Micro(Second))));
+      Eq(0 * Second));
   EXPECT_THAT((manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
-              AnyOf(IsNear(0.257_(1) * Metre / Second),
-                    IsNear(0.251_(1) * Metre / Second)));
+              IsNear(0.257_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:09:47"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:10:00"_DateTime)));
-  EXPECT_THAT(flyby_inclination,
-              AnyOf(IsNear(89.98_(1) * Degree), IsNear(90.00_(1) * Degree)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:09:47"_DateTime));
+  EXPECT_THAT(flyby_inclination, IsNear(89.98_(1) * Degree));
   EXPECT_EQ(34, number_of_evaluations);
   number_of_evaluations = 0;
 
@@ -479,17 +442,13 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      AnyOf(IsNear(0.46_(1) * Milli(Second)),
-            IsNear(0.60_(1) * Milli(Second))));
+      IsNear(0.46_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
-      AnyOf(IsNear(12.7_(1) * Metre / Second),
-            IsNear(12.3_(1) * Metre)));
+      IsNear(12.7_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:08:39"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:08:34"_DateTime)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:08:39"_DateTime));
   EXPECT_THAT(flyby_inclination, IsNear(90.00_(1) * Degree));
   EXPECT_EQ(54, number_of_evaluations);
   number_of_evaluations = 0;
@@ -504,12 +463,8 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
   Instant flyby_time;
   Length flyby_distance;
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:02:51"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(58591.4_(1) * Kilo(Metre)),
-                    IsNear(58534.2_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(58591.4_(1) * Kilo(Metre)));
 
   std::int64_t number_of_evaluations = 0;
   FlightPlanOptimizer optimizer(
@@ -528,19 +483,14 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      AnyOf(IsNear(16.8_(1) * Micro(Second)),
-            IsNear(14.7_(1) * Micro(Second))));
-  EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
-              AnyOf(IsNear(1.011_(1) * Metre / Second),
-                    IsNear(1.013_(1) * Metre / Second)));
+      IsNear(16.8_(1) * Micro(Second)));
+  EXPECT_THAT(
+      (manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
+      IsNear(1.011_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, flyby_time, flyby_distance);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:22:33"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:22:21"_DateTime)));
-  EXPECT_THAT(flyby_distance,
-              AnyOf(IsNear(3339.88_(1) * Kilo(Metre)),
-                    IsNear(3179.08_(1) * Kilo(Metre))));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:22:33"_DateTime));
+  EXPECT_THAT(flyby_distance, IsNear(3339.88_(1) * Kilo(Metre)));
   EXPECT_EQ(146, number_of_evaluations);
 }
 

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -201,7 +201,7 @@ class FlightPlanOptimizerTest : public testing::Test {
   }
 
   std::unique_ptr<Plugin const> plugin_;
-  FlightPlan* flight_plan_;
+  FlightPlan* flight_plan_ = nullptr;
 };
 
 // This test tweaks the burns of the flight plan that precede the Moon flyby, in
@@ -226,7 +226,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   // basically goes through the centre of the Moon.
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_THAT(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -243,7 +243,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_THAT(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -259,7 +259,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_THAT(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -296,7 +296,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -315,7 +315,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_OK(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -333,7 +333,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_OK(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -362,7 +362,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrindsToAHalt) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Micro(Metre) / Second));
 
   // The initial time doesn't change.
@@ -400,7 +400,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -419,7 +419,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_OK(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -437,7 +437,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_OK(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -478,7 +478,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -201,7 +201,7 @@ class FlightPlanOptimizerTest : public testing::Test {
   }
 
   std::unique_ptr<Plugin const> plugin_;
-  FlightPlan* flight_plan_ = nullptr;
+  FlightPlan* flight_plan_;
 };
 
 // This test tweaks the burns of the flight plan that precede the Moon flyby, in
@@ -230,7 +230,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   // basically goes through the centre of the Moon.
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_THAT(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -248,7 +248,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_THAT(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -267,7 +267,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_THAT(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second),
               StatusIs(termination_condition::VanishingStepSize));
 
@@ -275,7 +275,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
       AnyOf(IsNear(-77_(1) * Milli(Second)),
-            IsNear(-7.0_(1) * Milli(Second))));
+            IsNear(-70_(1) * Milli(Second))));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       IsNear(61.9_(1) * Metre / Second));
@@ -309,7 +309,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -334,7 +334,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_OK(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -358,7 +358,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_OK(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -392,7 +392,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrindsToAHalt) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Micro(Metre) / Second));
 
   // The initial time doesn't change.
@@ -434,7 +434,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -456,7 +456,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
 
   LOG(INFO) << "Optimizing manœuvre 6";
-  auto const& manœuvre6 = flight_plan_->GetManœuvre(6);
+  auto const manœuvre6 = flight_plan_->GetManœuvre(6);
   EXPECT_OK(optimizer.Optimize(/*index=*/6, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -480,7 +480,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
 
   LOG(INFO) << "Optimizing manœuvre 7";
-  auto const& manœuvre7 = flight_plan_->GetManœuvre(7);
+  auto const manœuvre7 = flight_plan_->GetManœuvre(7);
   EXPECT_OK(optimizer.Optimize(/*index=*/7, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(
@@ -529,7 +529,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
       [&number_of_evaluations](FlightPlan const&) { ++number_of_evaluations; });
 
   LOG(INFO) << "Optimizing manœuvre 5";
-  auto const& manœuvre5 = flight_plan_->GetManœuvre(5);
+  auto const manœuvre5 = flight_plan_->GetManœuvre(5);
   EXPECT_OK(optimizer.Optimize(/*index=*/5, 1 * Milli(Metre) / Second));
 
   EXPECT_THAT(

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -242,7 +242,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
               AnyOf(IsNear(1.054_(1) * Metre / Second),
                     IsNear(1.059_(1) * Metre / Second)));
-  EXPECT_THAT(number_of_evaluations, AnyOf(113, 112));
+  EXPECT_EQ(113, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
@@ -256,12 +256,12 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_ReachTheMoon) {
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
       AnyOf(IsNear(12.1_(1) * Micro(Second)),
-            IsNear(-4.7_(1) * Micro(Second))));
+            IsNear(-47.7_(1) * Micro(Second))));
   EXPECT_THAT(
       (manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
       AnyOf(IsNear(1.292_(1) * Metre / Second),
             IsNear(1.272_(1) * Metre / Second)));
-  EXPECT_THAT(number_of_evaluations, AnyOf(124, 87));
+  EXPECT_EQ(124, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
@@ -352,7 +352,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   EXPECT_THAT(flyby_distance,
               AnyOf(IsNear(2001.4_(1) * Kilo(Metre)),
                     IsNear(2025.7_(1) * Kilo(Metre))));
-  EXPECT_THAT(number_of_evaluations, AnyOf(72, 66));
+  EXPECT_EQ(72, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
@@ -376,7 +376,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_GrazeTheMoon) {
   EXPECT_THAT(flyby_distance,
               AnyOf(IsNear(2000.2_(1) * Kilo(Metre)),
                     IsNear(2000.5_(1) * Kilo(Metre))));
-  EXPECT_THAT(number_of_evaluations, AnyOf(86, 88));
+  EXPECT_EQ(86, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));
@@ -446,9 +446,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
                     IsNear(1.577_(1) * Centi(Metre) / Second)));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
-  EXPECT_THAT(flyby_time,
-              AnyOf(ResultOf(&TTSecond, "1972-03-27T01:09:20"_DateTime),
-                    ResultOf(&TTSecond, "1972-03-27T01:09:21"_DateTime)));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:09:20"_DateTime));
   EXPECT_THAT(flyby_inclination, IsNear(90.23_(1) * Degree));
   EXPECT_EQ(25, number_of_evaluations);
   number_of_evaluations = 0;
@@ -474,7 +472,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   EXPECT_THAT(flyby_inclination,
               AnyOf(IsNear(89.98_(1) * Degree),
                     IsNear(90.00_(1) * Degree)));
-  EXPECT_THAT(number_of_evaluations, AnyOf(34, 44));
+  EXPECT_EQ(34, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre6.burn(), /*index=*/6));
@@ -497,7 +495,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
               AnyOf(ResultOf(&TTSecond, "1972-03-27T01:08:39"_DateTime),
                     ResultOf(&TTSecond, "1972-03-27T01:08:34"_DateTime)));
   EXPECT_THAT(flyby_inclination, IsNear(90.00_(1) * Degree));
-  EXPECT_THAT(number_of_evaluations, AnyOf(54, 56));
+  EXPECT_EQ(54, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));
@@ -547,7 +545,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_Combined) {
   EXPECT_THAT(flyby_distance,
               AnyOf(IsNear(3339.88_(1) * Kilo(Metre)),
                     IsNear(3179.08_(1) * Kilo(Metre))));
-  EXPECT_THAT(number_of_evaluations, AnyOf(146, 151));
+  EXPECT_EQ(146, number_of_evaluations);
 }
 
 #if !_DEBUG

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -418,8 +418,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
               AnyOf(ResultOf(&TTSecond, "1972-03-27T01:02:40"_DateTime),
                     ResultOf(&TTSecond, "1972-03-27T01:02:51"_DateTime)));
   EXPECT_THAT(flyby_inclination,
-              AnyOf(IsNear(76.32_(1) * Degree),
-                    IsNear(76.64_(1) * Degree)));
+              AnyOf(IsNear(76.32_(1) * Degree), IsNear(76.64_(1) * Degree)));
 
   std::int64_t number_of_evaluations = 0;
   FlightPlanOptimizer optimizer(
@@ -468,8 +467,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
               AnyOf(ResultOf(&TTSecond, "1972-03-27T01:09:47"_DateTime),
                     ResultOf(&TTSecond, "1972-03-27T01:10:00"_DateTime)));
   EXPECT_THAT(flyby_inclination,
-              AnyOf(IsNear(89.98_(1) * Degree),
-                    IsNear(90.00_(1) * Degree)));
+              AnyOf(IsNear(89.98_(1) * Degree), IsNear(90.00_(1) * Degree)));
   EXPECT_EQ(34, number_of_evaluations);
   number_of_evaluations = 0;
 

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -439,8 +439,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre5.initial_time() - flight_plan_->GetManœuvre(5).initial_time(),
-      AnyOf(IsNear(0.715_(1) * Micro(Second)),
-            Eq(0 * Second)));
+      AnyOf(IsNear(0.715_(1) * Micro(Second)), Eq(0 * Second)));
   EXPECT_THAT((manœuvre5.Δv() - flight_plan_->GetManœuvre(5).Δv()).Norm(),
               AnyOf(IsNear(1.615_(1) * Centi(Metre) / Second),
                     IsNear(1.577_(1) * Centi(Metre) / Second)));
@@ -459,8 +458,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre6.initial_time() - flight_plan_->GetManœuvre(6).initial_time(),
-      AnyOf(Eq(0 * Second),
-            IsNear(-0.119_(1) * Micro(Second))));
+      AnyOf(Eq(0 * Second), IsNear(-0.119_(1) * Micro(Second))));
   EXPECT_THAT((manœuvre6.Δv() - flight_plan_->GetManœuvre(6).Δv()).Norm(),
               AnyOf(IsNear(0.257_(1) * Metre / Second),
                     IsNear(0.251_(1) * Metre / Second)));

--- a/principia.props
+++ b/principia.props
@@ -142,6 +142,7 @@
   <ItemDefinitionGroup Condition="!$(PrincipiaOptimize)">
     <ClCompile>
       <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalOptions>/ignore:4099</AdditionalOptions>
@@ -154,6 +155,7 @@
   <ItemDefinitionGroup Condition="$(PrincipiaOptimize)">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/principia.props
+++ b/principia.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <!--Define project configurations.  Nothing interesting can happen here.-->
   <ItemGroup Label="ProjectConfigurations">

--- a/principia.props
+++ b/principia.props
@@ -202,7 +202,7 @@
   <PropertyGroup>
     <!--Protocompiler.-->
     <Protoc>$(SolutionDir)..\Google\protobuf\vsprojects\Release\x64\protoc.exe</Protoc>
-    <ProtocCommand>"$(Protoc)" -I"$(SolutionDir)." --cpp_out=dllexport_decl=SERIALIZATION_DLL:.. "{0}"</ProtocCommand>
+    <ProtocCommand>"$(Protoc)" -I"$(SolutionDir)." --cpp_out=.. "{0}"</ProtocCommand>
     <ProtocMessage>Generating C++ files for {0}</ProtocMessage>
     <ProtocOutputs>{0}.pb.h;{0}.pb.cc;</ProtocOutputs>
     <!--Principia tools.-->
@@ -212,16 +212,8 @@
     <PrincipiaGenerateProfilesOutputs>..\ksp_plugin\interface.generated.h;..\journal\player.generated.cc;..\journal\profiles.generated.h;..\journal\profiles.generated.cc;..\ksp_plugin_adapter\interface.generated.cs</PrincipiaGenerateProfilesOutputs>
   </PropertyGroup>
 
-  <ItemDefinitionGroup Condition="$(ProjectName)==serialization">
-    <ClCompile>
-      <PreprocessorDefinitions>SERIALIZATION_DLL=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <!--Everybody depends on the serialization project.-->
   <ItemDefinitionGroup Condition="$(ProjectName)!=serialization">
-    <ClCompile>
-      <PreprocessorDefinitions>SERIALIZATION_DLL=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="$(ProjectName)!=serialization">
     <ProjectReference Include="$(SolutionDir)serialization\serialization.vcxproj">

--- a/principia.props
+++ b/principia.props
@@ -49,8 +49,8 @@
 
   <!--Target.-->
   <PropertyGroup>
-    <ConfigurationType Condition="$(ProjectName) == ksp_plugin or
-                                  $(ProjectName) == serialization">DynamicLibrary</ConfigurationType>
+    <ConfigurationType Condition="$(ProjectName) == ksp_plugin">DynamicLibrary</ConfigurationType>
+    <ConfigurationType Condition="$(ProjectName) == serialization">StaticLibrary</ConfigurationType>
     <ConfigurationType Condition="$(PrincipiaTestProject) or
                                   $(ProjectName) == tools or
                                   $(ProjectName) == benchmarks">Application</ConfigurationType>
@@ -214,13 +214,13 @@
 
   <ItemDefinitionGroup Condition="$(ProjectName)==serialization">
     <ClCompile>
-      <PreprocessorDefinitions>SERIALIZATION_DLL=__declspec(dllexport);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SERIALIZATION_DLL=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <!--Everybody depends on the serialization project.-->
   <ItemDefinitionGroup Condition="$(ProjectName)!=serialization">
     <ClCompile>
-      <PreprocessorDefinitions>SERIALIZATION_DLL=__declspec(dllimport);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SERIALIZATION_DLL=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="$(ProjectName)!=serialization">

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1949,8 +1949,7 @@ std::string JournalProtoProcessor::MarshalAs(
 #if PRINCIPIA_COMPILER_MSVC && \
     (_MSC_FULL_VER == 193'933'523 || \
      _MSC_FULL_VER == 194'033'813 || \
-     _MSC_FULL_VER == 194'134'123 || \
-     _MSC_FULL_VER == 194'334'809)
+     _MSC_FULL_VER == 194'134'123)
   std::abort();
 #endif
 }

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1949,7 +1949,8 @@ std::string JournalProtoProcessor::MarshalAs(
 #if PRINCIPIA_COMPILER_MSVC && \
     (_MSC_FULL_VER == 193'933'523 || \
      _MSC_FULL_VER == 194'033'813 || \
-     _MSC_FULL_VER == 194'134'123)
+     _MSC_FULL_VER == 194'134'123 || \
+     _MSC_FULL_VER == 194'334'809)
   std::abort();
 #endif
 }


### PR DESCRIPTION
And pin it at 10.0.22621 (Windows 11 22H2), which is before before 10.0.26100 (Windows 11 24H2).
(There is no Windows 11 SDK for 10.0.22631, Windows 11 23H2).

Fix #4188.

This also gets rid of the separate glog.dll, libprotobuf.dll, and serialization.dll, which had been introduced in #1686.