### PR TITLE
Allow replaying of journals produced by Leibniz

### DIFF
--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -2393,6 +2393,12 @@ message PluginReaderAwait {
 }
 
 message PluginReaderGet {
+  // If the call to `get` in the journal returned `nullptr`, do the same and
+  // don't call `get`, it would consume the plugin too early.  If the call to
+  // `get` in the journal returned a bona fide Plugin, call the entry point that
+  // awaits the result to make sure that deserialization has completed.
+  option (run_using) =
+    "[&message](PluginReader** reader) -> Plugin* {\n    if (message.return_().result() == 0) {\n      return nullptr;\n    } else {\n      return interface::principia__PluginReaderAwait(reader);\n    }\n  }";
   extend Method {
     optional PluginReaderGet extension = 5215;
   }
@@ -2942,5 +2948,9 @@ extend google.protobuf.MessageOptions {
   // If set, the struct used for journaling is not generated.  Useful for
   // methods for which we need interfacing but for which journaling would be
   // incorrect.
-  optional bool omit_journaling = 50017;
+  optional bool omit_journaling = 50018;
+  // A callable (e.g., a lambda or a function name) that is used instead of the
+  // normal interface function in the Run method.  This is useful is
+  // synchronization is needed based on the expected output of the Method.
+  optional string run_using = 50019;
 }

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -2398,7 +2398,7 @@ message PluginReaderGet {
   }
   message In {
     required fixed64 reader = 1 [(pointer_to) = "PluginReader",
-                                  (is_consumed_if) = "result != nullptr"];
+                                 (is_consumed_if) = "result != nullptr"];
   }
   message Out {
     required fixed64 reader = 1 [(pointer_to) = "PluginReader"];
@@ -2417,7 +2417,8 @@ message PluginReaderLogs {
     optional PluginReaderLogs extension = 5216;
   }
   message In {
-    required fixed64 reader = 1 [(pointer_to) = "PluginReader", (is_subject) = true];
+    required fixed64 reader = 1 [(pointer_to) = "PluginReader",
+                                 (is_subject) = true];
   }
   message Return {
     required string result = 1;
@@ -2431,7 +2432,8 @@ message PluginReaderWillBeSlow {
     optional PluginReaderWillBeSlow extension = 5217;
   }
   message In {
-    required fixed64 reader = 1 [(pointer_to) = "PluginReader const", (is_subject) = true];
+    required fixed64 reader = 1 [(pointer_to) = "PluginReader const",
+                                 (is_subject) = true];
   }
   message Return {
     required bool result = 1;
@@ -2445,7 +2447,8 @@ message PrepareToReportCollisions {
     optional PrepareToReportCollisions extension = 5118;
   }
   message In {
-    required fixed64 plugin = 1 [(pointer_to) = "Plugin", (is_subject) = true];
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin",
+                                 (is_subject) = true];
   }
   optional In in = 1;
 }

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1840,6 +1840,10 @@ void JournalProtoProcessor::ProcessMethodExtension(
     CHECK(options.GetExtension(journal::serialization::omit_journaling));
     needs_journaling_support = false;
   }
+  std::string run_using;
+  if (options.HasExtension(journal::serialization::run_using)) {
+    run_using = options.GetExtension(journal::serialization::run_using);
+  }
 
   if (needs_journaling_support) {
     cxx_toplevel_type_declaration_[descriptor] =
@@ -1968,9 +1972,15 @@ void JournalProtoProcessor::ProcessMethodExtension(
     } else {
       cxx_functions_implementation_[descriptor] += "  ";
     }
-    cxx_functions_implementation_[descriptor] +=
-        "interface::principia__" + name + "(" +
-        Join(cxx_run_arguments, /*joiner=*/", ") + ");\n";
+    std::string const joined_cxx_run_arguments =
+        "(" + Join(cxx_run_arguments, /*joiner=*/", ") + ")";
+    if (run_using.empty()) {
+      cxx_functions_implementation_[descriptor] +=
+          "interface::principia__" + name + joined_cxx_run_arguments + ";\n";
+    } else {
+      cxx_functions_implementation_[descriptor] +=
+          run_using + joined_cxx_run_arguments + ";\n";
+    }
     if (!run_conditional_compilation_symbol.empty()) {
       cxx_functions_implementation_[descriptor] += "#endif\n";
     }


### PR DESCRIPTION
The method `PluginReaderGet` causes problems during replaying because it might try to consume the deserialized plugin too early or too late with respect to the (asynchronous) deserialization.

I am adding a message option to allow replacing the reexecution in `Run` with custom code that does the right thing (including synchronizing) based on the expected output or result found in the message.  This is not overly elegant, but I cannot think of a more structured manner to handle this problem.

Here is the interesting bit of generated code:

Before:
```
  auto const result = interface::principia__PluginReaderGet(&reader);
```
After:
```
  auto const result = [&message](PluginReader** reader) -> Plugin* {
    if (message.return_().result() == 0) {
      return nullptr;
    } else {
      return interface::principia__PluginReaderAwait(reader);
    }
  }(&reader);
```
Found while analysing #4580.