### PR TITLE
Mark continuous trajectories as WithoutFMA if created or read on a machine without FMA

### DIFF
--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -12,6 +12,7 @@
 
 #include "geometry/interval.hpp"
 #include "glog/stl_logging.h"
+#include "numerics/fma.hpp"
 #include "numerics/newhall.hpp"
 #include "numerics/poisson_series.hpp"
 #include "numerics/polynomial_in_чебышёв_basis.hpp"
@@ -23,8 +24,8 @@ namespace physics {
 namespace _continuous_trajectory {
 namespace internal {
 
-using namespace principia::numerics::_fma;
 using namespace principia::geometry::_interval;
+using namespace principia::numerics::_fma;
 using namespace principia::numerics::_newhall;
 using namespace principia::numerics::_poisson_series;
 using namespace principia::numerics::_polynomial_in_чебышёв_basis;


### PR DESCRIPTION
Currently, a save created with Grossmann or later on a machine without FMA will change behaviour if transferred to a machine with FMA, potentially wrecking complex flight plans (see, e.g., #3931). With this change, opening a save on a machine without FMA will forever mark the continuous trajectories as not having FMA, thus work done on the machine without FMA should be readable on a machine with FMA.

Note that the other direction is not supported: a flight plan created on a machine with FMA may be broken if you open it on an old machine.