### PR TITLE
Fix integrator plots

### DIFF
--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -39,7 +39,7 @@ class ErrorAnalysisTest : public ::testing::Test {
 #if !defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
   google::LogToStderr();
-  GenerateSimpleHarmonicMotionWorkErrorGraphs();
+  //GenerateSimpleHarmonicMotionWorkErrorGraphs();
   // Circular.
   GenerateKeplerProblemWorkErrorGraphs(0.0);
   // Pluto.

--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -38,6 +38,7 @@ class ErrorAnalysisTest : public ::testing::Test {
 
 #if !defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
+  google::LogToStderr();
   GenerateSimpleHarmonicMotionWorkErrorGraphs();
   // Circular.
   GenerateKeplerProblemWorkErrorGraphs(0.0);

--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -36,10 +36,10 @@ class ErrorAnalysisTest : public ::testing::Test {
  protected:
 };
 
-#if 1||!defined(_DEBUG)
+#if defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
   google::LogToStderr();
-  //GenerateSimpleHarmonicMotionWorkErrorGraphs();
+  GenerateSimpleHarmonicMotionWorkErrorGraphs();
   // Circular.
   GenerateKeplerProblemWorkErrorGraphs(0.0);
   // Pluto.

--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -36,9 +36,8 @@ class ErrorAnalysisTest : public ::testing::Test {
  protected:
 };
 
-#if defined(_DEBUG)
+#if !defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
-  google::LogToStderr();
   GenerateSimpleHarmonicMotionWorkErrorGraphs();
   // Circular.
   GenerateKeplerProblemWorkErrorGraphs(0.0);

--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -36,7 +36,7 @@ class ErrorAnalysisTest : public ::testing::Test {
  protected:
 };
 
-#if !defined(_DEBUG)
+#if 1||!defined(_DEBUG)
 TEST_F(ErrorAnalysisTest, DISABLED_IntegratorPlots) {
   google::LogToStderr();
   //GenerateSimpleHarmonicMotionWorkErrorGraphs();

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -47,13 +47,12 @@
        &SymplecticRungeKuttaNyströmIntegrator<methods::name, ODE>()), \
    u8## #name,                                                        \
    (methods::name::evaluations)}
-#define EERKN_INTEGRATOR(name)                                             \
-  {static_cast<AdaptiveStepSizeIntegrator<ODE> const*>(                          \
+#define EERKN_INTEGRATOR(name)                                              \
+  {static_cast<AdaptiveStepSizeIntegrator<ODE> const*>(                     \
        &EmbeddedExplicitRungeKuttaNyströmIntegrator<methods::name, ODE>()), \
-   u8## #name,                                                             \
+   u8## #name,                                                              \
    0}
-#define SPRK_INTEGRATOR(name, composition) SPRK_INTEGRATOR##composition(name)
-#define SPRK_INTEGRATORBA(name)                        \
+#define SPRK_INTEGRATOR(name)                          \
   {static_cast<FixedStepSizeIntegrator<ODE> const*>(   \
        &SymplecticRungeKuttaNyströmIntegrator<         \
            methods::name,                              \
@@ -61,7 +60,7 @@
            ODE>()),                                    \
    u8## #name " BA",                                   \
    (methods::name::evaluations)}
-#define SPRK_INTEGRATORBAB(name)                         \
+#define SPRK_INTEGRATOR_FSAL(name)                       \
   {static_cast<FixedStepSizeIntegrator<ODE> const*>(     \
        &SymplecticRungeKuttaNyströmIntegrator<           \
            methods::name,                                \
@@ -138,21 +137,21 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
   SimpleHarmonicMotionPlottedIntegrator meow =
       SRKN_INTEGRATOR(BlanesMoan2002SRKN6B);
   return {// Order 2
-          SPRK_INTEGRATOR(NewtonDelambreStørmerVerletLeapfrog, BAB),
-          SPRK_INTEGRATOR(McLachlanAtela1992Order2Optimal, BA),
-          SPRK_INTEGRATOR(McLachlan1995S2, BAB),
+          SPRK_INTEGRATOR_FSAL(NewtonDelambreStørmerVerletLeapfrog),
+          SPRK_INTEGRATOR(McLachlanAtela1992Order2Optimal),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995S2),
           // Order 3
-          SPRK_INTEGRATOR(Ruth1983, BA),
-          SPRK_INTEGRATOR(McLachlanAtela1992Order3Optimal, BA),
+          SPRK_INTEGRATOR(Ruth1983),
+          SPRK_INTEGRATOR(McLachlanAtela1992Order3Optimal),
           EERKN_INTEGRATOR(Fine1987RKNG34),
           EERKN_INTEGRATOR(DormandالمكاوىPrince1986RKN434FM),
           // Order 4
-          SPRK_INTEGRATOR(CandyRozmus1991ForestRuth1990, BAB),
-          SPRK_INTEGRATOR(鈴木1990, BAB),
-          SPRK_INTEGRATOR(McLachlan1995SS5, BAB),
-          SPRK_INTEGRATOR(McLachlan1995S4, BAB),
-          SPRK_INTEGRATOR(McLachlan1995S5, BAB),
-          SPRK_INTEGRATOR(BlanesMoan2002S6, BAB),
+          SPRK_INTEGRATOR_FSAL(CandyRozmus1991ForestRuth1990),
+          SPRK_INTEGRATOR_FSAL(鈴木1990),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995SS5),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995S4),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995S5),
+          SPRK_INTEGRATOR_FSAL(BlanesMoan2002S6),
           SRKN_INTEGRATOR(McLachlanAtela1992Order4Optimal),
           SRKN_INTEGRATOR(McLachlan1995SB3A4),
           SRKN_INTEGRATOR(McLachlan1995SB3A5),
@@ -161,22 +160,22 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
           // Order 5
           SRKN_INTEGRATOR(McLachlanAtela1992Order5Optimal),
           // Order 6
-          SPRK_INTEGRATOR(吉田1990Order6A, BAB),
-          SPRK_INTEGRATOR(吉田1990Order6B, BAB),
-          SPRK_INTEGRATOR(吉田1990Order6C, BAB),
-          SPRK_INTEGRATOR(McLachlan1995SS9, BAB),
-          SPRK_INTEGRATOR(BlanesMoan2002S10, BAB),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order6A),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order6B),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order6C),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995SS9),
+          SPRK_INTEGRATOR_FSAL(BlanesMoan2002S10),
           SRKN_INTEGRATOR(OkunborSkeel1994Order6Method13),
           SRKN_INTEGRATOR(BlanesMoan2002SRKN11B),
           SRKN_INTEGRATOR(BlanesMoan2002SRKN14A),
           // Order 8
-          SPRK_INTEGRATOR(吉田1990Order8A, BAB),
-          SPRK_INTEGRATOR(吉田1990Order8B, BAB),
-          SPRK_INTEGRATOR(吉田1990Order8C, BAB),
-          SPRK_INTEGRATOR(吉田1990Order8D, BAB),
-          SPRK_INTEGRATOR(吉田1990Order8E, BAB),
-          SPRK_INTEGRATOR(McLachlan1995SS15, BAB),
-          SPRK_INTEGRATOR(McLachlan1995SS17, BAB),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order8A),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order8B),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order8C),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order8D),
+          SPRK_INTEGRATOR_FSAL(吉田1990Order8E),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995SS15),
+          SPRK_INTEGRATOR_FSAL(McLachlan1995SS17),
           SLMS_INTEGRATOR(QuinlanTremaine1990Order8),
           SLMS_INTEGRATOR(Quinlan1999Order8A),
           SLMS_INTEGRATOR(Quinlan1999Order8B),

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -50,14 +50,28 @@
         ODE>()),                                \
         u8###name, (methods::name::evaluations) \
   }
-#define SPRK_INTEGRATOR(name, composition)                   \
-  {                                                          \
-    (SymplecticRungeKuttaNyströmIntegrator<                  \
-        methods::name,                                       \
-        serialization::FixedStepSizeIntegrator::composition, \
-        ODE>()),                                             \
-        u8###name " " u8###composition,                      \
-        (methods::name::evaluations)                         \
+#define SPRK_INTEGRATOR(name, composition)              \
+  SPRK_INTEGRATOR##composition(name)
+#define SPRK_INTEGRATORBA(name)              \
+  {(SymplecticRungeKuttaNyströmIntegrator<              \
+       methods::name,                                   \
+       serialization::FixedStepSizeIntegrator::BA,     \
+       ODE>()),                                         \
+   u8## #name " BA",                                   \
+   (methods::name::evaluations)}
+#define SPRK_INTEGRATORBAB(name)              \
+  {(SymplecticRungeKuttaNyströmIntegrator<              \
+       methods::name,                                   \
+       serialization::FixedStepSizeIntegrator::ABA,     \
+       ODE>()),                                         \
+   u8## #name " ABA",                                   \
+   (methods::name::evaluations)},                       \
+  {                                                     \
+    (SymplecticRungeKuttaNyströmIntegrator<             \
+        methods::name,                                  \
+        serialization::FixedStepSizeIntegrator::BAB,    \
+        ODE>()),                                        \
+        u8## #name " BAB", (methods::name::evaluations) \
   }
 
 namespace principia {
@@ -249,7 +263,7 @@ class WorkErrorGraphGenerator {
                                                   e_errors_[i][j][k]);
         }
       }
-      names.emplace_back(ToMathematica(methods_[i].name));
+      names.emplace_back(methods_[i].name);
     }
     std::string result;
     result += Set("qErrorData", q_error_data, ExpressInSIUnits);
@@ -341,7 +355,7 @@ void GenerateSimpleHarmonicMotionWorkErrorGraphs() {
   initial_state.time = DoublePrecision<Instant>(t0);
 
   std::vector<Instant> const tmax = {
-      t0 + 50 * Second, t0 + 100 * Second, t0 + 200 * Second};
+      t0 + 50 * Second, t0 + 57.5 * Second, t0 + 75 * Second};
   auto const compute_error = [q_amplitude, v_amplitude, ω, m, k, t0](
       ODE::State const& state) {
     return WorkErrorGraphGenerator<Energy>::Errors{
@@ -393,8 +407,8 @@ void GenerateKeplerProblemWorkErrorGraphs(double const eccentricity) {
 
   std::vector<Instant> const tmax = {
       t0 + 8 * *orbit.elements_at_epoch().period,
-      t0 + 16 * *orbit.elements_at_epoch().period,
-      t0 + 32 * *orbit.elements_at_epoch().period};
+      t0 + 10 * *orbit.elements_at_epoch().period,
+      t0 + 12 * *orbit.elements_at_epoch().period};
 
   SpecificEnergy const initial_specific_energy =
       initial_dof.velocity().Norm²() / 2 -

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -144,6 +144,8 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
           // Order 3
           SPRK_INTEGRATOR(Ruth1983, BA),
           SPRK_INTEGRATOR(McLachlanAtela1992Order3Optimal, BA),
+          EERKN_INTEGRATOR(Fine1987RKNG34),
+          EERKN_INTEGRATOR(DormandالمكاوىPrince1986RKN434FM),
           // Order 4
           SPRK_INTEGRATOR(CandyRozmus1991ForestRuth1990, BAB),
           SPRK_INTEGRATOR(鈴木1990, BAB),
@@ -155,6 +157,7 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
           SRKN_INTEGRATOR(McLachlan1995SB3A4),
           SRKN_INTEGRATOR(McLachlan1995SB3A5),
           SRKN_INTEGRATOR(BlanesMoan2002SRKN6B),
+          EERKN_INTEGRATOR(Fine1987RKNG45),
           // Order 5
           SRKN_INTEGRATOR(McLachlanAtela1992Order5Optimal),
           // Order 6
@@ -166,7 +169,6 @@ std::vector<SimpleHarmonicMotionPlottedIntegrator> Methods() {
           SRKN_INTEGRATOR(OkunborSkeel1994Order6Method13),
           SRKN_INTEGRATOR(BlanesMoan2002SRKN11B),
           SRKN_INTEGRATOR(BlanesMoan2002SRKN14A),
-          EERKN_INTEGRATOR(Fine1987RKNG45),
           // Order 8
           SPRK_INTEGRATOR(吉田1990Order8A, BAB),
           SPRK_INTEGRATOR(吉田1990Order8B, BAB),

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)
+#include <limits>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -178,7 +180,8 @@ struct PlottedIntegrator final {
   std::variant<FixedStepSizeIntegrator<SecondOrderODE> const*,
                AdaptiveStepSizeIntegrator<SecondOrderODE> const*,
                FixedStepSizeIntegrator<FirstOrderODE> const*,
-               AdaptiveStepSizeIntegrator<FirstOrderODE> const*> const integrator;
+               AdaptiveStepSizeIntegrator<FirstOrderODE> const*> const
+      integrator;
   std::string name;
   std::vector<int> orders;
   std::string method_type;

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -225,23 +225,36 @@ class WorkErrorGraphGenerator {
     }
     CHECK_OK(bundle.Join());
 
-    std::vector<std::string> q_error_data;
-    std::vector<std::string> v_error_data;
-    std::vector<std::string> e_error_data;
+    std::vector<std::vector<std::vector<std::tuple<double, Length>>>>
+        q_error_data;
+    std::vector<std::vector<std::vector<std::tuple<double, Speed>>>>
+        v_error_data;
+    std::vector<std::vector<std::vector<std::tuple<double, Energy>>>>
+        e_error_data;
     std::vector<std::string> names;
     for (int i = 0; i < methods_.size(); ++i) {
-      q_error_data.emplace_back(
-          PlottableDataset(evaluations_[i], q_errors_[i], ExpressInSIUnits));
-      v_error_data.emplace_back(
-          PlottableDataset(evaluations_[i], v_errors_[i], ExpressInSIUnits));
-      e_error_data.emplace_back(
-          PlottableDataset(evaluations_[i], e_errors_[i], ExpressInSIUnits));
+      q_error_data.emplace_back();
+      v_error_data.emplace_back();
+      e_error_data.emplace_back();
+      for (int j = 0; j < integrations_per_integrator_; ++j) {
+        q_error_data.back().emplace_back();
+        v_error_data.back().emplace_back();
+        e_error_data.back().emplace_back();
+        for (int k = 0; k < tmax_.size(); ++k) {
+          q_error_data.back().back().emplace_back(evaluations_[i][j][k],
+                                                  q_errors_[i][j][k]);
+          v_error_data.back().back().emplace_back(evaluations_[i][j][k],
+                                                  v_errors_[i][j][k]);
+          e_error_data.back().back().emplace_back(evaluations_[i][j][k],
+                                                  e_errors_[i][j][k]);
+        }
+      }
       names.emplace_back(ToMathematica(methods_[i].name));
     }
     std::string result;
-    result += Set("qErrorData", q_error_data);
-    result += Set("vErrorData", v_error_data);
-    result += Set("eErrorData", e_error_data);
+    result += Set("qErrorData", q_error_data, ExpressInSIUnits);
+    result += Set("vErrorData", v_error_data, ExpressInSIUnits);
+    result += Set("eErrorData", e_error_data, ExpressInSIUnits);
     result += Set("names", names);
     return result;
   }

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -316,7 +316,8 @@ class WorkErrorGraphGenerator {
     LOG(INFO) << "Using " << std::thread::hardware_concurrency()
               << " worker threads";
     Bundle bundle;
-    for (std::int64_t method_index = 0; method_index < methods_.size(); ++method_index) {
+    for (std::int64_t method_index = 0; method_index < methods_.size();
+         ++method_index) {
       for (std::int64_t time_step_index = 0;
            time_step_index < integrations_per_integrator_;
            ++time_step_index) {

--- a/mathematica/integrator_plots.cpp
+++ b/mathematica/integrator_plots.cpp
@@ -39,75 +39,89 @@
 #include "testing_utilities/integration.hpp"
 #include "testing_utilities/numerics.hpp"
 
-#define SLMS_INTEGRATOR(name)                                                 \
-  {static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>(               \
-       &SymmetricLinearMultistepIntegrator<methods::name, SecondOrderODE>()), \
-   u8## #name,                                                                \
-   {methods::name::order},                                                    \
-   "SLMS",                                                                    \
-   1}
-#define SRKN_INTEGRATOR(name)                                     \
-  {static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>(   \
-       &SymplecticRungeKuttaNyströmIntegrator<methods::name,      \
-                                              SecondOrderODE>()), \
-   u8## #name,                                                    \
-   {methods::name::order},                                        \
-   "SRKN",                                                        \
-   (methods::name::evaluations)}
-#define ERK_INTEGRATOR(name)                                           \
-  {static_cast<FixedStepSizeIntegrator<FirstOrderODE> const*>(         \
-       &ExplicitRungeKuttaIntegrator<methods::name, FirstOrderODE>()), \
-   u8## #name,                                                         \
-   {methods::name::order},                                             \
-   "ERK",                                                              \
-   methods::name::first_same_as_last ? methods::name::stages - 1       \
-                                     : methods::name::stages}
-#define EERK_INTEGRATOR(name)                                                  \
-  {static_cast<AdaptiveStepSizeIntegrator<FirstOrderODE> const*>(              \
-       &EmbeddedExplicitRungeKuttaIntegrator<methods::name, FirstOrderODE>()), \
-   u8## #name,                                                                 \
-   {methods::name::lower_order, methods::name::higher_order},                  \
-   "EERK",                                                                     \
-   0}
-#define EERKN_INTEGRATOR(name)                                          \
-  {static_cast<AdaptiveStepSizeIntegrator<SecondOrderODE> const*>(      \
-       &EmbeddedExplicitRungeKuttaNyströmIntegrator<methods::name,      \
-                                                    SecondOrderODE>()), \
-   u8## #name,                                                          \
-   {methods::name::lower_order, methods::name::higher_order},           \
-   std::is_base_of_v<EmbeddedExplicitGeneralizedRungeKuttaNyström,      \
-                     methods::name>                                     \
-       ? "EEGRKN"                                                       \
-       : "EERKN",                                                       \
-   0}
-#define SPRK_INTEGRATOR(name)                                   \
-  {static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>( \
-       &SymplecticRungeKuttaNyströmIntegrator<                  \
-           methods::name,                                       \
-           serialization::FixedStepSizeIntegrator::BA,          \
-           SecondOrderODE>()),                                  \
-   u8## #name " BA",                                            \
-   {methods::name::order},                                      \
-   "SPRK",                                                      \
-   (methods::name::evaluations)}
-#define SPRK_INTEGRATOR_FSAL(name)                               \
-  {static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>(  \
-       &SymplecticRungeKuttaNyströmIntegrator<                   \
-           methods::name,                                        \
-           serialization::FixedStepSizeIntegrator::ABA,          \
-           SecondOrderODE>()),                                   \
-   u8## #name " ABA",                                            \
-   {methods::name::order},                                       \
-   "SPRK",                                                       \
-   (methods::name::evaluations)},                                \
-  {                                                              \
-    static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>( \
-        &SymplecticRungeKuttaNyströmIntegrator<                  \
-            methods::name,                                       \
-            serialization::FixedStepSizeIntegrator::BAB,         \
-            SecondOrderODE>()),                                  \
-        u8## #name " BAB", {methods::name::order}, "SPRK",       \
-        (methods::name::evaluations)                             \
+#define SLMS_INTEGRATOR(name)                                      \
+  {                                                                \
+      static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>( \
+          &SymmetricLinearMultistepIntegrator<methods::name,       \
+                                              SecondOrderODE>()),  \
+      u8## #name,                                                  \
+      {methods::name::order},                                      \
+      "SLMS",                                                      \
+      1,                                                           \
+  }
+#define SRKN_INTEGRATOR(name)                                        \
+  {                                                                  \
+      static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>(   \
+          &SymplecticRungeKuttaNyströmIntegrator<methods::name,      \
+                                                 SecondOrderODE>()), \
+      u8## #name,                                                    \
+      {methods::name::order},                                        \
+      "SRKN",                                                        \
+      (methods::name::evaluations),                                  \
+  }
+#define ERK_INTEGRATOR(name)                                              \
+  {                                                                       \
+      static_cast<FixedStepSizeIntegrator<FirstOrderODE> const*>(         \
+          &ExplicitRungeKuttaIntegrator<methods::name, FirstOrderODE>()), \
+      u8## #name,                                                         \
+      {methods::name::order},                                             \
+      "ERK",                                                              \
+      methods::name::first_same_as_last ? methods::name::stages - 1       \
+                                        : methods::name::stages,          \
+  }
+#define EERK_INTEGRATOR(name)                                        \
+  {                                                                  \
+      static_cast<AdaptiveStepSizeIntegrator<FirstOrderODE> const*>( \
+          &EmbeddedExplicitRungeKuttaIntegrator<methods::name,       \
+                                                FirstOrderODE>()),   \
+      u8## #name,                                                    \
+      {methods::name::lower_order, methods::name::higher_order},     \
+      "EERK",                                                        \
+  }
+#define EERKN_INTEGRATOR(name)                                             \
+  {                                                                        \
+      static_cast<AdaptiveStepSizeIntegrator<SecondOrderODE> const*>(      \
+          &EmbeddedExplicitRungeKuttaNyströmIntegrator<methods::name,      \
+                                                       SecondOrderODE>()), \
+      u8## #name,                                                          \
+      {methods::name::lower_order, methods::name::higher_order},           \
+      std::is_base_of_v<EmbeddedExplicitGeneralizedRungeKuttaNyström,      \
+                        methods::name>                                     \
+          ? "EEGRKN"                                                       \
+          : "EERKN",                                                       \
+  }
+#define SPRK_INTEGRATOR(name)                                      \
+  {                                                                \
+      static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>( \
+          &SymplecticRungeKuttaNyströmIntegrator<                  \
+              methods::name,                                       \
+              serialization::FixedStepSizeIntegrator::BA,          \
+              SecondOrderODE>()),                                  \
+      u8## #name " BA",                                            \
+      {methods::name::order},                                      \
+      "SPRK",                                                      \
+      (methods::name::evaluations),                                \
+  }
+#define SPRK_INTEGRATOR_FSAL(name)                                 \
+  {                                                                \
+      static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>( \
+          &SymplecticRungeKuttaNyströmIntegrator<                  \
+              methods::name,                                       \
+              serialization::FixedStepSizeIntegrator::ABA,         \
+              SecondOrderODE>()),                                  \
+      u8## #name " ABA",                                           \
+      {methods::name::order},                                      \
+      "SPRK",                                                      \
+      (methods::name::evaluations),                                \
+  },                                                               \
+  {                                                                \
+    static_cast<FixedStepSizeIntegrator<SecondOrderODE> const*>(   \
+        &SymplecticRungeKuttaNyströmIntegrator<                    \
+            methods::name,                                         \
+            serialization::FixedStepSizeIntegrator::BAB,           \
+            SecondOrderODE>()),                                    \
+        u8## #name " BAB", {methods::name::order}, "SPRK",         \
+        (methods::name::evaluations),                              \
   }
 
 namespace principia {
@@ -168,7 +182,8 @@ struct PlottedIntegrator final {
   std::string name;
   std::vector<int> orders;
   std::string method_type;
-  int evaluations;
+  // Theoretical number of evaluations per step, ignoring startup costs.
+  std::optional<int> evaluations;
 };
 
 // This list should be sorted by:
@@ -402,7 +417,7 @@ class WorkErrorGraphGenerator {
       case 0: {
         FixedStepSizeIntegrator<SecondOrderODE> const& integrator =
             *std::get<0>(method.integrator);
-        Time const Δt = method.evaluations *
+        Time const Δt = *method.evaluations *
                         starting_step_size_per_evaluation_ /
                         std::pow(step_reduction_, time_step_index);
         auto const instance = integrator.NewInstance(problem, append_state, Δt);
@@ -452,7 +467,7 @@ class WorkErrorGraphGenerator {
       case 2: {
         FixedStepSizeIntegrator<FirstOrderODE> const& integrator =
             *std::get<2>(method.integrator);
-        Time const Δt = method.evaluations *
+        Time const Δt = *method.evaluations *
                         starting_step_size_per_evaluation_ /
                         std::pow(step_reduction_, time_step_index);
         auto const instance = integrator.NewInstance(
@@ -524,7 +539,7 @@ class WorkErrorGraphGenerator {
       // that ignores any startup costs; that theoretical number is the one
       // used for plotting.
       int const amortized_evaluations =
-          method.evaluations * static_cast<int>(std::floor((tmax - t0) / Δt));
+          *method.evaluations * static_cast<int>(std::floor((tmax - t0) / Δt));
       LOG_EVERY_N(INFO, 50)
           << "[" << method_index << "," << time_step_index << "] "
           << problem_name_ << ": " << number_of_evaluations

--- a/mathematica/mathematica.hpp
+++ b/mathematica/mathematica.hpp
@@ -139,11 +139,6 @@ std::string Set(std::string const& name,
                 T const& right,
                 OptionalExpressIn express_in = std::nullopt);
 
-template<typename T, typename U, typename OptionalExpressIn = std::nullopt_t>
-std::string PlottableDataset(std::vector<T> const& x,
-                             std::vector<U> const& y,
-                             OptionalExpressIn express_in = std::nullopt);
-
 template<typename T, typename OptionalExpressIn = std::nullopt_t>
 std::string ToMathematica(std::vector<T> const& list,
                           OptionalExpressIn express_in = std::nullopt);
@@ -346,7 +341,6 @@ using internal::Apply;
 using internal::Evaluate;
 using internal::ExpressIn;
 using internal::ExpressInSIUnits;
-using internal::PlottableDataset;
 using internal::PreserveUnits;
 using internal::Rule;
 using internal::Set;

--- a/mathematica/mathematica_body.hpp
+++ b/mathematica/mathematica_body.hpp
@@ -316,15 +316,6 @@ std::string Set(std::string const& name,
   return RawApply("Set", {name, ToMathematica(right, express_in)}) + ";\n";
 }
 
-template<typename T, typename U, typename OptionalExpressIn>
-std::string PlottableDataset(std::vector<T> const& x,
-                             std::vector<U> const& y,
-                             OptionalExpressIn express_in) {
-  std::vector<std::string> const xy = {ToMathematica(x, express_in),
-                                       ToMathematica(y, express_in)};
-  return RawApply("Transpose", {RawApply("List", xy)});
-}
-
 template<typename T, typename OptionalExpressIn>
 std::string ToMathematica(std::vector<T> const& list,
                           OptionalExpressIn express_in) {

--- a/mathematica/mathematica_test.cpp
+++ b/mathematica/mathematica_test.cpp
@@ -357,13 +357,6 @@ TEST_F(MathematicaTest, Set) {
   EXPECT_EQ("Set[var," + ToMathematica(3.0) + "];\n", Set("var", 3.0));
 }
 
-TEST_F(MathematicaTest, PlottableDataset) {
-  std::vector<double> const abscissæ{2, 3};
-  std::vector<std::string> const ordinates{"2", "3"};
-  EXPECT_EQ("Transpose[" + ToMathematica(std::tuple{abscissæ, ordinates}) + "]",
-            PlottableDataset(abscissæ, ordinates));
-}
-
 TEST_F(MathematicaTest, Escape) {
   EXPECT_EQ(R"("foo")", ToMathematica("foo"));
   {

--- a/testing_utilities/integration.hpp
+++ b/testing_utilities/integration.hpp
@@ -58,10 +58,12 @@ absl::Status ComputeHarmonicOscillatorDerivatives1D(
 // the Runge-Kutta-Nyström formulation
 //   qʺ = -q μ / |q|³,
 // where μ = 1 m³ s⁻².
-absl::Status ComputeKeplerAcceleration(Instant const& t,
-                                       std::vector<Length> const& q,
-                                       std::vector<Acceleration>& result,
-                                       int* evaluations);
+template<typename Frame>
+absl::Status ComputeKeplerAcceleration(
+    Instant const& t,
+    std::vector<Position<Frame>> const& q,
+    std::vector<Vector<Acceleration, Frame>>& result,
+    int* evaluations);
 
 // The right-hand side of the Чебышёв differential equation, with the
 // independent variable scaled so that the interval [-1, 1] maps to

--- a/testing_utilities/integration_body.hpp
+++ b/testing_utilities/integration_body.hpp
@@ -58,16 +58,15 @@ inline absl::Status ComputeHarmonicOscillatorDerivatives1D(
   return absl::OkStatus();
 }
 
-inline absl::Status ComputeKeplerAcceleration(
+template<typename Frame>
+absl::Status ComputeKeplerAcceleration(
     Instant const& t,
-    std::vector<Length> const& q,
-    std::vector<Acceleration>& result,
+    std::vector<Position<Frame>> const& q,
+    std::vector<Vector<Acceleration, Frame>>& result,
     int* evaluations) {
-  auto const r² = q[0] * q[0] + q[1] * q[1];
-  auto const minus_μ_over_r³ =
-      -si::Unit<GravitationalParameter> * Sqrt(r²) / (r² * r²);
-  result[0] = q[0] * minus_μ_over_r³;
-  result[1] = q[1] * minus_μ_over_r³;
+  auto const r = q[0] - Frame::origin;
+  auto const r³ = Pow<3>(r.Norm());
+  result[0] = -r * si::Unit<GravitationalParameter> / r³;
   if (evaluations != nullptr) {
     ++*evaluations;
   }


### PR DESCRIPTION
Following some refactoring of `mathematica`, the tool had been generating strings instead of lists of numbers.

Also:
1. provide data on _all_ integrators: both ABA and BAB for the SPRKs as SRKN (bringing the number of varieties of symplectic or conjugate symplectic integrators from 37 to 57), and plot the integrators that are neither symplectic nor conjugate symplectic too;
2. provide information on the types of integrators to make it easier to filter them in Mathematica for specific plots;
3. solve the same problem with the same settings for different final times so that the evolution of the error over time can be examined (in particular, this shows the effect of the (conjugate-)symplectic property).
