### PR TITLE
Interrupt the analysers when recomputing a coast

### DIFF
--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -532,7 +532,7 @@ absl::Status FlightPlan::ComputeSegments(
       if (analysis_is_enabled_) {
         auto const& [first_time, first_degrees_of_freedom] = coast->front();
         auto& analyser = coast_analysers_[it - manœuvres_.begin()];
-        // Interrupt the analyses for the coast that are being recomputed as we
+        // Interrupt the analyses for the coasts that are being recomputed as we
         // won't use their result.
         analyser->Interrupt();
         analyser->RequestAnalysis(

--- a/ksp_plugin/flight_plan.cpp
+++ b/ksp_plugin/flight_plan.cpp
@@ -427,11 +427,7 @@ FlightPlan::FlightPlan()
           /*speed_integration_tolerance=*/1 * Metre / Second) {}
 
 absl::Status FlightPlan::RecomputeAllSegments() {
-  // It is important that the segments be destroyed in (reverse chronological)
-  // order of the forks.
-  while (segments_.size() > 1) {
-    PopLastSegment();
-  }
+  PopLastSegments(segments_.size() - 1);
   ResetLastSegment();
   return ComputeSegments(manœuvres_.begin(),
                          manœuvres_.end(),
@@ -447,8 +443,7 @@ absl::Status FlightPlan::RecomputeSegmentsAvoidingDeadlineIfNeeded() {
   int const anomalous_manœuvres = anomalous_segments_ / 2;
   auto it = manœuvres_.end();
   for (int i = 0; i < anomalous_manœuvres; ++i) {
-    PopLastSegment();
-    PopLastSegment();
+    PopLastSegments(2);
     --it;
   }
   ResetLastSegment();
@@ -602,12 +597,17 @@ void FlightPlan::ResetLastSegment() {
   }
 }
 
-void FlightPlan::PopLastSegment() {
-  auto& last_segment = segments_.back();
-  trajectory_.DeleteSegments(last_segment);
-  segments_.pop_back();
-  if (anomalous_segments_ > 0) {
-    --anomalous_segments_;
+void FlightPlan::PopLastSegments(std::int64_t const count) {
+  CHECK_EQ(0, count % 2) << count;
+  // It is important that the segments be destroyed in (reverse chronological)
+  // order of the forks.
+  for (std::int64_t i; i < count; ++i) {
+    auto& last_segment = segments_.back();
+    trajectory_.DeleteSegments(last_segment);
+    segments_.pop_back();
+    if (anomalous_segments_ > 0) {
+      --anomalous_segments_;
+    }
   }
 }
 
@@ -615,9 +615,7 @@ void FlightPlan::PopSegmentsAffectedByManœuvre(int const index) {
   // We will keep, for each manœuvre in [0, index[, its burn and the coast
   // preceding it, as well as the coast preceding manœuvre `index`.
   int const segments_kept = 2 * index + 1;
-  while (number_of_segments() > segments_kept) {
-    PopLastSegment();
-  }
+  PopLastSegments(number_of_segments() - segments_kept);
   ResetLastSegment();
 }
 

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -205,15 +205,12 @@ class FlightPlan {
 
   // Forgets the last trajectory after its fork.  If that trajectory was the
   // only anomalous one, there are no anomalous trajectories after this call.
-  // Interrupts the corresponding coast analyzer.
   void ResetLastSegment();
 
   // Deletes the last `count` trajectories and removes them from `segments_`. If
   // there are anomalous trajectories, their number is decremented and may
   // become 0.  `count` must be even (possibly 0) to maintain the invariant that
-  // the number of segments is odd.  Doesn't delete the `manœuvres_` or the
-  // `coast_analysers_`, but interrupts all the analysers for the popped
-  // segments.NONONO
+  // the number of segments is odd.
   void PopLastSegments(std::int64_t count);
 
   // Pops the burn of the manœuvre with the given index and all following

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -205,12 +205,15 @@ class FlightPlan {
 
   // Forgets the last trajectory after its fork.  If that trajectory was the
   // only anomalous one, there are no anomalous trajectories after this call.
+  // Interrupts the corresponding coast analyzer.
   void ResetLastSegment();
 
   // Deletes the last `count` trajectories and removes them from `segments_`. If
   // there are anomalous trajectories, their number is decremented and may
   // become 0.  `count` must be even (possibly 0) to maintain the invariant that
-  // the number of segments is odd.
+  // the number of segments is odd.  Doesn't delete the `manœuvres_` or the
+  // `coast_analysers_`, but interrupts all the analysers for the popped
+  // segments.NONONO
   void PopLastSegments(std::int64_t count);
 
   // Pops the burn of the manœuvre with the given index and all following

--- a/ksp_plugin/flight_plan.hpp
+++ b/ksp_plugin/flight_plan.hpp
@@ -207,9 +207,11 @@ class FlightPlan {
   // only anomalous one, there are no anomalous trajectories after this call.
   void ResetLastSegment();
 
-  // Deletes the last trajectory and removes it from `segments_`.  If there are
-  // anomalous trajectories, their number is decremented and may become 0.
-  void PopLastSegment();
+  // Deletes the last `count` trajectories and removes them from `segments_`. If
+  // there are anomalous trajectories, their number is decremented and may
+  // become 0.  `count` must be even (possibly 0) to maintain the invariant that
+  // the number of segments is odd.
+  void PopLastSegments(std::int64_t count);
 
   // Pops the burn of the manœuvre with the given index and all following
   // segments, then resets the last segment (which is the coast preceding


### PR DESCRIPTION
Also change the way that we pop segments to make it easier to enforce the invariant that the flight plan starts and ends with a coast.

Fix #4216.