### PR TITLE
Fix problems that recently appeared in the diurnal build

### DIFF
--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -413,7 +413,7 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
   EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:09:20"_DateTime));
   EXPECT_THAT(flyby_inclination, IsNear(90.23_(1) * Degree));
-  EXPECT_EQ(25, number_of_evaluations);
+  EXPECT_EQ(24, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre5.burn(), /*index=*/5));
@@ -442,15 +442,15 @@ TEST_F(FlightPlanOptimizerTest, DISABLED_PoleTheMoon) {
 
   EXPECT_THAT(
       manœuvre7.initial_time() - flight_plan_->GetManœuvre(7).initial_time(),
-      IsNear(0.46_(1) * Milli(Second)));
+      IsNear(0.57_(1) * Milli(Second)));
   EXPECT_THAT(
       (manœuvre7.Δv() - flight_plan_->GetManœuvre(7).Δv()).Norm(),
       IsNear(12.7_(1) * Metre / Second));
 
   ComputeFlyby(*flight_plan_, moon, *moon_frame, flyby_time, flyby_inclination);
-  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:08:39"_DateTime));
+  EXPECT_THAT(flyby_time, ResultOf(&TTSecond, "1972-03-27T01:08:40"_DateTime));
   EXPECT_THAT(flyby_inclination, IsNear(90.00_(1) * Degree));
-  EXPECT_EQ(54, number_of_evaluations);
+  EXPECT_EQ(60, number_of_evaluations);
   number_of_evaluations = 0;
 
   CHECK_OK(flight_plan_->Replace(manœuvre7.burn(), /*index=*/7));

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -672,7 +672,7 @@ TEST_F(PluginCompatibilityTest, DISABLED_4490) {
   // Various asynchronous activities may happen in the plugin between the time
   // it is read and the time it is written, so the size of the new save is not
   // deterministic.
-  EXPECT_THAT(bytes_written, AllOf(Gt(7'972'000), Lt(7'972'300)));
+  EXPECT_THAT(bytes_written, AllOf(Gt(7'971'900), Lt(7'972'300)));
   EXPECT_EQ(bytes_read, bytes_written);
 }
 #endif


### PR DESCRIPTION
It is not entirely clear which PR is causing tolerance changes in the optimizer test, because the diurnal build has been rather noisy lately.  Based on the timing, I would blame #4569.