### PR TITLE
Make the PlotMethod benchmarks more realistic by applying downsampling

### DIFF
--- a/benchmarks/planetarium_benchmark.cpp
+++ b/benchmarks/planetarium_benchmark.cpp
@@ -29,6 +29,7 @@
 #include "physics/body_surface_reference_frame.hpp"
 #include "physics/continuous_trajectory.hpp"
 #include "physics/discrete_trajectory.hpp"
+#include "physics/discrete_trajectory_segment.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/kepler_orbit.hpp"
 #include "physics/massive_body.hpp"
@@ -67,6 +68,7 @@ using namespace principia::physics::_body_centred_non_rotating_reference_frame;
 using namespace principia::physics::_body_surface_reference_frame;
 using namespace principia::physics::_continuous_trajectory;
 using namespace principia::physics::_discrete_trajectory;
+using namespace principia::physics::_discrete_trajectory_segment;
 using namespace principia::physics::_ephemeris;
 using namespace principia::physics::_kepler_orbit;
 using namespace principia::physics::_massive_body;
@@ -205,6 +207,8 @@ class Satellites {
     CHECK_OK(ephemeris_->Prolong(goes_8_epoch));
     KeplerOrbit<Barycentric> const goes_8_orbit(
         *earth_, MasslessBody{}, goes_8_elements, goes_8_epoch);
+    goes_8_trajectory_.segments().begin()->SetDownsampling(
+        DownsamplingParameters());
     CHECK_OK(goes_8_trajectory_.Append(
         goes_8_epoch,
         ephemeris_->trajectory(earth_)->EvaluateDegreesOfFreedom(goes_8_epoch) +
@@ -292,6 +296,14 @@ class Satellites {
             Quinlan1999Order8A,
             Ephemeris<Barycentric>::NewtonianMotionEquation>(),
         /*step=*/10 * Second);
+  }
+
+  DiscreteTrajectorySegment<Barycentric>::DownsamplingParameters
+  DownsamplingParameters() {
+    return DiscreteTrajectorySegment<Barycentric>::DownsamplingParameters{
+        .max_dense_intervals = 10'000,
+        .tolerance = 10 * Metre,
+    };
   }
 
   not_null<std::unique_ptr<SolarSystem<Barycentric>>> const solar_system_;


### PR DESCRIPTION
Profiling shows that the Hermite3 construction and evaluation are about 3× ~~most~~ less costly than the lookup.

Before:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
-------------------------------------------------------------------------------------------------------------------
Benchmark                                                                         Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------------
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveECI            4.01 ms         4.00 ms         3542 8763 points within -1.45679 ± 7028.54 × 3.74756 ± 7029.07 × -0.0327225 ± 77.5256
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveECI             1.72 ms         1.72 ms         8072 4003 points within -1.51318 ± 7028.57 × 3.6626 ± 7028.97 × -0.0421295 ± 77.5383
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveECI       5.03 ms         5.03 ms         2791 11057 points within -2.30957 ± 7027.73 × 4.86353 ± 7028.01 × -0.0536003 ± 77.5363
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveECI        1.72 ms         1.72 ms         8145 3308 points within -4.95557 ± 7023.55 × 4.02563 ± 7025.91 × -0.0381889 ± 77.3993
```
After:
```
Run on (48 X 3793 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 32768 KiB (x4)
-------------------------------------------------------------------------------------------------------------------
Benchmark                                                                         Time             CPU   Iterations
-------------------------------------------------------------------------------------------------------------------
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearPolarPerspectiveECI            2.44 ms         2.44 ms         5781 8763 points within -1.45703 ± 7028.54 × 3.74805 ± 7029.07 × -0.0327263 ± 77.5256
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarPolarPerspectiveECI             1.21 ms         1.21 ms        11636 4003 points within -1.51489 ± 7028.57 × 3.66138 ± 7028.97 × -0.0421257 ± 77.5382
BM_PlanetariumPlotMethod4DiscreteTrajectory/NearEquatorialPerspectiveECI       3.19 ms         3.19 ms         4414 11057 points within -2.31079 ± 7027.73 × 4.86206 ± 7028.01 × -0.0536499 ± 77.5362
BM_PlanetariumPlotMethod4DiscreteTrajectory/FarEquatorialPerspectiveECI        1.23 ms         1.22 ms        11636 3308 points within -4.95557 ± 7023.55 × 4.0481 ± 7025.88 × -0.0381889 ± 77.3993
```