### PR TITLE
Fix a race during the Лефшец-to-Leibniz migration

### DIFF
--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -420,8 +420,21 @@ void Vessel::RequestReanimation(Instant const& desired_t_min,
     reanimator_.Restart();
   }
 
-  reanimator_.Put({.desired_t_min = allowable_desired_t_min,
-                   .quiet = quiet});
+  {
+    absl::ReaderMutexLock l(&lock_);
+
+    // It is important for correctness that we *don't* enqueue a reanimation
+    // request if the desired time has already been reached.  When called from
+    // `AwaitReanimation`, there will be no waiting in that case.  If we
+    // enqueued a reanimation it would proceed asynchronously without anyone
+    // waiting, and this could cause a race if the trajectory being reanimated
+    // was destroyed soon thereafter, as can happen as part of the
+    // Лефшец-to-Leibniz migration.
+    if (!DesiredTMinReachedOrFullyReanimated(allowable_desired_t_min)) {
+      reanimator_.Put(
+          {.desired_t_min = allowable_desired_t_min, .quiet = quiet});
+    }
+  }
 }
 
 void Vessel::AwaitReanimation(Instant const& desired_t_min,
@@ -435,8 +448,7 @@ void Vessel::AwaitReanimation(Instant const& desired_t_min,
   RequestReanimation(desired_t_min, quiet);
 
   absl::MutexLock l(&lock_);
-  while (desired_t_min < trajectory_.t_min() &&
-         oldest_reanimated_checkpoint_ != checkpointer_->oldest_checkpoint()) {
+  while (!DesiredTMinReachedOrFullyReanimated(desired_t_min)) {
     lock_.Await(absl::Condition(&has_reanimated_trajectories));
 
     // Consume the reanimated trajectories and merge them into this trajectory.
@@ -1191,6 +1203,12 @@ absl::StatusOr<Instant> Vessel::ReanimateOneCheckpoint(
   }
 
   return reanimated_trajectory_t_initial;
+}
+
+bool Vessel::DesiredTMinReachedOrFullyReanimated(Instant const& desired_t_min) {
+  lock_.AssertReaderHeld();
+  return trajectory_.t_min() <= desired_t_min ||
+         oldest_reanimated_checkpoint_ == checkpointer_->oldest_checkpoint();
 }
 
 absl::StatusOr<DiscreteTrajectory<Barycentric>> Vessel::FlowPrognostication(

--- a/ksp_plugin/vessel.hpp
+++ b/ksp_plugin/vessel.hpp
@@ -372,6 +372,9 @@ class Vessel {
       Instant const& t_final,
       bool quiet) EXCLUDES(lock_);
 
+  bool DesiredTMinReachedOrFullyReanimated(Instant const& desired_t_min)
+      REQUIRES_SHARED(lock_);
+
   // Runs the integrator to compute the `prognostication_` based on the given
   // parameters.
   absl::StatusOr<DiscreteTrajectory<Barycentric>>


### PR DESCRIPTION
We had a test failure on Ubuntu x64:
```
2026-05-06T22:12:49.1483371Z [ RUN      ] InterfaceTestWithoutPlugin.DeserializePlugin
2026-05-06T22:12:49.1517903Z F0506 22:12:49.151322  115685 discrete_trajectory_iterator_body.hpp:87] Check failed: !is_at_end(point_) 
2026-05-06T22:12:49.1602999Z *** Check failure stack trace: ***
2026-05-06T22:12:49.1604220Z     @     0x5562d3e4bda4  absl::log_internal::LogMessage::SendToLog()
2026-05-06T22:12:49.1605987Z     @     0x5562d3e4bd52  absl::log_internal::LogMessage::Flush()
2026-05-06T22:12:49.1606638Z     @     0x5562d38b814f  principia::ksp_plugin::_vessel::internal::Vessel::Reanimate()
2026-05-06T22:12:49.1609039Z     @     0x5562d38b9742  std::__1::__function::__func<>::operator()()
2026-05-06T22:12:49.1609476Z     @     0x5562d38be685  principia::base::_recurring_thread::internal::RecurringThread<>::RunAction()
2026-05-06T22:12:49.1609977Z     @     0x5562d3433003  principia::base::_recurring_thread::internal::BaseRecurringThread::RepeatedlyRunAction()
2026-05-06T22:12:49.1610435Z     @     0x5562d33cf184  std::__1::__thread_proxy[abi:ne200100]<>()
2026-05-06T22:12:49.1610862Z     @     0x7f3368094ac3  (unknown)
```
Happily enough I was able to reproduce it with `wsl` under `lldb`.  What was happening was this:
1. The plugin being read was updated in #4415 ([commit](https://github.com/mockingbirdnest/Principia/commit/53bc3663536df8bd85ea49ab960d3da167c8da40)) and therefore requires migration to Leibniz.
2. The vessel's trajectory is "reanimated at birth", i.e., there is only a single checkpoint.
3. `AwaitReanimation` is called [here](https://github.com/mockingbirdnest/Principia/blob/4cc9882675529ae5eddeb70459437cae2c916f48/ksp_plugin/vessel.cpp#L921) to reanimate the entire history as part of the migration.
4. `RequestReanimation` enqueues a request on the `reanimator_` [here](https://github.com/mockingbirdnest/Principia/blob/4cc9882675529ae5eddeb70459437cae2c916f48/ksp_plugin/vessel.cpp#L423-L424) to reanimate until `InfinitePast`.
5. `AwaitReanimation` discovers [here](https://github.com/mockingbirdnest/Principia/blob/4cc9882675529ae5eddeb70459437cae2c916f48/ksp_plugin/vessel.cpp#L438-L439) that the vessel is already fully reanimated and returns immediately, without synchronization with the `reanimator_`.
6. The trajectory that we tried to reanimate at step 3 is moved to the graveyard [here](https://github.com/mockingbirdnest/Principia/blob/4cc9882675529ae5eddeb70459437cae2c916f48/ksp_plugin/vessel.cpp#L995); some time later it is destructed.
7. The `reanimator_` finally starts working and finds a deallocated/empty trajectory [here](https://github.com/mockingbirdnest/Principia/blob/4cc9882675529ae5eddeb70459437cae2c916f48/ksp_plugin/vessel.cpp#L1101).  Dereferencing `begin` causes the crash.

Tested with:
```
bin/x64/ksp_plugin_test/test --gtest_filter=InterfaceTest* --gtest_repeat=500
```
The sequence `InterfaceTest*` was failing about half of the time before this PR.