### PR TITLE
Increase the distance after setting focus to a celestial body

### DIFF
--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -641,7 +641,7 @@ internal class
               GUILayoutWidth(1))) {
         PlanetariumCamera.fetch.SetTarget(celestial);
         PlanetariumCamera.fetch.SetDistance(
-            (float)celestial.Radius * ScaledSpace.InverseScaleFactor * 2f);
+            (float)celestial.Radius * ScaledSpace.InverseScaleFactor * 2f * 4);
       }
     }
     if (!celestial.is_leaf(target)) {

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -640,8 +640,11 @@ internal class
                             UnityEngine.GUI.skin.button),
               GUILayoutWidth(1))) {
         PlanetariumCamera.fetch.SetTarget(celestial);
+        const double degree = Math.PI / 180;
+        const double apparent_size = 15 * degree;
         PlanetariumCamera.fetch.SetDistance(
-            (float)celestial.Radius * ScaledSpace.InverseScaleFactor * 2f * 4);
+            (float)celestial.Radius * ScaledSpace.InverseScaleFactor /
+                (float)Math.Tan(apparent_size / 2));
       }
     }
     if (!celestial.is_leaf(target)) {


### PR DESCRIPTION
I would like to propose the following change to the distance set when using the new feature for setting focus to a celestial body in the reference frame list. This would cause the distance after focus to no longer be the smallest possible, but rather give some room to better observe the surroundings of the body in the map view.

This came from personally getting a little bit annoyed by having to zoom out every time after using the focus button. I really appreciate the feature though. It's been a life saver since I run too many simulations and have to recreate plans every time.

This was tested locally, the images show how the bodies would be drawn with the new value. I think the ideal would having it be a setting so the user may set to whatever is preferred

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d0105381-e6a4-4803-bd39-850a9e506bdd" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/11a0d923-2905-40ab-a32e-af3e78f244e8" />
