### PR TITLE
Benchmark PlotMethod4 for continuous as well as discrete trajectories

### DIFF
--- a/benchmarks/planetarium_benchmark.cpp
+++ b/benchmarks/planetarium_benchmark.cpp
@@ -370,8 +370,7 @@ void BM_PlanetariumPlotMethod4DiscreteTrajectory(
   Planetarium planetarium = satellites.MakePlanetarium(
       1 * ArcMinute,
       perspective((satellites.gcrs().ToThisFrameAtTimeSimilarly(t) *
-                   plotting.FromThisFrameAtTimeSimilarly(t))
-                      .similarity(),
+                   plotting.FromThisFrameAtTimeSimilarly(t)).similarity(),
                   distance_from_earth),
       &plotting);
   std::vector<ScaledSpacePoint> line;
@@ -417,8 +416,7 @@ void BM_PlanetariumPlotMethod4ContinuousTrajectory(
   Planetarium planetarium = satellites.MakePlanetarium(
       1 * ArcMinute,
       perspective((satellites.gcrs().ToThisFrameAtTimeSimilarly(t) *
-                   plotting.FromThisFrameAtTimeSimilarly(t))
-                      .similarity(),
+                   plotting.FromThisFrameAtTimeSimilarly(t)).similarity(),
                   distance_from_earth),
       &plotting);
   std::vector<ScaledSpacePoint> line;


### PR DESCRIPTION
```
2025-10-12T17:52:10+02:00
Running C:\Users\robin\Projects\mockingbirdnest\Principia\Release\x64\benchmarks.exe
Run on (28 X 3312 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x14)
  L1 Instruction 32 KiB (x14)
  L2 Unified 1024 KiB (x14)
  L3 Unified 19712 KiB (x1)
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveECI               6.49 ms         6.25 ms           90 8763 points within -1.45679 ± 7028.54 × 3.74756 ± 7029.07 × -0.0327225 ± 77.5256
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECI            0.045 ms        0.046 ms        15448 146 points within 453.389 ± 63777.5 × -2838.57 ± 60538.8 × -958.486 ± 23377.4
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveECI                2.33 ms         2.29 ms          280 4003 points within -1.51318 ± 7028.57 × 3.6626 ± 7028.97 × -0.0421295 ± 77.5383
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECI             0.102 ms        0.100 ms         5600 325 points within 399.242 ± 63893.8 × -2835.85 ± 60541.5 × -978.858 ± 23392.3
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveECI          8.76 ms         8.75 ms           75 11057 points within -2.30957 ± 7027.73 × 4.86353 ± 7028.01 × -0.0536003 ± 77.5363
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECI       0.042 ms        0.041 ms        16593 128 points within 398.418 ± 63872.4 × -2828.16 ± 60549.2 × -965.033 ± 23347.2
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveECI           2.27 ms         2.23 ms          308 3308 points within -4.95557 ± 7023.55 × 4.02563 ± 7025.91 × -0.0381889 ± 77.3993
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECI        0.115 ms        0.115 ms         6400 366 points within 413.328 ± 63874.8 × -2830.43 ± 60546.9 × -955.3 ± 23378.1
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveECEF             0.800 ms        0.802 ms          896 791 points within 4623.92 ± 315.848 × 5279.21 ± 274.064 × 0.417866 ± 77.0841
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECEF            1.85 ms         1.84 ms          373 5510 points within 31.6758 ± 65381.2 × -10.3457 ± 65371.4 × -974.891 ± 23397.7
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveECEF              0.025 ms        0.025 ms        28000 35 points within 4624.78 ± 314.986 × 5279.21 ± 274.064 × 0.0913124 ± 73.8042
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECEF             2.61 ms         2.60 ms          264 8344 points within -20.3691 ± 65405.5 × 21.8438 ± 65399.3 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveECEF         1.16 ms         1.17 ms          560 1279 points within 4623.84 ± 315.932 × 5279.21 ± 274.064 × 0.168537 ± 77.2224
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECEF       1.89 ms         1.89 ms          373 5724 points within 21.1094 ± 65387.5 × 40.8242 ± 65392.8 × -974.874 ± 23397.8
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveECEF         0.237 ms        0.241 ms         2987 199 points within 4624.35 ± 315.417 × 5279.21 ± 274.064 × -0.0482635 ± 77.5457
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECEF        3.12 ms         3.14 ms          224 9848 points within -11.7363 ± 65411.6 × 45.1797 ± 65388.1 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveGSE               47.7 ms         47.9 ms           15 8820 points within -1.60645 ± 7026.85 × 3.84521 ± 7027.74 × -5.28809 ± 4125.41
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveGSE            0.819 ms        0.820 ms          896 134 points within -1690.02 ± 65280.4 × -3787.3 ± 59590 × -382.312 ± 29145.6
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveGSE                23.6 ms         23.4 ms           30 3923 points within -1.09595 ± 7026.04 × 3.76318 ± 7027.68 × -9.66626 ± 4119.89
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveGSE              1.74 ms         1.73 ms          407 297 points within -1676.42 ± 65468 × -3767.26 ± 59610.1 × -414.093 ± 29177.5
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveGSE          56.7 ms         55.4 ms           11 10519 points within -2.08276 ± 7026.31 × 4.42847 ± 7027.22 × -7.48145 ± 4127.47
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveGSE       0.768 ms        0.767 ms          896 120 points within -1674.17 ± 65299.1 × -3773.97 ± 59603.3 × -357.085 ± 29125.1
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveGSE           23.9 ms         24.0 ms           28 3326 points within -6.8335 ± 7021.37 × 5.28418 ± 7023.14 × -3.22949 ± 4121.18
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveGSE         1.87 ms         1.84 ms          373 318 points within -1683.23 ± 65471.7 × -3759.81 ± 59617.5 × -402.895 ± 29170.9
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveEML               77.9 ms         78.1 ms            9 8571 points within -0.944336 ± 7939.67 × 5.58252 ± 7242.11 × -7.2019 ± 5285.73
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveEML            0.017 ms        0.017 ms        40727 2 points within -5110.31 ± 0 × -63377.3 ± 0 × -23299.6 ± 0
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveEML                38.9 ms         39.1 ms           18 3843 points within 2.07397 ± 7932.87 × 0.4104 ± 7236.88 × -11.6028 ± 5278.79
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveEML             0.017 ms        0.017 ms        40727 2 points within -5110.31 ± 0 × -63377.3 ± 0 × -23299.6 ± 0
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveEML          90.0 ms         91.5 ms            7 9681 points within -0.130859 ± 7939.46 × 6.1853 ± 7241.12 × -7.25562 ± 5285.84
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveEML       0.017 ms        0.017 ms        40727 2 points within -5110.31 ± 0 × -63377.3 ± 0 × -23299.6 ± 0
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveEML           37.7 ms         37.3 ms           18 3416 points within -11.4094 ± 7929.21 × 5.08594 ± 7240.8 × -9.42554 ± 5282.39
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveEML        0.017 ms        0.017 ms        40727 2 points within -5110.31 ± 0 × -63377.3 ± 0 × -23299.6 ± 0
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveSEL                105 ms          104 ms            6 8852 points within -95.7419 ± 7746.52 × -715.461 ± 7746.18 × -336.921 ± 4221.58
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveSEL             1.82 ms         1.80 ms          407 136 points within -1242.14 ± 64045.8 × -4616.54 ± 58760.8 × -598.354 ± 28339.6
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveSEL                51.3 ms         51.6 ms           10 3900 points within -94.417 ± 7744.98 × -715.12 ± 7743.24 × -333.762 ± 4210.86
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveSEL              3.98 ms         4.00 ms          172 297 points within -1239.47 ± 64185.5 × -4610.2 ± 58767.1 × -629.173 ± 28399.4
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveSEL           124 ms          125 ms            6 10448 points within -96.7285 ± 7749.77 × -707.959 ± 7739.25 × -338.903 ± 4223.08
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveSEL        1.76 ms         1.76 ms          373 126 points within -1189.45 ± 64116.1 × -4657.6 ± 58719.7 × -690.67 ± 28326.3
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveSEL           49.1 ms         49.0 ms           15 3291 points within -100.596 ± 7740.77 × -703.426 ± 7732.34 × -339.767 ± 4215.44
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveSEL         4.20 ms         4.09 ms          172 317 points within -1247.65 ± 64187.5 × -4601.91 ± 58775.4 × -608.925 ± 28385.4
```