### PR TITLE
Change the EulerSolver API to take the inertia tensor

### DIFF
--- a/geometry/r3x3_matrix.hpp
+++ b/geometry/r3x3_matrix.hpp
@@ -51,7 +51,7 @@ class R3x3Matrix final {
   R3x3Matrix& operator/=(double right);
 
   static R3x3Matrix DiagonalMatrix(R3Element<Scalar> const& diagonal);
-
+  bool IsDiagonalMatrix() const;
   R3Element<Scalar> Diagonal() const;
 
   Scalar Trace() const;

--- a/geometry/r3x3_matrix_body.hpp
+++ b/geometry/r3x3_matrix_body.hpp
@@ -94,6 +94,13 @@ R3x3Matrix<Scalar> R3x3Matrix<Scalar>::DiagonalMatrix(
 }
 
 template<typename Scalar>
+bool R3x3Matrix<Scalar>::IsDiagonalMatrix() const {
+  return rows_[X].y == Scalar{} && rows_[X].z == Scalar{} &&
+             rows_[Y].x == Scalar{} && rows_[Y].z == Scalar{} &&
+             rows_[Z].x == Scalar{} && rows_[Z].y == Scalar{};
+}
+
+template<typename Scalar>
 R3Element<Scalar> R3x3Matrix<Scalar>::Diagonal() const {
   return {rows_[X].x, rows_[Y].y, rows_[Z].z};
 }

--- a/geometry/symmetric_bilinear_form.hpp
+++ b/geometry/symmetric_bilinear_form.hpp
@@ -85,6 +85,10 @@ class SymmetricBilinearForm {
   template<typename Eigenframe>
   Eigensystem<Eigenframe> Diagonalize() const;
 
+  // Returns true if the form is the result of a diagonalization: its matrix is
+  // diagonal and the diagonal elements are increasing.
+  bool IsDiagonalized() const;
+
   void WriteToMessage(
       not_null<serialization::SymmetricBilinearForm*> message) const;
   static SymmetricBilinearForm ReadFromMessage(

--- a/geometry/symmetric_bilinear_form_body.hpp
+++ b/geometry/symmetric_bilinear_form_body.hpp
@@ -248,6 +248,15 @@ typename SymmetricBilinearForm<Scalar, Frame, Multivector>::
 template<typename Scalar,
          typename Frame,
          template<typename, typename> typename Multivector>
+bool SymmetricBilinearForm<Scalar, Frame, Multivector>::IsDiagonalized() const {
+  return matrix_.IsDiagonalMatrix() &&
+         matrix_(0, 0) <= matrix_(1, 1) &&
+         matrix_(1, 1) <= matrix_(2, 2);
+}
+
+template<typename Scalar,
+         typename Frame,
+         template<typename, typename> typename Multivector>
 void SymmetricBilinearForm<Scalar, Frame, Multivector>::WriteToMessage(
     not_null<serialization::SymmetricBilinearForm*> message) const {
   Frame::WriteToMessage(message->mutable_frame());

--- a/ksp_plugin/pile_up.cpp
+++ b/ksp_plugin/pile_up.cpp
@@ -411,7 +411,7 @@ void PileUp::MakeEulerSolver(
     InertiaTensor<NonRotatingPileUp> const& inertia_tensor,
     Instant const& t) {
   auto const eigensystem = inertia_tensor.Diagonalize<PileUpPrincipalAxes>();
-  euler_solver_.emplace(eigensystem.form.coordinates().Diagonal(),
+  euler_solver_.emplace(eigensystem.form,
                         angular_momentum_,
                         eigensystem.rotation,
                         t);
@@ -525,11 +525,10 @@ void PileUp::DeformPileUpIfNeeded(Instant const& t) {
   // other things, on the attitude and angular velocity, and the Euler solver
   // changing attitude and angular velocity according to Euler’s equations.
   angular_momentum_ += intrinsic_torque_ * Δt + angular_momentum_change_;
-  euler_solver_.emplace(
-      apparent_inertia_eigensystem.form.coordinates().Diagonal(),
-      angular_momentum_,
-      initial_attitude,
-      t0);
+  euler_solver_.emplace(apparent_inertia_eigensystem.form,
+                        angular_momentum_,
+                        initial_attitude,
+                        t0);
 
   // This is where we compute our half of the splitting.
   RigidMotion<PileUpPrincipalAxes, NonRotatingPileUp> const

--- a/physics/euler_solver.hpp
+++ b/physics/euler_solver.hpp
@@ -12,6 +12,7 @@
 #include "geometry/space.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/rigid_motion.hpp"
+#include "physics/tensors.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 #include "serialization/physics.pb.h"
@@ -31,6 +32,7 @@ using namespace principia::geometry::_signature;
 using namespace principia::geometry::_space;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_rigid_motion;
+using namespace principia::physics::_tensors;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 
@@ -44,11 +46,11 @@ class EulerSolver {
   using AttitudeRotation = Rotation<PrincipalAxesFrame, InertialFrame>;
 
   // Constructs a solver for a body with the given moments_of_inertia in its
-  // principal axes frame.  The moments must be in increasing order.  At
-  // initial_time the angular momentum is initial_angular_momentum and the
-  // attitude initial_attitude.
+  // principal axes frame.  The tensor must be diagonal with the moments in
+  // increasing order.  At initial_time the angular momentum is
+  // `initial_angular_momentum` and the attitude `initial_attitude`.
   EulerSolver(
-      R3Element<MomentOfInertia> const& moments_of_inertia,
+      InertiaTensor<PrincipalAxesFrame> const& inertia_tensor,
       Bivector<AngularMomentum, InertialFrame> const& initial_angular_momentum,
       AttitudeRotation const& initial_attitude,
       Instant const& initial_time);

--- a/physics/euler_solver_body.hpp
+++ b/physics/euler_solver_body.hpp
@@ -7,6 +7,7 @@
 #include "base/algebra.hpp"
 #include "geometry/orthogonal_map.hpp"
 #include "geometry/quaternion.hpp"
+#include "geometry/r3x3_matrix.hpp"
 #include "geometry/sign.hpp"
 #include "geometry/space_transformations.hpp"
 #include "numerics/elementary_functions.hpp"
@@ -22,6 +23,7 @@ namespace internal {
 using namespace principia::base::_algebra;
 using namespace principia::geometry::_orthogonal_map;
 using namespace principia::geometry::_quaternion;
+using namespace principia::geometry::_r3x3_matrix;
 using namespace principia::geometry::_sign;
 using namespace principia::geometry::_space_transformations;
 using namespace principia::numerics::_elementary_functions;
@@ -31,11 +33,11 @@ using namespace principia::quantities::_si;
 
 template<typename InertialFrame, typename PrincipalAxesFrame>
 EulerSolver<InertialFrame, PrincipalAxesFrame>::EulerSolver(
-    R3Element<MomentOfInertia> const& moments_of_inertia,
+    InertiaTensor<PrincipalAxesFrame> const& inertia_tensor,
     Bivector<AngularMomentum, InertialFrame> const& initial_angular_momentum,
     AttitudeRotation const& initial_attitude,
     Instant const& initial_time)
-    : moments_of_inertia_(moments_of_inertia),
+    : moments_of_inertia_(inertia_tensor.coordinates().Diagonal()),
       serialized_initial_angular_momentum_(initial_angular_momentum),
       initial_attitude_(initial_attitude),
       initial_time_(initial_time),
@@ -43,6 +45,8 @@ EulerSolver<InertialFrame, PrincipalAxesFrame>::EulerSolver(
       ℛ_(Rotation<ℬʹ, InertialFrame>::Identity()),
       𝒮_(Signature<PrincipalAxesFrame,
                    PreferredPrincipalAxesFrame>::Identity()) {
+  CHECK(inertia_tensor.IsDiagonalized()) << inertia_tensor;
+
   // Do not use initial_angular_momentum after this point.
   auto const initial_angular_momentum_in_principal_axes =
       initial_attitude.Inverse()(initial_angular_momentum);
@@ -444,7 +448,10 @@ EulerSolver<InertialFrame, PrincipalAxesFrame>
 EulerSolver<InertialFrame, PrincipalAxesFrame>::ReadFromMessage(
     serialization::EulerSolver const& message) {
   return EulerSolver(
-      R3Element<MomentOfInertia>::ReadFromMessage(message.moments_of_inertia()),
+      InertiaTensor<PrincipalAxesFrame>(
+          R3x3Matrix<MomentOfInertia>::DiagonalMatrix(
+              R3Element<MomentOfInertia>::ReadFromMessage(
+                  message.moments_of_inertia()))),
       Bivector<AngularMomentum, InertialFrame>::ReadFromMessage(
           message.initial_angular_momentum()),
       AttitudeRotation::ReadFromMessage(message.initial_attitude()),

--- a/physics/euler_solver_test.cpp
+++ b/physics/euler_solver_test.cpp
@@ -17,10 +17,12 @@
 #include "geometry/instant.hpp"
 #include "geometry/permutation.hpp"
 #include "geometry/r3_element.hpp"
+#include "geometry/r3x3_matrix.hpp"
 #include "geometry/rotation.hpp"
 #include "geometry/space.hpp"
 #include "gtest/gtest.h"
 #include "numerics/elementary_functions.hpp"
+#include "physics/tensors.hpp"
 #include "quantities/named_quantities.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
@@ -45,10 +47,12 @@ using namespace principia::geometry::_grassmann;
 using namespace principia::geometry::_instant;
 using namespace principia::geometry::_permutation;
 using namespace principia::geometry::_r3_element;
+using namespace principia::geometry::_r3x3_matrix;
 using namespace principia::geometry::_rotation;
 using namespace principia::geometry::_space;
 using namespace principia::numerics::_elementary_functions;
 using namespace principia::physics::_euler_solver;
+using namespace principia::physics::_tensors;
 using namespace principia::quantities::_named_quantities;
 using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;
@@ -123,6 +127,12 @@ class EulerSolverTest : public ::testing::Test {
                 AlmostEquals(maximum_kinetic_energy, min_ulps, max_ulps));
   }
 
+  InertiaTensor<PrincipalAxes> MakeInertiaTensor(
+      R3Element<MomentOfInertia> const& moments_of_inertia) {
+    return InertiaTensor<PrincipalAxes>(
+        R3x3Matrix<MomentOfInertia>::DiagonalMatrix(moments_of_inertia));
+  }
+
   Solver::AttitudeRotation identity_attitude_;
   Bivector<double, PrincipalAxes> const e1_;
   Bivector<double, PrincipalAxes> const e2_;
@@ -153,7 +163,7 @@ TEST_F(EulerSolverTest, InitialStateRandom) {
              angular_momentum_distribution(random) *
                  si::Unit<AngularMomentum>});
 
-    Solver const solver(moments_of_inertia,
+    Solver const solver(MakeInertiaTensor(moments_of_inertia),
                         identity_attitude_(initial_angular_momentum),
                         identity_attitude_,
                         Instant());
@@ -193,7 +203,7 @@ TEST_F(EulerSolverTest, InitialStateSymmetrical) {
              angular_momentum_distribution(random) *
                  si::Unit<AngularMomentum>});
     {
-      Solver const solver1(moments_of_inertia1,
+      Solver const solver1(MakeInertiaTensor(moments_of_inertia1),
                            identity_attitude_(initial_angular_momentum),
                            identity_attitude_,
                            Instant());
@@ -205,7 +215,7 @@ TEST_F(EulerSolverTest, InitialStateSymmetrical) {
           << moments_of_inertia1 << " " << initial_angular_momentum;
     }
     {
-      Solver const solver2(moments_of_inertia2,
+      Solver const solver2(MakeInertiaTensor(moments_of_inertia2),
                            identity_attitude_(initial_angular_momentum),
                            identity_attitude_,
                            Instant());
@@ -217,7 +227,7 @@ TEST_F(EulerSolverTest, InitialStateSymmetrical) {
           << moments_of_inertia2 << " " << initial_angular_momentum;
     }
     {
-      Solver const solver3(moments_of_inertia3,
+      Solver const solver3(MakeInertiaTensor(moments_of_inertia3),
                            identity_attitude_(initial_angular_momentum),
                            identity_attitude_,
                            Instant());
@@ -260,7 +270,7 @@ TEST_F(EulerSolverTest, InitialStateFormulæ) {
       }
       Bivector<AngularMomentum, PrincipalAxes> const
           initial_angular_momentum({mx, si::Unit<AngularMomentum>, mz});
-      Solver const solver(moments_of_inertia,
+      Solver const solver(MakeInertiaTensor(moments_of_inertia),
                           identity_attitude_(initial_angular_momentum),
                           identity_attitude_,
                           Instant());
@@ -282,7 +292,7 @@ TEST_F(EulerSolverTest, InitialStateFormulæ) {
       }
       Bivector<AngularMomentum, PrincipalAxes> const
           initial_angular_momentum({mx, si::Unit<AngularMomentum>, mz});
-      Solver const solver(moments_of_inertia,
+      Solver const solver(MakeInertiaTensor(moments_of_inertia),
                           identity_attitude_(initial_angular_momentum),
                           identity_attitude_,
                           Instant());
@@ -307,7 +317,7 @@ TEST_F(EulerSolverTest, InitialStateFormulæ) {
       }
       Bivector<AngularMomentum, PrincipalAxes> const
           initial_angular_momentum({mx, si::Unit<AngularMomentum>, mz});
-      Solver const solver(moments_of_inertia,
+      Solver const solver(MakeInertiaTensor(moments_of_inertia),
                           identity_attitude_(initial_angular_momentum),
                           identity_attitude_,
                           Instant());
@@ -340,7 +350,7 @@ TEST_F(EulerSolverTest, ShortFatSymmetricTopPrecession) {
                              (moments_of_inertia[0] - moments_of_inertia[2]) /
                              (moments_of_inertia[0] * moments_of_inertia[2]);
 
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       initial_attitude(initial_angular_momentum),
                       initial_attitude,
                       Instant());
@@ -396,7 +406,7 @@ TEST_F(EulerSolverTest, TallSkinnySymmetricTopPrecession) {
                              (moments_of_inertia[1] - moments_of_inertia[0]) /
                              (moments_of_inertia[1] * moments_of_inertia[0]);
 
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       initial_attitude(initial_angular_momentum),
                       initial_attitude,
                       Instant());
@@ -452,7 +462,7 @@ TEST_F(EulerSolverTest, ДжанибековEffect) {
                                 0.01 * si::Unit<AngularMomentum>});
   Solver::AttitudeRotation const initial_attitude = identity_attitude_;
 
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       initial_attitude(initial_angular_momentum),
                       initial_attitude,
                       Instant());
@@ -549,7 +559,7 @@ TEST_F(EulerSolverTest, GeneralBodyNoRotation) {
       3 * si::Unit<MomentOfInertia>,
       5 * si::Unit<MomentOfInertia>};
 
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       Bivector<AngularMomentum, ICRS>(),
                       identity_attitude_,
                       Instant());
@@ -580,7 +590,7 @@ TEST_F(EulerSolverTest, GeneralBodyRotationAlongFirstAxis) {
       {5.0 * si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -618,7 +628,7 @@ TEST_F(EulerSolverTest, GeneralBodyRotationAlongSecondAxis) {
       {0.0 * si::Unit<AngularMomentum>,
        6.0 * si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -668,7 +678,7 @@ TEST_F(EulerSolverTest, GeneralBodyRotationAlongThirdAxis) {
       {0.0 * si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>,
        7.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -709,7 +719,7 @@ TEST_F(EulerSolverTest, GeneralBodyRotationCloseToThirdAxis) {
       {std::numeric_limits<double>::epsilon() * si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>,
        1.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -764,7 +774,7 @@ TEST_F(EulerSolverTest, GeneralBodyRotationVeryCloseToThirdAxis) {
            si::Unit<AngularMomentum>,
        0.0 * si::Unit<AngularMomentum>,
        1.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -820,7 +830,7 @@ TEST_F(EulerSolverTest, SphereRotationAlongRandomAxis) {
       -2.5 * Radian,
       EulerAngles::YZY,
       DefinesFrame<PrincipalAxes>{});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       initial_attitude(initial_angular_momentum),
                       initial_attitude,
                       Instant());
@@ -864,7 +874,7 @@ TEST_F(EulerSolverTest, SeparatrixConstantMomentum) {
       {0.0 * si::Unit<AngularMomentum>,
        4.0 * si::Unit<AngularMomentum>,
        5.0 * si::Unit<AngularMomentum>});
-  Solver const solver(moments_of_inertia,
+  Solver const solver(MakeInertiaTensor(moments_of_inertia),
                       identity_attitude_(initial_angular_momentum),
                       identity_attitude_,
                       Instant());
@@ -978,10 +988,11 @@ TEST_F(EulerSolverTest, Toutatis) {
                       angular_momentum_orientation_in_inertial.coordinates().z,
                       IsNear(0.014_(1)))));
 
-  Solver const solver(takahashi_to_vanilla(takahashi_moments_of_inertia),
-                      initial_attitude(initial_angular_momentum),
-                      initial_attitude,
-                      epoch);
+  Solver const solver(
+      MakeInertiaTensor(takahashi_to_vanilla(takahashi_moments_of_inertia)),
+      initial_attitude(initial_angular_momentum),
+      initial_attitude,
+      epoch);
 
   struct Observation {
     Instant t;
@@ -1168,7 +1179,7 @@ TEST_F(EulerSolverTest, Serialization) {
        0.01 * si::Unit<AngularMomentum>});
   Solver::AttitudeRotation const initial_attitude = identity_attitude_;
 
-  Solver const solver1(moments_of_inertia,
+  Solver const solver1(MakeInertiaTensor(moments_of_inertia),
                        initial_attitude(initial_angular_momentum),
                        initial_attitude,
                        Instant() + 3 * Second);


### PR DESCRIPTION
Passing the moments of inertia without an indication of frame is error-prone because there may be several principal axes around, notably those of the pile-up and those of the parts.

#4166.