### PR TITLE
Add flags to control the parallelism of deserialization

### DIFF
--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -88,13 +88,38 @@ Length const& MaxCollisionError() {
     if (Flags::IsPresent(name)) {
       auto const values = Flags::Values(name);
       CHECK_EQ(values.size(), 1);
-      return ParseQuantity<Length>(
-          *Flags::Values("max_collision_error").begin());
+      return ParseQuantity<Length>(*values.begin());
     } else {
       return 10 * Metre;
     }
   }();
   return max_collision_error;
+}
+
+// By default, we want deserialization to use all the cores.  But some users
+// have complained that the Leibniz migration uses up too much memory (RAM and
+// paging space), presumably because they have too little memory for the number
+// of cores.  So we allow them to specify a maximum number of threads.  This
+// should only be used during the migration, otherwise it will slow down
+// scene changes forever, but we don't enforce that: it would require to "peek"
+// at the save in the middle of a callback, and that's just messy.
+std::int64_t NumberOfThreadsForVesselDeserialization() {
+  static std::int64_t const number_of_threads_for_vessel_deserialization =
+      []() {
+        std::string_view const name =
+            "number_of_threads_for_vessel_deserialization";
+        if (Flags::IsPresent(name)) {
+          auto const values = Flags::Values(name);
+          CHECK_EQ(1, values.size());
+          return std::max(INT64_C(1), std::min<std::int64_t>(
+              std::thread::hardware_concurrency(),
+              std::stoul(
+                  values.begin()->c_str())));
+        } else {
+          return static_cast<std::int64_t>(std::thread::hardware_concurrency());
+        }
+      }();
+  return number_of_threads_for_vessel_deserialization;
 }
 
 }  // namespace
@@ -1582,9 +1607,9 @@ not_null<std::unique_ptr<Plugin>> Plugin::ReadFromMessage(
                              plugin->name_to_index_);
 
   // Deserialization of vessels may be slow because of the Лефшец-to-Leibniz
-  // migration, let's use all the cores.
+  // migration, let's do it in parallel.
   ThreadPool<not_null<std::unique_ptr<Vessel>>> vessel_deserialization_pool(
-      std::thread::hardware_concurrency());
+      NumberOfThreadsForVesselDeserialization());
   std::vector<std::future<not_null<std::unique_ptr<Vessel>>>> vessel_futures;
   vessel_futures.reserve(message.vessel_size());
   for (auto const& vessel_message : message.vessel()) {

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "absl/container/btree_set.h"
+#include "base/flags.hpp"
 #include "base/thread_pool.hpp"
 
 namespace principia {
@@ -14,7 +15,27 @@ namespace physics {
 namespace _checkpointer {
 namespace internal {
 
+using namespace principia::base::_flags;
 using namespace principia::base::_thread_pool;
+
+inline std::int64_t NumberOfThreadsForCheckpointerDeserialization() {
+  static std::int64_t const number_of_threads_for_checkpointer_deserialization =
+      []() {
+        std::string_view const name =
+            "number_of_threads_for_checkpointer_deserialization";
+        if (Flags::IsPresent(name)) {
+          auto const values = Flags::Values(name);
+          CHECK_EQ(1, values.size());
+          return std::max(INT64_C(1), std::min<std::int64_t>(
+              std::thread::hardware_concurrency(),
+              std::stoul(
+                  values.begin()->c_str())));
+        } else {
+          return static_cast<std::int64_t>(std::thread::hardware_concurrency());
+        }
+      }();
+  return number_of_threads_for_checkpointer_deserialization;
+}
 
 template<typename Message>
 Checkpointer<Message>::Checkpointer(Writer writer, Reader reader)
@@ -244,7 +265,7 @@ Checkpointer<Message>::ReadFromMessage(
     // For large checkpoints, rewriting is expensive, so we do it using multiple
     // threads.
     ThreadPool<typename Message::Checkpoint> rewrite_pool(
-        std::thread::hardware_concurrency());
+        NumberOfThreadsForCheckpointerDeserialization());
     std::vector<std::future<typename Message::Checkpoint>> rewrite_futures;
     rewrite_futures.reserve(message.size());
     for (auto const& checkpoint : message) {

--- a/physics/checkpointer_body.hpp
+++ b/physics/checkpointer_body.hpp
@@ -2,6 +2,7 @@
 
 #include "physics/checkpointer.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
This would help, to some extent, users who don't have enough memory to do the Leibniz conversion.  Syntax of the configuration file:
```
principia_flags {
  number_of_threads_for_checkpointer_deserialization = 1
  number_of_threads_for_vessel_deserialization = 2
}
```
The "vessel" flag is probably the one having the most sizeable effect.

Note that the user must remove this file after the migration, lest their scene changes would be slow for ever and ever.