### PR TITLE
Use EvaluateWithDerivative in EvaluateDegreesOfFreedom

### DIFF
--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -405,11 +405,11 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
       Instant t = polynomial.lower_bound();
       std::vector<Position<Frame>> q;
       std::vector<Velocity<Frame>> v;
-      Position<Frame> position;
+      Displacement<Frame> displacement;
       Velocity<Frame> velocity;
       for (int i = 0; i <= divisions; t += step, ++i) {
-        polynomial.EvaluateWithDerivative(t, position, velocity);
-        q.push_back(position);
+        polynomial.EvaluateWithDerivative(t, displacement, velocity);
+        q.push_back(Frame::origin + displacement);
         v.push_back(velocity);
       }
       Displacement<Frame> error_estimate;  // Should we do something with this?


### PR DESCRIPTION
The benchmarks show a small (a few percents) but consistent improvement.  On AVX:

Before:
```
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECI            0.030 ms        0.030 ms        22400 146 points within 453.389 ± 63777.5 × -2838.57 ± 60538.8 × -958.486 ± 23377.4
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECI             0.070 ms        0.070 ms         8960 325 points within 399.242 ± 63893.8 × -2835.85 ± 60541.5 × -978.858 ± 23392.3
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECI       0.028 ms        0.028 ms        24889 128 points within 398.418 ± 63872.4 × -2828.16 ± 60549.2 × -965.033 ± 23347.2
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECI        0.080 ms        0.080 ms         7467 366 points within 413.328 ± 63874.8 × -2830.43 ± 60546.9 × -955.3 ± 23378.1
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECEF            1.60 ms         1.60 ms          448 5510 points within 31.6758 ± 65381.2 × -10.3457 ± 65371.4 × -974.891 ± 23397.7
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECEF             2.35 ms         2.35 ms          299 8344 points within -20.3691 ± 65405.5 × 21.8438 ± 65399.3 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECEF       1.67 ms         1.65 ms          407 5724 points within 21.1094 ± 65387.5 × 40.8242 ± 65392.8 × -974.874 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECEF        2.83 ms         2.78 ms          236 9848 points within -11.7363 ± 65411.6 × 45.1797 ± 65388.1 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveGSE            0.561 ms        0.562 ms         1000 134 points within -1690.02 ± 65280.4 × -3787.3 ± 59590 × -382.312 ± 29145.6
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveGSE              1.20 ms         1.20 ms          560 297 points within -1676.42 ± 65468 × -3767.26 ± 59610.1 × -414.093 ± 29177.5
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveGSE       0.525 ms        0.516 ms         1120 120 points within -1674.17 ± 65299.1 × -3773.97 ± 59603.3 × -357.085 ± 29125.1
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveGSE         1.31 ms         1.29 ms          498 318 points within -1683.23 ± 65471.7 × -3759.81 ± 59617.5 × -402.895 ± 29170.9
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveSEL             1.22 ms         1.23 ms          560 136 points within -1242.14 ± 64045.8 × -4616.54 ± 58760.8 × -598.354 ± 28339.6
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveSEL              2.65 ms         2.68 ms          280 297 points within -1239.47 ± 64185.5 × -4610.2 ± 58767.1 × -629.173 ± 28399.4
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveSEL        1.21 ms         1.20 ms          560 126 points within -1189.45 ± 64116.1 × -4657.6 ± 58719.7 × -690.67 ± 28326.3
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveSEL         2.86 ms         2.85 ms          236 317 points within -1247.65 ± 64187.5 × -4601.91 ± 58775.4 × -608.925 ± 28385.4
```
After:
```
----------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations
----------------------------------------------------------------------------------------------------------------------
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECI            0.026 ms        0.025 ms        26353 146 points within 453.389 ± 63777.5 × -2838.57 ± 60538.8 × -958.486 ± 23377.4
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECI             0.063 ms        0.063 ms        11200 325 points within 399.242 ± 63893.8 × -2835.85 ± 60541.5 × -978.858 ± 23392.3
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECI       0.024 ms        0.024 ms        28000 128 points within 398.418 ± 63872.4 × -2828.16 ± 60549.2 × -965.033 ± 23347.2
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECI        0.073 ms        0.073 ms        11200 366 points within 413.328 ± 63874.8 × -2830.43 ± 60546.9 × -955.3 ± 23378.1
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveECEF            1.31 ms         1.31 ms          560 5510 points within 31.6758 ± 65381.2 × -10.3457 ± 65371.4 × -974.891 ± 23397.7
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveECEF             1.90 ms         1.93 ms          373 8344 points within -20.3691 ± 65405.5 × 21.8438 ± 65399.3 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveECEF       1.36 ms         1.37 ms          560 5724 points within 21.1094 ± 65387.5 × 40.8242 ± 65392.8 × -974.874 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveECEF        2.28 ms         2.25 ms          299 9848 points within -11.7363 ± 65411.6 × 45.1797 ± 65388.1 × -974.873 ± 23397.8
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveGSE            0.537 ms        0.547 ms         1000 134 points within -1690.02 ± 65280.4 × -3787.3 ± 59590 × -382.312 ± 29145.6
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveGSE              1.22 ms         1.22 ms          640 297 points within -1676.42 ± 65468 × -3767.26 ± 59610.1 × -414.093 ± 29177.5
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveGSE       0.514 ms        0.516 ms         1000 120 points within -1674.17 ± 65299.1 × -3773.97 ± 59603.3 × -357.085 ± 29125.1
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveGSE         1.28 ms         1.28 ms          560 318 points within -1683.23 ± 65471.7 × -3759.81 ± 59617.5 × -402.895 ± 29170.9
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearPolarPerspectiveSEL             1.21 ms         1.20 ms          560 136 points within -1242.14 ± 64045.8 × -4616.54 ± 58760.8 × -598.354 ± 28339.6
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarPolarPerspectiveSEL              2.61 ms         2.60 ms          264 297 points within -1239.47 ± 64185.5 × -4610.2 ± 58767.1 × -629.173 ± 28399.4
BM_PlanetariumPlotMethod4ContinuousTrajectory/NearEquatorialPerspectiveSEL        1.20 ms         1.20 ms          560 126 points within -1189.45 ± 64116.1 × -4657.6 ± 58719.7 × -690.67 ± 28326.3
BM_PlanetariumPlotMethod4ContinuousTrajectory/FarEquatorialPerspectiveSEL         2.80 ms         2.76 ms          249 317 points within -1247.65 ± 64187.5 × -4601.91 ± 58775.4 × -608.925 ± 28385.
```