### PR TITLE
Improve the handling of multithreading in reanimation

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -395,7 +395,10 @@ void Vessel::RequestReanimation(Instant const& desired_t_min,
   // No locking here because vessel reanimation is only invoked from the main
   // thread.
   bool must_restart;
+  Instant allowable_desired_t_min;
   {
+    absl::MutexLock l(&lock_);
+
     // If the reanimator is asked to do significantly less work (in terms of
     // checkpoints to reanimate) than it is currently doing, interrupt it.  Note
     // that this is fundamentally racy: for instance the reanimator may not have
@@ -403,7 +406,7 @@ void Vessel::RequestReanimation(Instant const& desired_t_min,
     // very long reanimation and wants to shorten it.  Note however that we must
     // not move the desired t_min beyond the point where there are clients
     // waiting for reanimation as they would never succeed.
-    Instant const allowable_desired_t_min =
+    allowable_desired_t_min =
         std::min(desired_t_min, reanimator_clientele_.first());
     must_restart =
         last_desired_t_min_.has_value() &&
@@ -413,20 +416,17 @@ void Vessel::RequestReanimation(Instant const& desired_t_min,
         << "Restarting reanimator because desired t_min went from "
         << last_desired_t_min_.value() << " to " << allowable_desired_t_min;
     last_desired_t_min_ = allowable_desired_t_min;
+
+    if (DesiredTMinReachedOrFullyReanimated(allowable_desired_t_min)) {
+      return;
+    }
   }
 
   if (must_restart) {
     reanimator_.Restart();
   }
 
-  {
-    absl::MutexLock l(&lock_);
-    if (DesiredTMinReachedOrFullyReanimated(last_desired_t_min_.value())) {
-      return;
-    }
-  }
-
-  reanimator_.Put({.desired_t_min = last_desired_t_min_.value(),
+  reanimator_.Put({.desired_t_min = allowable_desired_t_min,
                    .quiet = quiet});
 }
 

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -392,8 +392,6 @@ void Vessel::RequestReanimation(Instant const& desired_t_min,
                                 bool const quiet) {
   reanimator_.Start();
 
-  // No locking here because vessel reanimation is only invoked from the main
-  // thread.
   bool must_restart;
   Instant allowable_desired_t_min;
   {

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -445,7 +445,7 @@ class Vessel {
   Clientele<Instant> reanimator_clientele_;
 
   // Parameter passed to the last call to `RequestReanimation`, if any.
-  std::optional<Instant> last_desired_t_min_;
+  std::optional<Instant> last_desired_t_min_ ABSL_GUARDED_BY(lock_);
 
   // The trajectories that have been reanimated are put in this queue by
   // ReanimateOneCheckpoint and consumed by RequestReanimation.

--- a/physics/ephemeris.hpp
+++ b/physics/ephemeris.hpp
@@ -340,6 +340,9 @@ class Ephemeris {
       Instant const& t_initial,
       Instant const& t_final) EXCLUDES(lock_);
 
+  bool DesiredTMinReachedOrFullyReanimated(Instant const& desired_t_min)
+      REQUIRES_SHARED(lock_);
+
   // Callbacks for the integrators.
   void AppendMassiveBodiesState(
       typename NewtonianMotionEquation::State const& state)
@@ -534,11 +537,9 @@ class Ephemeris {
   not_null<
       std::unique_ptr<Checkpointer<serialization::Ephemeris>>> checkpointer_;
 
-  // This member must only be accessed by the `reanimator_` thread, or before
-  // the `reanimator_` thread is started.  An ephemeris that is constructed de
-  // novo won't ever need reanimation, so all the checkpoints are animate at
-  // birth.
-  Instant oldest_reanimated_checkpoint_ = InfinitePast;
+  // An ephemeris that is constructed de novo won't ever need reanimation, so
+  // all the checkpoints are animate at birth.
+  Instant oldest_reanimated_checkpoint_ ABSL_GUARDED_BY(lock_) = InfinitePast;
 
   // The techniques and terminology follow [Lov22].
   RecurringThread<Instant> reanimator_;

--- a/physics/ephemeris_body.hpp
+++ b/physics/ephemeris_body.hpp
@@ -266,6 +266,7 @@ void Ephemeris<Frame>::RequestReanimation(Instant const& desired_t_min) {
   reanimator_.Start();
 
   bool must_restart;
+  Instant allowable_desired_t_min;
   {
     absl::MutexLock l(&lock_);
 
@@ -277,7 +278,7 @@ void Ephemeris<Frame>::RequestReanimation(Instant const& desired_t_min) {
     // we must not move the desired t_min beyond the point where there are
     // clients waiting for reanimation (e.g., vessels) as they would never
     // succeed.
-    Instant const allowable_desired_t_min =
+    allowable_desired_t_min =
         std::min(desired_t_min, reanimator_clientele_.first());
     must_restart = last_desired_t_min_.has_value() &&
                    last_desired_t_min_.value() + max_time_between_checkpoints <
@@ -286,13 +287,17 @@ void Ephemeris<Frame>::RequestReanimation(Instant const& desired_t_min) {
         << "Restarting reanimator because desired t_min went from "
         << last_desired_t_min_.value() << " to " << allowable_desired_t_min;
     last_desired_t_min_ = allowable_desired_t_min;
+
+    if (DesiredTMinReachedOrFullyReanimated(allowable_desired_t_min)) {
+      return;
+    }
   }
 
   // Don't hold the lock while restarting, the reanimator needs it.
   if (must_restart) {
     reanimator_.Restart();
   }
-  reanimator_.Put(last_desired_t_min_.value());
+  reanimator_.Put(allowable_desired_t_min);
 }
 
 template<typename Frame>
@@ -1057,6 +1062,14 @@ absl::Status Ephemeris<Frame>::ReanimateOneCheckpoint(
   }
 
   return absl::OkStatus();
+}
+
+template<typename Frame>
+bool Ephemeris<Frame>::DesiredTMinReachedOrFullyReanimated(
+    Instant const& desired_t_min) {
+  lock_.AssertReaderHeld();
+  return t_min_locked() <= desired_t_min ||
+         oldest_reanimated_checkpoint_ == checkpointer_->oldest_checkpoint();
 }
 
 template<typename Frame>


### PR DESCRIPTION
1. `Vessel` was missing locking in `RequestReanimation` (I have to believe that it was lost at some point, there was a block where locking should have happened).
2. There was a race where `last_desired_t_min_` was read without holding the lock in `Ephemeris`.
3. The check that reanimation has already reached the desired time was missing from `Ephemeris` (probably because of a misguided attempt at making some of this code lock-free).
4. That check should happen before restarting the reanimator anyway: no point in restarting if we have nothing to do.

This makes `Vessel` and `Ephemeris` more similar, but the entire multithreading scheme is rather ugly, see #4555.

Related to #4490.