### PR TITLE
The Linux tests are broken because of protobuf ODR violations in TextProto handling.

### DIFF
--- a/principia_make.sh
+++ b/principia_make.sh
@@ -20,9 +20,10 @@ echo "Parallelism is ${PARALLELISM}."
 make clean
 
 make -j ${PARALLELISM} \
+  --ignore-errors \
   bin/${PRINCIPIA_PLATFORM}/benchmark \
   bin/${PRINCIPIA_PLATFORM}/nanobenchmark \
-  each_package_test
+  each_test
 
 if [[ "${AGENT_OS?}" == "Darwin" ]]; then
   # See https://github.com/actions/virtual-environments/issues/2619#issuecomment-788397841


### PR DESCRIPTION
See https://github.com/protocolbuffers/protobuf/issues/17465.