### PR TITLE
Evaluate the effect of the angular resolution on the cost and quality of PlotMethod3

### DIFF
--- a/base/status_utilities.hpp
+++ b/base/status_utilities.hpp
@@ -19,8 +19,12 @@ absl::Status const& GetStatus(absl::StatusOr<T> const& s) {
 
 }  // namespace internal
 
-#define CHECK_OK(value) CHECK_EQ((value), ::absl::OkStatus())
-#define DCHECK_OK(value) DCHECK_EQ((value), ::absl::OkStatus())
+#define CHECK_OK(value)                                                      \
+  CHECK_EQ(::principia::base::_status_utilities::internal::GetStatus(value), \
+           ::absl::OkStatus())
+#define DCHECK_OK(value)                                                      \
+  DCHECK_EQ(::principia::base::_status_utilities::internal::GetStatus(value), \
+            ::absl::OkStatus())
 
 #define RETURN_IF_ERROR(expr)                                                \
   do {                                                                       \

--- a/benchmarks/planetarium_benchmark.cpp
+++ b/benchmarks/planetarium_benchmark.cpp
@@ -236,7 +236,8 @@ class Satellites {
         perspective,
         ephemeris_.get(),
         plotting_frame,
-        [plotting_to_gcrs](Position<Navigation> const& plotted_point) {
+        [plotting_to_gcrs](Instant const&,
+                           Position<Navigation> const& plotted_point) {
           constexpr auto inverse_scale_factor = 1 / (6000 * Metre);
           return ScaledSpacePoint::FromCoordinates(
               ((plotting_to_gcrs(plotted_point) - GCRS::origin) *

--- a/ksp_plugin/interface_planetarium.cpp
+++ b/ksp_plugin/interface_planetarium.cpp
@@ -101,6 +101,7 @@ Planetarium* __cdecl principia__PlanetariumCreate(
       [plotting_to_world = world_to_plotting_affine_map.Inverse(),
        scaled_space_origin = FromXYZ<Position<World>>(scaled_space_origin),
        inverse_scale_factor = inverse_scale_factor * (1 / Metre)](
+          Instant const&,
           Position<Navigation> const& plotted_point) {
         return ScaledSpacePoint::FromCoordinates(
             ((plotting_to_world(plotted_point) - scaled_space_origin) *

--- a/ksp_plugin/planetarium.hpp
+++ b/ksp_plugin/planetarium.hpp
@@ -76,7 +76,8 @@ class Planetarium {
   };
 
   using PlottingToScaledSpaceConversion =
-      std::function<ScaledSpacePoint(Position<Navigation> const&)>;
+      std::function<ScaledSpacePoint(Instant const&,
+                                     Position<Navigation> const&)>;
 
   // TODO(phl): All this Navigation is weird.  Should it be named Plotting?
   // In particular Navigation vs. NavigationFrame is a mess.

--- a/ksp_plugin/planetarium_body.hpp
+++ b/ksp_plugin/planetarium_body.hpp
@@ -80,7 +80,7 @@ void Planetarium::PlotMethod3(
       initial_degrees_of_freedom.velocity();
   Time Δt = final_time - previous_time;
 
-  add_point(plotting_to_scaled_space_(previous_position));
+  add_point(plotting_to_scaled_space_(previous_time, previous_position));
   int points_added = 1;
 
   Instant t;
@@ -124,7 +124,7 @@ void Planetarium::PlotMethod3(
     previous_position = position;
     previous_velocity = degrees_of_freedom->velocity();
 
-    add_point(plotting_to_scaled_space_(position));
+    add_point(plotting_to_scaled_space_(t, position));
     ++points_added;
 
     if (minimal_distance != nullptr) {

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1189,8 +1189,7 @@ void Plugin::ClearOrbitAnalysersOfVesselsOtherThan(Vessel const& vessel) {
 not_null<std::unique_ptr<Planetarium>> Plugin::NewPlanetarium(
     Planetarium::Parameters const& parameters,
     Perspective<Navigation, Camera> const& perspective,
-    std::function<ScaledSpacePoint(Position<Navigation> const&)>
-        plotting_to_scaled_space)
+    Planetarium::PlottingToScaledSpaceConversion plotting_to_scaled_space)
     const {
   return make_not_null_unique<Planetarium>(parameters,
                                            perspective,

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -414,8 +414,8 @@ class Plugin {
   virtual not_null<std::unique_ptr<Planetarium>> NewPlanetarium(
       Planetarium::Parameters const& parameters,
       Perspective<Navigation, Camera> const& perspective,
-      std::function<ScaledSpacePoint(Position<Navigation> const&)>
-          plotting_to_scaled_space) const;
+      Planetarium::PlottingToScaledSpaceConversion plotting_to_scaled_space)
+      const;
 
   virtual not_null<std::unique_ptr<NavigationFrame>>
   NewBarycentricRotatingNavigationFrame(Index primary_index,

--- a/ksp_plugin_test/mock_planetarium.hpp
+++ b/ksp_plugin_test/mock_planetarium.hpp
@@ -32,7 +32,7 @@ class MockPlanetarium : public Planetarium {
                 1 * Metre),
             make_not_null<Ephemeris<Barycentric> const*>(),
             make_not_null<NavigationFrame const*>(),
-            [](Position<Navigation> const& plotted_point) {
+            [](Instant const&, Position<Navigation> const& plotted_point) {
               constexpr auto inverse_scale_factor = 1 / (6000 * Metre);
               return ScaledSpacePoint::FromCoordinates(
                   ((plotted_point - Navigation::origin) *

--- a/ksp_plugin_test/mock_plugin.hpp
+++ b/ksp_plugin_test/mock_plugin.hpp
@@ -105,7 +105,7 @@ class MockPlugin : public Plugin {
               NewPlanetarium,
               (Planetarium::Parameters const& parameters,
                (Perspective<Navigation, Camera> const& perspective),
-               std::function<ScaledSpacePoint(Position<Navigation> const&)>
+               Planetarium::PlottingToScaledSpaceConversion
                    plotting_to_scaled_space),
               (const, override));
   MOCK_METHOD(not_null<std::unique_ptr<NavigationFrame>>,

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -532,7 +532,6 @@ TEST_F(PlanetariumTest, PlotMethod3_Equipotentials_AngularResolution) {
         break;
     }
   }
-
 }
 
 #endif

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -392,6 +392,15 @@ TEST_F(PlanetariumTest, PlotMethod3_Equipotentials) {
           .Forget<Similarity>(),
       /*focal=*/5 * Metre);
 
+    auto const plotting_to_scaled_space =
+    [](Instant const& time,
+       Position<Navigation> const& plotted_point) {
+      constexpr auto inverse_scale_factor = 1 / (6000 * Metre);
+      return ScaledSpacePoint::FromCoordinates(
+          ((plotted_point - Navigation::origin) * inverse_scale_factor)
+              .coordinates());
+    };
+
   // No dark area, human visual acuity, wide field of view.
   Planetarium::Parameters planetarium_parameters(
       /*sphere_radius_multiplier=*/1.0,

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -449,7 +449,7 @@ TEST_F(PlanetariumTest, PlotMethod2_RealSolarSystem) {
   EXPECT_EQ(9, rp2_lines[1].size());
 }
 
-TEST_F(PlanetariumTest, PlotMethod3_Equipotentials) {
+TEST_F(PlanetariumTest, PlotMethod3_Equipotentials_04ArcMin) {
   auto const plotted_trajectories = ComputePlottedLines(
       // No dark area, human visual acuity, wide field of view.
       Planetarium::Parameters(
@@ -463,6 +463,22 @@ TEST_F(PlanetariumTest, PlotMethod3_Equipotentials) {
   }
 
   EXPECT_EQ(100692, number_of_points);
+}
+
+TEST_F(PlanetariumTest, PlotMethod3_Equipotentials_4ArcMin) {
+  auto const plotted_trajectories = ComputePlottedLines(
+      // No dark area, human visual acuity, wide field of view.
+      Planetarium::Parameters(
+          /*sphere_radius_multiplier=*/1.0,
+          /*angular_resolution=*/4 * ArcMinute,
+          /*field_of_view=*/90 * Degree));
+
+  std::int64_t number_of_points = 0;
+  for (auto const& plotted_trajectory : plotted_trajectories) {
+    number_of_points += plotted_trajectory.size();
+  }
+
+  EXPECT_EQ(33426, number_of_points);
 }
 
 #endif


### PR DESCRIPTION
This code plots the same equipotentials at various angular resolutions and determines (1) their cost, given by the total number of points produced; and (2) their quality, given by the Euclidean distance from the plot at the "correct" resolution (human visual accuracy).

For convenience, the plotted lines are turned into `DiscreteTrajectory` objects, as that makes it possible to evaluate them at any time.

The outcome is that the cost varies approximately like `1/Sqrt[resolution]` and the distance to the "correct" plot like `Sqrt[resolution]`.

Note that at this point there is no telling how the distance corresponds to the "pleasantness" of the graph.  That will need to be examined in game.