### PR TITLE
Adjust the filters in the benchmark sources to avoid overlaps

### DIFF
--- a/benchmark_automation/benchmark_automation.cs
+++ b/benchmark_automation/benchmark_automation.cs
@@ -13,7 +13,6 @@ internal class BenchmarkAutomation {
   private static void Main(string[] args) {
     var benchmark_directory = new DirectoryInfo(args[0]);
     var mathematica_directory = new DirectoryInfo(args[1]);
-    var jenkins_directory = new DirectoryInfo(args[2]);
     DateTime date = DateTime.UtcNow;
     string mathematica_date = date.ToString("{yyyy, M, d, H, m, s.fffffff},");
     string mathematica_output_file =

--- a/benchmarks/discrete_trajectory_benchmark.cpp
+++ b/benchmarks/discrete_trajectory_benchmark.cpp
@@ -1,4 +1,4 @@
-// .\Release\x64\benchmarks.exe --benchmark_filter=DiscreteTrajectory --benchmark_repetitions=5  // NOLINT(whitespace/line_length)
+// .\Release\x64\benchmarks.exe --benchmark_filter=BM_DiscreteTrajectory --benchmark_repetitions=5  // NOLINT(whitespace/line_length)
 
 #include <optional>
 #include <vector>

--- a/benchmarks/planetarium_benchmark.cpp
+++ b/benchmarks/planetarium_benchmark.cpp
@@ -1,4 +1,4 @@
-// .\Release\x64\benchmarks.exe --benchmark_repetitions=3 --benchmark_filter=Planetarium  // NOLINT(whitespace/line_length)
+// .\Release\x64\benchmarks.exe --benchmark_repetitions=3 --benchmark_filter=BM_Planetarium  // NOLINT(whitespace/line_length)
 
 #include <limits>
 #include <memory>


### PR DESCRIPTION
Also remove an unused parameter (adjusted the Jenkins command line accordingly).