### PR TITLE
Add an IsFinite predicate for most of our geometry and physics types

### DIFF
--- a/geometry/affine_map.hpp
+++ b/geometry/affine_map.hpp
@@ -56,6 +56,9 @@ class AffineMap final {
       AffineMap<From, Through, S, Map> const& right);
   template<typename From, typename To, typename S,
            template<typename, typename> class Map>
+  friend bool IsFinite(AffineMap<From, To, S, Map> const& affine_map);
+  template<typename From, typename To, typename S,
+           template<typename, typename> class Map>
   friend std::ostream& operator<<(
       std::ostream& out,
       AffineMap<From, To, S, Map> const& affine_map);
@@ -66,6 +69,11 @@ template<typename FromFrame, typename ThroughFrame, typename ToFrame,
 AffineMap<FromFrame, ToFrame, Scalar, LinearMap> operator*(
     AffineMap<ThroughFrame, ToFrame, Scalar, LinearMap> const& left,
     AffineMap<FromFrame, ThroughFrame, Scalar, LinearMap> const& right);
+
+template<typename FromFrame, typename ToFrame, typename Scalar,
+         template<typename, typename> class LinearMap>
+bool IsFinite(
+    AffineMap<FromFrame, ToFrame, Scalar, LinearMap> const& affine_map);
 
 template<typename FromFrame, typename ToFrame, typename Scalar,
          template<typename, typename> class LinearMap>

--- a/geometry/affine_map_body.hpp
+++ b/geometry/affine_map_body.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <utility>
 #include "affine_map.hpp"
+
+#include <utility>
 
 namespace principia {
 namespace geometry {

--- a/geometry/affine_map_body.hpp
+++ b/geometry/affine_map_body.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include "affine_map.hpp"
 
 namespace principia {
 namespace geometry {
@@ -104,6 +105,15 @@ AffineMap<FromFrame, ToFrame, Scalar, LinearMap> operator*(
       /*to_origin=*/left.to_origin_ +
           left.linear_map_(right.to_origin_ - left.from_origin_),
       /*linear_map=*/left.linear_map_ * right.linear_map_);
+}
+
+template<typename FromFrame, typename ToFrame, typename Scalar,
+         template<typename, typename> class LinearMap>
+bool IsFinite(
+    AffineMap<FromFrame, ToFrame, Scalar, LinearMap> const& affine_map) {
+  return IsFinite(affine_map.from_origin_) &&
+         IsFinite(affine_map.to_origin_) &&
+         IsFinite(affine_map.linear_map_);
 }
 
 template<typename FromFrame, typename ToFrame, typename Scalar,

--- a/geometry/affine_map_body.hpp
+++ b/geometry/affine_map_body.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "affine_map.hpp"
+#include "geometry/affine_map.hpp"
 
 #include <utility>
 

--- a/geometry/direct_sum.hpp
+++ b/geometry/direct_sum.hpp
@@ -134,6 +134,9 @@ constexpr auto InnerProduct(DirectSum<T...> const& left,
                             DirectSum<T...> const& right);
 
 template<affine... T>
+bool IsFinite(DirectSum<T...> const& direct_sum);
+
+template<affine... T>
 std::string DebugString(DirectSum<T...> const& direct_sum);
 
 template<affine... T>

--- a/geometry/direct_sum_body.hpp
+++ b/geometry/direct_sum_body.hpp
@@ -215,6 +215,15 @@ constexpr auto InnerProduct(DirectSum<T...> const& left,
   return product;
 }
 
+template<affine ...T>
+bool IsFinite(DirectSum<T...> const& direct_sum) {
+  bool is_finite = true;
+  for_all_of(direct_sum).loop([&is_finite](auto const& component) {
+    is_finite &= IsFinite(component);
+  });
+  return is_finite;
+}
+
 template<affine... T>
 std::string DebugString(DirectSum<T...> const& direct_sum) {
   std::vector<std::string> strings;

--- a/geometry/grassmann.hpp
+++ b/geometry/grassmann.hpp
@@ -323,6 +323,9 @@ FusedNegatedMultiplySubtract(
     Multivector<Product<LScalar, RScalar>, Frame, rank> const& c);
 
 template<typename Scalar, typename Frame, int rank>
+bool IsFinite(Multivector<Scalar, Frame, rank> const& multivector);
+
+template<typename Scalar, typename Frame, int rank>
 std::string DebugString(Multivector<Scalar, Frame, rank> const& multivector);
 
 template<typename Scalar, typename Frame, int rank>

--- a/geometry/grassmann_body.hpp
+++ b/geometry/grassmann_body.hpp
@@ -546,6 +546,11 @@ FusedNegatedMultiplySubtract(
 }
 
 template<typename Scalar, typename Frame, int rank>
+bool IsFinite(Multivector<Scalar, Frame, rank> const& multivector) {
+  return IsFinite(multivector.coordinates());
+}
+
+template<typename Scalar, typename Frame, int rank>
 std::string DebugString(Multivector<Scalar, Frame, rank> const& multivector) {
   // This `using` is required for the `Trivector`, whose `DebugString(Scalar)`
   // will not be found by ADL if `Scalar` is `double`.

--- a/geometry/orthogonal_map.hpp
+++ b/geometry/orthogonal_map.hpp
@@ -143,6 +143,9 @@ class OrthogonalMap : public LinearMap<OrthogonalMap<FromFrame, ToFrame>,
       OrthogonalMap<From, Through> const& right);
 
   template<typename From, typename To>
+  friend bool IsFinite(OrthogonalMap<From, To> const& orthogonal_map);
+
+  template<typename From, typename To>
   friend std::ostream& operator<<(
       std::ostream& out,
       OrthogonalMap<From, To> const& orthogonal_map);
@@ -155,6 +158,9 @@ template<typename FromFrame, typename ThroughFrame, typename ToFrame>
 OrthogonalMap<FromFrame, ToFrame> operator*(
     OrthogonalMap<ThroughFrame, ToFrame> const& left,
     OrthogonalMap<FromFrame, ThroughFrame> const& right);
+
+template<typename FromFrame, typename ToFrame>
+bool IsFinite(OrthogonalMap<FromFrame, ToFrame> const& orthogonal_map);
 
 template<typename FromFrame, typename ToFrame>
 std::ostream& operator<<(

--- a/geometry/orthogonal_map_body.hpp
+++ b/geometry/orthogonal_map_body.hpp
@@ -158,6 +158,11 @@ OrthogonalMap<FromFrame, ToFrame> operator*(
 }
 
 template<typename FromFrame, typename ToFrame>
+bool IsFinite(OrthogonalMap<FromFrame, ToFrame> const& orthogonal_map) {
+  return IsFinite(orthogonal_map.quaternion_);
+}
+
+template<typename FromFrame, typename ToFrame>
 std::ostream& operator<<(
     std::ostream& out,
     OrthogonalMap<FromFrame, ToFrame> const& orthogonal_map) {

--- a/geometry/point.hpp
+++ b/geometry/point.hpp
@@ -81,6 +81,8 @@ class Point final {
   friend constexpr Point<V> NextDown(Point<V> x);
 
   template<typename V>
+  friend bool IsFinite(Point<V> const& point);
+  template<typename V>
   friend std::string DebugString(Point<V> const& point);
 };
 
@@ -101,6 +103,9 @@ template<convertible_to_quantity Vector>
 constexpr Point<Vector> NextUp(Point<Vector> x);
 template<convertible_to_quantity Vector>
 constexpr Point<Vector> NextDown(Point<Vector> x);
+
+template<typename Vector>
+bool IsFinite(Point<Vector> const& point);
 
 template<typename Vector>
 std::string DebugString(Point<Vector> const& point);

--- a/geometry/point_body.hpp
+++ b/geometry/point_body.hpp
@@ -140,6 +140,11 @@ constexpr Point<Vector> NextDown(Point<Vector> const x) {
 }
 
 template<typename Vector>
+bool IsFinite(Point<Vector> const& point) {
+  return IsFinite(point.coordinates_);
+}
+
+template<typename Vector>
 std::string DebugString(Point<Vector> const& point) {
   using quantities::_quantities::DebugString;
   return DebugString(point.coordinates_);

--- a/geometry/quaternion.hpp
+++ b/geometry/quaternion.hpp
@@ -64,10 +64,13 @@ Quaternion operator/(Quaternion const& left, double right);
 
 Quaternion Normalize(Quaternion const& quaternion);
 
+bool IsFinite(Quaternion const& quaternion);
+
 std::ostream& operator<<(std::ostream& out, Quaternion const& quaternion);
 
 }  // namespace internal
 
+using internal::IsFinite;
 using internal::Normalize;
 using internal::Quaternion;
 

--- a/geometry/quaternion.hpp
+++ b/geometry/quaternion.hpp
@@ -70,7 +70,6 @@ std::ostream& operator<<(std::ostream& out, Quaternion const& quaternion);
 
 }  // namespace internal
 
-using internal::IsFinite;
 using internal::Normalize;
 using internal::Quaternion;
 

--- a/geometry/quaternion_body.hpp
+++ b/geometry/quaternion_body.hpp
@@ -147,6 +147,11 @@ inline Quaternion Normalize(Quaternion const& quaternion) {
   return quaternion / quaternion.Norm();
 }
 
+inline bool IsFinite(Quaternion const& quaternion) {
+  return quantities::_quantities::IsFinite(quaternion.real_part()) &&
+         IsFinite(quaternion.imaginary_part());
+}
+
 inline std::ostream& operator<<(std::ostream& out,
                                 Quaternion const& quaternion) {
   double const w = quaternion.real_part();

--- a/geometry/r3_element.hpp
+++ b/geometry/r3_element.hpp
@@ -212,6 +212,9 @@ template<typename Scalar>
 R3Element<double> NormalizeOrZero(R3Element<Scalar> const& r3_element);
 
 template<typename Scalar>
+bool IsFinite(R3Element<Scalar> const& r3_element);
+
+template<typename Scalar>
 std::string DebugString(R3Element<Scalar> const& r3_element);
 
 template<typename Scalar>

--- a/geometry/r3_element_body.hpp
+++ b/geometry/r3_element_body.hpp
@@ -538,6 +538,13 @@ R3Element<double> NormalizeOrZero(R3Element<Scalar> const& r3_element) {
 }
 
 template<typename Scalar>
+bool IsFinite(R3Element<Scalar> const& r3_element) {
+  return quantities::_quantities::IsFinite(r3_element.x) &&
+         quantities::_quantities::IsFinite(r3_element.y) &&
+         quantities::_quantities::IsFinite(r3_element.z);
+}
+
+template<typename Scalar>
 std::string DebugString(R3Element<Scalar> const& r3_element) {
   using quantities::_quantities::DebugString;
   std::string result = "{";

--- a/geometry/r3x3_matrix.hpp
+++ b/geometry/r3x3_matrix.hpp
@@ -41,11 +41,6 @@ class R3x3Matrix final {
   friend bool operator!=(R3x3Matrix const& left,
                          R3x3Matrix const& right) = default;
 
-  template<typename Scalar>
-  bool IsFinite(R3x3Matrix<Scalar> const& r3x3_matrix) {
-    return false;
-  }
-
   Scalar operator()(int r, int c) const;
   Scalar& operator()(int r, int c);
 

--- a/geometry/r3x3_matrix.hpp
+++ b/geometry/r3x3_matrix.hpp
@@ -41,6 +41,11 @@ class R3x3Matrix final {
   friend bool operator!=(R3x3Matrix const& left,
                          R3x3Matrix const& right) = default;
 
+  template<typename Scalar>
+  bool IsFinite(R3x3Matrix<Scalar> const& r3x3_matrix) {
+    return false;
+  }
+
   Scalar operator()(int r, int c) const;
   Scalar& operator()(int r, int c);
 
@@ -124,6 +129,9 @@ class R3x3Matrix final {
                                                 RS const& right);
 
   template<typename S>
+  friend bool IsFinite(R3x3Matrix<S> const& r3x3_matrix);
+
+  template<typename S>
   friend std::string DebugString(R3x3Matrix<S> const& r3x3_matrix);
 #endif
 };
@@ -180,6 +188,9 @@ bool operator==(R3x3Matrix<Scalar> const& left,
 template<typename Scalar>
 bool operator!=(R3x3Matrix<Scalar> const& left,
                 R3x3Matrix<Scalar> const& right);
+
+template<typename Scalar>
+bool IsFinite(R3x3Matrix<Scalar> const& r3x3_matrix);
 
 template<typename Scalar>
 std::string DebugString(R3x3Matrix<Scalar> const& r3x3_matrix);

--- a/geometry/r3x3_matrix_body.hpp
+++ b/geometry/r3x3_matrix_body.hpp
@@ -391,6 +391,16 @@ R3x3Matrix<Product<LScalar, RScalar>> KroneckerProduct(
 }
 
 template<typename Scalar>
+bool IsFinite(R3x3Matrix<Scalar> const& r3x3_matrix) {
+  constexpr auto X = R3x3Matrix<Scalar>::X;
+  constexpr auto Y = R3x3Matrix<Scalar>::Y;
+  constexpr auto Z = R3x3Matrix<Scalar>::Z;
+  return IsFinite(r3x3_matrix.rows_[X]) &&
+         IsFinite(r3x3_matrix.rows_[Y]) &&
+         IsFinite(r3x3_matrix.rows_[Z]);
+}
+
+template<typename Scalar>
 std::string DebugString(R3x3Matrix<Scalar> const& r3x3_matrix) {
   constexpr auto X = R3x3Matrix<Scalar>::X;
   constexpr auto Y = R3x3Matrix<Scalar>::Y;

--- a/geometry/rotation.hpp
+++ b/geometry/rotation.hpp
@@ -278,6 +278,9 @@ class Rotation : public LinearMap<Rotation<FromFrame, ToFrame>,
                                       Rotation<From, Through> const& right);
 
   template<typename From, typename To>
+  friend bool IsFinite(Rotation<From, To> const& rotation);
+
+  template<typename From, typename To>
   friend std::ostream& operator<<(std::ostream& out,
                                   Rotation<From, To> const& rotation);
 };
@@ -290,6 +293,9 @@ template<typename FromFrame, typename ThroughFrame, typename ToFrame>
 Rotation<FromFrame, ToFrame> operator*(
     Rotation<ThroughFrame, ToFrame> const& left,
     Rotation<FromFrame, ThroughFrame> const& right);
+
+template<typename FromFrame, typename ToFrame>
+bool IsFinite(Rotation<FromFrame, ToFrame> const& rotation);
 
 template<typename FromFrame, typename ToFrame>
 std::ostream& operator<<(std::ostream& out,

--- a/geometry/rotation_body.hpp
+++ b/geometry/rotation_body.hpp
@@ -379,6 +379,11 @@ Rotation<FromFrame, ToFrame> operator*(
 }
 
 template<typename FromFrame, typename ToFrame>
+bool IsFinite(Rotation<FromFrame, ToFrame> const& rotation) {
+  return IsFinite(rotation.quaternion_);
+}
+
+template<typename FromFrame, typename ToFrame>
 std::ostream& operator<<(std::ostream& out,
                          Rotation<FromFrame, ToFrame> const& rotation) {
   return out << rotation.quaternion_;

--- a/numerics/double_precision.hpp
+++ b/numerics/double_precision.hpp
@@ -162,6 +162,9 @@ DoublePrecision<Quotient<T, U>> operator/(DoublePrecision<T> const& left,
                                           DoublePrecision<U> const& right);
 
 template<typename T>
+bool IsFinite(DoublePrecision<T> const& double_precision);
+
+template<typename T>
 std::string DebugString(DoublePrecision<T> const& double_precision);
 
 template<typename T>

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -526,6 +526,11 @@ DoublePrecision<Quotient<T, U>> operator/(DoublePrecision<T> const& left,
 }
 
 template<typename T>
+bool IsFinite(DoublePrecision<T> const& double_precision) {
+  return IsFinite(double_precision.value) && IsFinite(double_precision.error);
+}
+
+template<typename T>
 std::string DebugString(DoublePrecision<T> const& double_precision) {
   // We use `DebugString` to get all digits when `T` is `double`.  In that case
   // ADL will not find it, so we need the `using`.  For some values of `T`,

--- a/numerics/double_precision_body.hpp
+++ b/numerics/double_precision_body.hpp
@@ -117,7 +117,8 @@ struct ComponentwiseComparator<T, U> {
     // implementation.  We don't want to die because of the weird comparisons of
     // NaNs.
     return Abs(left) >= Abs(right) || left == T{} ||
-           !IsFinite(left) || !IsFinite(right);
+           !quantities::_quantities::IsFinite(left) ||
+           !quantities::_quantities::IsFinite(right);
   }
 };
 

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -126,7 +126,7 @@ void ComputeApsides(Trajectory<Frame> const& reference,
 
       // This can happen for instance if the square distance is stationary.
       // Safer to give up.
-      if (!IsFinite(apsis_time - Instant{})) {
+      if (!IsFinite(apsis_time)) {
         break;
       }
 

--- a/physics/rigid_motion.hpp
+++ b/physics/rigid_motion.hpp
@@ -150,6 +150,13 @@ class AcceleratedRigidMotion final {
 };
 
 template<typename FromFrame, typename ToFrame>
+bool IsFinite(RigidMotion<FromFrame, ToFrame> const& rigid_motion);
+
+template<typename FromFrame, typename ToFrame>
+bool IsFinite(
+    AcceleratedRigidMotion<FromFrame, ToFrame> const& accelerated_rigid_motion);
+
+template<typename FromFrame, typename ToFrame>
 std::ostream& operator<<(std::ostream& out,
                          RigidMotion<FromFrame, ToFrame> const& rigid_motion);
 

--- a/physics/rigid_motion_body.hpp
+++ b/physics/rigid_motion_body.hpp
@@ -183,31 +183,6 @@ RigidMotion<FromFrame, ToFrame> operator*(
 }
 
 template<typename FromFrame, typename ToFrame>
-std::ostream& operator<<(std::ostream& out,
-                         RigidMotion<FromFrame, ToFrame> const& rigid_motion) {
-  return out << "{transformation: " << rigid_motion.rigid_transformation()
-             << ", angular velocity: "
-             << rigid_motion.template angular_velocity_of<ToFrame>()
-             << ", velocity: "
-             << rigid_motion.template velocity_of_origin_of<ToFrame>()
-             << "}";
-}
-
-template<typename FromFrame, typename ToFrame>
-std::ostream& operator<<(std::ostream& out,
-                         AcceleratedRigidMotion<FromFrame, ToFrame> const&
-                             accelerated_rigid_motion) {
-  return out
-         << "{motion: " << accelerated_rigid_motion.rigid_motion()
-         << ", angular acceleration: "
-         << accelerated_rigid_motion.template angular_acceleration_of<ToFrame>()
-         << ", acceleration: "
-         << accelerated_rigid_motion
-                .template acceleration_of_origin_of<ToFrame>()
-         << "}";
-}
-
-template<typename FromFrame, typename ToFrame>
 AcceleratedRigidMotion<FromFrame, ToFrame>::AcceleratedRigidMotion(
     RigidMotion<FromFrame, ToFrame> const& rigid_motion,
     Bivector<AngularAcceleration, FromFrame> const&
@@ -255,6 +230,48 @@ AcceleratedRigidMotion<FromFrame, ToFrame>::acceleration_of_origin_of() const {
     static_assert(std::is_same_v<F, ToFrame> || std::is_same_v<F, FromFrame>,
                   "Nonsensical frame");
   }
+}
+
+template<typename FromFrame, typename ToFrame>
+bool IsFinite(RigidMotion<FromFrame, ToFrame> const& rigid_motion) {
+  return IsFinite(rigid_motion.rigid_transformation()) &&
+         IsFinite(rigid_motion.angular_velocity_of<ToFrame>()) &&
+         IsFinite(rigid_motion.velocity_of_origin_of<ToFrame>());
+}
+
+template<typename FromFrame, typename ToFrame>
+bool IsFinite(AcceleratedRigidMotion<FromFrame, ToFrame> const&
+                  accelerated_rigid_motion) {
+  return IsFinite(accelerated_rigid_motion.rigid_motion()) &&
+         IsFinite(
+             accelerated_rigid_motion.angular_acceleration_of<ToFrame>()) &&
+         IsFinite(
+             accelerated_rigid_motion.acceleration_of_origin_of<ToFrame>());
+}
+
+template<typename FromFrame, typename ToFrame>
+std::ostream& operator<<(std::ostream& out,
+                         RigidMotion<FromFrame, ToFrame> const& rigid_motion) {
+  return out << "{transformation: " << rigid_motion.rigid_transformation()
+             << ", angular velocity: "
+             << rigid_motion.template angular_velocity_of<ToFrame>()
+             << ", velocity: "
+             << rigid_motion.template velocity_of_origin_of<ToFrame>()
+             << "}";
+}
+
+template<typename FromFrame, typename ToFrame>
+std::ostream& operator<<(std::ostream& out,
+                         AcceleratedRigidMotion<FromFrame, ToFrame> const&
+                             accelerated_rigid_motion) {
+  return out
+         << "{motion: " << accelerated_rigid_motion.rigid_motion()
+         << ", angular acceleration: "
+         << accelerated_rigid_motion.template angular_acceleration_of<ToFrame>()
+         << ", acceleration: "
+         << accelerated_rigid_motion
+                .template acceleration_of_origin_of<ToFrame>()
+         << "}";
 }
 
 }  // namespace internal

--- a/quantities/quantities.hpp
+++ b/quantities/quantities.hpp
@@ -148,6 +148,7 @@ constexpr Q Infinity = SIUnit<Q>() * std::numeric_limits<double>::infinity();
 template <typename Q>
 CONSTEXPR_NAN Q NaN = SIUnit<Q>() * std::numeric_limits<double>::quiet_NaN();
 
+bool IsFinite(double x);
 template<typename Q>
 constexpr bool IsFinite(Q const& x);
 

--- a/quantities/quantities_body.hpp
+++ b/quantities/quantities_body.hpp
@@ -145,6 +145,10 @@ __m256d ToM256D(Quantity<Dimensions> const x) {
   return _mm256_set1_pd(x.magnitude_);
 }
 
+inline bool IsFinite(double const x) {
+  return std::isfinite(x);
+}
+
 template<typename Q>
 constexpr bool IsFinite(Q const& x) {
   return std::isfinite(x / SIUnit<Q>());


### PR DESCRIPTION
It makes it easier to debug computations that yield non-finite (mostly NaN) results.  It can also potentially be used in checks to detect anomalies.

This function is generally found by ADL, so it's not exported from the `internal` namespaces.  Except for `double` where obviously ADL is not applicable.