### PR TITLE
A better representation of empty trajectory segments

### DIFF
--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -261,14 +261,18 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
       is_pre_fréchet || (message.has_pre_frenet_inertia_tensor() &&
                          !message.has_intrinsic_torque());
   bool const is_pre_galileo = !message.has_centre_of_mass();
-  bool const is_pre_hamilton = message.prehistory().segment_size() == 0;
-  LOG_IF(WARNING, is_pre_hamilton)
-      << "Reading pre-"
-      << (is_pre_cesàro    ? "Cesàro"
-          : is_pre_fréchet ? "Fréchet"
-          : is_pre_frenet  ? "Frenet"
-          : is_pre_galileo ? "Galileo"
-                           : "Hamilton") << " Part";
+  bool const is_pre_leibniz =
+      !message.prehistory().has_number_of_leading_empty_segments();
+  bool const is_pre_hamilton =
+      is_pre_leibniz && message.prehistory().segment_size() == 0;
+  LOG_IF(WARNING, is_pre_leibniz) << "Reading pre-"
+                                  << (is_pre_cesàro     ? "Cesàro"
+                                      : is_pre_fréchet  ? "Fréchet"
+                                      : is_pre_frenet   ? "Frenet"
+                                      : is_pre_galileo  ? "Galileo"
+                                      : is_pre_hamilton ? "Hamilton"
+                                                        : "Leibniz")
+                                  << " Part";
 
   std::unique_ptr<Part> part;
   if (is_pre_fréchet) {

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -261,8 +261,7 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
       is_pre_fréchet || (message.has_pre_frenet_inertia_tensor() &&
                          !message.has_intrinsic_torque());
   bool const is_pre_galileo = !message.has_centre_of_mass();
-  bool const is_pre_leibniz =
-      !message.prehistory().has_number_of_leading_empty_segments();
+  bool const is_pre_leibniz = !message.prehistory().has_is_leibniz_trajectory();
   bool const is_pre_hamilton =
       is_pre_leibniz && message.prehistory().segment_size() == 0;
   LOG_IF(WARNING, is_pre_leibniz) << "Reading pre-"

--- a/ksp_plugin/part.cpp
+++ b/ksp_plugin/part.cpp
@@ -261,7 +261,8 @@ not_null<std::unique_ptr<Part>> Part::ReadFromMessage(
       is_pre_fréchet || (message.has_pre_frenet_inertia_tensor() &&
                          !message.has_intrinsic_torque());
   bool const is_pre_galileo = !message.has_centre_of_mass();
-  bool const is_pre_leibniz = !message.prehistory().has_is_leibniz_trajectory();
+  bool const is_pre_leibniz =
+      !message.prehistory().has_leibniz_trajectory_marker();
   bool const is_pre_hamilton =
       is_pre_leibniz && message.prehistory().segment_size() == 0;
   LOG_IF(WARNING, is_pre_leibniz) << "Reading pre-"

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -14,8 +14,10 @@
 #include <variant>
 #include <vector>
 
+#include "absl/base/log_severity.h"
 #include "absl/container/btree_set.h"
 #include "absl/log/check.h"
+#include "absl/log/globals.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -850,10 +852,44 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
                      &vessel->prediction_});
     vessel->is_collapsible_ = message.is_collapsible();
 
+    auto rewriter = [](serialization::Vessel::Checkpoint const& checkpoint) {
+      if (checkpoint.non_collapsible_segment()
+              .has_number_of_leading_empty_segments()) {
+        return checkpoint;
+      } else {
+        DiscreteTrajectorySegmentIterator<Barycentric> backstory;
+        DiscreteTrajectory<Barycentric> non_collapsible_segment;
+        {
+          // The read would emit "pre-Leibniz" warnings for each checkpoint, and
+          // there may be many.  Just silence these warnings locally.
+          absl::log_internal::ScopedMinLogLevel scoped_min_log_level(
+              absl::LogSeverityAtLeast::kError);
+          non_collapsible_segment =
+              DiscreteTrajectory<Barycentric>::ReadFromMessage(
+                  checkpoint.non_collapsible_segment(),
+                  /*tracked=*/{&backstory});
+        }
+        serialization::Vessel::Checkpoint rewritten = checkpoint;
+        rewritten.clear_non_collapsible_segment();
+        non_collapsible_segment.WriteToMessage(
+            rewritten.mutable_non_collapsible_segment(),
+            backstory->begin(),
+            backstory->end(),
+            /*tracked=*/{backstory},
+            /*exact=*/{});
+        LOG_EVERY_N_SEC(WARNING, 1)
+            << "Rewriting pre-Leibniz Vessel::Checkpoint, size before "
+            << checkpoint.ByteSizeLong() << "B, size after "
+            << rewritten.ByteSizeLong() << "B";
+        return rewritten;
+      }
+    };
+
     vessel->checkpointer_ =
         Checkpointer<serialization::Vessel>::ReadFromMessage(
             vessel->MakeCheckpointerWriter(),
             vessel->MakeCheckpointerReader(),
+            rewriter,
             message.checkpoint());
     if (message.has_downsampling_parameters()) {
       vessel->downsampling_parameters_ =

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -852,7 +852,7 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
 
     auto rewriter = [](serialization::Vessel::Checkpoint const& checkpoint) {
       if (checkpoint.non_collapsible_segment()
-              .has_number_of_leading_empty_segments()) {
+              .has_is_leibniz_trajectory()) {
         return checkpoint;
       } else {
         DiscreteTrajectorySegmentIterator<Barycentric> backstory;

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -747,8 +747,8 @@ void Vessel::WriteToMessage(not_null<serialization::Vessel*> const message,
   message->set_selected_flight_plan_index(selected_flight_plan_index_);
   message->set_is_collapsible(is_collapsible_);
   checkpointer_->WriteToMessage(message->mutable_checkpoint());
-  LOG(INFO) << name_ << " " << NAMED(message->SpaceUsed()) << " "
-            << NAMED(message->ByteSize());
+  LOG(INFO) << name_ << " " << NAMED(message->SpaceUsedLong()) << " "
+            << NAMED(message->ByteSizeLong());
 }
 
 not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -14,10 +14,8 @@
 #include <variant>
 #include <vector>
 
-#include "absl/base/log_severity.h"
 #include "absl/container/btree_set.h"
 #include "absl/log/check.h"
-#include "absl/log/globals.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -858,17 +856,13 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
         return checkpoint;
       } else {
         DiscreteTrajectorySegmentIterator<Barycentric> backstory;
-        DiscreteTrajectory<Barycentric> non_collapsible_segment;
-        {
-          // The read would emit "pre-Leibniz" warnings for each checkpoint, and
-          // there may be many.  Just silence these warnings locally.
-          absl::log_internal::ScopedMinLogLevel scoped_min_log_level(
-              absl::LogSeverityAtLeast::kError);
-          non_collapsible_segment =
-              DiscreteTrajectory<Barycentric>::ReadFromMessage(
-                  checkpoint.non_collapsible_segment(),
-                  /*tracked=*/{&backstory});
-        }
+        // The read would emit "pre-Leibniz" warnings for each checkpoint, and
+        // there may be many.  Just silence these warnings.
+        DiscreteTrajectory<Barycentric> const non_collapsible_segment =
+            DiscreteTrajectory<Barycentric>::ReadFromMessage(
+                checkpoint.non_collapsible_segment(),
+                /*tracked=*/{&backstory},
+                /*quiet=*/true);
         serialization::Vessel::Checkpoint rewritten = checkpoint;
         rewritten.clear_non_collapsible_segment();
         non_collapsible_segment.WriteToMessage(

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -852,7 +852,7 @@ not_null<std::unique_ptr<Vessel>> Vessel::ReadFromMessage(
 
     auto rewriter = [](serialization::Vessel::Checkpoint const& checkpoint) {
       if (checkpoint.non_collapsible_segment()
-              .has_is_leibniz_trajectory()) {
+              .has_leibniz_trajectory_marker()) {
         return checkpoint;
       } else {
         DiscreteTrajectorySegmentIterator<Barycentric> backstory;

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -48,7 +48,9 @@ using ::testing::AllOf;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::Gt;
 using ::testing::HasSubstr;
+using ::testing::Lt;
 using ::testing::Not;
 using ::testing::Pair;
 using ::testing::ResultOf;
@@ -555,8 +557,11 @@ TEST_F(PluginCompatibilityTest, 4490) {
   std::int64_t bytes_written;
   std::int64_t bytes_read;
   WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
-  EXPECT_EQ(bytes_written, 26'967'685);
-  EXPECT_EQ(bytes_read, 26'967'685);
+  // Various asynchronous activities may happen in the plugin between the time
+  // it is read and the time it is written, so the size of the new save is not
+  // deterministic.
+  EXPECT_THAT(bytes_written, AllOf(Gt(26'967'000), Lt(26'967'999)));
+  EXPECT_EQ(bytes_read, bytes_written);
 }
 #endif
 

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -555,8 +555,8 @@ TEST_F(PluginCompatibilityTest, 4490) {
   std::int64_t bytes_written;
   std::int64_t bytes_read;
   WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
-  EXPECT_EQ(bytes_written, 1'000'000);
-  EXPECT_EQ(bytes_read, 1'000'000);
+  EXPECT_EQ(bytes_written, 26'967'685);
+  EXPECT_EQ(bytes_read, 26'967'685);
 }
 #endif
 

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -80,7 +80,9 @@ constexpr std::string_view preferred_encoder = "base64";
 class PluginCompatibilityTest : public testing::Test {
  protected:
   static not_null<std::unique_ptr<Plugin const>> WriteAndReadBack(
-      not_null<std::unique_ptr<Plugin const>> plugin1) {
+      not_null<std::unique_ptr<Plugin const>> plugin1,
+      std::int64_t& bytes_written,
+      std::int64_t& bytes_read) {
     // There may be solidi in the path due to parameterized tests, so we remove
     // them.
     std::string const sanitized_name = absl::StrCat(
@@ -92,21 +94,26 @@ class PluginCompatibilityTest : public testing::Test {
     WritePluginToFile(TEMP_DIR / sanitized_name,
                       preferred_compressor,
                       preferred_encoder,
-                      std::move(plugin1));
+                      std::move(plugin1),
+                      bytes_written);
 
     // Read the plugin from the new file to make sure that it's fine.
     return ReadPluginFromFile(TEMP_DIR / sanitized_name,
                               preferred_compressor,
-                              preferred_encoder);
+                              preferred_encoder,
+                              bytes_read);
   }
 
   static void CheckSaveCompatibility(std::filesystem::path const& filename,
                                      std::string_view const compressor,
                                      std::string_view const encoder) {
+    std::int64_t bytes_written;
+    std::int64_t bytes_read;
+
     // Read a plugin from the given file.
     auto plugin = ReadPluginFromFile(filename, compressor, encoder);
 
-    WriteAndReadBack(std::move(plugin));
+    WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
   }
 
   absl::ScopedStderrThreshold scoped_stderr_threshold_{
@@ -155,7 +162,9 @@ TEST_F(PluginCompatibilityTest, Reach) {
       SOLUTION_DIR / "ksp_plugin_test" / "saves" / "3072.proto.b64",
       /*compressor=*/"gipfeli",
       /*encoder=*/"base64");
-  plugin = WriteAndReadBack(std::move(plugin));
+  std::int64_t bytes_written;
+  std::int64_t bytes_read;
+  plugin = WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
   auto const test = plugin->GetVessel("f2d77873-4776-4809-9dfb-de9e7a0620a6");
   EXPECT_THAT(test->name(), Eq("TEST"));
   EXPECT_THAT(TTSecond(test->trajectory().front().time),
@@ -307,7 +316,9 @@ TEST_F(PluginCompatibilityTest, DISABLED_Butcher) {
       R"(P:\Public Mockingbird\Principia\Saves\1119\1119.proto.b64)",
       /*compressor=*/"gipfeli",
       /*encoder=*/"base64");
-  plugin = WriteAndReadBack(std::move(plugin));
+  std::int64_t bytes_written;
+  std::int64_t bytes_read;
+  plugin = WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
   auto const& orbiter =
       *plugin->GetVessel("e180ca12-492f-45bf-a194-4c5255aec8a0");
   EXPECT_THAT(orbiter.name(), Eq("Mercury Orbiter 1"));
@@ -378,7 +389,9 @@ TEST_F(PluginCompatibilityTest, DISABLED_Lpg) {
       R"(P:\Public Mockingbird\Principia\Saves\3136\3136.proto.b64)",
       /*compressor=*/"gipfeli",
       /*encoder=*/"base64");
-  plugin = WriteAndReadBack(std::move(plugin));
+  std::int64_t bytes_written;
+  std::int64_t bytes_read;
+  plugin = WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
 
   // The vessel with the longest history.
   auto const& vessel =
@@ -458,7 +471,9 @@ TEST_F(PluginCompatibilityTest, DISABLED_Egg) {
   mutable_plugin.CatchUpVessel("1e07aaa2-d1f8-4f6d-8b32-495b46109d98");
 
   // Make sure that we can upgrade, save, and reload.
-  WriteAndReadBack(std::move(plugin));
+  std::int64_t bytes_written;
+  std::int64_t bytes_read;
+  WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
 }
 
 TEST_F(PluginCompatibilityTest, PreHardy) {
@@ -503,6 +518,45 @@ TEST_F(PluginCompatibilityTest, 3273) {
   double const κ = nd / (Ωʹᴛ - Ωʹ);
   EXPECT_THAT(vessel->flight_plan().analysis(2)->recurrence(),
               Eq(std::nullopt));
+}
+
+TEST_F(PluginCompatibilityTest, 4490) {
+  absl::ScopedMockLog log;
+  EXPECT_CALL(log,
+              Log(absl::LogSeverity::kWarning,
+                  _,
+                  HasSubstr("pre-Leibniz DiscreteTrajectory")))
+      .Times(AtLeast(1));
+  EXPECT_CALL(log,
+              Log(absl::LogSeverity::kWarning,
+                  _,
+                  HasSubstr("pre-Leibniz Part")))
+      .Times(AtLeast(1));
+  EXPECT_CALL(log,
+              Log(absl::LogSeverity::kWarning,
+                  _,
+                  HasSubstr("pre-Hamilton DiscreteTrajectory")))
+      .Times(0);
+  EXPECT_CALL(log,
+              Log(absl::LogSeverity::kWarning,
+                  _,
+                  HasSubstr("pre-Hamilton Part")))
+      .Times(0);
+  log.StartCapturingLogs();
+
+  std::int64_t bytes_processed;
+  not_null<std::unique_ptr<Plugin const>> plugin = ReadPluginFromFile(
+      R"(C:\Users\Public\Public Mockingbird\Principia\Issues\4490\4490a.proto.b64)",
+      /*compressor=*/"gipfeli",
+      /*encoder=*/"base64",
+      bytes_processed);
+  EXPECT_EQ(bytes_processed, 114'345'631);
+
+  std::int64_t bytes_written;
+  std::int64_t bytes_read;
+  WriteAndReadBack(std::move(plugin), bytes_written, bytes_read);
+  EXPECT_EQ(bytes_written, 1'000'000);
+  EXPECT_EQ(bytes_read, 1'000'000);
 }
 #endif
 

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -560,7 +560,7 @@ TEST_F(PluginCompatibilityTest, 4490) {
   // Various asynchronous activities may happen in the plugin between the time
   // it is read and the time it is written, so the size of the new save is not
   // deterministic.
-  EXPECT_THAT(bytes_written, AllOf(Gt(26'967'000), Lt(26'967'999)));
+  EXPECT_THAT(bytes_written, AllOf(Gt(27'026'000), Lt(27'028'000)));
   EXPECT_EQ(bytes_read, bytes_written);
 }
 #endif

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -522,7 +522,7 @@ TEST_F(PluginCompatibilityTest, 3273) {
               Eq(std::nullopt));
 }
 
-TEST_F(PluginCompatibilityTest, 4490) {
+TEST_F(PluginCompatibilityTest, DISABLED_4490) {
   absl::ScopedMockLog log;
   EXPECT_CALL(log,
               Log(absl::LogSeverity::kWarning,
@@ -548,7 +548,7 @@ TEST_F(PluginCompatibilityTest, 4490) {
 
   std::int64_t bytes_processed;
   not_null<std::unique_ptr<Plugin const>> plugin = ReadPluginFromFile(
-      R"(C:\Users\Public\Public Mockingbird\Principia\Issues\4490\4490a.proto.b64)",
+      R"(P:\Public Mockingbird\Principia\Saves\4490\4490a.proto.b64)",
       /*compressor=*/"gipfeli",
       /*encoder=*/"base64",
       bytes_processed);

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -639,21 +639,25 @@ TEST_F(VesselTest, CheckpointsWithoutDownsampling) {
   {
     auto const& checkpoint = message.checkpoint(1);
     EXPECT_EQ(25, checkpoint.time().scalar().magnitude());
-    EXPECT_EQ(5, checkpoint.non_collapsible_segment().segment_size());
+    EXPECT_EQ(
+        1, checkpoint.non_collapsible_segment().leading_empty_segments_size());
+    auto const& segments0 =
+        checkpoint.non_collapsible_segment().leading_empty_segments(0);
+    EXPECT_EQ(1, segments0.count());
+    EXPECT_FALSE(segments0.has_downsampling_parameters());
+    EXPECT_EQ(4, checkpoint.non_collapsible_segment().segment_size());
     auto const& segment0 = checkpoint.non_collapsible_segment().segment(0);
-    EXPECT_EQ(0, segment0.zfp().timeline_size());
+    EXPECT_EQ(1, segment0.zfp().timeline_size());
+    EXPECT_EQ(10, segment0.exact(0).instant().scalar().magnitude());
     auto const& segment1 = checkpoint.non_collapsible_segment().segment(1);
-    EXPECT_EQ(1, segment1.zfp().timeline_size());
+    EXPECT_EQ(16, segment1.zfp().timeline_size());
     EXPECT_EQ(10, segment1.exact(0).instant().scalar().magnitude());
     auto const& segment2 = checkpoint.non_collapsible_segment().segment(2);
-    EXPECT_EQ(16, segment2.zfp().timeline_size());
-    EXPECT_EQ(10, segment2.exact(0).instant().scalar().magnitude());
+    EXPECT_EQ(1, segment2.zfp().timeline_size());
+    EXPECT_EQ(25, segment2.exact(0).instant().scalar().magnitude());
     auto const& segment3 = checkpoint.non_collapsible_segment().segment(3);
     EXPECT_EQ(1, segment3.zfp().timeline_size());
     EXPECT_EQ(25, segment3.exact(0).instant().scalar().magnitude());
-    auto const& segment4 = checkpoint.non_collapsible_segment().segment(4);
-    EXPECT_EQ(1, segment4.zfp().timeline_size());
-    EXPECT_EQ(25, segment4.exact(0).instant().scalar().magnitude());
     EXPECT_EQ(
         2,
         checkpoint.non_collapsible_segment().segment_by_left_endpoint_size());

--- a/ksp_plugin_test/vessel_test.cpp
+++ b/ksp_plugin_test/vessel_test.cpp
@@ -809,21 +809,25 @@ TEST_F(VesselTest, CheckpointsWithDownsampling) {
   {
     auto const& checkpoint = message.checkpoint(1);
     EXPECT_EQ(25, checkpoint.time().scalar().magnitude());
-    EXPECT_EQ(5, checkpoint.non_collapsible_segment().segment_size());
+    EXPECT_EQ(
+        1, checkpoint.non_collapsible_segment().leading_empty_segments_size());
+    auto const& segments0 =
+        checkpoint.non_collapsible_segment().leading_empty_segments(0);
+    EXPECT_EQ(1, segments0.count());
+    EXPECT_TRUE(segments0.has_downsampling_parameters());
+    EXPECT_EQ(4, checkpoint.non_collapsible_segment().segment_size());
     auto const& segment0 = checkpoint.non_collapsible_segment().segment(0);
-    EXPECT_EQ(0, segment0.zfp().timeline_size());
+    EXPECT_EQ(1, segment0.zfp().timeline_size());
+    EXPECT_EQ(10, segment0.exact(0).instant().scalar().magnitude());
     auto const& segment1 = checkpoint.non_collapsible_segment().segment(1);
-    EXPECT_EQ(1, segment1.zfp().timeline_size());
+    EXPECT_EQ(3, segment1.zfp().timeline_size());
     EXPECT_EQ(10, segment1.exact(0).instant().scalar().magnitude());
     auto const& segment2 = checkpoint.non_collapsible_segment().segment(2);
-    EXPECT_EQ(3, segment2.zfp().timeline_size());
-    EXPECT_EQ(10, segment2.exact(0).instant().scalar().magnitude());
+    EXPECT_EQ(1, segment2.zfp().timeline_size());
+    EXPECT_EQ(25, segment2.exact(0).instant().scalar().magnitude());
     auto const& segment3 = checkpoint.non_collapsible_segment().segment(3);
     EXPECT_EQ(1, segment3.zfp().timeline_size());
     EXPECT_EQ(25, segment3.exact(0).instant().scalar().magnitude());
-    auto const& segment4 = checkpoint.non_collapsible_segment().segment(4);
-    EXPECT_EQ(1, segment4.zfp().timeline_size());
-    EXPECT_EQ(25, segment4.exact(0).instant().scalar().magnitude());
     EXPECT_EQ(
         2,
         checkpoint.non_collapsible_segment().segment_by_left_endpoint_size());
@@ -957,30 +961,32 @@ TEST_F(VesselTest, TailSerialization) {
   vessel_.WriteToMessage(&message,
                          serialization_index_for_pile_up.AsStdFunction());
 
-  EXPECT_EQ(4, message.history().segment_size());
+  EXPECT_EQ(1, message.history().leading_empty_segments_size());
   {
     // Non-collapsible segment of the history, entirely excluded.
-    auto const& segment0 = message.history().segment(0);
-    EXPECT_EQ(0, segment0.zfp().timeline_size());
+    auto const& segments0 = message.history().leading_empty_segments(0);
+    EXPECT_EQ(1, segments0.count());
+    EXPECT_TRUE(segments0.has_downsampling_parameters());
   }
+  EXPECT_EQ(3, message.history().segment_size());
   {
     // Collapsible segment of the history (backstory), truncated to the left.
-    auto const& segment1 = message.history().segment(1);
+    auto const& segment0 = message.history().segment(0);
     EXPECT_EQ("2000-01-02T04:40:12"_TT,
-              Instant::ReadFromMessage(segment1.exact(0).instant()));
+              Instant::ReadFromMessage(segment0.exact(0).instant()));
     EXPECT_EQ(t0_ + (number_of_points - 1) * Second,
-              Instant::ReadFromMessage(segment1.exact(1).instant()));
-    EXPECT_EQ(20'000, segment1.zfp().timeline_size());
+              Instant::ReadFromMessage(segment0.exact(1).instant()));
+    EXPECT_EQ(20'000, segment0.zfp().timeline_size());
   }
   {
     // Psychohistory, only one point.
-    auto const& segment2 = message.history().segment(2);
-    EXPECT_EQ(1, segment2.zfp().timeline_size());
+    auto const& segment1 = message.history().segment(1);
+    EXPECT_EQ(1, segment1.zfp().timeline_size());
   }
   {
     // Prediction, excluded except for its first point.
-    auto const& segment3 = message.history().segment(3);
-    EXPECT_EQ(1, segment3.zfp().timeline_size());
+    auto const& segment2 = message.history().segment(2);
+    EXPECT_EQ(1, segment2.zfp().timeline_size());
   }
 
   auto const v = Vessel::ReadFromMessage(

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -49,6 +49,14 @@ class Checkpointer {
   using Reader =
       std::function<absl::Status(typename Message::Checkpoint const&)>;
 
+// Saves produced by [Лефшец, Leibniz[ had a ton of empty segments at the
+// beginning of the non-collapsible part of their checkpoints, causing storage
+// to explode: we saw a vessel with 1.8 million checkpoints, about 10'000 of
+// which were non-empty. To fix these saves, we rewrite the checkpoints.  That's
+// what we get for writing quadratic code.
+  using Rewriter = std::function<typename Message::Checkpoint(
+      typename Message::Checkpoint const&)>;
+
   Checkpointer(Writer writer, Reader reader);
 
   // Returns the oldest checkpoint in this object, or +∞ if no checkpoint was
@@ -118,9 +126,11 @@ class Checkpointer {
   void WriteToMessage(not_null<google::protobuf::RepeatedPtrField<
                           typename Message::Checkpoint>*> message) const
       EXCLUDES(lock_);
+  // `rewriter` may be null, in which case checkpoints are used as-is.
   static not_null<std::unique_ptr<Checkpointer>> ReadFromMessage(
       Writer writer,
       Reader reader,
+      Rewriter rewriter,
       google::protobuf::RepeatedPtrField<typename Message::Checkpoint> const&
           message);
 

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "absl/container/btree_set.h"
 #include "base/thread_pool.hpp"

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -211,13 +211,18 @@ not_null<std::unique_ptr<Checkpointer<Message>>>
 Checkpointer<Message>::ReadFromMessage(
     Writer writer,
     Reader reader,
+    Rewriter rewriter,
     google::protobuf::RepeatedPtrField<typename Message::Checkpoint> const&
         message) {
   auto checkpointer =
       std::make_unique<Checkpointer>(std::move(writer), std::move(reader));
   for (auto const& checkpoint : message) {
     Instant const time = Instant::ReadFromMessage(checkpoint.time());
-    checkpointer->checkpoints_.emplace(time, checkpoint);
+    if (rewriter == nullptr) {
+      checkpointer->checkpoints_.emplace(time, checkpoint);
+    } else {
+      checkpointer->checkpoints_.emplace(time, rewriter(checkpoint));
+    }
   }
   return std::move(checkpointer);
 }

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -6,11 +6,14 @@
 #include <utility>
 
 #include "absl/container/btree_set.h"
+#include "base/thread_pool.hpp"
 
 namespace principia {
 namespace physics {
 namespace _checkpointer {
 namespace internal {
+
+using namespace principia::base::_thread_pool;
 
 template<typename Message>
 Checkpointer<Message>::Checkpointer(Writer writer, Reader reader)
@@ -216,12 +219,26 @@ Checkpointer<Message>::ReadFromMessage(
         message) {
   auto checkpointer =
       std::make_unique<Checkpointer>(std::move(writer), std::move(reader));
-  for (auto const& checkpoint : message) {
-    Instant const time = Instant::ReadFromMessage(checkpoint.time());
-    if (rewriter == nullptr) {
+  if (rewriter == nullptr) {
+    for (auto const& checkpoint : message) {
+      Instant const time = Instant::ReadFromMessage(checkpoint.time());
       checkpointer->checkpoints_.emplace(time, checkpoint);
-    } else {
-      checkpointer->checkpoints_.emplace(time, rewriter(checkpoint));
+    }
+  } else {
+    // For large checkpoints, rewriting is expensive, so we do it using multiple
+    // threads.
+    ThreadPool<typename Message::Checkpoint> rewrite_pool(
+        std::thread::hardware_concurrency());
+    std::vector<std::future<typename Message::Checkpoint>> rewrite_futures;
+    rewrite_futures.reserve(message.size());
+    for (auto const& checkpoint : message) {
+      rewrite_futures.push_back(rewrite_pool.Add(
+          [&checkpoint, &rewriter]() { return rewriter(checkpoint); }));
+    }
+    for (std::int64_t i = 0; i < message.size(); ++i) {
+      auto const& checkpoint = message[i];
+      Instant const time = Instant::ReadFromMessage(checkpoint.time());
+      checkpointer->checkpoints_.emplace(time, rewrite_futures[i].get());
     }
   }
   return std::move(checkpointer);

--- a/physics/checkpointer_test.cpp
+++ b/physics/checkpointer_test.cpp
@@ -218,6 +218,7 @@ TEST_F(CheckpointerTest, Serialization) {
   auto const checkpointer =
       Checkpointer<Message>::ReadFromMessage(writer_.AsStdFunction(),
                                              reader_.AsStdFunction(),
+                                             /*rewriter=*/nullptr,
                                              m.checkpoint());
   EXPECT_EQ(Instant() + 10 * Second, checkpointer->oldest_checkpoint());
 }

--- a/physics/continuous_trajectory_body.hpp
+++ b/physics/continuous_trajectory_body.hpp
@@ -546,12 +546,14 @@ ContinuousTrajectory<Frame>::ReadFromMessage(
         Checkpointer<serialization::ContinuousTrajectory>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerWriter(),
             continuous_trajectory->MakeCheckpointerReader(),
+            /*rewriter=*/nullptr,
             serialized_continuous_trajectory.checkpoint());
   } else {
     continuous_trajectory->checkpointer_ =
         Checkpointer<serialization::ContinuousTrajectory>::ReadFromMessage(
             continuous_trajectory->MakeCheckpointerWriter(),
             continuous_trajectory->MakeCheckpointerReader(),
+            /*rewriter=*/nullptr,
             message.checkpoint());
   }
 

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -146,7 +146,8 @@ class DiscreteTrajectory : public Trajectory<Frame> {
   // are past-the-end iff they were past-the-end at serialization time.
   static DiscreteTrajectory ReadFromMessage(
       serialization::DiscreteTrajectory const& message,
-      std::vector<SegmentIterator*> const& tracked)
+      std::vector<SegmentIterator*> const& tracked,
+      bool quiet = false)
     requires serializable<Frame>;
 
  private:

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -15,6 +15,7 @@
 #include "geometry/space.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/discrete_trajectory_iterator.hpp"
+#include "physics/discrete_trajectory_segment.hpp"
 #include "physics/discrete_trajectory_segment_iterator.hpp"
 #include "physics/discrete_trajectory_types.hpp"
 #include "physics/trajectory.hpp"
@@ -32,6 +33,7 @@ using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_discrete_trajectory_iterator;
+using namespace principia::physics::_discrete_trajectory_segment;
 using namespace principia::physics::_discrete_trajectory_segment_iterator;
 using namespace principia::physics::_discrete_trajectory_types;
 using namespace principia::physics::_trajectory;
@@ -156,6 +158,21 @@ class DiscreteTrajectory : public Trajectory<Frame> {
   using Segments = _discrete_trajectory_types::Segments<Frame>;
   using SegmentByLeftEndpoint =
       absl::btree_map<Instant, typename Segments::iterator>;
+
+  // Represents a sequence of empty segments with the given downsampling
+  // parameters.
+  struct EmptySegments {
+    std::int32_t count = 0;
+    std::optional<
+        typename DiscreteTrajectorySegment<Frame>::DownsamplingParameters>
+        downsampling_parameters;
+
+    void WriteToMessage(
+        not_null<serialization::DiscreteTrajectoryEmptySegments*> message)
+        const;
+    static EmptySegments ReadFromMessage(
+        serialization::DiscreteTrajectoryEmptySegments const& message);
+  };
 
   // This constructor leaves the list of segments empty (but allocated) as well
   // as the time-to-segment mapping.

--- a/physics/discrete_trajectory.hpp
+++ b/physics/discrete_trajectory.hpp
@@ -183,12 +183,6 @@ class DiscreteTrajectory : public Trajectory<Frame> {
       DiscreteTrajectory& to,
       typename Segments::iterator to_segments_begin);
 
-  // Reads a pre-Hamilton downsampling message and return the downsampling
-  // parameters.
-  static void ReadFromPreHamiltonMessage(
-      serialization::DiscreteTrajectory::Downsampling const& message,
-      DownsamplingParameters& downsampling_parameters);
-
   // Reads a set of pre-Hamilton children.  Checks that there is only one child,
   // and that it is at the end of the preceding segment.  Append a segment to
   // the trajectory and returns an iterator to that segment.

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -632,8 +632,8 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   requires serializable<Frame> {
   DiscreteTrajectory trajectory(uninitialized);
 
-  bool const is_pre_hamilton = message.segment_size() == 0;
   bool const is_pre_leibniz = !message.has_number_of_leading_empty_segments();
+  bool const is_pre_hamilton = is_pre_leibniz && message.segment_size() == 0;
   LOG_IF(WARNING, is_pre_leibniz)
       << "Reading pre-" << (is_pre_hamilton ? "Hamilton" : "Leibniz")
       << " DiscreteTrajectory";

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -884,8 +884,7 @@ template<typename Frame>
 void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
     serialization::DiscreteTrajectory::Downsampling const& message,
     DownsamplingParameters& downsampling_parameters) {
-  downsampling_parameters = {
-      .tolerance = Length::ReadFromMessage(message.tolerance())};
+  downsampling_parameters = DownsamplingParameters::ReadFromMessage(message);
 }
 
 template<typename Frame>
@@ -935,9 +934,8 @@ void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
     }
     if (message.has_downsampling()) {
       DownsamplingParameters downsampling_parameters;
-      ReadFromPreHamiltonMessage(message.downsampling(),
-                                 downsampling_parameters);
-      sit->SetDownsamplingUnconditionally(downsampling_parameters);
+      sit->SetDownsamplingUnconditionally(
+          DownsamplingParameters::ReadFromMessage(message.downsampling));
     }
   } else {
     // Starting with Frobenius we use ZFP so the easiest is to build a
@@ -948,14 +946,11 @@ void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
     *serialized_segment.mutable_zfp() = message.zfp();
     *serialized_segment.mutable_exact() = message.exact();
 
-    DownsamplingParameters downsampling_parameters;
     if (message.has_downsampling()) {
-      ReadFromPreHamiltonMessage(message.downsampling(),
-                                 downsampling_parameters);
-      auto* const serialized_downsampling_parameters =
-          serialized_segment.mutable_downsampling_parameters();
-      downsampling_parameters.tolerance.WriteToMessage(
-          serialized_downsampling_parameters->mutable_tolerance());
+      DownsamplingParameters const downsampling_parameters =
+          ReadFromPreHamiltonMessage(message.downsampling());
+      downsampling_parameters.WriteToMessage(
+          serialized_segment.mutable_downsampling_parameters());
     }
     *sit = DiscreteTrajectorySegment<Frame>::ReadFromMessage(serialized_segment,
                                                              self);

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -505,7 +505,7 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
     iterator const end,
     std::vector<SegmentIterator> const& tracked,
     std::vector<iterator> const& exact) const {
-  message->set_is_leibniz_trajectory(true);
+  message->mutable_leibniz_trajectory_marker();
 
   // Construct a map to efficiently find if a segment must be tracked.  The
   // keys are pointers to segments in `tracked`, the values are the
@@ -647,7 +647,7 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   requires serializable<Frame> {
   DiscreteTrajectory trajectory(uninitialized);
 
-  bool const is_pre_leibniz = !message.has_is_leibniz_trajectory();
+  bool const is_pre_leibniz = !message.has_leibniz_trajectory_marker();
   bool const is_pre_hamilton = is_pre_leibniz && message.segment_size() == 0;
   LOG_IF(WARNING, !quiet && is_pre_leibniz)
       << "Reading pre-" << (is_pre_hamilton ? "Hamilton" : "Leibniz")

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -628,13 +628,14 @@ template<typename Frame>
 DiscreteTrajectory<Frame>
 DiscreteTrajectory<Frame>::ReadFromMessage(
     serialization::DiscreteTrajectory const& message,
-    std::vector<SegmentIterator*> const& tracked)
+    std::vector<SegmentIterator*> const& tracked,
+    bool const quiet)
   requires serializable<Frame> {
   DiscreteTrajectory trajectory(uninitialized);
 
   bool const is_pre_leibniz = !message.has_number_of_leading_empty_segments();
   bool const is_pre_hamilton = is_pre_leibniz && message.segment_size() == 0;
-  LOG_IF(WARNING, is_pre_leibniz)
+  LOG_IF(WARNING, !quiet && is_pre_leibniz)
       << "Reading pre-" << (is_pre_hamilton ? "Hamilton" : "Leibniz")
       << " DiscreteTrajectory";
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -537,6 +537,7 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
   absl::flat_hash_set<
       DiscreteTrajectorySegment<Frame> const*> intersecting_segments;
   bool intersect_range = false;
+  std::int32_t number_of_leading_empty_segments = 0;
 
   // The position of a segment in the repeated field `segment`.
   int segment_position = 0;
@@ -566,8 +567,16 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
 
     // Note that we execute this call for the segments that precede the
     // intersection in order to write the correct structure of (empty) segments.
-    sit->WriteToMessage(
-        message->add_segment(), begin_time_it, end_time_it, exact);
+    // It's important to somehow record the leading empty segments, as we will
+    // need to reconstruct the proper segment structure when deserializing.  We
+    // don't want to write the segments themselves, though, as there may be many
+    // of them in case of many small burns.
+    if (intersect_range) {
+      sit->WriteToMessage(
+          message->add_segment(), begin_time_it, end_time_it, exact);
+    } else {
+      ++number_of_leading_empty_segments;
+    }
 
     const auto [position_begin, position_end] =
         segment_to_position.equal_range(&*sit);
@@ -579,6 +588,8 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
       message->set_tracked_position(position_it->second, segment_position);
     }
   }
+  message->set_number_of_leading_empty_segments(
+      number_of_leading_empty_segments);
 
   // Write the left endpoints by scanning them in parallel with the segments.
   std::optional<Instant> last_left_endpoint;
@@ -622,9 +633,12 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   DiscreteTrajectory trajectory(uninitialized);
 
   bool const is_pre_hamilton = message.segment_size() == 0;
+  bool const is_pre_leibniz = !message.has_number_of_leading_empty_segments();
+  LOG_IF(WARNING, is_pre_leibniz)
+      << "Reading pre-" << (is_pre_hamilton ? "Hamilton" : "Leibniz")
+      << " DiscreteTrajectory";
+
   if (is_pre_hamilton) {
-    LOG_IF(WARNING, is_pre_hamilton)
-        << "Reading pre-Hamilton DiscreteTrajectory";
     ReadFromPreHamiltonMessage(
         message, tracked, /*fork_point=*/nullptr, trajectory);
     CHECK_OK(trajectory.ConsistencyStatus());
@@ -632,9 +646,21 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   }
 
   // First restore the segments themselves.  `segment_iterators` will be used to
-  // restore the tracked segments.
+  // restore the tracked segments.  We must start with the empty segments if
+  // this is a pre-Leibniz message, but we don't need to set their downsampling
+  // parameters.
   std::vector<SegmentIterator> segment_iterators;
-  segment_iterators.reserve(message.segment_size());
+  segment_iterators.reserve(message.number_of_leading_empty_segments() +
+                            message.segment_size());
+  for (std::int64_t i = 0;
+       i < message.number_of_leading_empty_segments();
+       ++i) {
+    trajectory.segments_->emplace_back();
+    auto const sit = --trajectory.segments_->end();
+    auto const self = SegmentIterator(trajectory.segments_.get(), sit);
+    *sit = DiscreteTrajectorySegment<Frame>::(serialized_segment, self);
+    segment_iterators.push_back(self);
+  }
   for (auto const& serialized_segment : message.segment()) {
     trajectory.segments_->emplace_back();
     auto const sit = --trajectory.segments_->end();

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -577,6 +577,8 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
       // many of them in checkpoints for many small burns.
       if (sit->downsampling_parameters_ !=
           leading_empty_segments.downsampling_parameters) {
+        // Write a `DiscreteTrajectoryEmptySegments` if the downsampling
+        // parameters change.
         if (leading_empty_segments.count > 0) {
           leading_empty_segments.WriteToMessage(
               message->add_leading_empty_segments());

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -10,7 +10,6 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
 #include "base/status_utilities.hpp"  // 🧙 For RETURN_IF_ERROR.
-#include "physics/discrete_trajectory_segment.hpp"
 #include "quantities/quantities.hpp"
 
 namespace principia {
@@ -18,7 +17,6 @@ namespace physics {
 namespace _discrete_trajectory {
 namespace internal {
 
-using namespace principia::physics::_discrete_trajectory_segment;
 using namespace principia::quantities::_quantities;
 
 template<typename Frame>
@@ -507,6 +505,8 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
     iterator const end,
     std::vector<SegmentIterator> const& tracked,
     std::vector<iterator> const& exact) const {
+  message->set_is_leibniz_trajectory(true);
+
   // Construct a map to efficiently find if a segment must be tracked.  The
   // keys are pointers to segments in `tracked`, the values are the
   // corresponding indices.  Note that multiple tracked segments may turn out to
@@ -537,7 +537,7 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
   absl::flat_hash_set<
       DiscreteTrajectorySegment<Frame> const*> intersecting_segments;
   bool intersect_range = false;
-  std::int32_t number_of_leading_empty_segments = 0;
+  EmptySegments leading_empty_segments;
 
   // The position of a segment in the repeated field `segment`.
   int segment_position = 0;
@@ -568,14 +568,28 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
     // Note that we execute this call for the segments that precede the
     // intersection in order to write the correct structure of (empty) segments.
     // It's important to somehow record the leading empty segments, as we will
-    // need to reconstruct the proper segment structure when deserializing.  We
-    // don't want to write the segments themselves, though, as there may be many
-    // of them in case of many small burns.
+    // need to reconstruct the proper segment structure when deserializing.
     if (intersect_range) {
       sit->WriteToMessage(
           message->add_segment(), begin_time_it, end_time_it, exact);
     } else {
-      ++number_of_leading_empty_segments;
+      // We don't want to write the empty segments themselves, as there may be
+      // many of them in checkpoints for many small burns.
+      if (sit->downsampling_parameters_ !=
+          leading_empty_segments.downsampling_parameters) {
+        if (leading_empty_segments.count > 0) {
+          leading_empty_segments.WriteToMessage(
+              message->add_leading_empty_segments());
+        }
+        leading_empty_segments = {
+            .count = 0,
+            .downsampling_parameters = sit->downsampling_parameters_};
+      }
+      ++leading_empty_segments.count;
+    }
+    if (leading_empty_segments.count > 0) {
+      leading_empty_segments.WriteToMessage(
+          message->add_leading_empty_segments());
     }
 
     const auto [position_begin, position_end] =
@@ -588,8 +602,6 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
       message->set_tracked_position(position_it->second, segment_position);
     }
   }
-  message->set_number_of_leading_empty_segments(
-      number_of_leading_empty_segments);
 
   // Write the left endpoints by scanning them in parallel with the segments.
   std::optional<Instant> last_left_endpoint;
@@ -633,7 +645,7 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   requires serializable<Frame> {
   DiscreteTrajectory trajectory(uninitialized);
 
-  bool const is_pre_leibniz = !message.has_number_of_leading_empty_segments();
+  bool const is_pre_leibniz = !message.has_is_leibniz_trajectory();
   bool const is_pre_hamilton = is_pre_leibniz && message.segment_size() == 0;
   LOG_IF(WARNING, !quiet && is_pre_leibniz)
       << "Reading pre-" << (is_pre_hamilton ? "Hamilton" : "Leibniz")
@@ -647,21 +659,30 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   }
 
   // First restore the segments themselves.  `segment_iterators` will be used to
-  // restore the tracked segments.  We must start with the empty segments if
-  // this is a pre-Leibniz message, but we don't need to set their downsampling
-  // parameters.
+  // restore the tracked segments.
   std::vector<SegmentIterator> segment_iterators;
-  segment_iterators.reserve(message.number_of_leading_empty_segments() +
+  segment_iterators.reserve(message.leading_empty_segments_size() +
                             message.segment_size());
-  for (std::int64_t i = 0;
-       i < message.number_of_leading_empty_segments();
-       ++i) {
-    trajectory.segments_->emplace_back();
-    auto const sit = --trajectory.segments_->end();
-    auto const self = SegmentIterator(trajectory.segments_.get(), sit);
-    *sit = DiscreteTrajectorySegment<Frame>(self);
-    segment_iterators.push_back(self);
+
+  // We must start with the empty segments if there are any, setting their
+  // downsampling parameters as needed.
+  for (auto const& leading_empty_segments : message.leading_empty_segments()) {
+    auto const empty_segments =
+        EmptySegments::ReadFromMessage(leading_empty_segments);
+    for (std::int32_t i = 0; i < empty_segments.count; ++i) {
+      trajectory.segments_->emplace_back();
+      auto const sit = --trajectory.segments_->end();
+      auto const self = SegmentIterator(trajectory.segments_.get(), sit);
+      *sit = DiscreteTrajectorySegment<Frame>(self);
+      if (empty_segments.downsampling_parameters.has_value()) {
+        sit->SetDownsamplingUnconditionally(
+            *empty_segments.downsampling_parameters);
+      }
+      segment_iterators.push_back(self);
+    }
   }
+
+  // Now the non-empty segments.
   for (auto const& serialized_segment : message.segment()) {
     trajectory.segments_->emplace_back();
     auto const sit = --trajectory.segments_->end();
@@ -700,6 +721,33 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
 
   CHECK_OK(trajectory.ConsistencyStatus());
   return trajectory;
+}
+
+template<typename Frame>
+void DiscreteTrajectory<Frame>::EmptySegments::WriteToMessage(
+    not_null<serialization::DiscreteTrajectoryEmptySegments*> const message)
+    const {
+  CHECK_LT(0, count);
+  message->set_count(count);
+  if (downsampling_parameters.has_value()) {
+    downsampling_parameters->WriteToMessage<
+        serialization::DiscreteTrajectoryEmptySegments::DownsamplingParameters>(
+        message->mutable_downsampling_parameters());
+  }
+}
+
+template<typename Frame>
+DiscreteTrajectory<Frame>::EmptySegments
+DiscreteTrajectory<Frame>::EmptySegments::ReadFromMessage(
+    serialization::DiscreteTrajectoryEmptySegments const& message) {
+  if (message.has_downsampling_parameters()) {
+    return EmptySegments{
+        .count = message.count(),
+        .downsampling_parameters = DownsamplingParameters::ReadFromMessage(
+            message.downsampling_parameters())};
+  } else {
+    return EmptySegments{.count = message.count()};
+  }
 }
 
 template<typename Frame>
@@ -881,13 +929,6 @@ void DiscreteTrajectory<Frame>::AdjustAfterSplicing(
 }
 
 template<typename Frame>
-void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
-    serialization::DiscreteTrajectory::Downsampling const& message,
-    DownsamplingParameters& downsampling_parameters) {
-  downsampling_parameters = DownsamplingParameters::ReadFromMessage(message);
-}
-
-template<typename Frame>
 DiscreteTrajectorySegmentIterator<Frame>
 DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
     serialization::DiscreteTrajectory::Brood const& message,
@@ -933,9 +974,8 @@ void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
                       instantaneous_dof.degrees_of_freedom())).IgnoreError();
     }
     if (message.has_downsampling()) {
-      DownsamplingParameters downsampling_parameters;
       sit->SetDownsamplingUnconditionally(
-          DownsamplingParameters::ReadFromMessage(message.downsampling));
+          DownsamplingParameters::ReadFromMessage(message.downsampling()));
     }
   } else {
     // Starting with Frobenius we use ZFP so the easiest is to build a
@@ -947,9 +987,10 @@ void DiscreteTrajectory<Frame>::ReadFromPreHamiltonMessage(
     *serialized_segment.mutable_exact() = message.exact();
 
     if (message.has_downsampling()) {
-      DownsamplingParameters const downsampling_parameters =
-          ReadFromPreHamiltonMessage(message.downsampling());
-      downsampling_parameters.WriteToMessage(
+      auto const downsampling_parameters =
+          DownsamplingParameters::ReadFromMessage(message.downsampling());
+      downsampling_parameters.WriteToMessage<
+          serialization::DiscreteTrajectorySegment::DownsamplingParameters>(
           serialized_segment.mutable_downsampling_parameters());
     }
     *sit = DiscreteTrajectorySegment<Frame>::ReadFromMessage(serialized_segment,

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -587,10 +587,6 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
       }
       ++leading_empty_segments.count;
     }
-    if (leading_empty_segments.count > 0) {
-      leading_empty_segments.WriteToMessage(
-          message->add_leading_empty_segments());
-    }
 
     const auto [position_begin, position_end] =
         segment_to_position.equal_range(&*sit);
@@ -601,6 +597,10 @@ void DiscreteTrajectory<Frame>::WriteToMessage(
       // Its value is the position of a tracked segment in the field `segment`.
       message->set_tracked_position(position_it->second, segment_position);
     }
+  }
+  if (leading_empty_segments.count > 0) {
+    leading_empty_segments.WriteToMessage(
+        message->add_leading_empty_segments());
   }
 
   // Write the left endpoints by scanning them in parallel with the segments.
@@ -661,7 +661,11 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
   // First restore the segments themselves.  `segment_iterators` will be used to
   // restore the tracked segments.
   std::vector<SegmentIterator> segment_iterators;
-  segment_iterators.reserve(message.leading_empty_segments_size() +
+  std::int32_t total_leading_empty_segments = 0;
+  for (auto const& leading_empty_segments : message.leading_empty_segments()) {
+    total_leading_empty_segments += leading_empty_segments.count();
+  }
+  segment_iterators.reserve(total_leading_empty_segments +
                             message.segment_size());
 
   // We must start with the empty segments if there are any, setting their
@@ -746,7 +750,8 @@ DiscreteTrajectory<Frame>::EmptySegments::ReadFromMessage(
         .downsampling_parameters = DownsamplingParameters::ReadFromMessage(
             message.downsampling_parameters())};
   } else {
-    return EmptySegments{.count = message.count()};
+    return EmptySegments{.count = message.count(),
+                         .downsampling_parameters = std::nullopt};
   }
 }
 

--- a/physics/discrete_trajectory_body.hpp
+++ b/physics/discrete_trajectory_body.hpp
@@ -658,7 +658,7 @@ DiscreteTrajectory<Frame>::ReadFromMessage(
     trajectory.segments_->emplace_back();
     auto const sit = --trajectory.segments_->end();
     auto const self = SegmentIterator(trajectory.segments_.get(), sit);
-    *sit = DiscreteTrajectorySegment<Frame>::(serialized_segment, self);
+    *sit = DiscreteTrajectorySegment<Frame>(self);
     segment_iterators.push_back(self);
   }
   for (auto const& serialized_segment : message.segment()) {

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -309,9 +309,8 @@ DiscreteTrajectorySegment<Frame>::ReadFromMessage(
 
   // Finally, restore the downsampling information.
   if (message.has_downsampling_parameters()) {
-    segment.downsampling_parameters_ = DownsamplingParameters{
-        .tolerance = Length::ReadFromMessage(
-            message.downsampling_parameters().tolerance())};
+    segment.downsampling_parameters_ = DownsamplingParameters::ReadFromMessage(
+        message.downsampling_parameters());
   }
 
   return segment;
@@ -671,10 +670,8 @@ void DiscreteTrajectorySegment<Frame>::WriteToMessage(
     std::int64_t const timeline_size,
     std::vector<iterator> const& exact) const {
   if (downsampling_parameters_.has_value()) {
-    auto* const serialized_downsampling_parameters =
-        message->mutable_downsampling_parameters();
-    downsampling_parameters_->tolerance.WriteToMessage(
-        serialized_downsampling_parameters->mutable_tolerance());
+    downsampling_parameters_->WriteToMessage(
+        message->mutable_downsampling_parameters());
   }
 
   // Convert the `exact` vector into a set, and add the extremities.  This

--- a/physics/discrete_trajectory_segment_body.hpp
+++ b/physics/discrete_trajectory_segment_body.hpp
@@ -670,7 +670,8 @@ void DiscreteTrajectorySegment<Frame>::WriteToMessage(
     std::int64_t const timeline_size,
     std::vector<iterator> const& exact) const {
   if (downsampling_parameters_.has_value()) {
-    downsampling_parameters_->WriteToMessage(
+    downsampling_parameters_->WriteToMessage<
+        serialization::DiscreteTrajectorySegment::DownsamplingParameters>(
         message->mutable_downsampling_parameters());
   }
 

--- a/physics/discrete_trajectory_types.hpp
+++ b/physics/discrete_trajectory_types.hpp
@@ -36,8 +36,11 @@ using namespace principia::quantities::_quantities;
 struct DownsamplingParameters {
   Length tolerance;
 
+  friend bool operator==(DownsamplingParameters const&,
+                         DownsamplingParameters const&) = default;
+
   template<typename Message>
-  void WriteToMessage(not_null<Message*> message);
+  void WriteToMessage(not_null<Message*> message) const;
   template<typename Message>
   static DownsamplingParameters ReadFromMessage(Message const& message);
 };

--- a/physics/discrete_trajectory_types.hpp
+++ b/physics/discrete_trajectory_types.hpp
@@ -6,6 +6,7 @@
 
 #include "absl/container/btree_set.h"
 #include "base/macros.hpp"  // 🧙 For forward declarations.
+#include "base/not_null.hpp"
 #include "geometry/instant.hpp"
 #include "geometry/space.hpp"
 #include "numerics/hermite3.hpp"
@@ -25,6 +26,7 @@ FORWARD_DECLARE(TEMPLATE(typename Frame) class,
 namespace _discrete_trajectory_types {
 namespace internal {
 
+using namespace principia::base::_not_null;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_hermite3;
@@ -33,6 +35,11 @@ using namespace principia::quantities::_quantities;
 
 struct DownsamplingParameters {
   Length tolerance;
+
+  template<typename Message>
+  void WriteToMessage(not_null<Message*> message);
+  template<typename Message>
+  static DownsamplingParameters ReadFromMessage(Message const& message);
 };
 
 // The `error` is an upper bound on the interpolation error after `hermite3` has

--- a/physics/discrete_trajectory_types_body.hpp
+++ b/physics/discrete_trajectory_types_body.hpp
@@ -11,7 +11,7 @@ namespace _discrete_trajectory_types {
 namespace internal {
 
 template<typename Message>
-void DownsamplingParameters::WriteToMessage(not_null<Message*> message) {
+void DownsamplingParameters::WriteToMessage(not_null<Message*> message) const {
   tolerance.WriteToMessage(message->mutable_tolerance());
 }
 

--- a/physics/discrete_trajectory_types_body.hpp
+++ b/physics/discrete_trajectory_types_body.hpp
@@ -10,6 +10,18 @@ namespace physics {
 namespace _discrete_trajectory_types {
 namespace internal {
 
+template<typename Message>
+void DownsamplingParameters::WriteToMessage(not_null<Message*> message) {
+  tolerance.WriteToMessage(message->mutable_tolerance());
+}
+
+template<typename Message>
+DownsamplingParameters DownsamplingParameters::ReadFromMessage(
+    Message const& message) {
+  return DownsamplingParameters{
+      .tolerance = Length::ReadFromMessage(message.tolerance())};
+}
+
 template<typename Frame>
 value_type<Frame>::value_type(Instant const& time,
                               DegreesOfFreedom<Frame> const& degrees_of_freedom)

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -871,12 +871,14 @@ not_null<std::unique_ptr<Ephemeris<Frame>>> Ephemeris<Frame>::ReadFromMessage(
         Checkpointer<serialization::Ephemeris>::ReadFromMessage(
             ephemeris->MakeCheckpointerWriter(),
             ephemeris->MakeCheckpointerReader(),
+            /*rewriter=*/nullptr,
             serialized_ephemeris.checkpoint());
   } else {
     ephemeris->checkpointer_ =
         Checkpointer<serialization::Ephemeris>::ReadFromMessage(
             ephemeris->MakeCheckpointerWriter(),
             ephemeris->MakeCheckpointerReader(),
+            /*rewriter=*/nullptr,
             message.checkpoint());
   }
 

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -797,8 +797,8 @@ void Ephemeris<Frame>::WriteToMessage(
       message->mutable_fixed_step_parameters());
   accuracy_parameters_.WriteToMessage(
       message->mutable_accuracy_parameters());
-  LOG(INFO) << NAMED(message->SpaceUsed());
-  LOG(INFO) << NAMED(message->ByteSize());
+  LOG(INFO) << NAMED(message->SpaceUsedLong());
+  LOG(INFO) << NAMED(message->ByteSizeLong());
 }
 
 template<typename Frame>

--- a/physics/ephemeris_test.cpp
+++ b/physics/ephemeris_test.cpp
@@ -1399,7 +1399,7 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
   CHECK(message.SerializePartialToString(&uncompressed));
   EXPECT_THAT(uncompressed.size(),
               AnyOf(21'596,    // ZFP 85: Windows, Ubuntu, macOS AVX.
-                    21'597,    // ZFP 4112: Windows.
+                    21'599,    // ZFP 4112: Windows.
                     21'588,    // ZFP 85: macOS SSE.
                     21'589));  // ZFP 4112: macOS SSE.
 
@@ -1409,7 +1409,7 @@ TEST(EphemerisTestNoFixture, DiscreteTrajectoryCompression) {
 
   EXPECT_THAT(compressed.size(),
               AnyOf(20'331,    // ZFP 85: Windows, Ubuntu, macOS AVX.
-                    20'332,    // ZFP 4112: Windows.
+                    20'334,    // ZFP 4112: Windows.
                     20'323,    // ZFP 85: macOS SSE.
                     20'324));  // ZFP 4112: macOS SSE.
 

--- a/serialization/base.proto
+++ b/serialization/base.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package principia.serialization;
+
+option cc_enable_arenas = true;
+
+// A marker used to indicate that a message was written at or after a particular
+// version.
+message VersionMarker {}

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -123,6 +123,8 @@ message DiscreteTrajectory {
     required Point left_endpoint = 1;
     required int32 segment = 2;
   }
+  // Added in Leibniz.
+  optional int32 number_of_leading_empty_segments = 10;
   repeated DiscreteTrajectorySegment segment = 7;
   repeated SegmentByLeftEndpoint segment_by_left_endpoint = 8;
   repeated int32 tracked_position = 9;

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -123,11 +123,23 @@ message DiscreteTrajectory {
     required Point left_endpoint = 1;
     required int32 segment = 2;
   }
-  // Added in Leibniz.
-  optional int32 number_of_leading_empty_segments = 10;
   repeated DiscreteTrajectorySegment segment = 7;
   repeated SegmentByLeftEndpoint segment_by_left_endpoint = 8;
   repeated int32 tracked_position = 9;
+
+  // Added in Leibniz.
+  repeated DiscreteTrajectoryEmptySegments leading_empty_segments = 10;
+  optional bool is_leibniz_trajectory = 11;
+}
+
+// Represents a sequence of empty `DiscreteTrajectorySegment` all having the
+// same downsampling parameters.
+message DiscreteTrajectoryEmptySegments {
+  message DownsamplingParameters {
+    required Quantity tolerance = 1;
+  }
+  required int32 count = 1;
+  optional DownsamplingParameters downsampling_parameters = 2;
 }
 
 // Added in Hamilton.  Note that some nested messages are shared with the

--- a/serialization/physics.proto
+++ b/serialization/physics.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 
+import "serialization/base.proto";
 import "serialization/geometry.proto";
 import "serialization/integrators.proto";
 import "serialization/numerics.proto";
@@ -129,7 +130,7 @@ message DiscreteTrajectory {
 
   // Added in Leibniz.
   repeated DiscreteTrajectoryEmptySegments leading_empty_segments = 10;
-  optional bool is_leibniz_trajectory = 11;
+  optional VersionMarker leibniz_trajectory_marker = 11;
 }
 
 // Represents a sequence of empty `DiscreteTrajectorySegment` all having the

--- a/serialization/serialization.vcxproj
+++ b/serialization/serialization.vcxproj
@@ -21,6 +21,13 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <CustomBuild Include="base.proto">
+      <FileType>Document</FileType>
+      <AdditionalInputs>$(Protoc)</AdditionalInputs>
+      <Command>$([System.String]::Format($(ProtocCommand), '%(FullPath)'))</Command>
+      <Message>$([System.String]::Format($(ProtocMessage), '%(FullPath)'))</Message>
+      <Outputs>$([System.String]::Format($(ProtocOutputs), '%(Filename)'))</Outputs>
+    </CustomBuild>
     <CustomBuild Include="geometry.proto">
       <FileType>Document</FileType>
       <AdditionalInputs>$(Protoc)</AdditionalInputs>
@@ -89,6 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="astronomy.pb.h" />
+    <ClInclude Include="base.pb.h" />
     <ClInclude Include="geometry.pb.h" />
     <ClInclude Include="integrators.pb.h" />
     <ClInclude Include="journal.pb.h" />
@@ -101,6 +109,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="astronomy.pb.cc" />
+    <ClCompile Include="base.pb.cc" />
     <ClCompile Include="geometry.pb.cc" />
     <ClCompile Include="integrators.pb.cc" />
     <ClCompile Include="journal.pb.cc" />

--- a/serialization/serialization.vcxproj.filters
+++ b/serialization/serialization.vcxproj.filters
@@ -11,6 +11,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <CustomBuild Include="base.proto" />
     <CustomBuild Include="geometry.proto" />
     <CustomBuild Include="quantities.proto" />
     <CustomBuild Include="physics.proto" />
@@ -52,6 +53,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="base.pb.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="geometry.pb.cc">
@@ -79,6 +83,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="testing_utilities.pb.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="base.pb.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
When serializing a trajectory that has many burns for checkpointing purposes, we are typically only interested in the latest burn, but we must record the overall structure of the segments.  This used to be done by explicitly writing empty segments, but that leads to quadratic complexity.  Instead, I am writing to the save the number of empty segments at the beginning of the trajectory.

Fix #4490.