### PR TITLE
A nanobenchmark for Payne-Hanek reduction

### DIFF
--- a/nanobenchmarks/elementary_functions_nanobenchmark.cpp
+++ b/nanobenchmarks/elementary_functions_nanobenchmark.cpp
@@ -3,17 +3,23 @@
 #include <cmath>
 
 #include "nanobenchmarks/nanobenchmark.hpp"  // 🧙 For NANOBENCHMARK_*.
+#include "numerics/angle_reduction.hpp"
 #include "numerics/cbrt.hpp"
+#include "numerics/double_precision.hpp"
 #include "numerics/elementary_functions.hpp"
+#include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
 
 namespace principia {
 namespace nanobenchmarks {
 namespace {
 
+using namespace principia::numerics::_angle_reduction;
 using namespace principia::numerics::_cbrt;
+using namespace principia::numerics::_double_precision;
 using namespace principia::nanobenchmarks::_nanobenchmark;
 using namespace principia::numerics::_elementary_functions;
+using namespace principia::quantities::_quantities;
 using namespace principia::quantities::_si;
 
 NANOBENCHMARK_FUNCTION(Cbrt);
@@ -49,6 +55,13 @@ NANOBENCHMARK(principia_sin_cos) {
   // price of an extra `and` (1 cycle).
   return _mm_cvtsd_f64(
       _mm_and_pd(_mm_set_sd(values.sin), _mm_set_sd(values.cos)));
+}
+
+NANOBENCHMARK(payne_hanek) {
+  DoublePrecision<Angle> x_reduced;
+  std::int64_t quadrant;
+  PayneHanek<61>(x * Radian, x_reduced, quadrant);
+  return x_reduced.value / Radian;
 }
 
 }  // namespace

--- a/numerics/angle_reduction_body.hpp
+++ b/numerics/angle_reduction_body.hpp
@@ -211,14 +211,16 @@ void PayneHanek(Angle const& x,
   // below for the chunk.
   double const scale = std::scalbn(1.0, e - n + 1);
 
+  // The most significant chunk has extra bits that we don't need because they
+  // are part of `Left(e, p)`.  Drop them: the first bit that is preserved here
+  // is the one numbered n - e + 1.
+  double const medium_first_mod = std::scalbn(1.0, n - e + 2);
+
   DoublePrecision<double> h;
   for (std::int64_t i = medium_last; i >= medium_first; --i) {
     double chunk = PayneHanekChunks[i];
     if (i == medium_first) {
-      // The most significant chunk has extra bits that we don't need because
-      // they are part of `Left(e, p)`.  Drop them: the first bit that is
-      // preserved here is the one numbered n - e + 1.
-      chunk = std::remainder(chunk, std::scalbn(1.0, n - e + 2));
+      chunk = std::remainder(chunk, medium_first_mod);
     }
     double const schunk = scale * chunk;
     // The products are exact by construction of the chunks.

--- a/numerics/angle_reduction_body.hpp
+++ b/numerics/angle_reduction_body.hpp
@@ -198,9 +198,18 @@ void PayneHanek(Angle const& x,
   // medium_last].
   std::int64_t const medium_first = bit_to_index(n - e + 1);
   std::int64_t const medium_last = bit_to_index(-n - e - 1 - p);
-  // This is not in [Mul97].  The bit numbered 2 - e is the smallest one that
-  // can contribute to `h mod 8`.
+  // This is not in [Mul97].  The bit numbered 2 - e can only contribute a value
+  // sligtly smaller than 8 to `h`.  However, if this bit is 1 and some bits
+  // with lower number of the same chunk are 1, then the contribution to `h` can
+  // exceed 8.  Therefore, bit 2 - e must be taken into account when computing
+  // `h mod 8`.
   std::int64_t const medium_mod_8 = bit_to_index(2 - e);
+
+  // The bits of the chunks must be scaled up by 2^(n + e + 1 + p) to make
+  // `Medium(e, p)` an integer.  The computation of `h` then involves a
+  // multiplication by 2^(-2n -p).  All together, this results in the scaling
+  // below for the chunk.
+  double const scale = std::scalbn(1.0, e - n + 1);
 
   DoublePrecision<double> h;
   for (std::int64_t i = medium_last; i >= medium_first; --i) {
@@ -211,11 +220,7 @@ void PayneHanek(Angle const& x,
       // preserved here is the one numbered n - e + 1.
       chunk = std::remainder(chunk, std::scalbn(1.0, n - e + 2));
     }
-    // The bits of the chunks must be scaled up by 2^(n + e + 1 + p) to make
-    // `Medium(e, p)` an integer.  The computation of `h` then involves a
-    // multiplication by 2^(-2n -p).  All together, this results in the scaling
-    // below for the chunk.
-    double const schunk = std::scalbn(chunk, e - n + 1);
+    double const schunk = scale * chunk;
     // The products are exact by construction of the chunks.
     double Xl_schunk = Xl * schunk;
     double Xh_schunk = Xh * schunk;
@@ -227,7 +232,11 @@ void PayneHanek(Angle const& x,
     // chunks that can contribute to `h mod 8`, so that gives us an upper bound
     // of roughly 0.308 n for `h`.
     if (i <= medium_mod_8) {
-      Xl_schunk = std::remainder(Xl_schunk, 8.0);
+      if (i < medium_mod_8) {
+        Xl_schunk = std::remainder(Xl_schunk, 8.0);
+      } else {
+        DCHECK_LE(Xl_schunk, 8.0);
+      }
       Xh_schunk = std::remainder(Xh_schunk, 8.0);
     } else {
       DCHECK_LE(Xl_schunk, 8.0);


### PR DESCRIPTION
And some micro-optimizations.

#4536
```
> .\Release\x64_AVX_FMA\nanobenchmarks.exe --benchmark_filter='.*payne.*' --input 300000 --loop_iterations 1000
AuthenticAMD AMD Ryzen Threadripper PRO 5965WX 24-Cores
Features: FPU SSE SSE2 SSE3 FMA SSE4_1 AVX AVX2
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            5.02   +0.00   +0.00   +0.00   +0.00   +0.00   +0.04
     mulsd_xmm0_xmm0            7.52   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.01   +0.00   +0.00   +0.04   +0.04   +0.04   +0.04
    sqrtps_xmm0_xmm0           16.68   +0.04   +0.15   +0.15   +0.19   +0.19   +0.19
Slope: 1.200695 cycle/TSC    Overhead: 5.019830 TSC
Correlation coefficient: 1.000000
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.00   +0.00   +0.00   +0.00   +0.00   +0.00   +0.05
R    mulsd_xmm0_xmm0       3    3.01   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.00   +0.00   +0.00   +0.05   +0.05   +0.05   +0.05
R   sqrtps_xmm0_xmm0      14   14.00   +0.05   +0.18   +0.18   +0.23   +0.23   +0.23
         payne_hanek          604.18   +4.06   +4.56  +10.04  +11.00  +14.10  +16.01
```