### PR TITLE
A nanobenchmark for cr_cos and cr_sin

### DIFF
--- a/nanobenchmarks/elementary_functions_nanobenchmark.cpp
+++ b/nanobenchmarks/elementary_functions_nanobenchmark.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "core-math/cos.h"
+#include "core-math/sin.h"
 #include "nanobenchmarks/nanobenchmark.hpp"  // 🧙 For NANOBENCHMARK_*.
 #include "numerics/angle_reduction.hpp"
 #include "numerics/cbrt.hpp"
@@ -37,12 +39,20 @@ NANOBENCHMARK(std_sin) {
   return std::sin(x);
 }
 
+NANOBENCHMARK(cr_sin) {
+  return cr_sin(x);
+}
+
 NANOBENCHMARK(principia_sin) {
   return Sin(x * Radian);
 }
 
 NANOBENCHMARK(std_cos) {
   return std::cos(x);
+}
+
+NANOBENCHMARK(cr_cos) {
+  return cr_cos(x);
 }
 
 NANOBENCHMARK(principia_cos) {


### PR DESCRIPTION
```
> .\Release\x64_AVX_FMA\nanobenchmarks.exe --benchmark_filter='.*([Ss]in|[Cc]os).*' --input 3
RAW TSC:                         min      1‰      1%      5%     10%     25%     50%
            identity            4.94   +0.00   +0.00   +0.00   +0.00   +0.38   +0.38
     mulsd_xmm0_xmm0            7.60   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
  mulsd_xmm0_xmm0_4x           15.20   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
    sqrtps_xmm0_xmm0           16.72   +0.00   +0.00   +0.00   +0.38   +0.38   +0.38
Slope: 1.186186 cycle/TSC    Overhead: 5.002973 TSC
Correlation coefficient: 0.999887
Cycles:             expected     min      1‰      1%      5%     10%     25%     50%
R           identity       0   -0.07   +0.00   +0.00   +0.00   +0.00   +0.45   +0.45
R    mulsd_xmm0_xmm0       3    3.08   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R mulsd_xmm0_xmm0_4x      12   12.10   +0.00   +0.00   +0.00   +0.00   +0.00   +0.00
R   sqrtps_xmm0_xmm0      14   13.90   +0.00   +0.00   +0.00   +0.45   +0.45   +0.45
              cr_cos          418.22   +0.45   +0.90   +1.35   +1.35   +1.80   +2.70
              cr_sin          413.26   +0.45   +0.90   +0.90   +1.35   +1.80   +2.25
       principia_cos           59.42   +0.90   +1.35   +1.35   +1.35   +1.80   +1.80
       principia_sin           58.97   +1.35   +3.16   +3.16   +3.61   +3.61   +3.61
   principia_sin_cos           77.00   +0.45   +0.45   +0.90   +0.90   +0.90   +1.35
             std_cos           53.56   +0.45   +1.35   +1.35   +1.35   +1.35   +1.80
             std_sin           63.48   +0.00   +0.45   +0.45   +0.45   +0.45   +0.90
```