### PR TITLE
We no longer care about compatibility with pre-Haar downsampling parameters

### DIFF
--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -424,8 +424,7 @@ TEST_F(PluginCompatibilityTest, DISABLED_Egg) {
       R"(P:\Public Mockingbird\Principia\Saves\3136\3136b.proto.b64)",
       /*compressor=*/"gipfeli",
       /*decoder=*/"base64");
-  EXPECT_THAT(log_warning.string(),  // NOLINT(build/include_what_you_use)
-              HasSubstr("pre-Hamilton"));
+  EXPECT_THAT(log_warning.string(), HasSubstr("pre-Hamilton"));
 
   auto& mutable_plugin = const_cast<Plugin&>(*plugin);
 

--- a/physics/discrete_trajectory_test.cpp
+++ b/physics/discrete_trajectory_test.cpp
@@ -843,7 +843,8 @@ TEST_F(DiscreteTrajectoryTest, DISABLED_SerializationPreHamiltonCompatibility) {
   DiscreteTrajectory<World>::SegmentIterator psychohistory;
   auto const history = DiscreteTrajectory<World>::ReadFromMessage(
       message1, /*tracked=*/{&psychohistory});
-  EXPECT_THAT(log_warning.string(), HasSubstr("pre-Hamilton"));
+  EXPECT_THAT(log_warning.string(),  // NOLINT(build/include_what_you_use)
+              HasSubstr("pre-Hamilton"));
 
   // Note that the sizes don't have the same semantics as pre-Hamilton.  The
   // history now counts all segments.  The psychohistory has a duplicated point


### PR DESCRIPTION
In effect, the Лефшец downsamping parameters are a subset of the pre-Haar ones.