### PR TITLE
Remove copy constructors for Point that lead to inefficient code generation

### DIFF
--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -35,16 +35,10 @@ class Point final {
  public:
   constexpr Point();
 
-#if PRINCIPIA_COMPILER_MSVC && !__INTELLISENSE__
-  // Explicitly define constexpr default copy and move constructors because
-  // otherwise MSVC fails to initialize constant expressions.  In addition,
-  // Intellisense gets confused by these (because of course MSVC and
-  // Intellisense are different compilers and have bugs in different places).
-  constexpr Point(Point const& other);
-  constexpr Point(Point&& other);
+  constexpr Point(Point const& other) = default;
+  constexpr Point(Point&& other) = default;
   Point& operator=(Point const& other) = default;
   Point& operator=(Point&& other) = default;
-#endif
 
   constexpr friend bool operator==(Point const& left,
                                    Point const& right) = default;

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -56,16 +56,6 @@ struct PointSerializer<Multivector<Scalar, Frame, rank>> : not_constructible {
 template<typename Vector>
 constexpr Point<Vector>::Point() : coordinates_() {}
 
-#if PRINCIPIA_COMPILER_MSVC && !__INTELLISENSE__
-template<typename Vector>
-constexpr Point<Vector>::Point(Point const& other)
-    : coordinates_(other.coordinates_) {}
-
-template<typename Vector>
-constexpr Point<Vector>::Point(Point&& other)
-    : coordinates_(std::move(other.coordinates_)) {}
-#endif
-
 template<typename Vector>
 constexpr Vector Point<Vector>::operator-(Point const& from) const {
   return coordinates_ - from.coordinates_;

--- a/nanobenchmarks/nanobenchmarks.cpp
+++ b/nanobenchmarks/nanobenchmarks.cpp
@@ -13,7 +13,7 @@ using namespace principia::numerics::_cbrt;
 using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_si;
 
-BENCHMARKED_FUNCTION(twice) {
+BENCHMARKED_FUNCTION(twice, double, double) {
   return 2 * x;
 }
 

--- a/nanobenchmarks/nanobenchmarks.cpp
+++ b/nanobenchmarks/nanobenchmarks.cpp
@@ -13,7 +13,7 @@ using namespace principia::numerics::_cbrt;
 using namespace principia::numerics::_elementary_functions;
 using namespace principia::quantities::_si;
 
-BENCHMARKED_FUNCTION(twice, double, double) {
+BENCHMARKED_FUNCTION(twice) {
   return 2 * x;
 }
 

--- a/nanobenchmarks/nanobenchmarks.vcxproj
+++ b/nanobenchmarks/nanobenchmarks.vcxproj
@@ -13,15 +13,6 @@
     <Link>
       <AdditionalDependencies>powrprof.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
-    <ClCompile>
-      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Release_AVX_FMA|x64'">AssemblyCode</AssemblerOutput>
-    </ClCompile>
-    <ClCompile>
-      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AssemblyCode</AssemblerOutput>
-    </ClCompile>
-    <ClCompile>
-      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AssemblyCode</AssemblerOutput>
-    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="function_registry.cpp" />

--- a/nanobenchmarks/nanobenchmarks.vcxproj
+++ b/nanobenchmarks/nanobenchmarks.vcxproj
@@ -18,7 +18,7 @@
     <ClCompile Include="function_registry.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="performance_settings_controller.cpp" />
-    <ClCompile Include="examples.cpp" />
+    <ClCompile Include="nanobenchmarks.cpp" />
     <ClCompile Include="microarchitectures.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/nanobenchmarks/nanobenchmarks.vcxproj
+++ b/nanobenchmarks/nanobenchmarks.vcxproj
@@ -13,6 +13,15 @@
     <Link>
       <AdditionalDependencies>powrprof.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <ClCompile>
+      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Release_AVX_FMA|x64'">AssemblyCode</AssemblerOutput>
+    </ClCompile>
+    <ClCompile>
+      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AssemblyCode</AssemblerOutput>
+    </ClCompile>
+    <ClCompile>
+      <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AssemblyCode</AssemblerOutput>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="function_registry.cpp" />

--- a/nanobenchmarks/nanobenchmarks.vcxproj.filters
+++ b/nanobenchmarks/nanobenchmarks.vcxproj.filters
@@ -24,7 +24,7 @@
     <ClCompile Include="function_registry.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="examples.cpp">
+    <ClCompile Include="nanobenchmarks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="microarchitectures.cpp">

--- a/principia.props
+++ b/principia.props
@@ -74,6 +74,7 @@
       <AdditionalIncludeDirectories>C:\Program Files;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 /bigobj /w14714 /Zc:char8_t- /Zf</AdditionalOptions>
       <AdditionalOptions Condition="$(ProjectName) != serialization">/w14061 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerOutput Condition="$(ProjectName) == nanobenchmarks">AssemblyCode</AssemblerOutput>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <UseStandardPreprocessor>true</UseStandardPreprocessor>


### PR DESCRIPTION
Also rename the unfortunately-named `examples.cpp` and enable assembly generation in `nanobenchmarks`: we often want to look at the code in this project.

#3019.