### PR TITLE
Tune the parameters of the integrator used for computing equipotentials

### DIFF
--- a/integrators/ordinary_differential_equations.hpp
+++ b/integrators/ordinary_differential_equations.hpp
@@ -35,7 +35,8 @@ namespace termination_condition {
 constexpr absl::StatusCode Done = absl::StatusCode::kOk;
 // The integration may be retried with the same arguments and progress will
 // happen.
-constexpr absl::StatusCode ReachedMaximalStepCount = absl::StatusCode::kAborted;
+constexpr absl::StatusCode ReachedMaximalStepCount =
+    absl::StatusCode::kResourceExhausted;
 // A singularity.
 constexpr absl::StatusCode VanishingStepSize =
     absl::StatusCode::kFailedPrecondition;

--- a/ksp_plugin_test/planetarium_test.cpp
+++ b/ksp_plugin_test/planetarium_test.cpp
@@ -487,7 +487,7 @@ TEST_F(PlanetariumTest, PlotMethod3_Equipotentials_AngularResolution) {
   for (auto const& plotted_trajectory : plotted_trajectories_reference) {
     number_of_points_reference += plotted_trajectory.size();
   }
-  EXPECT_EQ(100692, number_of_points_reference);
+  EXPECT_EQ(100683, number_of_points_reference);
 
   // Compute plotted lines at progressively worse resolution and their distance
   // to the reference line.
@@ -515,15 +515,15 @@ TEST_F(PlanetariumTest, PlotMethod3_Equipotentials_AngularResolution) {
 
     switch (i) {
       case 0:
-        EXPECT_EQ(51752, number_of_points);
+        EXPECT_EQ(51749, number_of_points);
         EXPECT_THAT(max_distance, IsNear(0.83_(1) * Centi(Metre)));
         break;
       case 1:
-        EXPECT_EQ(26677, number_of_points);
+        EXPECT_EQ(26679, number_of_points);
         EXPECT_THAT(max_distance, IsNear(1.48_(1) * Centi(Metre)));
         break;
       case 2:
-        EXPECT_EQ(13786, number_of_points);
+        EXPECT_EQ(13788, number_of_points);
         EXPECT_THAT(max_distance, IsNear(3.35_(1) * Centi(Metre)));
         break;
       case 3:

--- a/physics/equipotential_body.hpp
+++ b/physics/equipotential_body.hpp
@@ -87,7 +87,15 @@ auto Equipotential<InertialFrame, Frame>::ComputeLine(
 
   auto const instance = adaptive_parameters_.integrator().NewInstance(
       problem, append_state, tolerance_to_error_ratio, integrator_parameters);
+
+  using namespace principia::integrators::_ordinary_differential_equations::
+      termination_condition;
   auto status = instance->Solve(s_final_);
+  if (status.code() == ReachedMaximalStepCount) {
+    LOG(WARNING) << "Equipotential computation at time " << t
+                 << " starting from " << position << " reached "
+                 << adaptive_parameters_.max_steps() << " steps: " << status;
+  }
 
   return equipotential;
 }

--- a/physics/lagrange_equipotentials_body.hpp
+++ b/physics/lagrange_equipotentials_body.hpp
@@ -43,9 +43,21 @@ constexpr Length box_side = 3 * Metre;
 // This is a length in the rotating-pulsating frame, so really one billionth of
 // the distance between the bodies.
 constexpr Length characteristic_length = 1 * Nano(Metre);
-constexpr Length length_integration_tolerance = 1 * Nano(Metre);///TODO comment
-//constexpr Length length_integration_tolerance = 0.01 * Nano(Metre);EarthMoon
-constexpr std::int64_t max_steps = 1000;
+
+// These parameters were tuned on the Sun-Earth and Earth-Moon system using the
+// test
+// `LagrangeEquipotentialsTest.DISABLED_RotatingPulsating_GlobalOptimization`.
+// A small tolerance is necessary because we compute equipotentials very close
+// to L1 and L2, and we must make sure that the integrator doesn't "jump" over
+// these points: if it did, the curve wouldn't close, and that would cause
+// wasted work or artifacts later during plotting.
+// Note that for Pluto-Charon these numbers are not sufficient and we would need
+// to go to (at least) 1 fm and 100'000 points.
+constexpr Length length_integration_tolerance = 10 * Femto(Metre);
+// Maximum observed for Sun-Earth: 3380; for Earth-Moon: 3759.  Typical
+// equipotentials have a few hundred points.
+constexpr std::int64_t max_steps = 10'000;
+
 constexpr std::int64_t points_per_round = 1000;
 constexpr Length local_search_tolerance = 1e-3 * Metre;
 

--- a/physics/lagrange_equipotentials_body.hpp
+++ b/physics/lagrange_equipotentials_body.hpp
@@ -43,6 +43,8 @@ constexpr Length box_side = 3 * Metre;
 // This is a length in the rotating-pulsating frame, so really one billionth of
 // the distance between the bodies.
 constexpr Length characteristic_length = 1 * Nano(Metre);
+constexpr Length length_integration_tolerance = 1 * Nano(Metre);///TODO comment
+//constexpr Length length_integration_tolerance = 0.01 * Nano(Metre);EarthMoon
 constexpr std::int64_t max_steps = 1000;
 constexpr std::int64_t points_per_round = 1000;
 constexpr Length local_search_tolerance = 1e-3 * Metre;
@@ -94,7 +96,7 @@ LagrangeEquipotentials<Inertial, RotatingPulsating>::ComputeLines(
            DormandPrince1986RK547FC,
            typename Equipotential<Inertial, RotatingPulsating>::ODE>(),
        max_steps,
-       /*length_integration_tolerance=*/characteristic_length},
+       length_integration_tolerance},
       &reference_frame,
       characteristic_length);
 

--- a/physics/lagrange_equipotentials_test.cpp
+++ b/physics/lagrange_equipotentials_test.cpp
@@ -222,6 +222,7 @@ TEST_F(LagrangeEquipotentialsTest,
                       AllOf(Gt(0.736 * Metre), Lt(1.322 * Metre)));
           equipotential.push_back(dof.position());
         }
+        EXPECT_THAT(equipotential.size(), AllOf(Ge(591), Le(3759)));
       }
     }
     logger.Append("energies", energies, ExpressIn(Metre, Second));


### PR DESCRIPTION
The tolerance was too large, causing the integrator to jump over L1 and L2, and to produce equipotentials that were not closing.  This in turn was causing the plotting to waste work and to create visual artifacts.

This is not a complete solution though.  For the Pluto-Charon system, the tolerance would have to go down to (at least) 1 fm and would generate trajectories with 80,000 points, which is excessive.  For the stock system, there remain some visual artifacts to be investigated.