### PR TITLE
Make Pow type-agnostic and move it back to numerics

### DIFF
--- a/numerics/elementary_functions.hpp
+++ b/numerics/elementary_functions.hpp
@@ -54,6 +54,11 @@ constexpr Q NextUp(Q const& x);
 template<typename Q>
 constexpr Q NextDown(Q const& x);
 
+// Equivalent to `std::pow(x, exponent)` unless -3 ≤ x ≤ 3, in which case
+// explicit specialization yields multiplications statically.
+template<int exponent, typename Q>
+constexpr Exponentiation<Q, exponent> Pow(Q const& x);
+
 double Sin(Angle const& α);
 double Cos(Angle const& α);
 double Tan(Angle const& α);

--- a/numerics/elementary_functions_body.hpp
+++ b/numerics/elementary_functions_body.hpp
@@ -117,6 +117,62 @@ constexpr Q NextDown(Q const& x) {
   return si::Unit<Q> * numerics::_next::NextDown(x / si::Unit<Q>);
 }
 
+template<int exponent>
+constexpr double Pow(double x) {
+  // Use the Russian peasant algorithm for small exponents.
+  if constexpr (exponent > 0 && exponent < 32) {
+    // The end of the recursion is handled by the specializations below.
+    auto const y = Pow<exponent / 2>(x);
+    auto const y² = y * y;
+    if constexpr (exponent % 2 == 1) {
+      return y² * x;
+    } else {
+      return y²;
+    }
+  } else if constexpr (exponent < 0 && exponent > -32) {
+    return 1 / Pow<-exponent>(x);
+  } else {
+    return std::pow(x, exponent);
+  }
+}
+
+// Static specializations for frequently-used exponents, so that this gets
+// turned into multiplications at compile time.
+
+template<>
+inline constexpr double Pow<0>(double) {
+  return 1;
+}
+
+template<>
+inline constexpr double Pow<1>(double x) {
+  return x;
+}
+
+template<>
+inline constexpr double Pow<2>(double x) {
+  return x * x;
+}
+
+template<>
+inline constexpr double Pow<3>(double x) {
+  return x * x * x;
+}
+
+template<int exponent, typename Q>
+constexpr Exponentiation<Q, exponent> Pow(Q const& x) {
+  if constexpr (number_category<Q>::value == number_kind_rational) {
+    // It seems that Boost does not define `pow` for `cpp_rational`.
+    return cpp_rational(pow(numerator(x), exponent),
+                        pow(denominator(x), exponent));
+  } else if constexpr (is_number<Q>::value) {
+    return pow(x, exponent);
+  } else {
+    return si::Unit<Exponentiation<Q, exponent>> *
+           Pow<exponent>(x / si::Unit<Q>);
+  }
+}
+
 inline double Sin(Angle const& α) {
   return std::sin(α / Radian);
 }

--- a/physics/lagrange_equipotentials_test.cpp
+++ b/physics/lagrange_equipotentials_test.cpp
@@ -15,7 +15,6 @@
 #include "integrators/symmetric_linear_multistep_integrator.hpp"
 #include "mathematica/logger.hpp"
 #include "mathematica/mathematica.hpp"
-#include "numerics/elementary_functions.hpp"
 #include "physics/body_centred_body_direction_reference_frame.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/discrete_trajectory.hpp"
@@ -47,7 +46,6 @@ using namespace principia::integrators::_methods;
 using namespace principia::integrators::_symmetric_linear_multistep_integrator;
 using namespace principia::mathematica::_logger;
 using namespace principia::mathematica::_mathematica;
-using namespace principia::numerics::_elementary_functions;
 using namespace principia::physics::_body_centred_body_direction_reference_frame;  // NOLINT
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_discrete_trajectory;
@@ -129,7 +127,8 @@ TEST_F(LagrangeEquipotentialsTest,
   Position<World> const q_moon = moon_world_dof.position();
   Position<World> const initial_earth_moon_l5 =
       Barycentre({q_earth, q_moon}, {1.0, 1.0}) +
-      (q_earth - q_moon).Norm() * Vector<double, World>({0, Sqrt(3) / 2, 0});
+      (q_earth - q_moon).Norm() *
+          Vector<double, World>({0, quantities::Sqrt(3) / 2, 0});
   using MEO = Frame<struct MEOTag, Arbitrary>;
   BodyCentredBodyDirectionReferenceFrame<Barycentric, MEO> meo(
       ephemeris_.get(), moon, earth);

--- a/quantities/astronomy.hpp
+++ b/quantities/astronomy.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "numerics/elementary_functions.hpp"
 #include "quantities/constants.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -12,6 +13,7 @@ namespace quantities {
 namespace _astronomy {
 namespace internal {
 
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_constants;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;

--- a/quantities/bipm.hpp
+++ b/quantities/bipm.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "numerics/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
@@ -7,6 +8,7 @@
 namespace principia {
 namespace quantities {
 
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;

--- a/quantities/constants.hpp
+++ b/quantities/constants.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "numerics/elementary_functions.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
@@ -9,6 +10,7 @@ namespace quantities {
 namespace _constants {
 namespace internal {
 
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;

--- a/quantities/generators.hpp
+++ b/quantities/generators.hpp
@@ -9,9 +9,6 @@ namespace internal {
 // the result of the operation applied to argument(s) of the `Quantity` types
 // given as template parameter(s).
 
-template<typename Q, int n>
-struct ExponentiationGenerator;
-
 // Only legal if `n` divides the dimensions of `Q`.
 template<typename Q, int n, typename = void>
 struct NthRootGenerator;
@@ -24,7 +21,6 @@ struct QuotientGenerator;
 
 }  // namespace internal
 
-using internal::ExponentiationGenerator;
 using internal::NthRootGenerator;
 using internal::ProductGenerator;
 using internal::QuotientGenerator;

--- a/quantities/generators_body.hpp
+++ b/quantities/generators_body.hpp
@@ -62,11 +62,6 @@ struct ProductGenerator<double, Right> : not_constructible {
   using Type = Right;
 };
 
-template<>
-struct ProductGenerator<double, double> : not_constructible {
-  using Type = double;
-};
-
 template<template<typename> typename Quantity, typename Left, typename Right>
 struct QuotientGenerator<Quantity<Left>, Quantity<Right>> : not_constructible {
   using Type = typename Collapse<Quantity<
@@ -82,11 +77,6 @@ template<template<typename> typename Quantity, typename Right>
 struct QuotientGenerator<double, Quantity<Right>> : not_constructible {
   using Type = typename Collapse<Quantity<
       typename DimensionsQuotientGenerator<NoDimensions, Right>::Type>>::Type;
-};
-
-template<>
-struct QuotientGenerator<double, double> : not_constructible {
-  using Type = double;
 };
 
 }  // namespace internal

--- a/quantities/generators_body.hpp
+++ b/quantities/generators_body.hpp
@@ -31,29 +31,6 @@ struct Collapse<Quantity<NoDimensions>> : not_constructible {
 };
 
 template<template<typename> typename Quantity, typename D, int n>
-  requires (!is_number<Quantity<D>>::value)  // NOLINT
-struct ExponentiationGenerator<Quantity<D>, n> : not_constructible {
-  using Type = typename Collapse<
-      Quantity<typename DimensionsExponentiationGenerator<D, n>::Type>>::Type;
-};
-
-template<int n>
-struct ExponentiationGenerator<double, n> : not_constructible {
-  using Type = double;
-};
-
-template<int n>
-struct ExponentiationGenerator<int, n> : not_constructible {
-  using Type = int;
-};
-
-template<typename Number, int n>
-  requires is_number<Number>::value
-struct ExponentiationGenerator<Number, n> : not_constructible {
-  using Type = Number;
-};
-
-template<template<typename> typename Quantity, typename D, int n>
 struct NthRootGenerator<Quantity<D>, n, void> : not_constructible {
   using Type = typename Collapse<
       Quantity<typename DimensionsNthRootGenerator<D, n>::Type>>::Type;

--- a/quantities/named_quantities.hpp
+++ b/quantities/named_quantities.hpp
@@ -7,6 +7,7 @@ namespace quantities {
 namespace _named_quantities {
 namespace internal {
 
+using namespace principia::base::_not_constructible;
 using namespace principia::quantities::_quantities;
 
 // The result type of +, -, * and / on arguments of types `Left` and `Right`.
@@ -23,8 +24,23 @@ template<typename Q>
 using Inverse = Quotient<double, Q>;
 
 template<typename T, int exponent>
-using Exponentiation =
-    typename _generators::ExponentiationGenerator<T, exponent>::Type;
+struct ExponentiationGenerator : not_constructible {
+  using type =
+      Product<T, typename ExponentiationGenerator<T, exponent - 1>::type>;
+};
+template<typename T, int exponent>
+  requires(exponent < 0)
+struct ExponentiationGenerator<T, exponent> : not_constructible {
+  using type =
+      Quotient<T, typename ExponentiationGenerator<T, -exponent + 1>::type>;
+};
+template<typename T>
+struct ExponentiationGenerator<T, 1> : not_constructible {
+  using type = T;
+};
+
+template<typename T, int exponent>
+using Exponentiation = typename ExponentiationGenerator<T, exponent>::type;
 template<typename Q>
 using Square = Exponentiation<Q, 2>;
 template<typename Q>

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -49,10 +49,6 @@ using Product = typename ProductGenerator<Left, Right>::Type;
 template<typename Left, typename Right>
 using Quotient = typename QuotientGenerator<Left, Right>::Type;
 
-template<typename T, int exponent>
-using Exponentiation =
-    typename _generators::ExponentiationGenerator<T, exponent>::Type;
-
 template<typename D>
 class Quantity final {
  public:
@@ -123,11 +119,6 @@ template<typename RDimensions>
 constexpr Quotient<double, Quantity<RDimensions>>
 operator/(double, Quantity<RDimensions> const&);
 
-// Equivalent to `std::pow(x, exponent)` unless -3 ≤ x ≤ 3, in which case
-// explicit specialization yields multiplications statically.
-template<int exponent, typename Q>
-constexpr Exponentiation<Q, exponent> Pow(Q const& x);
-
 // Used for implementing `si::Unit`.  Don't call directly, don't export from
 // this namespace.  Defined here to break circular dependencies.
 template<typename Q>
@@ -181,7 +172,6 @@ using internal::Length;
 using internal::LuminousIntensity;
 using internal::Mass;
 using internal::NaN;
-using internal::Pow;
 using internal::Quantity;
 using internal::Temperature;
 using internal::Time;

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -127,62 +127,6 @@ constexpr Quotient<double, Quantity<RDimensions>> operator/(
   return Quotient<double, Quantity<RDimensions>>(left / right.magnitude_);
 }
 
-// Static specializations for frequently-used exponents, so that this gets
-// turned into multiplications at compile time.
-
-template<int exponent>
-constexpr double Pow(double x) {
-  // Use the Russian peasant algorithm for small exponents.
-  if constexpr (exponent > 0 && exponent < 32) {
-    // The end of the recursion is handled by the specializations below.
-    auto const y = Pow<exponent / 2>(x);
-    auto const y² = y * y;
-    if constexpr (exponent % 2 == 1) {
-      return y² * x;
-    } else {
-      return y²;
-    }
-  } else if constexpr (exponent < 0 && exponent > -32) {
-    return 1 / Pow<-exponent>(x);
-  } else {
-    return std::pow(x, exponent);
-  }
-}
-
-template<>
-inline constexpr double Pow<0>(double) {
-  return 1;
-}
-
-template<>
-inline constexpr double Pow<1>(double x) {
-  return x;
-}
-
-template<>
-inline constexpr double Pow<2>(double x) {
-  return x * x;
-}
-
-template<>
-inline constexpr double Pow<3>(double x) {
-  return x * x * x;
-}
-
-template<int exponent, typename Q>
-constexpr Exponentiation<Q, exponent> Pow(Q const& x) {
-  if constexpr (number_category<Q>::value == number_kind_rational) {
-    // It seems that Boost does not define `pow` for `cpp_rational`.
-    return cpp_rational(pow(numerator(x), exponent),
-                        pow(denominator(x), exponent));
-  } else if constexpr (is_number<Q>::value) {
-    return pow(x, exponent);
-  } else {
-    return SIUnit<Exponentiation<Q, exponent>>() *
-           Pow<exponent>(x / SIUnit<Q>());
-  }
-}
-
 inline __m128d ToM128D(double const x) {
   return _mm_set1_pd(x);
 }

--- a/quantities/quantities_test.cpp
+++ b/quantities/quantities_test.cpp
@@ -4,7 +4,9 @@
 #include <string>
 
 #include "glog/logging.h"
+#include "google/protobuf/stubs/common.h"
 #include "gtest/gtest.h"
+#include "numerics/elementary_functions.hpp"
 #include "quantities/astronomy.hpp"
 #include "quantities/constants.hpp"
 #include "quantities/named_quantities.hpp"
@@ -18,6 +20,7 @@ namespace quantities {
 using ::testing::Eq;
 using ::testing::Lt;
 using ::testing::MatchesRegex;
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_astronomy;
 using namespace principia::quantities::_constants;
 using namespace principia::quantities::_named_quantities;

--- a/quantities/uk.hpp
+++ b/quantities/uk.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "numerics/elementary_functions.hpp"
 #include "quantities/constants.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
@@ -14,6 +15,7 @@ namespace quantities {
 namespace _uk {
 namespace internal {
 
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_constants;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;


### PR DESCRIPTION
This makes the generators in quantities/generators.hpp specific to the definition of operations on Quantity that correspond to predefined operations. When we introduce our own functions that work on Quantity and other things (e.g., `Pow`), we put that in `numerics` (why would `Pow` on a boost multiprecision type live in `quantities`?).

`Exponentiation` works like `Product` and does not know anything about how `Quantity` works (and thus likewise for `Derivatives` etc.).
`Pow` returns an `Exponentiation` and thus does not need to know anything about how `Quantity` works (just like other templatized numerics, e.g., `DoublePrecision`.

The headers that define constants depend on numerics::elementary_functions.