### PR TITLE
Fix hex output after the spring 2026 migration

### DIFF
--- a/astronomy/ksp_fingerprint_test.cpp
+++ b/astronomy/ksp_fingerprint_test.cpp
@@ -40,16 +40,16 @@ class KSPFingerprintTest : public ::testing::Test {
 
 TEST_F(KSPFingerprintTest, Stock) {
   std::uint64_t const fingerprint = solar_system_.Fingerprint();
-  LOG(INFO) << "Stock KSP fingerprint is 0x" << std::hex << std::uppercase
-            << fingerprint;
+  LOG(INFO) << "Stock KSP fingerprint is 0x" << std::noshowbase << std::hex
+            << std::uppercase << fingerprint;
   EXPECT_THAT(fingerprint, Eq(KSPStockSystemFingerprints[KSP191]));
 }
 
 TEST_F(KSPFingerprintTest, Corrected) {
   StabilizeKSP(solar_system_);
   std::uint64_t const fingerprint = solar_system_.Fingerprint();
-  LOG(INFO) << "Corrected KSP fingerprint is 0x" << std::hex << std::uppercase
-            << fingerprint;
+  LOG(INFO) << "Corrected KSP fingerprint is 0x" << std::noshowbase << std::hex
+            << std::uppercase << fingerprint;
   EXPECT_THAT(fingerprint, Eq(KSPStabilizedSystemFingerprints[KSP191]));
 }
 

--- a/base/array_body.hpp
+++ b/base/array_body.hpp
@@ -67,8 +67,8 @@ constexpr Array<Element>::Array(Character (&characters)[size_plus_1])
                 "reinterpret_cast is unsafe");
   if (characters[size] != 0) {
     LOG(FATAL) << "Array constructed with a character array terminated by the "
-                  "non-null 0x"
-               << std::hex << static_cast<uint32_t>(characters[size]);
+               << "non-null 0x" << std::noshowbase << std::hex << std::uppercase
+               << static_cast<uint32_t>(characters[size]);
   }
 }
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -188,8 +188,8 @@ void Plugin::EndInitialization() {
   // Check if this is the stock KSP system in which case it needs to be
   // stabilized.
   system_fingerprint_ = solar_system.Fingerprint();
-  LOG(INFO) << "System fingerprint is 0x" << std::hex << std::uppercase
-            << system_fingerprint_;
+  LOG(INFO) << "System fingerprint is 0x" << std::noshowbase << std::hex
+            << std::uppercase << system_fingerprint_;
 
   bool is_well_known = false;
   for (auto const ksp_version : {KSP122, KSP191PreLegendre, KSP191}) {
@@ -197,8 +197,9 @@ void Plugin::EndInitialization() {
       LOG(WARNING) << "This appears to be the dreaded KSP stock system!";
       StabilizeKSP(solar_system);
       system_fingerprint_ = solar_system.Fingerprint();
-      LOG(INFO) << "System fingerprint after stabilization is 0x" << std::hex
-                << std::uppercase << system_fingerprint_;
+      LOG(INFO) << "System fingerprint after stabilization is 0x"
+                << std::noshowbase << std::hex << std::uppercase
+                << system_fingerprint_;
       CHECK_EQ(KSPStabilizedSystemFingerprints[ksp_version],
                system_fingerprint_)
           << "Attempt at stabilizing the KSP system failed!\n"
@@ -1551,8 +1552,9 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
         break;
       }
     }
-    LOG(INFO) << "System has fingerprint 0x" << std::hex << std::uppercase
-              << plugin->system_fingerprint_ << "; " << details;
+    LOG(INFO) << "System has fingerprint 0x" << std::noshowbase << std::hex
+              << std::uppercase << plugin->system_fingerprint_ << "; "
+              << details;
   }
 
   plugin->game_epoch_ = Instant::ReadFromMessage(message.game_epoch());


### PR DESCRIPTION
We'll write our own `0x` instead of letting Abseil output `0X`.