### PR TITLE
Make the tests hermetic

### DIFF
--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -642,7 +642,7 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval(),
               AllOf(Field(&Interval<Angle>::min,
                           AnyOf(IsNear(74.7_(1) * Degree),    // Windows.
-                                IsNear(75.1_(1) * Degree))),  // Ubuntu.
+                                IsNear(75.1_(1) * Degree),    // Ubuntu.
                                 IsNear(75.0_(1) * Degree))),  // macOS.
                     Field(&Interval<Angle>::max,
                           AnyOf(IsNear(99.0_(1) * Degree),      // Windows.

--- a/astronomy/orbit_analysis_test.cpp
+++ b/astronomy/orbit_analysis_test.cpp
@@ -374,9 +374,9 @@ TEST_F(OrbitAnalysisTest, 北斗MEO) {
               AnyOf(IsNear(0.000554_(1)),    // Windows, Ubuntu.
                     IsNear(0.000550_(1))));  // macOS.
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              AnyOf(IsNear(0.7875_(1) * Degree),      // Windows.
-                    IsNear(1.133_(1) * Degree),       // Ubuntu.
-                    IsNear(-0.07348_(1) * Degree)));  // macOS.
+              AnyOf(IsNear(0.7875_(1) * Degree),   // Windows.
+                    IsNear(1.349_(1) * Degree),    // Ubuntu.
+                    IsNear(1.011_(1) * Degree)));  // macOS.
 }
 
 // COSPAR ID 2016-030A.
@@ -410,6 +410,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
               AllOf(AbsoluteErrorFrom(
                         nominal_anomalistic_mean_motion,
                         AnyOf(IsNear(0.46_(1) * Degree / Day),    // Windows.
+                              IsNear(0.65_(1) * Degree / Day),    // Ubuntu.
                               IsNear(0.63_(1) * Degree / Day))),  // macOS.
                     RelativeErrorFrom(nominal_anomalistic_mean_motion,
                                       AnyOf(IsNear(0.00075_(1)),  // Windows.
@@ -420,7 +421,9 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
               AbsoluteErrorFrom(29'599.8 * Kilo(Metre),
                                 IsNear(0.33_(1) * Kilo(Metre))));
   EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
-              IsNear(0.087_(1) * Kilo(Metre)));
+              AnyOf(IsNear(0.087_(1) * Kilo(Metre)),    // Windows.
+                    IsNear(0.089_(1) * Kilo(Metre)),    // Ubuntu.
+                    IsNear(0.092_(1) * Kilo(Metre))));  // macOS.
 
   // Nominal: 0.0.
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
@@ -428,8 +431,7 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
                     IsNear(0.000'18_(1))));  // macOS.
   EXPECT_THAT(elements.mean_eccentricity_interval().measure(),
               AnyOf(IsNear(0.000'020_(1)),    // Windows.
-                    IsNear(0.000'025_(1)),    // Ubuntu.
-                    IsNear(0.000'022_(1))));  // macOS.
+                    IsNear(0.000'017_(1))));  // Ubuntu, macOS.
 
   EXPECT_THAT(elements.mean_inclination_interval().midpoint(),
               AbsoluteErrorFrom(56.0 * Degree, IsNear(0.61_(1) * Degree)));
@@ -446,11 +448,12 @@ TEST_F(OrbitAnalysisTest, GalileoNominalSlot) {
   // set ω = 0, ω′ = 0.
   // However, e is never quite 0; we can compute a mean ω.
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
-              IsNear(88_(1) * Degree));
+              AnyOf(IsNear(88_(1) * Degree),    // Windows.
+                    IsNear(89_(1) * Degree)));  // Ubuntu.
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().measure(),
               AnyOf(IsNear(5.2_(1) * Degree),    // Windows.
-                    IsNear(7.2_(1) * Degree),    // Ubuntu.
-                    IsNear(7.3_(1) * Degree)));  // macOS.
+                    IsNear(7.5_(1) * Degree),    // Ubuntu.
+                    IsNear(6.2_(1) * Degree)));  // macOS.
 
   // Since the reference parameters conventionally set ω = 0, the given mean
   // anomaly is actually the mean argument of latitude; in order to get numbers
@@ -501,11 +504,11 @@ TEST_F(OrbitAnalysisTest, GalileoExtendedSlot) {
       elements.mean_semimajor_axis_interval().midpoint(),
               AbsoluteErrorFrom(27'977.6 * Kilo(Metre),
                         AnyOf(IsNear(0.0534_(1) * Kilo(Metre)),     // Windows.
-                              IsNear(0.0531_(1) * Kilo(Metre)),     // Ubuntu.
-                              IsNear(0.0534_(1) * Kilo(Metre)))));  // macOS.
+                              IsNear(0.0490_(1) * Kilo(Metre)),     // Ubuntu.
+                              IsNear(0.0503_(1) * Kilo(Metre)))));  // macOS.
   EXPECT_THAT(elements.mean_semimajor_axis_interval().measure(),
               AnyOf(IsNear(00'000.101_(1) * Kilo(Metre)),    // Windows.
-                    IsNear(00'000.099_(1) * Kilo(Metre)),    // Ubuntu.
+                    IsNear(00'000.105_(1) * Kilo(Metre)),    // Ubuntu.
                     IsNear(00'000.098_(1) * Kilo(Metre))));  // macOS.
 
   EXPECT_THAT(elements.mean_eccentricity_interval().midpoint(),
@@ -602,8 +605,8 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
       elements.mean_semimajor_axis_interval().midpoint(),
               DifferenceFrom(7714.42938 * Kilo(Metre),
                              AnyOf(IsNear(2.73_(1) * Metre),     // Windows.
-                                   IsNear(2.52_(1) * Metre),     // Ubuntu.
-                                   IsNear(2.34_(1) * Metre))));  // macOS.
+                                   IsNear(2.15_(1) * Metre),     // Ubuntu.
+                                   IsNear(1.91_(1) * Metre))));  // macOS.
   // Reference inclination from the legend of figure 9 of [BSFL98]; that
   // value is given as 66.040° in table 1 of [BSFL98], 66.039° in [BS96], and
   // 66.04° in [Ben97].
@@ -635,11 +638,12 @@ TEST_F(OrbitAnalysisTest, TOPEXPoséidon) {
                                 IsNear(88e-6_(1)))),  // macOS.
                     Field(&Interval<double>::max,
                           AnyOf(IsNear(109e-6_(1)),      // Windows, macOS.
-                                IsNear(112e-6_(1))))));  // Ubuntu.
+                                IsNear(110e-6_(1))))));  // Ubuntu.
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval(),
               AllOf(Field(&Interval<Angle>::min,
-                          AnyOf(IsNear(74.7_(1) * Degree),    // Windows, macOS.
-                                IsNear(74.0_(1) * Degree))),  // Ubuntu.
+                          AnyOf(IsNear(74.7_(1) * Degree),    // Windows.
+                                IsNear(75.1_(1) * Degree))),  // Ubuntu.
+                                IsNear(75.0_(1) * Degree))),  // macOS.
                     Field(&Interval<Angle>::max,
                           AnyOf(IsNear(99.0_(1) * Degree),      // Windows.
                                 IsNear(98.9_(1) * Degree),      // Ubuntu.
@@ -726,8 +730,8 @@ TEST_F(OrbitAnalysisTest, SPOT5) {
               IsNear(0.0012_(1)));
   EXPECT_THAT(elements.mean_argument_of_periapsis_interval().midpoint(),
               AnyOf(IsNear(89.58_(1) * Degree),    // Windows.
-                    IsNear(89.24_(1) * Degree),    // Ubuntu.
-                    IsNear(89.47_(1) * Degree)));  // macOS.
+                    IsNear(89.41_(1) * Degree),    // Ubuntu.
+                    IsNear(89.64_(1) * Degree)));  // macOS.
 
   // The nominal mean solar times of the nodes are 22:30 ascending, 10:30
   // descending.

--- a/astronomy/лидов_古在_test.cpp
+++ b/astronomy/лидов_古在_test.cpp
@@ -144,8 +144,7 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
 
   EXPECT_THAT(mercury_centred_trajectory.size(),
               AnyOf(Eq(1'534'272),    // Windows.
-                    Eq(1'534'438),    // Ubuntu.
-                    Eq(1'534'680)));  // macOS.
+                    Eq(1'534'335)));  // Ubuntu, macOS.
   OrbitalElements const elements = OrbitalElements::ForTrajectory(
       mercury_centred_trajectory, mercury_, MasslessBody{}).value();
   // The constants c₁ and c₂ are defined in [Лид61], equations (58) and (59)
@@ -186,8 +185,9 @@ TEST_F(Лидов古在Test, MercuryOrbiter) {
   // pumping energy into nor out of it.  The true values are 14'910.01 and
   // 14'910.28 km.
   EXPECT_THAT(elements.mean_semimajor_axis_interval().min,
-              AnyOf(IsNear(14'910.01_(1) * Kilo(Metre)),    // Windows, macOS.
-                    IsNear(14'909.96_(1) * Kilo(Metre))));  // Ubuntu.
+              AnyOf(IsNear(14'910.01_(1) * Kilo(Metre)),    // Windows.
+                    IsNear(14'909.96_(1) * Kilo(Metre)),    // Ubuntu.
+                    IsNear(14'909.99_(1) * Kilo(Metre))));  // macOS.
   EXPECT_THAT(elements.mean_semimajor_axis_interval().max,
               AnyOf(IsNear(14'910.28_(1) * Kilo(Metre)),    // Windows, macOS.
                     IsNear(14'910.29_(1) * Kilo(Metre))));  // Ubuntu.

--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -43,8 +43,7 @@ class PlayerTest : public ::testing::Test {
   PlayerTest()
       : test_info_(testing::UnitTest::GetInstance()->current_test_info()),
         test_case_name_(test_info_->test_case_name()),
-        test_name_(test_info_->name()),
-        plugin_(interface::principia__NewPlugin("MJD0", "MJD0", 0)) {}
+        test_name_(test_info_->name()) {}
 
   template<typename Profile>
   bool RunIfAppropriate(serialization::Method const& method_in,
@@ -56,21 +55,23 @@ class PlayerTest : public ::testing::Test {
   ::testing::TestInfo const* const test_info_;
   std::string const test_case_name_;
   std::string const test_name_;
-  std::unique_ptr<Plugin> plugin_;
 };
 
 TEST_F(PlayerTest, PlayTiny) {
   {
+    std::unique_ptr<Plugin> const plugin(
+        interface::principia__NewPlugin("MJD0", "MJD0", 0));
+
     Recorder* const r(new Recorder(test_name_ + ".journal.hex"));
     Recorder::Activate(r);
 
     {
       Method<NewPlugin> m({"MJD1", "MJD2", 3});
-      m.Return(plugin_.get());
+      m.Return(plugin.get());
     }
     {
-      const Plugin* plugin = plugin_.get();
-      Method<DeletePlugin> m({&plugin}, {&plugin});
+      const Plugin* p = plugin.get();
+      Method<DeletePlugin> m({&p}, {&p});
       m.Return();
     }
     Recorder::Deactivate();

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -119,7 +119,7 @@ Plugin::Plugin(std::string const& game_epoch,
       planetarium_rotation_(planetarium_rotation),
       game_epoch_(ParseTT(game_epoch)),
       current_time_(ParseTT(solar_system_epoch)) {
-  StaticInitialization(uses_correct_sin_cos_);
+  ConfigureElementaryFunctions(uses_correct_sin_cos_);
   gravity_model_.set_plugin_frame(serialization::Frame::BARYCENTRIC);
   initial_state_.set_epoch(solar_system_epoch);
   initial_state_.set_plugin_frame(serialization::Frame::BARYCENTRIC);
@@ -1547,7 +1547,7 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
 
   plugin->uses_correct_sin_cos_ = message.has_uses_correct_sin_cos() &&
       message.uses_correct_sin_cos();
-  StaticInitialization(plugin->uses_correct_sin_cos_);
+  ConfigureElementaryFunctions(plugin->uses_correct_sin_cos_);
 
   if (message.has_system_fingerprint()) {
     plugin->system_fingerprint_ = message.system_fingerprint();

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -34,6 +34,7 @@
 #include "ksp_plugin/planetarium.hpp"
 #include "ksp_plugin/renderer.hpp"
 #include "ksp_plugin/vessel.hpp"
+#include "numerics/elementary_functions.hpp"
 #include "physics/body.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/discrete_trajectory.hpp"
@@ -82,6 +83,7 @@ using namespace principia::ksp_plugin::_pile_up;
 using namespace principia::ksp_plugin::_planetarium;
 using namespace principia::ksp_plugin::_renderer;
 using namespace principia::ksp_plugin::_vessel;
+using namespace principia::numerics::_elementary_functions;
 using namespace principia::physics::_body;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_discrete_trajectory;
@@ -534,8 +536,9 @@ class Plugin {
   bool is_loaded(not_null<Vessel*> vessel) const;
 
   // Initialization objects.
-  Monostable initializing_;
+  ElementaryFunctionsConfigurationSaver configuration_saver_;  // Must be first.
   bool uses_correct_sin_cos_ = true;
+  Monostable initializing_;
   serialization::GravityModel gravity_model_;
   serialization::InitialState initial_state_;
   std::map<std::string, Index> name_to_index_;

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -166,10 +166,10 @@ class InterfaceTest : public InterfaceTestWithoutPlugin {
 
 Recorder* InterfaceTestWithoutPlugin::recorder_ = nullptr;
 
-using InterfaceDeathTest = InterfaceTest;
+using InterfaceDeathTestWithoutPlugin = InterfaceTestWithoutPlugin;
 
 // And there is only one thing we say to Death.
-TEST_F(InterfaceDeathTest, Errors) {
+TEST_F(InterfaceDeathTestWithoutPlugin, Errors) {
   Plugin* plugin = nullptr;
   EXPECT_DEATH({
     principia__DeletePlugin(nullptr);
@@ -211,7 +211,7 @@ TEST_F(InterfaceTest, InitGoogleLogging1) {
   principia__InitGoogleLogging();
 }
 
-TEST_F(InterfaceDeathTest, InitGoogleLogging2) {
+TEST_F(InterfaceDeathTestWithoutPlugin, InitGoogleLogging2) {
   // We use EXPECT_EXIT in this test to avoid interfering with the execution of
   // the other tests.
   int const exit_code = 66;
@@ -223,7 +223,7 @@ TEST_F(InterfaceDeathTest, InitGoogleLogging2) {
   }, ExitedWithCode(exit_code), "");
 }
 
-TEST_F(InterfaceDeathTest, ActivateRecorder) {
+TEST_F(InterfaceDeathTestWithoutPlugin, ActivateRecorder) {
   EXPECT_DEATH({
     Recorder::Deactivate();
     // Fails because the glog directory doesn't exist.
@@ -678,7 +678,7 @@ TEST_F(InterfaceTestWithoutPlugin, DeserializePlugin) {
   principia__DeletePlugin(&plugin);
 }
 
-TEST_F(InterfaceDeathTest, SettersAndGetters) {
+TEST_F(InterfaceDeathTestWithoutPlugin, SettersAndGetters) {
   // We use EXPECT_EXITs in this test to avoid interfering with the execution of
   // the other tests.
   int const exit_code = 66;

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -135,7 +135,7 @@ class InterfaceTestWithoutPlugin : public testing::Test {
   }
 
   InterfaceTestWithoutPlugin()
-      : // Use PluginTest.Serialization to create these files.
+      : // Use PluginTest.Serialization to create these files.  // NOLINT
         hexadecimal_simple_plugin_(ReadFromHexadecimalFile(
             SOLUTION_DIR / "ksp_plugin_test" / "simple_plugin.proto.hex")),
         serialized_simple_plugin_(ReadFromBinaryFile(

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -143,7 +143,7 @@ class InterfaceTest : public testing::Test {
             SOLUTION_DIR / "ksp_plugin_test" / "simple_plugin.proto.bin")) {}
 
   MockRenderer renderer_;
-  not_null<std::unique_ptr<StrictMock<MockPlugin>>> plugin_;
+  std::unique_ptr<StrictMock<MockPlugin>> plugin_;
   std::string const hexadecimal_simple_plugin_;
   std::vector<std::uint8_t> const serialized_simple_plugin_;
   Instant const t0_;
@@ -224,6 +224,7 @@ TEST_F(InterfaceTest, Log) {
 }
 
 TEST_F(InterfaceTest, NewPlugin) {
+  plugin_ = nullptr;
   std::unique_ptr<Plugin> plugin(principia__NewPlugin(
                                      "MJD1",
                                      "MJD2",
@@ -648,6 +649,7 @@ TEST_F(InterfaceTest, SerializePlugin) {
 }
 
 TEST_F(InterfaceTest, DeserializePlugin) {
+  plugin_ = nullptr;
   PushDeserializer* deserializer = nullptr;
   Plugin const* plugin = nullptr;
   principia__DeserializePlugin(hexadecimal_simple_plugin_.c_str(),

--- a/ksp_plugin_test/interface_test.cpp
+++ b/ksp_plugin_test/interface_test.cpp
@@ -164,7 +164,7 @@ class InterfaceTest : public InterfaceTestWithoutPlugin {
   not_null<std::unique_ptr<StrictMock<MockPlugin>>> plugin_;
 };
 
-Recorder* InterfaceTest::recorder_ = nullptr;
+Recorder* InterfaceTestWithoutPlugin::recorder_ = nullptr;
 
 using InterfaceDeathTest = InterfaceTest;
 

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -141,7 +141,7 @@ class PluginIntegrationTest : public testing::Test {
   std::string initial_time_;
   Angle planetarium_rotation_;
 
-  not_null<std::unique_ptr<Plugin>> plugin_;
+  std::unique_ptr<Plugin> plugin_;
 
   // These initial conditions will yield a low circular orbit around Earth.
   Displacement<AliceSun> satellite_initial_displacement_;
@@ -171,6 +171,7 @@ TEST_F(PluginIntegrationTest, AdvanceTimeWithCelestialsOnly) {
       Lt(0.01));
   serialization::Plugin plugin_message;
   plugin_->WriteToMessage(&plugin_message);
+  plugin_ = nullptr;
   plugin_ = Plugin::ReadFromMessage(plugin_message);
   // Having saved and loaded, we compute a new segment again, this probably
   // exercises apocalypse-type bugs.
@@ -666,6 +667,7 @@ TEST_F(PluginIntegrationTest, PhysicsBubble) {
 // with unit gravitational parameter at unit distance.  Since predictions are
 // only computed on `AdvanceTime()`, we advance time by a small amount.
 TEST_F(PluginIntegrationTest, Prediction) {
+  plugin_ = nullptr;
   Index const celestial = 0;
   Plugin plugin("JD2451545.0", "JD2451545.0", 0 * Radian);
   serialization::GravityModel::Body gravity_model;

--- a/ksp_plugin_test/plugin_integration_test.cpp
+++ b/ksp_plugin_test/plugin_integration_test.cpp
@@ -89,17 +89,14 @@ char const vessel_name[] = "NCC-1701-D";
 
 }  // namespace
 
-class PluginIntegrationTest : public testing::Test {
+class PluginIntegrationTestWithoutPlugin : public testing::Test {
  protected:
-  PluginIntegrationTest()
+  PluginIntegrationTestWithoutPlugin()
       : solar_system_(
             SolarSystemFactory::AtСпутник1Launch(
                 SolarSystemFactory::Accuracy::MinorAndMajorBodies)),
         initial_time_("JD2451545.0625"),
-        planetarium_rotation_(1 * Radian),
-        plugin_(make_not_null_unique<Plugin>(initial_time_,
-                                             initial_time_,
-                                             planetarium_rotation_)) {
+        planetarium_rotation_(1 * Radian) {
     satellite_initial_displacement_ =
         Displacement<AliceSun>({3111.0 * Kilo(Metre),
                                 4400.0 * Kilo(Metre),
@@ -119,6 +116,22 @@ class PluginIntegrationTest : public testing::Test {
                  satellite_initial_displacement_.Norm()) * unit_tangent;
   }
 
+  not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
+  std::string initial_time_;
+  Angle planetarium_rotation_;
+
+  // These initial conditions will yield a low circular orbit around Earth.
+  Displacement<AliceSun> satellite_initial_displacement_;
+  Velocity<AliceSun> satellite_initial_velocity_;
+};
+
+class PluginIntegrationTest : public PluginIntegrationTestWithoutPlugin {
+ protected:
+  PluginIntegrationTest()
+      : plugin_(std::make_unique<Plugin>(initial_time_,
+                                         initial_time_,
+                                         planetarium_rotation_)) {}
+
   void InsertAllSolarSystemBodies() {
     for (int index = SolarSystemFactory::Sun;
          index <= SolarSystemFactory::LastBody;
@@ -137,15 +150,7 @@ class PluginIntegrationTest : public testing::Test {
     }
   }
 
-  not_null<std::unique_ptr<SolarSystem<ICRS>>> solar_system_;
-  std::string initial_time_;
-  Angle planetarium_rotation_;
-
   std::unique_ptr<Plugin> plugin_;
-
-  // These initial conditions will yield a low circular orbit around Earth.
-  Displacement<AliceSun> satellite_initial_displacement_;
-  Velocity<AliceSun> satellite_initial_velocity_;
 };
 
 TEST_F(PluginIntegrationTest, AdvanceTimeWithCelestialsOnly) {
@@ -666,8 +671,7 @@ TEST_F(PluginIntegrationTest, PhysicsBubble) {
 // Checks that we correctly predict a full circular orbit around a massive body
 // with unit gravitational parameter at unit distance.  Since predictions are
 // only computed on `AdvanceTime()`, we advance time by a small amount.
-TEST_F(PluginIntegrationTest, Prediction) {
-  plugin_ = nullptr;
+TEST_F(PluginIntegrationTestWithoutPlugin, Prediction) {
   Index const celestial = 0;
   Plugin plugin("JD2451545.0", "JD2451545.0", 0 * Radian);
   serialization::GravityModel::Body gravity_model;

--- a/ksp_plugin_test/plugin_test.cpp
+++ b/ksp_plugin_test/plugin_test.cpp
@@ -280,13 +280,14 @@ class PluginTest : public PluginTestWithoutPlugin {
   not_null<std::unique_ptr<TestablePlugin>> plugin_;
 };
 
-RigidMotion<ICRS, Barycentric> const PluginTest::id_icrs_barycentric_(
-    RigidTransformation<ICRS, Barycentric>(
-        ICRS::origin,
-        Barycentric::origin,
-        OrthogonalMap<ICRS, Barycentric>::Identity()),
-    ICRS::nonrotating,
-    ICRS::unmoving);
+RigidMotion<ICRS, Barycentric> const
+    PluginTestWithoutPlugin::id_icrs_barycentric_(
+        RigidTransformation<ICRS, Barycentric>(
+            ICRS::origin,
+            Barycentric::origin,
+            OrthogonalMap<ICRS, Barycentric>::Identity()),
+        ICRS::nonrotating,
+        ICRS::unmoving);
 
 using PluginDeathTestWithoutPlugin = PluginTestWithoutPlugin;
 using PluginDeathTest = PluginTest;

--- a/numerics/elementary_functions.hpp
+++ b/numerics/elementary_functions.hpp
@@ -19,8 +19,11 @@ using namespace principia::quantities::_concepts;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 
-//TODO(phl)comments
-using ElementaryFunctionPointer = double(__cdecl*)(double θ);
+using ElementaryFunctionPointer = double(__cdecl*)(double θ);  // NOLINT
+
+// An RAII object that saves the configuration of the elementary function
+// pointers when it is constructed and restores them when it is destroyed.  This
+// is required to isolate the tests that construct plugins.
 class ElementaryFunctionsConfigurationSaver {
  public:
   ElementaryFunctionsConfigurationSaver();
@@ -32,9 +35,9 @@ class ElementaryFunctionsConfigurationSaver {
   ElementaryFunctionPointer sin_;
 };
 
-// Initializes the library to use either the platform functions or correctly-
+// Configures the library to use either the platform functions or correctly-
 // rounded ones, depending on the state of the save and the capabilities of the
-// platform.
+// platform.  By default, correctly-rounded functions are used.
 void ConfigureElementaryFunctions(bool uses_correct_sin_cos);
 
 // Equivalent to `std::fma(x, y, z)`.

--- a/numerics/elementary_functions.hpp
+++ b/numerics/elementary_functions.hpp
@@ -31,8 +31,8 @@ class ElementaryFunctionsConfigurationSaver {
 
  private:
   static std::atomic_bool active_;
-  ElementaryFunctionPointer cos_;
-  ElementaryFunctionPointer sin_;
+  ElementaryFunctionPointer const cos_;
+  ElementaryFunctionPointer const sin_;
 };
 
 // Configures the library to use either the platform functions or correctly-

--- a/numerics/elementary_functions.hpp
+++ b/numerics/elementary_functions.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "base/concepts.hpp"
 #include "quantities/arithmetic.hpp"
 #include "quantities/concepts.hpp"
@@ -16,6 +18,24 @@ using namespace principia::quantities::_arithmetic;
 using namespace principia::quantities::_concepts;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
+
+//TODO(phl)comments
+using ElementaryFunctionPointer = double(__cdecl*)(double θ);
+class ElementaryFunctionsConfigurationSaver {
+ public:
+  ElementaryFunctionsConfigurationSaver();
+  ~ElementaryFunctionsConfigurationSaver();
+
+ private:
+  static std::atomic_bool active_;
+  ElementaryFunctionPointer cos_;
+  ElementaryFunctionPointer sin_;
+};
+
+// Initializes the library to use either the platform functions or correctly-
+// rounded ones, depending on the state of the save and the capabilities of the
+// platform.
+void ConfigureElementaryFunctions(bool uses_correct_sin_cos);
 
 // Equivalent to `std::fma(x, y, z)`.
 template<typename Q1, typename Q2>
@@ -149,11 +169,6 @@ template<typename Q>
   requires boost_cpp_number<Q> || std::floating_point<Q>
 Q Round(Q const& x);
 
-// Initializes the library to use either the platform functions or correctly-
-// rounded ones, depending on the state of the save and the capabilities of the
-// platform.
-void StaticInitialization(bool uses_correct_sin_cos);
-
 }  // namespace internal
 
 using internal::Abs;
@@ -164,8 +179,10 @@ using internal::ArcSinh;
 using internal::ArcTan;
 using internal::ArcTanh;
 using internal::Cbrt;
+using internal::ConfigureElementaryFunctions;
 using internal::Cos;
 using internal::Cosh;
+using internal::ElementaryFunctionsConfigurationSaver;
 using internal::FusedMultiplyAdd;
 using internal::FusedMultiplySubtract;
 using internal::FusedNegatedMultiplyAdd;
@@ -177,7 +194,6 @@ using internal::Pow;
 using internal::Round;
 using internal::Sin;
 using internal::Sinh;
-using internal::StaticInitialization;
 using internal::Sqrt;
 using internal::Tan;
 using internal::Tanh;

--- a/numerics/elementary_functions_body.hpp
+++ b/numerics/elementary_functions_body.hpp
@@ -39,7 +39,6 @@ inline nullptr_t static_initialization = [](){
 inline ElementaryFunctionsConfigurationSaver::
 ElementaryFunctionsConfigurationSaver()
     : cos_(cos), sin_(sin) {
-  LOG(ERROR)<<"Plugin!";
   CHECK(!active_);
   active_ = true;
 }

--- a/numerics/elementary_functions_body.hpp
+++ b/numerics/elementary_functions_body.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include "boost/multiprecision/cpp_bin_float.hpp"
+#include "glog/logging.h"
 #include "numerics/cbrt.hpp"
 #include "numerics/fma.hpp"
 #include "numerics/next.hpp"
@@ -25,15 +26,48 @@ using namespace principia::numerics::_next;
 using namespace principia::numerics::_sin_cos;
 using namespace principia::quantities::_si;
 
-// Pointers used for indirect calls, set by `StaticInitialization`.
-inline double (__cdecl *cos)(double θ) = nullptr;
-inline double (__cdecl *sin)(double θ) = nullptr;
+// Pointers used for indirect calls, set by `ConfigureElementaryFunctions`.
+inline ElementaryFunctionPointer cos = nullptr;
+inline ElementaryFunctionPointer sin = nullptr;
 inline nullptr_t static_initialization = [](){
   // By default, use the correctly-rounded implementation.  This can be
   // overridden based on the save.
-  StaticInitialization(/*uses_correct_sin_cos=*/true);
+  ConfigureElementaryFunctions(/*uses_correct_sin_cos=*/true);
   return nullptr;
 }();
+
+inline ElementaryFunctionsConfigurationSaver::
+ElementaryFunctionsConfigurationSaver()
+    : cos_(cos), sin_(sin) {
+  LOG(ERROR)<<"Plugin!";
+  CHECK(!active_);
+  active_ = true;
+}
+
+inline ElementaryFunctionsConfigurationSaver::
+~ElementaryFunctionsConfigurationSaver() {
+  cos = cos_;
+  sin = sin_;
+  active_ = false;
+}
+
+inline std::atomic_bool ElementaryFunctionsConfigurationSaver::active_ = false;
+
+inline void ConfigureElementaryFunctions(bool const uses_correct_sin_cos) {
+  // Beware!  This function cannot use `CanUseHardwareFMA` as it's called from a
+  // static declaration and we have no way to know if that variable has already
+  // been initialized.
+  if (!uses_correct_sin_cos) {
+    cos = &std::cos;
+    sin = &std::sin;
+  } else if (EarlyCanUseHardwareFMA()) {
+    cos = &numerics::_sin_cos::Cos<FMAPresence::Present>;
+    sin = &numerics::_sin_cos::Sin<FMAPresence::Present>;
+  } else {
+    cos = &numerics::_sin_cos::Cos<FMAPresence::Absent>;
+    sin = &numerics::_sin_cos::Sin<FMAPresence::Absent>;
+  }
+}
 
 template<typename Q1, typename Q2>
   requires((boost_cpp_int<Q1> && boost_cpp_int<Q2>) ||
@@ -310,22 +344,6 @@ inline Angle ArcTanh(double const x) {
 inline Angle UnwindFrom(Angle const& previous_angle, Angle const& α) {
   return α + std::nearbyint((previous_angle - α) / (2 * π * Radian)) *
                  (2 * π * Radian);
-}
-
-inline void StaticInitialization(bool const uses_correct_sin_cos) {
-  // Beware!  This function cannot use `CanUseHardwareFMA` as it's called from a
-  // static declaration and we have no way to know if that variable has already
-  // been initialized.
-  if (!uses_correct_sin_cos) {
-    cos = &std::cos;
-    sin = &std::sin;
-  } else if (EarlyCanUseHardwareFMA()) {
-    cos = &numerics::_sin_cos::Cos<FMAPresence::Present>;
-    sin = &numerics::_sin_cos::Sin<FMAPresence::Present>;
-  } else {
-    cos = &numerics::_sin_cos::Cos<FMAPresence::Absent>;
-    sin = &numerics::_sin_cos::Sin<FMAPresence::Absent>;
-  }
 }
 
 }  // namespace internal

--- a/numerics/poisson_series_test.cpp
+++ b/numerics/poisson_series_test.cpp
@@ -390,7 +390,7 @@ TEST_F(PoissonSeriesTest, PoorlyConditionedInnerProduct2) {
                                   AnyOf(IsNear(0.316_(1)),     // Windows.
                                         IsNear(0.318_(1)),     // Windows.
                                         IsNear(0.372_(1)),     // Ubuntu.
-                                        IsNear(0.274_(1)))));  // macOS.
+                                        IsNear(0.368_(1)))));  // macOS.
   }
   {
     auto const product =
@@ -597,9 +597,9 @@ TEST_F(PoissonSeriesTest, PoorlyConditionedInnerProduct3) {
                      t_min, t_max);
     EXPECT_THAT(product,
                 RelativeErrorFrom(expected_product,
-                                  AnyOf(IsNear(0.000487_(1)),    // Windows.
-                                        IsNear(0.00116_(1)),     // Ubuntu.
-                                        IsNear(0.00131_(1)))));  // macOS.
+                                  AnyOf(IsNear(0.000487_(1)),     // Windows.
+                                        IsNear(0.00116_(1)),      // Ubuntu.
+                                        IsNear(0.000995_(1)))));  // macOS.
   }
   // This test demonstrates how bad Integrate can be, for products that arise in
   // practice.  Exact integration of the result of PointwiseInnerProduct yields

--- a/numerics/quadrature_test.cpp
+++ b/numerics/quadrature_test.cpp
@@ -74,7 +74,7 @@ TEST_F(QuadratureTest, Sin) {
                   5.0 * Radian,
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
-              AlmostEquals(ʃf, 2, 4));
+              AlmostEquals(ʃf, 3, 4));
   EXPECT_THAT(evaluations, Eq(65));
 }
 

--- a/numerics/quadrature_test.cpp
+++ b/numerics/quadrature_test.cpp
@@ -74,7 +74,7 @@ TEST_F(QuadratureTest, Sin) {
                   5.0 * Radian,
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
-              AlmostEquals(ʃf, 3, 4));
+              AlmostEquals(ʃf, 2, 4));
   EXPECT_THAT(evaluations, Eq(65));
 }
 
@@ -129,7 +129,10 @@ TEST_F(QuadratureTest, Sin10) {
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
               AlmostEquals(ʃf, 2, 20));
-  EXPECT_EQ(524289, evaluations);
+  EXPECT_THAT(evaluations,
+              AnyOf(Eq(524289),    // Windows.
+                    Eq(1048577),   // Ubuntu.
+                    Eq(262145)));  // macOS.
 }
 
 }  // namespace quadrature

--- a/numerics/quadrature_test.cpp
+++ b/numerics/quadrature_test.cpp
@@ -129,10 +129,7 @@ TEST_F(QuadratureTest, Sin10) {
                   /*max_relative_error=*/std::numeric_limits<double>::epsilon(),
                   /*max_points=*/std::nullopt),
               AlmostEquals(ʃf, 2, 20));
-  EXPECT_THAT(evaluations,
-              AnyOf(Eq(524289),    // Windows.
-                    Eq(1048577),   // Ubuntu.
-                    Eq(262145)));  // macOS.
+  EXPECT_EQ(524289, evaluations);
 }
 
 }  // namespace quadrature


### PR DESCRIPTION
1. Add a saver object to the plugin to restore the configuration of the elementary functions across creations/destructions of plugins.
2. Change the computation of the Lobatto points to always use the correctly-rounded implementation.
3. Tentatively change the tolerances on Linux and macOS.

#1760.