### PR TITLE
Add *= and /= to DoublePrecision so that it satisfies algebra concepts.

### DIFF
--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -39,6 +39,11 @@ struct DoublePrecision final {
   DoublePrecision<T>& operator-=(DoublePrecision<Difference<T>> const& right);
   DoublePrecision<T>& operator-=(Difference<T> const& right);
 
+  template<typename U>
+  DoublePrecision<T>& operator*=(U const& right);
+  template<typename U>
+  DoublePrecision<T>& operator/=(U const& right);
+
   // Compensated summation.  This is less precise, but more efficient, than
   // `operator-=` or `operator+=`.  Unlike `QuickTwoSum`, these functions don't
   // DCHECK their argument, so the caller must ensure that `right` is small

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -161,6 +161,20 @@ DoublePrecision<T>& DoublePrecision<T>::operator-=(
   return *this;
 }
 
+template<typename T>
+template<typename U>
+DoublePrecision<T>& DoublePrecision<T>::operator*=(U const& right) {
+  *this = *this * right;
+  return *this;
+}
+
+template<typename T>
+template<typename U>
+DoublePrecision<T>& DoublePrecision<T>::operator/=(U const& right) {
+  *this = *this / right;
+  return *this;
+}
+
 template <typename T>
 DoublePrecision<T>& DoublePrecision<T>::Decrement(Difference<T> const& right) {
   // See Higham, Accuracy and Stability of Numerical Algorithms, Algorithm 4.2.

--- a/numerics/double_precision_test.cpp
+++ b/numerics/double_precision_test.cpp
@@ -70,6 +70,14 @@ TEST_F(DoublePrecisionTest, DISABLED_IACA) {
 }
 #endif
 
+TEST_F(DoublePrecisionTest, AlgebraConcepts) {
+  static_assert(real_vector_space<DoublePrecision<double>>);
+  static_assert(real_vector_space<DoublePrecision<Displacement<World>>>);
+
+  static_assert(real_affine_space<DoublePrecision<Position<World>>>);
+  static_assert(!real_vector_space<DoublePrecision<Position<World>>>);
+}
+
 TEST_F(DoublePrecisionTest, CompensatedSummationIncrement) {
   Position<World> const initial =
       World::origin + Displacement<World>({1 * Metre, 0 * Metre, 0 * Metre});


### PR DESCRIPTION
This allows it to be used in `DirectSum` (which requires `affine`).

#4440.