### PR TITLE
Minor UI fixes

### DIFF
--- a/ksp_plugin_adapter/localization/en-us.cfg
+++ b/ksp_plugin_adapter/localization/en-us.cfg
@@ -89,7 +89,7 @@ Localization {
     #Principia_ReferenceFrameSelector_Tooltip_BodySurface = <<1>> reference frame: for operations involving the surface of <<A:2>>: landings, remote sensing, imaging, ground communications, etc.
     #Principia_ReferenceFrameSelector_Tooltip_BodyCentredParentDirection = <<1>> reference frame: for flybys of <<A:2>>, transfers to or from it.
     #Principia_ReferenceFrameSelector_Tooltip_RotatingPulsating = <<5>> reference frame: for low-energy transfers or orbits about the <<nom:3>>–<<nom:1>> Lagrange points.
-    #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>> reference frame: for intercepts or rendez-vous with the target vessel.
+    #Principia_ReferenceFrameSelector_Tooltip_Target = <<1>> reference frame: for intercepts or rendezvous with the target vessel.
     #Principia_ReferenceFrameSelector_Target = Target: <<1>>
     #Principia_ReferenceFrameSelector_Pin = Pin
     #Principia_ReferenceFrameSelector_Focus = Focus

--- a/ksp_plugin_adapter/reference_frame_selector.cs
+++ b/ksp_plugin_adapter/reference_frame_selector.cs
@@ -725,7 +725,7 @@ internal class
   }
 
   private void RenderSubtreeToggleGrid(CelestialBody celestial) {
-    int column_width = 2;
+    const float column_width = 2.25f;
     using (new UnityEngine.GUILayout.HorizontalScope()) {
       if (ToggleButton(
               SelectedFrameIs(celestial, FrameType.BODY_CENTRED_NON_ROTATING),


### PR DESCRIPTION
1. Make the reference frame buttons a bit wider, in the stock game (and maybe others) the text is clipped.
2. Fix a typo in the en-us localization.