### PR TITLE
Don’t escape filenames when listing files changed by include_what_you_using

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -120,9 +120,12 @@ jobs:
       shell: pwsh
       run: |
         &.\include_what_you_using_all_the_things.ps1
-        $files = (git diff --name-only -z).Split("`0", [StringSplitOptions]::RemoveEmptyEntries)
-        foreach ($file in $files) {
-          $diff = (git diff $file)
-          echo "::warning file=$file,line=1,title=Include what you using::include_what_you_using_all_the_things.ps1 modifies this file as follows:%0A$([string]::join('%0A', (git diff $file)))"
+        $files = (git diff --name-only -z)
+        if ($files) {
+          $files = $files.Split("`0", [StringSplitOptions]::RemoveEmptyEntries)
+          foreach ($file in $files) {
+            $diff = (git diff $file)
+            echo "::warning file=$file,line=1,title=Include what you using::include_what_you_using_all_the_things.ps1 modifies this file as follows:%0A$([string]::join('%0A', (git diff $file)))"
+          }
+          exit $files.Length
         }
-        exit $files.Length


### PR DESCRIPTION
Spotted in #4409.