### PR TITLE
The tests of the recorder and player should not change on Linux/macOS

### DIFF
--- a/journal/player_test.cpp
+++ b/journal/player_test.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <thread>
 
+#include "base/macros.hpp"  // 🧙 For PRINCIPIA_COMPILER_MSVC.
 #include "benchmark/benchmark.h"
 #include "glog/logging.h"
 #include "gtest/gtest.h"
@@ -84,7 +85,11 @@ TEST_F(PlayerTest, PlayTiny) {
   while (player.Play(count)) {
     ++count;
   }
+#if PRINCIPIA_COMPILER_MSVC
   EXPECT_EQ(2, count);
+#else
+  EXPECT_EQ(3, count);
+#endif
 }
 
 TEST_F(PlayerTest, DISABLED_SECULAR_Benchmarks) {

--- a/journal/recorder.cpp
+++ b/journal/recorder.cpp
@@ -41,9 +41,10 @@ void Recorder::Activate(not_null<Recorder*> const recorder) {
 
   // When the recorder gets activated, pretend that we got a GetVersion call.
   // This will record the version at the beginning of the journal, which is
-  // useful for forensics.  Note that this call doesn't register in the tests of
-  // the `journal` project, because there we have two `active_recorder`s, the
-  // one from the test and the one from the DLL.
+  // useful for forensics.  Note that on Windows this call doesn't register in
+  // the tests of the `journal` project, because there we have two
+  // `active_recorder`s, the one from the test and the one from the DLL.  On
+  // other platforms we don't use the DLL in tests.
   char const* build_date;
   char const* version;
   char const* platform;


### PR DESCRIPTION
On these platforms we don't link the tests again the DLL, so there is a single recorder in sight, and it registers `GetVersion`.