### PR TITLE
Change ReferenceFrame to be usable as a key to a hash map

### DIFF
--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -172,6 +172,11 @@ class BarycentricRotatingReferenceFrame
       ABSL_GUARDED_BY(lock_);
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& right);
+
 }  // namespace internal
 
 using internal::BarycentricRotatingReferenceFrame;

--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -170,6 +170,11 @@ class BarycentricRotatingReferenceFrame
       ABSL_GUARDED_BY(lock_);
   mutable CachedDerivatives last_evaluated_secondary_derivatives_
       ABSL_GUARDED_BY(lock_);
+
+  template<typename IF, typename TF>
+  friend bool operator==(
+      BarycentricRotatingReferenceFrame<IF, TF> const& left,
+      BarycentricRotatingReferenceFrame<IF, TF> const& right);
 };
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "absl/hash/hash.h"
 #include "base/algebra.hpp"
 #include "base/not_null.hpp"
 #include "geometry/barycentre_calculator.hpp"
@@ -87,6 +88,8 @@ class BarycentricRotatingReferenceFrame
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
+
+  void HashValue(absl::HashState state) const override;
 
   void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const override;

--- a/physics/barycentric_rotating_reference_frame.hpp
+++ b/physics/barycentric_rotating_reference_frame.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "absl/container/btree_set.h"
 #include "absl/hash/hash.h"
 #include "base/algebra.hpp"
 #include "base/not_null.hpp"
@@ -163,6 +164,9 @@ class BarycentricRotatingReferenceFrame
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;
   std::vector<not_null<MassiveBody const*>> const primaries_;
   std::vector<not_null<MassiveBody const*>> const secondaries_;
+  // Ordered for intersection.
+  absl::btree_set<not_null<MassiveBody const*>> const primary_set_;
+  absl::btree_set<not_null<MassiveBody const*>> const secondary_set_;
   GravitationalParameter const primary_gravitational_parameter_;
   GravitationalParameter const secondary_gravitational_parameter_;
   mutable absl::Mutex lock_;

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -457,6 +457,7 @@ template<typename InertialFrame, typename ThisFrame>
 bool operator==(
     BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
     BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  CHECK_EQ(left.ephemeris_, right.ephemeris_);
   // The comparison does not depend on the order of the bodies.  Note that the
   // bodies are pointers to objects held by the ephemeris, so comparing them is
   // legitimate.

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -453,6 +453,25 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ToThisFrame(
       barycentre_degrees_of_freedom.velocity());
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  // The comparison does not depend on the order of the bodies.  Note that the
+  // bodies are pointers to objects held by the ephemeris, so comparing them is
+  // legitimate.
+  absl::flat_hash_set<not_null<MassiveBody const*>> const left_primaries(
+      left.primaries_.begin(), left.primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const right_primaries(
+      right.primaries_.begin(), right.primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const left_secondaries(
+      left.secondaries_.begin(), left.secondaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const right_secondaries(
+      right.secondaries_.begin(), right.secondaries_.end());
+  return left_primaries == right_primaries &&
+         left_secondaries == right_secondaries;
+}
+
 }  // namespace internal
 }  // namespace _barycentric_rotating_reference_frame
 }  // namespace physics

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -162,6 +162,16 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
 }
 
 template<typename InertialFrame, typename ThisFrame>
+void BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
+    absl::HashState state) const {
+  absl::flat_hash_set<not_null<MassiveBody const*>> const primaries_set(
+      primaries_.begin(), primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
+      secondaries_.begin(), secondaries_.end());
+  absl::HashState::combine(std::move(state), primaries_set, secondaries_set);
+}
+
+template<typename InertialFrame, typename ThisFrame>
 void BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
 WriteToMessage(not_null<serialization::ReferenceFrame*> const message) const {
   auto* const extension = message->MutableExtension(
@@ -461,6 +471,7 @@ bool operator==(
   // The comparison does not depend on the order of the bodies.  Note that the
   // bodies are pointers to objects held by the ephemeris, so comparing them is
   // legitimate.
+  //TODO(phl)Precompute?
   absl::flat_hash_set<not_null<MassiveBody const*>> const left_primaries(
       left.primaries_.begin(), left.primaries_.end());
   absl::flat_hash_set<not_null<MassiveBody const*>> const right_primaries(

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -61,16 +61,14 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
           std::accumulate(secondaries_.begin(),
                           secondaries_.end(),
                           GravitationalParameter{},
-                          &add_gravitational_parameter)) {
-  absl::btree_set<not_null<MassiveBody const*>> primary_set(primaries_.begin(),
-                                                            primaries_.end());
-  absl::btree_set<not_null<MassiveBody const*>> secondary_set(
-      secondaries_.begin(), secondaries_.end());
+                          &add_gravitational_parameter)),
+      primary_set_(primaries_.begin(), primaries_.end()),
+      secondary_set_(secondaries_.begin(), secondaries_.end()) {
   absl::btree_set<not_null<MassiveBody const*>> intersection;
-  std::set_intersection(primary_set.begin(),
-                        primary_set.end(),
-                        secondary_set.begin(),
-                        secondary_set.end(),
+  std::set_intersection(primary_set_.begin(),
+                        primary_set_.end(),
+                        secondary_set_.begin(),
+                        secondary_set_.end(),
                         std::inserter(intersection, intersection.begin()));
   auto const names = [](auto const& bodies) {
     return absl::StrJoin(
@@ -81,9 +79,9 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::
         });
   };
   CHECK_GE(primaries_.size(), 1) << names(primaries_);
-  CHECK_EQ(primary_set.size(), primaries_.size()) << names(primaries_);
+  CHECK_EQ(primary_set_.size(), primaries_.size()) << names(primaries_);
   CHECK_GE(secondaries_.size(), 1) << names(secondaries_);
-  CHECK_EQ(secondary_set.size(), secondaries_.size()) << names(secondaries_);
+  CHECK_EQ(secondary_set_.size(), secondaries_.size()) << names(secondaries_);
   CHECK_EQ(intersection.size(), 0) << names(intersection);
 }
 
@@ -164,15 +162,11 @@ BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
 template<typename InertialFrame, typename ThisFrame>
 void BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
     absl::HashState state) const {
-  absl::flat_hash_set<not_null<MassiveBody const*>> const primaries_set(
-      primaries_.begin(), primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
-      secondaries_.begin(), secondaries_.end());
   absl::HashState::combine(
       std::move(state),
       serialization::BarycentricRotatingReferenceFrame::extension.number(),
-      primaries_set,
-      secondaries_set);
+      primary_set_,
+      secondary_set_);
 }
 
 template<typename InertialFrame, typename ThisFrame>
@@ -475,17 +469,8 @@ bool operator==(
   // The comparison does not depend on the order of the bodies.  Note that the
   // bodies are pointers to objects held by the ephemeris, so comparing them is
   // legitimate.
-  //TODO(phl)Precompute?
-  absl::flat_hash_set<not_null<MassiveBody const*>> const left_primaries(
-      left.primaries_.begin(), left.primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const right_primaries(
-      right.primaries_.begin(), right.primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const left_secondaries(
-      left.secondaries_.begin(), left.secondaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const right_secondaries(
-      right.secondaries_.begin(), right.secondaries_.end());
-  return left_primaries == right_primaries &&
-         left_secondaries == right_secondaries;
+  return left.primary_set_ == right.primary_set_ &&
+         left.secondary_set_ == right.secondary_set_;
 }
 
 }  // namespace internal

--- a/physics/barycentric_rotating_reference_frame_body.hpp
+++ b/physics/barycentric_rotating_reference_frame_body.hpp
@@ -168,7 +168,11 @@ void BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
       primaries_.begin(), primaries_.end());
   absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
       secondaries_.begin(), secondaries_.end());
-  absl::HashState::combine(std::move(state), primaries_set, secondaries_set);
+  absl::HashState::combine(
+      std::move(state),
+      serialization::BarycentricRotatingReferenceFrame::extension.number(),
+      primaries_set,
+      secondaries_set);
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -17,6 +17,7 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/massive_body.hpp"
+#include "physics/reference_frame_key.hpp"
 #include "physics/rigid_reference_frame.hpp"
 #include "physics/solar_system.hpp"
 #include "quantities/named_quantities.hpp"
@@ -48,6 +49,7 @@ using namespace principia::physics::_barycentric_rotating_reference_frame;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_ephemeris;
 using namespace principia::physics::_massive_body;
+using namespace principia::physics::_reference_frame_key;
 using namespace principia::physics::_rigid_reference_frame;
 using namespace principia::physics::_solar_system;
 using namespace principia::quantities::_named_quantities;
@@ -98,7 +100,7 @@ class BarycentricRotatingReferenceFrameTest : public ::testing::Test {
             {big_initial_state_, small_initial_state_},
             {big_gravitational_parameter_, small_gravitational_parameter_})) {
     EXPECT_OK(ephemeris_->Prolong(t0_ + 2 * period_));
-    big_small_frame_ = std::make_shared<
+    big_small_frame_ = std::make_unique<
         BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
         ephemeris_.get(), big_, small_);
   }
@@ -115,7 +117,7 @@ class BarycentricRotatingReferenceFrameTest : public ::testing::Test {
   GravitationalParameter const small_gravitational_parameter_;
   DegreesOfFreedom<ICRS> const centre_of_mass_initial_state_;
 
-  std::shared_ptr<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>
+  std::unique_ptr<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>
       big_small_frame_;
 };
 
@@ -233,25 +235,18 @@ TEST_F(BarycentricRotatingReferenceFrameTest, Serialization) {
 }
 
 TEST_F(BarycentricRotatingReferenceFrameTest, Hashing) {
-  auto const small_big_frame =
-      std::make_shared<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
+  auto small_big_frame =
+      std::make_unique<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
           ephemeris_.get(), small_, big_);
   EXPECT_EQ(*big_small_frame_, *big_small_frame_);
   EXPECT_NE(*small_big_frame, *big_small_frame_);
+
+  ReferenceFrameKey<ICRS, BigSmallFrame> const big_small_frame_key(
+      std::move(big_small_frame_));
+  ReferenceFrameKey<ICRS, BigSmallFrame> const small_big_frame_key(
+      std::move(small_big_frame));
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
-      {big_small_frame_, big_small_frame_, small_big_frame}));
-
-  //TODO(phl)example
-  //auto const hash = [](std::shared_ptr<F> const& frame) {
-  //  return absl::Hash<F>{}(*frame);
-  //};
-  //auto const eq = [](std::shared_ptr<F> const& left,
-  //                   std::shared_ptr<F> const& right) {
-  //  return *left == *right;
-  //};
-
-  //absl::flat_hash_map<std::shared_ptr<F>, int, decltype(hash), decltype(eq)> m;
-  //m.insert(std::make_pair(std::move(small_small_frame1), 3));
+      {big_small_frame_key, big_small_frame_key, small_big_frame_key}));
 }
 
 }  // namespace physics

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -234,7 +234,7 @@ TEST_F(BarycentricRotatingReferenceFrameTest, Serialization) {
             read_big_small_frame->GeometricAcceleration(t, point_dof));
 }
 
-TEST_F(BarycentricRotatingReferenceFrameTest, Hashing) {
+TEST_F(BarycentricRotatingReferenceFrameTest, Key) {
   auto small_big_frame =
       std::make_unique<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
           ephemeris_.get(), small_, big_);

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -208,7 +208,7 @@ TEST_F(BarycentricRotatingReferenceFrameTest, Serialization) {
 
   EXPECT_TRUE(message.HasExtension(
       serialization::BarycentricRotatingReferenceFrame::extension));
-  auto const extension = message.GetExtension(
+  auto const& extension = message.GetExtension(
       serialization::BarycentricRotatingReferenceFrame::extension);
   EXPECT_EQ(1, extension.primary().size());
   EXPECT_EQ(1, extension.secondary().size());
@@ -229,6 +229,10 @@ TEST_F(BarycentricRotatingReferenceFrameTest, Serialization) {
                                 1 * Metre / Second})};
   EXPECT_EQ(big_small_frame_->GeometricAcceleration(t, point_dof),
             read_big_small_frame->GeometricAcceleration(t, point_dof));
+}
+
+TEST_F(BarycentricRotatingReferenceFrameTest, Hashing) {
+  EXPECT_EQ(*big_small_frame_, *big_small_frame_);
 }
 
 }  // namespace physics

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"
 #include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
@@ -97,7 +98,7 @@ class BarycentricRotatingReferenceFrameTest : public ::testing::Test {
             {big_initial_state_, small_initial_state_},
             {big_gravitational_parameter_, small_gravitational_parameter_})) {
     EXPECT_OK(ephemeris_->Prolong(t0_ + 2 * period_));
-    big_small_frame_ = std::make_unique<
+    big_small_frame_ = std::make_shared<
         BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
         ephemeris_.get(), big_, small_);
   }
@@ -114,7 +115,7 @@ class BarycentricRotatingReferenceFrameTest : public ::testing::Test {
   GravitationalParameter const small_gravitational_parameter_;
   DegreesOfFreedom<ICRS> const centre_of_mass_initial_state_;
 
-  std::unique_ptr<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>
+  std::shared_ptr<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>
       big_small_frame_;
 };
 
@@ -232,7 +233,25 @@ TEST_F(BarycentricRotatingReferenceFrameTest, Serialization) {
 }
 
 TEST_F(BarycentricRotatingReferenceFrameTest, Hashing) {
+  auto const small_big_frame =
+      std::make_shared<BarycentricRotatingReferenceFrame<ICRS, BigSmallFrame>>(
+          ephemeris_.get(), small_, big_);
   EXPECT_EQ(*big_small_frame_, *big_small_frame_);
+  EXPECT_NE(*small_big_frame, *big_small_frame_);
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {big_small_frame_, big_small_frame_, small_big_frame}));
+
+  //TODO(phl)example
+  //auto const hash = [](std::shared_ptr<F> const& frame) {
+  //  return absl::Hash<F>{}(*frame);
+  //};
+  //auto const eq = [](std::shared_ptr<F> const& left,
+  //                   std::shared_ptr<F> const& right) {
+  //  return *left == *right;
+  //};
+
+  //absl::flat_hash_map<std::shared_ptr<F>, int, decltype(hash), decltype(eq)> m;
+  //m.insert(std::make_pair(std::move(small_small_frame1), 3));
 }
 
 }  // namespace physics

--- a/physics/barycentric_rotating_reference_frame_test.cpp
+++ b/physics/barycentric_rotating_reference_frame_test.cpp
@@ -1,6 +1,7 @@
 #include "physics/barycentric_rotating_reference_frame.hpp"
 
 #include <memory>
+#include <utility>
 
 #include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"

--- a/physics/body_centred_body_direction_reference_frame.hpp
+++ b/physics/body_centred_body_direction_reference_frame.hpp
@@ -72,6 +72,8 @@ class BodyCentredBodyDirectionReferenceFrame
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
 
+  void HashValue(absl::HashState state) const override;
+
   void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const override;
 

--- a/physics/body_centred_body_direction_reference_frame.hpp
+++ b/physics/body_centred_body_direction_reference_frame.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/instant.hpp"

--- a/physics/body_centred_body_direction_reference_frame.hpp
+++ b/physics/body_centred_body_direction_reference_frame.hpp
@@ -117,6 +117,12 @@ class BodyCentredBodyDirectionReferenceFrame
       secondary_trajectory_;
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(BodyCentredBodyDirectionReferenceFrame<InertialFrame,
+                                                       ThisFrame> const& left,
+                BodyCentredBodyDirectionReferenceFrame<InertialFrame,
+                                                       ThisFrame> const& right);
+
 }  // namespace internal
 
 using internal::BodyCentredBodyDirectionReferenceFrame;

--- a/physics/body_centred_body_direction_reference_frame.hpp
+++ b/physics/body_centred_body_direction_reference_frame.hpp
@@ -115,6 +115,11 @@ class BodyCentredBodyDirectionReferenceFrame
   std::function<Trajectory<InertialFrame> const&()> const primary_trajectory_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const
       secondary_trajectory_;
+
+  template<typename IF, typename TF>
+  friend bool operator==(
+      BodyCentredBodyDirectionReferenceFrame<IF, TF> const& left,
+      BodyCentredBodyDirectionReferenceFrame<IF, TF> const& right);
 };
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_body_direction_reference_frame_body.hpp
+++ b/physics/body_centred_body_direction_reference_frame_body.hpp
@@ -253,6 +253,21 @@ BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame>::ToThisFrame(
              primary_degrees_of_freedom.velocity());
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame> const&
+        left,
+    BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame> const&
+        right) {
+  if (left.primary == nullptr || right.primary == nullptr) {
+    // One of the frames is a target frame.
+    return false;
+  } else {
+    return left.primary_ == right.primary_ &&
+           left.secondary_ == right.secondary_;
+  }
+}
+
 }  // namespace internal
 }  // namespace _body_centred_body_direction_reference_frame
 }  // namespace physics

--- a/physics/body_centred_body_direction_reference_frame_body.hpp
+++ b/physics/body_centred_body_direction_reference_frame_body.hpp
@@ -127,7 +127,11 @@ ToThisFrameAtTime(Instant const& t) const {
 template<typename InertialFrame, typename ThisFrame>
 void BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame>::
     HashValue(absl::HashState state) const {
-  absl::HashState::combine(std::move(state), primary_, secondary_);
+  absl::HashState::combine(
+      std::move(state),
+      serialization::BodyCentredBodyDirectionReferenceFrame::extension.number(),
+      primary_,
+      secondary_);
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_body_direction_reference_frame_body.hpp
+++ b/physics/body_centred_body_direction_reference_frame_body.hpp
@@ -259,8 +259,10 @@ bool operator==(
         left,
     BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame> const&
         right) {
-  if (left.primary == nullptr || right.primary == nullptr) {
-    // One of the frames is a target frame.
+  CHECK_EQ(left.ephemeris_, right.ephemeris_);
+  if (left.primary_ == nullptr || right.primary_ == nullptr) {
+    // One of the frames is a target frame.  Target frames, like unhappy
+    // families, are all different.
     return false;
   } else {
     return left.primary_ == right.primary_ &&

--- a/physics/body_centred_body_direction_reference_frame_body.hpp
+++ b/physics/body_centred_body_direction_reference_frame_body.hpp
@@ -126,6 +126,12 @@ ToThisFrameAtTime(Instant const& t) const {
 
 template<typename InertialFrame, typename ThisFrame>
 void BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame>::
+    HashValue(absl::HashState state) const {
+  absl::HashState::combine(std::move(state), primary_, secondary_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
+void BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame>::
 WriteToMessage(not_null<serialization::ReferenceFrame*> const message) const {
   auto* const extension =
       message->MutableExtension(

--- a/physics/body_centred_body_direction_reference_frame_test.cpp
+++ b/physics/body_centred_body_direction_reference_frame_test.cpp
@@ -258,9 +258,9 @@ TEST_F(BodyCentredBodyDirectionReferenceFrameTest, ConstructFromOneBody) {
     EXPECT_THAT(
         (dof_from_discrete.velocity() - dof_from_both_bodies.velocity()).Norm(),
         VanishesBefore(1 * Kilo(Metre) / Second, 0, 93));
-    // For the moment, the `BodyCentredBodyDirectionReferenceFrame` assumes that
-    // its reference trajectories are free-falling, and gives us the wrong
-    // geometric acceleration when this is not the case.
+    // For now, the `BodyCentredBodyDirectionReferenceFrame` assumes that its
+    // reference trajectories are free-falling, and gives us the wrong geometric
+    // acceleration when this is not the case.
     auto const intrinsic_acceleration =
         ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(
             ICRS::origin + Displacement<ICRS>({0 * Kilo(Metre),
@@ -275,6 +275,10 @@ TEST_F(BodyCentredBodyDirectionReferenceFrameTest, ConstructFromOneBody) {
              dof_from_both_bodies)).Norm(),
          AlmostEquals(intrinsic_acceleration.Norm(), 0, 142));
   }
+}
+
+TEST_F(BodyCentredBodyDirectionReferenceFrameTest, Hashing) {
+  EXPECT_EQ(*big_small_frame_, *big_small_frame_);
 }
 
 }  // namespace physics

--- a/physics/body_centred_body_direction_reference_frame_test.cpp
+++ b/physics/body_centred_body_direction_reference_frame_test.cpp
@@ -1,6 +1,7 @@
 #include "physics/body_centred_body_direction_reference_frame.hpp"
 
 #include <memory>
+#include <utility>
 
 #include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"

--- a/physics/body_centred_body_direction_reference_frame_test.cpp
+++ b/physics/body_centred_body_direction_reference_frame_test.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"
 #include "geometry/barycentre_calculator.hpp"
 #include "geometry/frame.hpp"
@@ -18,6 +19,7 @@
 #include "physics/discrete_trajectory.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/massive_body.hpp"
+#include "physics/reference_frame_key.hpp"
 #include "physics/rigid_reference_frame.hpp"
 #include "physics/solar_system.hpp"
 #include "quantities/named_quantities.hpp"
@@ -52,6 +54,7 @@ using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_discrete_trajectory;
 using namespace principia::physics::_ephemeris;
 using namespace principia::physics::_massive_body;
+using namespace principia::physics::_reference_frame_key;
 using namespace principia::physics::_rigid_reference_frame;
 using namespace principia::physics::_solar_system;
 using namespace principia::quantities::_named_quantities;
@@ -277,8 +280,19 @@ TEST_F(BodyCentredBodyDirectionReferenceFrameTest, ConstructFromOneBody) {
   }
 }
 
-TEST_F(BodyCentredBodyDirectionReferenceFrameTest, Hashing) {
+TEST_F(BodyCentredBodyDirectionReferenceFrameTest, Key) {
+  auto small_big_frame = std::make_unique<
+      BodyCentredBodyDirectionReferenceFrame<ICRS, BigSmallFrame>>(
+      ephemeris_.get(), small_, big_);
   EXPECT_EQ(*big_small_frame_, *big_small_frame_);
+  EXPECT_NE(*small_big_frame, *big_small_frame_);
+
+  ReferenceFrameKey<ICRS, BigSmallFrame> const big_small_frame_key(
+      std::move(big_small_frame_));
+  ReferenceFrameKey<ICRS, BigSmallFrame> const small_big_frame_key(
+      std::move(small_big_frame));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {big_small_frame_key, big_small_frame_key, small_big_frame_key}));
 }
 
 }  // namespace physics

--- a/physics/body_centred_body_direction_reference_frame_test.cpp
+++ b/physics/body_centred_body_direction_reference_frame_test.cpp
@@ -262,9 +262,9 @@ TEST_F(BodyCentredBodyDirectionReferenceFrameTest, ConstructFromOneBody) {
     EXPECT_THAT(
         (dof_from_discrete.velocity() - dof_from_both_bodies.velocity()).Norm(),
         VanishesBefore(1 * Kilo(Metre) / Second, 0, 93));
-    // For now, the `BodyCentredBodyDirectionReferenceFrame` assumes that its
-    // reference trajectories are free-falling, and gives us the wrong geometric
-    // acceleration when this is not the case.
+    // For the moment, the `BodyCentredBodyDirectionReferenceFrame` assumes that
+    // its reference trajectories are free-falling, and gives us the wrong
+    // geometric acceleration when this is not the case.
     auto const intrinsic_acceleration =
         ephemeris_->ComputeGravitationalAccelerationOnMasslessBody(
             ICRS::origin + Displacement<ICRS>({0 * Kilo(Metre),

--- a/physics/body_centred_non_rotating_reference_frame.hpp
+++ b/physics/body_centred_non_rotating_reference_frame.hpp
@@ -96,6 +96,11 @@ class BodyCentredNonRotatingReferenceFrame
   OrthogonalMap<InertialFrame, ThisFrame> const orthogonal_map_;
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const&
+        right);
 
 }  // namespace internal
 

--- a/physics/body_centred_non_rotating_reference_frame.hpp
+++ b/physics/body_centred_non_rotating_reference_frame.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/instant.hpp"
@@ -71,6 +72,8 @@ class BodyCentredNonRotatingReferenceFrame
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
+
+  void HashValue(absl::HashState state) const override;
 
   void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const override;

--- a/physics/body_centred_non_rotating_reference_frame.hpp
+++ b/physics/body_centred_non_rotating_reference_frame.hpp
@@ -94,6 +94,11 @@ class BodyCentredNonRotatingReferenceFrame
   not_null<MassiveBody const*> const centre_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const centre_trajectory_;
   OrthogonalMap<InertialFrame, ThisFrame> const orthogonal_map_;
+
+  template<typename IF, typename TF>
+  friend bool operator==(
+      BodyCentredNonRotatingReferenceFrame<IF, TF> const& left,
+      BodyCentredNonRotatingReferenceFrame<IF, TF> const& right);
 };
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_non_rotating_reference_frame_body.hpp
+++ b/physics/body_centred_non_rotating_reference_frame_body.hpp
@@ -128,6 +128,7 @@ bool operator==(
     BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
     BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const&
         right) {
+  CHECK_EQ(left.ephemeris_, right.ephemeris_);
   return left.centre_ == right.centre_;
 }
 

--- a/physics/body_centred_non_rotating_reference_frame_body.hpp
+++ b/physics/body_centred_non_rotating_reference_frame_body.hpp
@@ -79,6 +79,12 @@ ToThisFrameAtTime(Instant const& t) const {
 }
 
 template<typename InertialFrame, typename ThisFrame>
+void BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
+    absl::HashState state) const {
+  absl::HashState::combine(std::move(state), centre_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
 void BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame>::
 WriteToMessage(not_null<serialization::ReferenceFrame*> const message) const {
   message->MutableExtension(

--- a/physics/body_centred_non_rotating_reference_frame_body.hpp
+++ b/physics/body_centred_non_rotating_reference_frame_body.hpp
@@ -123,6 +123,14 @@ MotionOfThisFrame(Instant const& t) const {
                  ComputeGravitationalAccelerationOnMassiveBody(centre_, t));
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame> const&
+        right) {
+  return left.centre_ == right.centre_;
+}
+
 }  // namespace internal
 }  // namespace _body_centred_non_rotating_reference_frame
 }  // namespace physics

--- a/physics/body_centred_non_rotating_reference_frame_body.hpp
+++ b/physics/body_centred_non_rotating_reference_frame_body.hpp
@@ -81,7 +81,10 @@ ToThisFrameAtTime(Instant const& t) const {
 template<typename InertialFrame, typename ThisFrame>
 void BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
     absl::HashState state) const {
-  absl::HashState::combine(std::move(state), centre_);
+  absl::HashState::combine(
+      std::move(state),
+      serialization::BodyCentredNonRotatingReferenceFrame::extension.number(),
+      centre_);
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_centred_non_rotating_reference_frame_test.cpp
+++ b/physics/body_centred_non_rotating_reference_frame_test.cpp
@@ -248,7 +248,6 @@ TEST_F(BodyCentredNonRotatingReferenceFrameTest, Key) {
       std::move(mixed_frame));
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
       {big_frame_key, big_frame_key, mixed_frame_key}));
-
 }
 
 }  // namespace physics

--- a/physics/body_centred_non_rotating_reference_frame_test.cpp
+++ b/physics/body_centred_non_rotating_reference_frame_test.cpp
@@ -1,6 +1,7 @@
 #include "physics/body_centred_non_rotating_reference_frame.hpp"
 
 #include <memory>
+#include <utility>
 
 #include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"

--- a/physics/body_centred_non_rotating_reference_frame_test.cpp
+++ b/physics/body_centred_non_rotating_reference_frame_test.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
@@ -15,6 +16,7 @@
 #include "numerics/elementary_functions.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/ephemeris.hpp"
+#include "physics/reference_frame_key.hpp"
 #include "physics/rigid_reference_frame.hpp"
 #include "physics/solar_system.hpp"
 #include "quantities/named_quantities.hpp"
@@ -46,6 +48,7 @@ using namespace principia::numerics::_elementary_functions;
 using namespace principia::physics::_body_centred_non_rotating_reference_frame;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_ephemeris;
+using namespace principia::physics::_reference_frame_key;
 using namespace principia::physics::_rigid_reference_frame;
 using namespace principia::physics::_solar_system;
 using namespace principia::quantities::_named_quantities;
@@ -230,9 +233,21 @@ TEST_F(BodyCentredNonRotatingReferenceFrameTest, Serialization) {
             read_small_frame->GeometricAcceleration(t, point_dof));
 }
 
-TEST_F(BodyCentredNonRotatingReferenceFrameTest, Hashing) {
+TEST_F(BodyCentredNonRotatingReferenceFrameTest, Key) {
+  auto mixed_frame =
+      std::make_unique<BodyCentredNonRotatingReferenceFrame<ICRS, Big>>(
+          ephemeris_.get(), solar_system_.massive_body(*ephemeris_, small));
   EXPECT_EQ(*big_frame_, *big_frame_);
   EXPECT_EQ(*small_frame_, *small_frame_);
+  EXPECT_NE(*big_frame_, *mixed_frame);
+
+  ReferenceFrameKey<ICRS, Big> const big_frame_key(
+      std::move(big_frame_));
+  ReferenceFrameKey<ICRS, Big> const mixed_frame_key(
+      std::move(mixed_frame));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {big_frame_key, big_frame_key, mixed_frame_key}));
+
 }
 
 }  // namespace physics

--- a/physics/body_centred_non_rotating_reference_frame_test.cpp
+++ b/physics/body_centred_non_rotating_reference_frame_test.cpp
@@ -209,7 +209,7 @@ TEST_F(BodyCentredNonRotatingReferenceFrameTest, Serialization) {
 
   EXPECT_TRUE(message.HasExtension(
       serialization::BodyCentredNonRotatingReferenceFrame::extension));
-  auto const extension = message.GetExtension(
+  auto const& extension = message.GetExtension(
       serialization::BodyCentredNonRotatingReferenceFrame::extension);
   EXPECT_TRUE(extension.has_centre());
   EXPECT_EQ(1, extension.centre());
@@ -228,6 +228,11 @@ TEST_F(BodyCentredNonRotatingReferenceFrameTest, Serialization) {
                         1 * Metre / Second})};
   EXPECT_EQ(small_frame_->GeometricAcceleration(t, point_dof),
             read_small_frame->GeometricAcceleration(t, point_dof));
+}
+
+TEST_F(BodyCentredNonRotatingReferenceFrameTest, Hashing) {
+  EXPECT_EQ(*big_frame_, *big_frame_);
+  EXPECT_EQ(*small_frame_, *small_frame_);
 }
 
 }  // namespace physics

--- a/physics/body_surface_reference_frame.hpp
+++ b/physics/body_surface_reference_frame.hpp
@@ -80,6 +80,10 @@ class BodySurfaceReferenceFrame : public RigidReferenceFrame<InertialFrame,
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;
   not_null<RotatingBody<InertialFrame> const*> const centre_;
   not_null<ContinuousTrajectory<InertialFrame> const*> const centre_trajectory_;
+
+  template<typename IF, typename TF>
+  friend bool operator==(BodySurfaceReferenceFrame<IF, TF> const& left,
+                         BodySurfaceReferenceFrame<IF, TF> const& right);
 };
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_surface_reference_frame.hpp
+++ b/physics/body_surface_reference_frame.hpp
@@ -50,8 +50,9 @@ class BodySurfaceReferenceFrame : public RigidReferenceFrame<InertialFrame,
   static_assert(ThisFrame::may_rotate);
 
  public:
-  BodySurfaceReferenceFrame(not_null<Ephemeris<InertialFrame> const*> ephemeris,
-                          not_null<RotatingBody<InertialFrame> const*> centre);
+  BodySurfaceReferenceFrame(
+      not_null<Ephemeris<InertialFrame> const*> ephemeris,
+      not_null<RotatingBody<InertialFrame> const*> centre);
 
   not_null<RotatingBody<InertialFrame> const*> centre() const;
 

--- a/physics/body_surface_reference_frame.hpp
+++ b/physics/body_surface_reference_frame.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/grassmann.hpp"
 #include "geometry/instant.hpp"
@@ -59,6 +60,8 @@ class BodySurfaceReferenceFrame : public RigidReferenceFrame<InertialFrame,
 
   RigidMotion<InertialFrame, ThisFrame> ToThisFrameAtTime(
       Instant const& t) const override;
+
+  void HashValue(absl::HashState state) const override;
 
   void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const override;

--- a/physics/body_surface_reference_frame.hpp
+++ b/physics/body_surface_reference_frame.hpp
@@ -82,6 +82,11 @@ class BodySurfaceReferenceFrame : public RigidReferenceFrame<InertialFrame,
   not_null<ContinuousTrajectory<InertialFrame> const*> const centre_trajectory_;
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& right);
+
 }  // namespace internal
 
 using internal::BodySurfaceReferenceFrame;

--- a/physics/body_surface_reference_frame_body.hpp
+++ b/physics/body_surface_reference_frame_body.hpp
@@ -122,6 +122,13 @@ BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::MotionOfThisFrame(
              acceleration_of_to_frame_origin);
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& left,
+    BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  return left.centre_ == right.centre_;
+}
+
 }  // namespace internal
 }  // namespace _body_surface_reference_frame
 }  // namespace physics

--- a/physics/body_surface_reference_frame_body.hpp
+++ b/physics/body_surface_reference_frame_body.hpp
@@ -126,6 +126,7 @@ template<typename InertialFrame, typename ThisFrame>
 bool operator==(
     BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& left,
     BodySurfaceReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  CHECK_EQ(left.ephemeris_, right.ephemeris_);
   return left.centre_ == right.centre_;
 }
 

--- a/physics/body_surface_reference_frame_body.hpp
+++ b/physics/body_surface_reference_frame_body.hpp
@@ -69,6 +69,12 @@ BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
 }
 
 template<typename InertialFrame, typename ThisFrame>
+void BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::HashValue(
+    absl::HashState state) const {
+  absl::HashState::combine(std::move(state), centre_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
 void BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::
 WriteToMessage(not_null<serialization::ReferenceFrame*> const message) const {
   message->MutableExtension(

--- a/physics/body_surface_reference_frame_body.hpp
+++ b/physics/body_surface_reference_frame_body.hpp
@@ -71,7 +71,10 @@ BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::ToThisFrameAtTime(
 template<typename InertialFrame, typename ThisFrame>
 void BodySurfaceReferenceFrame<InertialFrame, ThisFrame>::HashValue(
     absl::HashState state) const {
-  absl::HashState::combine(std::move(state), centre_);
+  absl::HashState::combine(
+      std::move(state),
+      serialization::BodySurfaceReferenceFrame::extension.number(),
+      centre_);
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/body_surface_reference_frame_test.cpp
+++ b/physics/body_surface_reference_frame_test.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash_testing.h"
 #include "astronomy/frames.hpp"
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
@@ -16,6 +17,7 @@
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/ephemeris.hpp"
 #include "physics/massive_body.hpp"
+#include "physics/reference_frame_key.hpp"
 #include "physics/rigid_reference_frame.hpp"
 #include "physics/rotating_body.hpp"
 #include "physics/solar_system.hpp"
@@ -48,6 +50,7 @@ using namespace principia::physics::_body_surface_reference_frame;
 using namespace principia::physics::_degrees_of_freedom;
 using namespace principia::physics::_ephemeris;
 using namespace principia::physics::_massive_body;
+using namespace principia::physics::_reference_frame_key;
 using namespace principia::physics::_rigid_reference_frame;
 using namespace principia::physics::_rotating_body;
 using namespace principia::physics::_solar_system;
@@ -228,7 +231,8 @@ TEST_F(BodySurfaceReferenceFrameTest, Serialization) {
             read_big_frame->GeometricAcceleration(t, point_dof));
 }
 
-TEST_F(BodySurfaceReferenceFrameTest, Hashing) {
+TEST_F(BodySurfaceReferenceFrameTest, Key) {
+  // This test is very limited because we only have one rotating body, `big_`.
   EXPECT_EQ(*big_frame_, *big_frame_);
 }
 

--- a/physics/body_surface_reference_frame_test.cpp
+++ b/physics/body_surface_reference_frame_test.cpp
@@ -207,7 +207,7 @@ TEST_F(BodySurfaceReferenceFrameTest, Serialization) {
 
   EXPECT_TRUE(message.HasExtension(
       serialization::BodySurfaceReferenceFrame::extension));
-  auto const extension = message.GetExtension(
+  auto const& extension = message.GetExtension(
       serialization::BodySurfaceReferenceFrame::extension);
   EXPECT_TRUE(extension.has_centre());
   EXPECT_EQ(0, extension.centre());
@@ -226,6 +226,10 @@ TEST_F(BodySurfaceReferenceFrameTest, Serialization) {
                                 1 * Metre / Second})};
   EXPECT_EQ(big_frame_->GeometricAcceleration(t, point_dof),
             read_big_frame->GeometricAcceleration(t, point_dof));
+}
+
+TEST_F(BodySurfaceReferenceFrameTest, Hashing) {
+  EXPECT_EQ(*big_frame_, *big_frame_);
 }
 
 }  // namespace physics

--- a/physics/mock_rigid_reference_frame.hpp
+++ b/physics/mock_rigid_reference_frame.hpp
@@ -28,6 +28,8 @@ class MockRigidReferenceFrame : public RigidReferenceFrame<InertialFrame,
   MOCK_METHOD(Instant, t_min, (), (const, override));
   MOCK_METHOD(Instant, t_max, (), (const, override));
 
+  MOCK_METHOD(void, HashValue, (absl::HashState state), (const, override));
+
   MOCK_METHOD(void,
               WriteToMessage,
               (not_null<serialization::ReferenceFrame*> message),

--- a/physics/physics.vcxproj
+++ b/physics/physics.vcxproj
@@ -51,6 +51,8 @@
     <ClInclude Include="degrees_of_freedom.hpp" />
     <ClInclude Include="reference_frame.hpp" />
     <ClInclude Include="reference_frame_body.hpp" />
+    <ClInclude Include="reference_frame_key.hpp" />
+    <ClInclude Include="reference_frame_key_body.hpp" />
     <ClInclude Include="rigid_reference_frame.hpp" />
     <ClInclude Include="euler_solver.hpp" />
     <ClInclude Include="euler_solver_body.hpp" />

--- a/physics/physics.vcxproj.filters
+++ b/physics/physics.vcxproj.filters
@@ -257,6 +257,12 @@
     <ClInclude Include="lagrange_equipotentials_body.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="reference_frame_key.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="reference_frame_key_body.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="degrees_of_freedom_test.cpp">

--- a/physics/reference_frame.hpp
+++ b/physics/reference_frame.hpp
@@ -116,9 +116,6 @@ class ReferenceFrame {
 
   virtual void HashValue(absl::HashState state) const = 0;
 
-  template<typename H, typename IF, typename TF>
-  friend H AbslHashValue(H state, const ReferenceFrame<IF, TF>& frame);
-
   virtual void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const = 0;
 
@@ -132,13 +129,6 @@ class ReferenceFrame {
 template<typename InertialFrame, typename ThisFrame>
 bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
                 ReferenceFrame<InertialFrame, ThisFrame> const& right);
-
-template<typename H, typename InertialFrame, typename ThisFrame>
-H AbslHashValue(H state,
-                const ReferenceFrame<InertialFrame, ThisFrame>& frame) {
-  frame.HashValue(absl::HashState::Create(&state));
-  return std::move(state);
-}
 
 }  // namespace internal
 

--- a/physics/reference_frame.hpp
+++ b/physics/reference_frame.hpp
@@ -121,11 +121,23 @@ class ReferenceFrame {
   static not_null<std::unique_ptr<ReferenceFrame>>
       ReadFromMessage(serialization::ReferenceFrame const& message,
                       not_null<Ephemeris<InertialFrame> const*> ephemeris);
+
+  virtual void HashValue(absl::HashState state) const = 0;
+
+  template<typename H, typename IF, typename TF>
+  friend H AbslHashValue(H state, const ReferenceFrame<IF, TF>& frame);
 };
 
 template<typename InertialFrame, typename ThisFrame>
 bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
                 ReferenceFrame<InertialFrame, ThisFrame> const& right);
+
+template<typename H, typename InertialFrame, typename ThisFrame>
+H AbslHashValue(H state,
+                const ReferenceFrame<InertialFrame, ThisFrame>& frame) {
+  value.HashValue(absl::HashState::Create(&state));
+  return std::move(state);
+}
 
 }  // namespace internal
 

--- a/physics/reference_frame.hpp
+++ b/physics/reference_frame.hpp
@@ -123,6 +123,10 @@ class ReferenceFrame {
                       not_null<Ephemeris<InertialFrame> const*> ephemeris);
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
+                ReferenceFrame<InertialFrame, ThisFrame> const& right);
+
 }  // namespace internal
 
 using internal::Frenet;

--- a/physics/reference_frame.hpp
+++ b/physics/reference_frame.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "absl/hash/ha"
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
@@ -113,6 +114,11 @@ class ReferenceFrame {
       Instant const& t,
       DegreesOfFreedom<ThisFrame> const& degrees_of_freedom) const;
 
+  virtual void HashValue(absl::HashState state) const = 0;
+
+  template<typename H, typename IF, typename TF>
+  friend H AbslHashValue(H state, const ReferenceFrame<IF, TF>& frame);
+
   virtual void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const = 0;
 
@@ -121,11 +127,6 @@ class ReferenceFrame {
   static not_null<std::unique_ptr<ReferenceFrame>>
       ReadFromMessage(serialization::ReferenceFrame const& message,
                       not_null<Ephemeris<InertialFrame> const*> ephemeris);
-
-  virtual void HashValue(absl::HashState state) const = 0;
-
-  template<typename H, typename IF, typename TF>
-  friend H AbslHashValue(H state, const ReferenceFrame<IF, TF>& frame);
 };
 
 template<typename InertialFrame, typename ThisFrame>
@@ -135,7 +136,7 @@ bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
 template<typename H, typename InertialFrame, typename ThisFrame>
 H AbslHashValue(H state,
                 const ReferenceFrame<InertialFrame, ThisFrame>& frame) {
-  value.HashValue(absl::HashState::Create(&state));
+  frame.HashValue(absl::HashState::Create(&state));
   return std::move(state);
 }
 

--- a/physics/reference_frame.hpp
+++ b/physics/reference_frame.hpp
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "absl/hash/ha"
+#include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"

--- a/physics/reference_frame_body.hpp
+++ b/physics/reference_frame_body.hpp
@@ -73,6 +73,33 @@ ReferenceFrame<InertialFrame, ThisFrame>::ReadFromMessage(
   }
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
+                ReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  // We exceptionally use RTTI here because `operator==` is hopelessly broken
+  // in C++ in the presence of inheritance.
+  if (typeid(left) != typeid(right)) {
+    return false;
+  }
+  {
+    using RotatingPulsating =
+        RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(RotatingPulsating)) {
+      return static_cast<RotatingPulsating const&>(left) ==
+             static_cast<RotatingPulsating const&>(right);
+    }
+  }
+  {
+    using Rigid = RigidReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(Rigid)) {
+      return static_cast<Rigid const&>(left) ==
+             static_cast<Rigid const&>(right);
+    }
+  }
+  LOG(FATAL) << "Unrecognized reference frame types: " << typeid(left).name()
+             << " and " << typeid(right).name();
+}
+
 }  // namespace internal
 }  // namespace _reference_frame
 }  // namespace physics

--- a/physics/reference_frame_body.hpp
+++ b/physics/reference_frame_body.hpp
@@ -90,14 +90,18 @@ bool operator==(ReferenceFrame<InertialFrame, ThisFrame> const& left,
     }
   }
   {
+    // The type must be descended from `RigidReferenceFrame`, but we cannot
+    // check this using `typeid`.
+    // TODO(phl): Improve once we have reflection in C++26.
     using Rigid = RigidReferenceFrame<InertialFrame, ThisFrame>;
-    if (typeid(left) == typeid(Rigid)) {
-      return static_cast<Rigid const&>(left) ==
-             static_cast<Rigid const&>(right);
-    }
+    auto const* left_rigid = dynamic_cast<Rigid const*>(&left);
+    auto const* right_rigid = dynamic_cast<Rigid const*>(&right);
+    CHECK_NE(nullptr, left_rigid)
+        << "The type of left is " << typeid(left).name();
+    CHECK_NE(nullptr, right_rigid)
+        << "The type of right is " << typeid(right).name();
+    return *left_rigid == *right_rigid;
   }
-  LOG(FATAL) << "Unrecognized reference frame types: " << typeid(left).name()
-             << " and " << typeid(right).name();
 }
 
 }  // namespace internal

--- a/physics/reference_frame_key.hpp
+++ b/physics/reference_frame_key.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "base/not_null.hpp"
 #include "physics/reference_frame.hpp"
@@ -23,22 +24,18 @@ class ReferenceFrameKey {
           frame);
 
   template<typename H>
-  friend H AbslHashValue(H h, ReferenceFrameKey const& key);
+  friend H AbslHashValue(H h, ReferenceFrameKey const& key) {
+    return H::combine(std::move(h), *key.frame_);
+  }
+
+  friend bool operator==(ReferenceFrameKey const& lhs,
+                         ReferenceFrameKey const& rhs) {
+    return *lhs.frame_ == *rhs.frame_;
+  }
 
  private:
   not_null<std::shared_ptr<ReferenceFrame<InertialFrame, ThisFrame>>> frame_;
-
-  template<typename IF, typename TF>
-  friend bool operator==(ReferenceFrameKey<IF, TF> const& lhs,
-                         ReferenceFrameKey<IF, TF> const& rhs);
 };
-
-template<typename H, typename InertialFrame, typename ThisFrame>
-H AbslHashValue(H h, ReferenceFrameKey<InertialFrame, ThisFrame> const& key);
-
-template<typename InertialFrame, typename ThisFrame>
-bool operator==(ReferenceFrameKey<InertialFrame, ThisFrame> const& lhs,
-                ReferenceFrameKey<InertialFrame, ThisFrame> const& rhs);
 
 }  // namespace internal
 

--- a/physics/reference_frame_key.hpp
+++ b/physics/reference_frame_key.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <memory>
+
+#include "base/not_null.hpp"
+#include "physics/reference_frame.hpp"
+
+namespace principia {
+namespace physics {
+namespace _reference_frame_key {
+namespace internal {
+
+using namespace principia::base::_not_null;
+using namespace principia::physics::_reference_frame;
+
+// A copyable container for using `ReferenceFrame` and its subclasses as keys in
+// hash maps.
+template<typename InertialFrame, typename ThisFrame>
+class ReferenceFrameKey {
+ public:
+  explicit ReferenceFrameKey(
+      not_null<std::unique_ptr<ReferenceFrame<InertialFrame, ThisFrame>>>
+          frame);
+
+  template<typename H>
+  friend H AbslHashValue(H h, ReferenceFrameKey const& key);
+
+ private:
+  not_null<std::shared_ptr<ReferenceFrame<InertialFrame, ThisFrame>>> frame_;
+
+  template<typename IF, typename TF>
+  friend bool operator==(ReferenceFrameKey<IF, TF> const& lhs,
+                         ReferenceFrameKey<IF, TF> const& rhs);
+};
+
+template<typename H, typename InertialFrame, typename ThisFrame>
+H AbslHashValue(H h, ReferenceFrameKey<InertialFrame, ThisFrame> const& key);
+
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(ReferenceFrameKey<InertialFrame, ThisFrame> const& lhs,
+                ReferenceFrameKey<InertialFrame, ThisFrame> const& rhs);
+
+}  // namespace internal
+
+using internal::ReferenceFrameKey;
+
+}  // namespace _reference_frame_key
+}  // namespace physics
+}  // namespace principia
+
+#include "physics/reference_frame_key_body.hpp"

--- a/physics/reference_frame_key.hpp
+++ b/physics/reference_frame_key.hpp
@@ -25,7 +25,8 @@ class ReferenceFrameKey {
 
   template<typename H>
   friend H AbslHashValue(H h, ReferenceFrameKey const& key) {
-    return H::combine(std::move(h), *key.frame_);
+    key.frame_->HashValue(absl::HashState::Create(&h));
+    return std::move(h);
   }
 
   friend bool operator==(ReferenceFrameKey const& lhs,

--- a/physics/reference_frame_key_body.hpp
+++ b/physics/reference_frame_key_body.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "physics/reference_frame_key.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace principia {
+namespace physics {
+namespace _reference_frame_key {
+namespace internal {
+
+template<typename InertialFrame, typename ThisFrame>
+ReferenceFrameKey<InertialFrame, ThisFrame>::ReferenceFrameKey(
+    not_null<std::unique_ptr<ReferenceFrame<InertialFrame, ThisFrame>>> frame)
+    : frame_(std::move(frame)) {}
+
+template<typename H, typename InertialFrame, typename ThisFrame>
+H AbslHashValue(H h, ReferenceFrameKey<InertialFrame, ThisFrame> const& key) {
+  return H::combine(std::move(h), *key.frame_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(ReferenceFrameKey<InertialFrame, ThisFrame> const& lhs,
+                ReferenceFrameKey<InertialFrame, ThisFrame> const& rhs) {
+  return *lhs.frame_ == *rhs.frame_;
+}
+
+}  // namespace internal
+}  // namespace _reference_frame_key
+}  // namespace physics
+}  // namespace principia

--- a/physics/reference_frame_key_body.hpp
+++ b/physics/reference_frame_key_body.hpp
@@ -15,17 +15,6 @@ ReferenceFrameKey<InertialFrame, ThisFrame>::ReferenceFrameKey(
     not_null<std::unique_ptr<ReferenceFrame<InertialFrame, ThisFrame>>> frame)
     : frame_(std::move(frame)) {}
 
-template<typename H, typename InertialFrame, typename ThisFrame>
-H AbslHashValue(H h, ReferenceFrameKey<InertialFrame, ThisFrame> const& key) {
-  return H::combine(std::move(h), *key.frame_);
-}
-
-template<typename InertialFrame, typename ThisFrame>
-bool operator==(ReferenceFrameKey<InertialFrame, ThisFrame> const& lhs,
-                ReferenceFrameKey<InertialFrame, ThisFrame> const& rhs) {
-  return *lhs.frame_ == *rhs.frame_;
-}
-
 }  // namespace internal
 }  // namespace _reference_frame_key
 }  // namespace physics

--- a/physics/rigid_reference_frame.hpp
+++ b/physics/rigid_reference_frame.hpp
@@ -190,6 +190,10 @@ class RigidReferenceFrame : public ReferenceFrame<InertialFrame, ThisFrame> {
       Instant const& t) const = 0;
 };
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(RigidReferenceFrame<InertialFrame, ThisFrame> const& left,
+                RigidReferenceFrame<InertialFrame, ThisFrame> const& right);
+
 }  // namespace internal
 
 using internal::RigidReferenceFrame;

--- a/physics/rigid_reference_frame_body.hpp
+++ b/physics/rigid_reference_frame_body.hpp
@@ -397,6 +397,47 @@ ComputeGeometricAccelerations(
   euler_acceleration = -dΩ_over_dt * r / Radian;
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(RigidReferenceFrame<InertialFrame, ThisFrame> const& left,
+                RigidReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  if (typeid(left) != typeid(right)) {
+    return false;
+  }
+  {
+    using BarycentricRotating =
+        BarycentricRotatingReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(BarycentricRotating)) {
+      return static_cast<BarycentricRotating const&>(left) ==
+             static_cast<BarycentricRotating const&>(right);
+    }
+  }
+  {
+    using BodyCentredBodyDirection =
+        BodyCentredBodyDirectionReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(BodyCentredBodyDirection)) {
+      return static_cast<BodyCentredBodyDirection const&>(left) ==
+             static_cast<BodyCentredBodyDirection const&>(right);
+    }
+  }
+  {
+    using BodyCentredNonRotating =
+        BodyCentredNonRotatingReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(BodyCentredNonRotating)) {
+      return static_cast<BodyCentredNonRotating const&>(left) ==
+             static_cast<BodyCentredNonRotating const&>(right);
+    }
+  }
+  {
+    using BodySurface = BodySurfaceReferenceFrame<InertialFrame, ThisFrame>;
+    if (typeid(left) == typeid(BodySurface)) {
+      return static_cast<BodySurface const&>(left) ==
+             static_cast<BodySurface const&>(right);
+    }
+  }
+  LOG(FATAL) << "Unrecognized reference frame types: " << typeid(left).name()
+             << " and " << typeid(right).name();
+}
+
 }  // namespace internal
 }  // namespace _rigid_reference_frame
 }  // namespace physics

--- a/physics/rotating_pulsating_reference_frame.hpp
+++ b/physics/rotating_pulsating_reference_frame.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "absl/container/btree_set.h"
 #include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
@@ -110,6 +111,9 @@ class RotatingPulsatingReferenceFrame
   not_null<Ephemeris<InertialFrame> const*> const ephemeris_;
   std::vector<not_null<MassiveBody const*>> const primaries_;
   std::vector<not_null<MassiveBody const*>> const secondaries_;
+  // Ordered for intersection.
+  absl::btree_set<not_null<MassiveBody const*>> const primary_set_;
+  absl::btree_set<not_null<MassiveBody const*>> const secondary_set_;
   BarycentricRotatingReferenceFrame<InertialFrame, RotatingFrame> const
       rotating_frame_;
 

--- a/physics/rotating_pulsating_reference_frame.hpp
+++ b/physics/rotating_pulsating_reference_frame.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "absl/hash/hash.h"
 #include "base/not_null.hpp"
 #include "geometry/frame.hpp"
 #include "geometry/grassmann.hpp"
@@ -84,6 +85,8 @@ class RotatingPulsatingReferenceFrame
   SpecificEnergy GeometricPotential(
       Instant const& t,
       Position<ThisFrame> const& position) const override;
+
+  void HashValue(absl::HashState state) const override;
 
   void WriteToMessage(
       not_null<serialization::ReferenceFrame*> message) const override;

--- a/physics/rotating_pulsating_reference_frame.hpp
+++ b/physics/rotating_pulsating_reference_frame.hpp
@@ -109,7 +109,16 @@ class RotatingPulsatingReferenceFrame
   std::vector<not_null<MassiveBody const*>> const secondaries_;
   BarycentricRotatingReferenceFrame<InertialFrame, RotatingFrame> const
       rotating_frame_;
+
+  template<typename IF, typename TF>
+  friend bool operator==(RotatingPulsatingReferenceFrame<IF, TF> const& left,
+                         RotatingPulsatingReferenceFrame<IF, TF> const& right);
 };
+
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& right);
 
 }  // namespace internal
 

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -40,16 +40,14 @@ RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::
     : ephemeris_(ephemeris),
       primaries_(std::move(primaries)),
       secondaries_(std::move(secondaries)),
-      rotating_frame_(ephemeris_, primaries_, secondaries_) {
-  absl::btree_set<not_null<MassiveBody const*>> primary_set(primaries_.begin(),
-                                                            primaries_.end());
-  absl::btree_set<not_null<MassiveBody const*>> secondary_set(
-      secondaries_.begin(), secondaries_.end());
+      rotating_frame_(ephemeris_, primaries_, secondaries_),
+      primary_set_(primaries_.begin(), primaries_.end()),
+      secondary_set_(secondaries_.begin(), secondaries_.end()) {
   absl::btree_set<not_null<MassiveBody const*>> intersection;
-  std::set_intersection(primary_set.begin(),
-                        primary_set.end(),
-                        secondary_set.begin(),
-                        secondary_set.end(),
+  std::set_intersection(primary_set_.begin(),
+                        primary_set_.end(),
+                        secondary_set_.begin(),
+                        secondary_set_.end(),
                         std::inserter(intersection, intersection.begin()));
   auto const names = [](auto const& bodies) {
     return absl::StrJoin(
@@ -60,9 +58,9 @@ RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::
         });
   };
   CHECK_GE(primaries_.size(), 1) << names(primaries_);
-  CHECK_EQ(primary_set.size(), primaries_.size()) << names(primaries_);
+  CHECK_EQ(primary_set_.size(), primaries_.size()) << names(primaries_);
   CHECK_GE(secondaries_.size(), 1) << names(secondaries_);
-  CHECK_EQ(secondary_set.size(), secondaries_.size()) << names(secondaries_);
+  CHECK_EQ(secondary_set_.size(), secondaries_.size()) << names(secondaries_);
   CHECK_EQ(intersection.size(), 0) << names(intersection);
 }
 
@@ -158,15 +156,11 @@ RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::GeometricPotential(
 template<typename InertialFrame, typename ThisFrame>
 void RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
     absl::HashState state) const {
-  absl::flat_hash_set<not_null<MassiveBody const*>> const primaries_set(
-      primaries_.begin(), primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
-      secondaries_.begin(), secondaries_.end());
   auto s = absl::HashState::combine(
       std::move(state),
       serialization::RotatingPulsatingReferenceFrame::extension.number(),
-      primaries_set,
-      secondaries_set);
+      primary_set_,
+      secondary_set_);
   rotating_frame_.HashValue(std::move(s));
 }
 
@@ -252,16 +246,8 @@ bool operator==(
   // The comparison does not depend on the order of the bodies.  Note that the
   // bodies are pointers to objects held by the ephemeris, so comparing them is
   // legitimate.
-  absl::flat_hash_set<not_null<MassiveBody const*>> const left_primaries(
-      left.primaries_.begin(), left.primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const right_primaries(
-      right.primaries_.begin(), right.primaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const left_secondaries(
-      left.secondaries_.begin(), left.secondaries_.end());
-  absl::flat_hash_set<not_null<MassiveBody const*>> const right_secondaries(
-      right.secondaries_.begin(), right.secondaries_.end());
-  return left_primaries == right_primaries &&
-         left_secondaries == right_secondaries &&
+  return left.primary_set_ == right.primary_set_ &&
+         left.secondary_set_ == right.secondary_set_ &&
          left.rotating_frame_ == right.rotating_frame_;
 }
 

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -233,6 +233,7 @@ template<typename InertialFrame, typename ThisFrame>
 bool operator==(
     RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& left,
     RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  CHECK_EQ(left.ephemeris_, right.ephemeris_);
   // The comparison does not depend on the order of the bodies.  Note that the
   // bodies are pointers to objects held by the ephemeris, so comparing them is
   // legitimate.

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -229,6 +229,26 @@ auto RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::ToRotatingFrame(
       Homothecy<double, ThisFrame, RotatingFrame>(r / (1 * Metre)), ṙ / r);
 }
 
+template<typename InertialFrame, typename ThisFrame>
+bool operator==(
+    RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& left,
+    RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame> const& right) {
+  // The comparison does not depend on the order of the bodies.  Note that the
+  // bodies are pointers to objects held by the ephemeris, so comparing them is
+  // legitimate.
+  absl::flat_hash_set<not_null<MassiveBody const*>> const left_primaries(
+      left.primaries_.begin(), left.primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const right_primaries(
+      right.primaries_.begin(), right.primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const left_secondaries(
+      left.secondaries_.begin(), left.secondaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const right_secondaries(
+      right.secondaries_.begin(), right.secondaries_.end());
+  return left_primaries == right_primaries &&
+         left_secondaries == right_secondaries &&
+         left.rotating_frame_ == right.rotating_frame_;
+}
+
 }  // namespace internal
 }  // namespace _rotating_pulsating_reference_frame
 }  // namespace physics

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -162,12 +162,12 @@ void RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
       primaries_.begin(), primaries_.end());
   absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
       secondaries_.begin(), secondaries_.end());
-  absl::HashState::combine(
+  auto s = absl::HashState::combine(
       std::move(state),
       serialization::RotatingPulsatingReferenceFrame::extension.number(),
       primaries_set,
-      secondaries_set,
-      rotating_frame_);
+      secondaries_set);
+  rotating_frame_.HashValue(std::move(s));
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -156,6 +156,17 @@ RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::GeometricPotential(
 }
 
 template<typename InertialFrame, typename ThisFrame>
+void RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
+    absl::HashState state) const {
+  absl::flat_hash_set<not_null<MassiveBody const*>> const primaries_set(
+      primaries_.begin(), primaries_.end());
+  absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
+      secondaries_.begin(), secondaries_.end());
+  absl::HashState::combine(
+      std::move(state), primaries_set, secondaries_set, rotating_frame_);
+}
+
+template<typename InertialFrame, typename ThisFrame>
 void RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::WriteToMessage(
     not_null<serialization::ReferenceFrame*> message) const {
   auto* const extension = message->MutableExtension(

--- a/physics/rotating_pulsating_reference_frame_body.hpp
+++ b/physics/rotating_pulsating_reference_frame_body.hpp
@@ -163,7 +163,11 @@ void RotatingPulsatingReferenceFrame<InertialFrame, ThisFrame>::HashValue(
   absl::flat_hash_set<not_null<MassiveBody const*>> const secondaries_set(
       secondaries_.begin(), secondaries_.end());
   absl::HashState::combine(
-      std::move(state), primaries_set, secondaries_set, rotating_frame_);
+      std::move(state),
+      serialization::RotatingPulsatingReferenceFrame::extension.number(),
+      primaries_set,
+      secondaries_set,
+      rotating_frame_);
 }
 
 template<typename InertialFrame, typename ThisFrame>

--- a/physics/rotating_pulsating_reference_frame_test.cpp
+++ b/physics/rotating_pulsating_reference_frame_test.cpp
@@ -1,6 +1,7 @@
 #include "physics/rotating_pulsating_reference_frame.hpp"
 
 #include <memory>
+#include <utility>
 
 #include "absl/hash/hash_testing.h"
 #include "absl/status/status.h"

--- a/physics/rotating_pulsating_reference_frame_test.cpp
+++ b/physics/rotating_pulsating_reference_frame_test.cpp
@@ -180,5 +180,9 @@ TEST_F(RotatingPulsatingReferenceFrameTest, GeometricAcceleration) {
 
 #endif
 
+TEST_F(RotatingPulsatingReferenceFrameTest, Hashing) {
+  EXPECT_EQ(earth_moon_, earth_moon_);
+}
+
 }  // namespace physics
 }  // namespace principia

--- a/physics/rotating_pulsating_reference_frame_test.cpp
+++ b/physics/rotating_pulsating_reference_frame_test.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "absl/hash/hash_testing.h"
 #include "absl/status/status.h"
 #include "astronomy/epoch.hpp"
 #include "astronomy/frames.hpp"
@@ -20,6 +21,7 @@
 #include "physics/kepler_orbit.hpp"
 #include "physics/massive_body.hpp"
 #include "physics/massless_body.hpp"
+#include "physics/reference_frame_key.hpp"
 #include "physics/solar_system.hpp"
 #include "quantities/quantities.hpp"
 #include "quantities/si.hpp"
@@ -49,6 +51,7 @@ using namespace principia::physics::_ephemeris;
 using namespace principia::physics::_kepler_orbit;
 using namespace principia::physics::_massive_body;
 using namespace principia::physics::_massless_body;
+using namespace principia::physics::_reference_frame_key;
 using namespace principia::physics::_rotating_pulsating_reference_frame;
 using namespace principia::physics::_solar_system;
 using namespace principia::quantities::_quantities;
@@ -180,8 +183,22 @@ TEST_F(RotatingPulsatingReferenceFrameTest, GeometricAcceleration) {
 
 #endif
 
-TEST_F(RotatingPulsatingReferenceFrameTest, Hashing) {
-  EXPECT_EQ(earth_moon_, earth_moon_);
+TEST_F(RotatingPulsatingReferenceFrameTest, Key) {
+  auto earth_moon =
+      std::make_unique<RotatingPulsatingReferenceFrame<ICRS, EarthMoon>>(
+          ephemeris_.get(), earth_, moon_);
+  auto moon_earth =
+      std::make_unique<RotatingPulsatingReferenceFrame<ICRS, EarthMoon>>(
+          ephemeris_.get(), moon_, earth_);
+  EXPECT_EQ(earth_moon, earth_moon);
+  EXPECT_NE(moon_earth, earth_moon);
+
+  ReferenceFrameKey<ICRS, EarthMoon> const earth_moon_key(
+      std::move(earth_moon));
+  ReferenceFrameKey<ICRS, EarthMoon> const moon_earth_key(
+      std::move(moon_earth));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {earth_moon_key, earth_moon_key, moon_earth_key}));
 }
 
 }  // namespace physics


### PR DESCRIPTION
1. Add `operator==` and `HashValue` to `ReferenceFrame` and its subclasses.
2. Add a copyable wrapper `ReferenceFrameKey` that is hashable and equality-comparable.

This is preparatory work for #4624.