### PR TITLE
Use libdl.so.2, not libdl.so, on Linux

### DIFF
--- a/ksp_plugin_adapter/ksp_plugin_adapter.dll.config
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.dll.config
@@ -1,4 +1,4 @@
 ﻿<configuration>
-  <dllmap dll="dl" os="linux" cpu="x86-64" target="libdl.so"/>
+  <dllmap dll="dl" os="linux" cpu="x86-64" target="libdl.so.2"/>
   <dllmap dll="dl" os="osx" cpu="x86-64" target="libdl.dylib" />
 </configuration>


### PR DESCRIPTION
See [this stackoverflow discussion](https://stackoverflow.com/questions/75855053/how-to-address-crash-due-to-missing-libdl-so-on-ubuntu-22).

Thanks to @Nazfib and @NovemberOrWhatever for helping us find this bug.