### PR TITLE
Print the base address from the loader and adjust the stacktrace decoder

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -18,11 +18,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
-#if OS_WIN
-#include <windows.h>
-#include <psapi.h>
-#endif
 
 #include "absl/log/check.h"
 #include "absl/log/die_if_null.h"
@@ -727,15 +722,6 @@ void __cdecl principia__InitGoogleLogging() {
     LOG(ERROR) << "Running on " << ProcessorBrandString() << " ("
                << CPUVendorIdentificationString() << ")";
     LOG(ERROR) << "with " << CPUFeatures();
-#if OS_WIN
-  MODULEINFO module_info;
-  memset(&module_info, 0, sizeof(module_info));
-  CHECK(GetModuleInformation(GetCurrentProcess(),
-                             GetModuleHandle(TEXT("principia")),
-                             &module_info,
-                             sizeof(module_info)));
-  LOG(ERROR) << "Base address is " << module_info.lpBaseOfDll;
-#endif
   }
 }
 

--- a/ksp_plugin_adapter/loader.cs
+++ b/ksp_plugin_adapter/loader.cs
@@ -85,6 +85,8 @@ internal static class Loader {
         // our mind and load the x64_AVX_FMA DLL.  It's necessary to unload the
         // DLL, otherwise the base address reported by `InitGoogleLogging` might
         // (incorrectly) be the one of the `x64` DLL.
+        // ETA: For some reason unloading has no effect starting in April 2026:
+        // we can call `SayHello` after the unloading.
         string error_unload = UnloadPrincipiaDll(platform: "x64");
         if (error_unload != null) {
           return error_unload;
@@ -99,6 +101,7 @@ internal static class Loader {
       }
       loaded_principia_dll = true;
       Log.InitGoogleLogging();
+      Log.Info("Base address is " + principia_dll_.ToString("X16"));
       Log.Info("Processor " +
                (has_avx ? "has" : "does not have") +
                " AVX support and " +

--- a/stacktrace_decoder/stacktrace_decoder.cs
+++ b/stacktrace_decoder/stacktrace_decoder.cs
@@ -159,7 +159,7 @@ class StackTraceDecoder {
         unity_crash,
         @"(?i)GameData\\Principia\\x64\\principia.dll:principia.dll " +
         @"\(([0-9A-F]+)\)",
-        "interface\\.cpp",
+        @"(?:interface\.cpp|loader\.cs)",
         stream);
     Console.Write(
         comment($"Using Principia base address {principia_base_address:X}"));


### PR DESCRIPTION
It appears that starting with the `test4557` release we get the wrong base address (`x64` instead of `x64_AVX_FMA`) if printed from the C++ code.