### PR TITLE
Allocate checkpoints in an arena 🦁 owned by the checkpointer

### DIFF
--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -151,7 +151,8 @@ class Checkpointer {
   // key is the source of truth.
   CheckpointsByTime checkpoints_;
 
-  //TODO(phl)comment
+  // The checkpoints held in the `checkpoints_` map are all allocated in this
+  // arena.
   google::protobuf::Arena arena_;
 };
 

--- a/physics/checkpointer.hpp
+++ b/physics/checkpointer.hpp
@@ -9,6 +9,7 @@
 #include "absl/synchronization/mutex.h"
 #include "base/not_null.hpp"
 #include "geometry/instant.hpp"
+#include "google/protobuf/arena.h"
 #include "google/protobuf/repeated_field.h"
 #include "quantities/quantities.hpp"
 
@@ -135,8 +136,9 @@ class Checkpointer {
           message);
 
  private:
-  using CheckpointsByTime =
-      absl::btree_map<Instant, typename Message::Checkpoint>;
+  using CheckpointsByTime = absl::btree_map<
+      Instant,
+      google::protobuf::Arena::UniquePtr<typename Message::Checkpoint>>;
 
   void WriteToCheckpointLocked(Instant const& t)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
@@ -148,6 +150,9 @@ class Checkpointer {
   // The time field of the Checkpoint message may or may not be set.  The map
   // key is the source of truth.
   CheckpointsByTime checkpoints_;
+
+  //TODO(phl)comment
+  google::protobuf::Arena arena_;
 };
 
 }  // namespace internal

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -143,7 +143,7 @@ absl::Status Checkpointer<Message>::ReadFromOldestCheckpoint() const {
     if (checkpoints_.empty()) {
       return absl::NotFoundError("No checkpoint");
     }
-    checkpoint = &checkpoints_.cbegin()->second;
+    checkpoint = checkpoints_.cbegin()->second.get();
   }
   return reader_(*checkpoint);
 }
@@ -156,7 +156,7 @@ absl::Status Checkpointer<Message>::ReadFromNewestCheckpoint() const {
     if (checkpoints_.empty()) {
       return absl::NotFoundError("No checkpoint");
     }
-    checkpoint = &checkpoints_.crbegin()->second;
+    checkpoint = checkpoints_.crbegin()->second.get();
   }
   return reader_(*checkpoint);
 }
@@ -172,7 +172,7 @@ absl::Status Checkpointer<Message>::ReadFromCheckpointAtOrBefore(
     if (it == checkpoints_.cbegin()) {
       return absl::NotFoundError("No checkpoint");
     }
-    checkpoint = &std::prev(it)->second;
+    checkpoint = std::prev(it)->second.get();
   }
   return reader_(*checkpoint);
 }
@@ -189,7 +189,7 @@ absl::Status Checkpointer<Message>::ReadFromCheckpointAt(
       return absl::NotFoundError("No checkpoint found");
     }
   }
-  return reader(it->second);
+  return reader(*it->second);
 }
 
 template<typename Message>
@@ -205,7 +205,7 @@ void Checkpointer<Message>::WriteToMessage(
   absl::ReaderMutexLock l(&lock_);
   for (auto const& [time, checkpoint] : checkpoints_) {
     typename Message::Checkpoint* const message_checkpoint = message->Add();
-    *message_checkpoint = checkpoint;
+    *message_checkpoint = *checkpoint;
     time.WriteToMessage(message_checkpoint->mutable_time());
   }
 }
@@ -223,7 +223,10 @@ Checkpointer<Message>::ReadFromMessage(
   if (rewriter == nullptr) {
     for (auto const& checkpoint : message) {
       Instant const time = Instant::ReadFromMessage(checkpoint.time());
-      checkpointer->checkpoints_.emplace(time, checkpoint);
+      checkpointer->checkpoints_.emplace(
+          time,
+          google::protobuf::Arena::MakeUnique<typename Message::Checkpoint>(
+              &checkpointer->arena_, checkpoint));
     }
   } else {
     // For large checkpoints, rewriting is expensive, so we do it using multiple
@@ -239,7 +242,10 @@ Checkpointer<Message>::ReadFromMessage(
     for (std::int64_t i = 0; i < message.size(); ++i) {
       auto const& checkpoint = message[i];
       Instant const time = Instant::ReadFromMessage(checkpoint.time());
-      checkpointer->checkpoints_.emplace(time, rewrite_futures[i].get());
+      checkpointer->checkpoints_.emplace(
+          time,
+          google::protobuf::Arena::MakeUnique<typename Message::Checkpoint>(
+              &checkpointer->arena_, rewrite_futures[i].get()));
     }
   }
   return std::move(checkpointer);
@@ -250,9 +256,12 @@ void Checkpointer<Message>::WriteToCheckpointLocked(Instant const& t) {
   lock_.AssertHeld();
   CHECK(!checkpoints_.contains(t)) << t;
   auto const it = checkpoints_.emplace_hint(
-      checkpoints_.end(), t, typename Message::Checkpoint());
+      checkpoints_.end(),
+      t,
+      google::protobuf::Arena::MakeUnique<typename Message::Checkpoint>(
+          &arena_));
   lock_.Unlock();
-  writer_(&it->second);
+  writer_(it->second.get());
   lock_.Lock();
 }
 


### PR DESCRIPTION
When there are many checkpoints, or when they are big, this speeds up their destruction.

Related to #4490.