### PR TITLE
Integrator plots: A bug and error history

### DIFF
--- a/mathematica/error_analysis_test.cpp
+++ b/mathematica/error_analysis_test.cpp
@@ -34,6 +34,9 @@ using namespace principia::quantities::_quantities;
 
 class ErrorAnalysisTest : public ::testing::Test {
  protected:
+  ErrorAnalysisTest() {
+    google::LogToStderr();
+  }
 };
 
 #if !defined(_DEBUG)


### PR DESCRIPTION
I had written 1 / min_step_per_evaluation instead of 1.0 / min_step_per_evaluation when addressing https://github.com/mockingbirdnest/Principia/pull/4194#discussion_r2030054902, which broke the fixed-step graphs.

Also record energy error over time, instead of just the maximum.