### PR TITLE
Incorrect argument reduction for large angles in elliptic functions

### DIFF
--- a/numerics/elementary_functions.hpp
+++ b/numerics/elementary_functions.hpp
@@ -79,9 +79,8 @@ Q Abs(Q const& x);
 template<convertible_to_quantity Q>
 Q Abs(Q const& x);
 
-// Returns a value between zero and `modulus`.
 template<typename Q>
-Q Mod(Q const& argument, Q const& modulus);
+Q FMod(Q const& argument, Q const& modulus);
 
 // Equivalent to `std::sqrt(x)`.
 template<typename Q>
@@ -157,11 +156,11 @@ using internal::ConfigureElementaryFunctions;
 using internal::Cos;
 using internal::Cosh;
 using internal::ElementaryFunctionsConfigurationSaver;
+using internal::FMod;
 using internal::FusedMultiplyAdd;
 using internal::FusedMultiplySubtract;
 using internal::FusedNegatedMultiplyAdd;
 using internal::FusedNegatedMultiplySubtract;
-using internal::Mod;
 using internal::NextDown;
 using internal::NextUp;
 using internal::Pow;

--- a/numerics/elementary_functions_body.hpp
+++ b/numerics/elementary_functions_body.hpp
@@ -130,14 +130,8 @@ FORCE_INLINE Q Abs(Q const& x) {
 }
 
 template<typename Q>
-Q Mod(Q const& argument, Q const& modulus) {
-  double const result =
-      std::fmod(argument / si::Unit<Q>, modulus / si::Unit<Q>);
-  if (result > 0.0) {
-    return result * si::Unit<Q>;
-  } else {
-    return result * si::Unit<Q> + modulus;
-  }
+Q FMod(Q const& argument, Q const& modulus) {
+  return std::fmod(argument / si::Unit<Q>, modulus / si::Unit<Q>) * si::Unit<Q>;
 }
 
 template<typename Q>

--- a/numerics/elliptic_functions.cpp
+++ b/numerics/elliptic_functions.cpp
@@ -154,8 +154,8 @@ void JacobiSNCNDNWithK(Angle const& u,
     Angle const two_k = 2.0 * k;
     Angle const three_k = 3.0 * k;
     Angle const four_k = 4.0 * k;
-    abs_u =
-        abs_u - four_k * static_cast<double>(static_cast<int>(abs_u / four_k));
+    abs_u = FMod(abs_u, four_k);
+    CHECK_LE(abs_u, four_k);
     if (abs_u < 0.5 * k) {
       JacobiSNCNDNReduced(abs_u, mc, s, c, d);
     } else if (abs_u < k) {

--- a/numerics/elliptic_functions_test.cpp
+++ b/numerics/elliptic_functions_test.cpp
@@ -12,7 +12,10 @@
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
 #include "testing_utilities/almost_equals.hpp"
+#include "testing_utilities/approximate_quantity.hpp"
+#include "testing_utilities/is_near.hpp"
 #include "testing_utilities/numerics.hpp"
+#include "testing_utilities/numerics_matchers.hpp"
 #include "testing_utilities/serialization.hpp"
 
 namespace principia {
@@ -25,7 +28,10 @@ using namespace principia::numerics::_elliptic_integrals;
 using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;
 using namespace principia::testing_utilities::_almost_equals;
+using namespace principia::testing_utilities::_approximate_quantity;
+using namespace principia::testing_utilities::_is_near;
 using namespace principia::testing_utilities::_numerics;
+using namespace principia::testing_utilities::_numerics_matchers;
 using namespace principia::testing_utilities::_serialization;
 
 class EllipticFunctionsTest : public ::testing::Test {};
@@ -109,6 +115,23 @@ TEST_F(EllipticFunctionsTest, Mathematica) {
     EXPECT_THAT(actual_value_a, AlmostEquals(expected_value_a, 0, 22074))
         << argument_u << " " << argument_m;
   }
+}
+
+TEST_F(EllipticFunctionsTest, LargeArgumentReduction) {
+  Angle const u = -20171088911.704613 * Radian;
+  double const mc = 0.99998808836160413;
+
+  double actual_value_s;
+  double actual_value_c;
+  double actual_value_d;
+  JacobiSNCNDN(u, mc, actual_value_s, actual_value_c, actual_value_d);
+
+  EXPECT_THAT(actual_value_s,
+              RelativeErrorFrom(0.9981213878030822832, IsNear(3.7e-7_(1))));
+  EXPECT_THAT(actual_value_c,
+              RelativeErrorFrom(-0.0612674074043371423, IsNear(9.8e-5_(1))));
+  EXPECT_THAT(actual_value_d,
+              RelativeErrorFrom(0.9999940665195289649, IsNear(4.4e-12_(1))));
 }
 
 #if !defined(_DEBUG)


### PR DESCRIPTION
Casting to `int` might overflow for large angles (such angles show up e.g., when something explodes).