### PR TITLE
Implement the rounding test from Muller et al.

### DIFF
--- a/numerics/sin_cos.cpp
+++ b/numerics/sin_cos.cpp
@@ -167,7 +167,7 @@ double DetectDangerousRounding(double const x, double const Δx) {
   } else {
 #if _DEBUG
     LOG(ERROR) << std::setprecision(25) << x << " " << std::hexfloat << value
-               << " " << error << " " << normalized_error;
+               << " " << error << " " << e;
 #endif
     return std::numeric_limits<double>::quiet_NaN();
   }


### PR DESCRIPTION
This saves about 3 cycles on `Cos` for small angles.
Command run on Zen3:
```
 .\nanobenchmarks_NewRoundingTest.exe --benchmark_filter '.*([cC]os|[sS]in).*'
```
Before:
```
       principia_cos           66.29   +0.92   +1.37   +1.37   +1.37   +1.83   +1.83
       principia_sin           64.92   +2.75   +3.66   +4.12   +4.12   +4.12   +4.58
             std_cos           62.63   +0.00   +0.46   +0.46   +0.46   +0.46   +0.46
             std_sin           56.22   +0.46   +0.46   +0.46   +0.46   +0.46   +0.92
```
After:
```
       principia_cos           63.03   +1.35   +2.70   +3.16   +3.16   +3.61   +3.61
       principia_sin           64.83   +1.35   +2.70   +2.70   +2.70   +2.70   +3.16
             std_cos           61.68   +0.00   +0.45   +0.45   +0.45   +0.45   +0.45
             std_sin           57.62   +0.00   +0.00   +0.45   +0.45   +0.45   +0.45
```
#1760.