### PR TITLE
Replace maps and sets keyed by pointers by flat_hash_map/set

### DIFF
--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/globals.h"
 #include "absl/log/log.h"
@@ -77,7 +77,7 @@ class KSPResonanceTest : public ::testing::Test {
  protected:
   using KSP = Frame<struct KSPTag, Inertial>;
 
-  using Periods = std::map<not_null<MassiveBody const*>, Time>;
+  using Periods = absl::flat_hash_map<not_null<MassiveBody const*>, Time>;
 
   KSPResonanceTest()
       : solar_system_(

--- a/astronomy/ksp_resonance_test.cpp
+++ b/astronomy/ksp_resonance_test.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/globals.h"
 #include "absl/log/log.h"
@@ -77,7 +77,7 @@ class KSPResonanceTest : public ::testing::Test {
  protected:
   using KSP = Frame<struct KSPTag, Inertial>;
 
-  using Periods = absl::flat_hash_map<not_null<MassiveBody const*>, Time>;
+  using Periods = absl::node_hash_map<not_null<MassiveBody const*>, Time>;
 
   KSPResonanceTest()
       : solar_system_(

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <chrono>
-#include <map>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -215,8 +214,9 @@ TEST_F(KSPSystemTest, KerbalSystem) {
   EXPECT_OK(ephemeris_->Prolong(final_time));
   LOG(INFO) << "Integration done";
 
-  std::map<not_null<MassiveBody const*>, Length> last_separations;
-  std::map<not_null<MassiveBody const*>, Sign> last_separation_changes;
+  absl::flat_hash_map<not_null<MassiveBody const*>, Length> last_separations;
+  absl::flat_hash_map<not_null<MassiveBody const*>, Sign>
+      last_separation_changes;
 
   Instant t = solar_system_.epoch();
 

--- a/astronomy/ksp_system_test.cpp
+++ b/astronomy/ksp_system_test.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <map>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/journal/player.hpp
+++ b/journal/player.hpp
@@ -2,9 +2,9 @@
 
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <memory>
 
+#include "absl/container/flat_hash_map.h"
 #include "serialization/journal.pb.h"
 
 namespace principia {
@@ -18,7 +18,7 @@ namespace internal {
 
 class Player final {
  public:
-  using PointerMap = std::map<std::uint64_t, void*>;
+  using PointerMap = absl::flat_hash_map<std::uint64_t, void*>;
 
   explicit Player(std::filesystem::path const& path);
 

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -9,7 +9,6 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -18,6 +17,7 @@
 #include <vector>
 
 #include "absl/containers/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -940,7 +940,7 @@ void Plugin::SetPredictionAdaptiveStepParameters(
 
 void Plugin::UpdatePrediction(std::vector<GUID> const& vessel_guids) const {
   CHECK(!initializing_);
-  std::set<not_null<Vessel*>> predicted_vessels;
+  absl::flat_hash_set<not_null<Vessel*>> predicted_vessels;
   for (auto const& guid : vessel_guids) {
     predicted_vessels.insert(FindOrDie(vessels_, guid).get());
   }

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -17,7 +17,7 @@
 #include <vector>
 
 #include "absl/containers/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
+#include "absl/containers/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/containers/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -1476,7 +1477,8 @@ void Plugin::WriteToMessage(
     message->set_system_fingerprint(system_fingerprint_);
   }
   ephemeris_->Prolong(current_time_).IgnoreError();
-  std::map<not_null<Celestial const*>, Index const> celestial_to_index;
+  absl::flat_hash_map<not_null<Celestial const*>, Index const>
+      celestial_to_index;
   for (auto const& [index, owned_celestial] : celestials_) {
     celestial_to_index.emplace(owned_celestial.get(), index);
   }
@@ -1493,7 +1495,8 @@ void Plugin::WriteToMessage(
   }
 
   // Construct a map to help serialization of the pile-ups.
-  std::map<not_null<PileUp const*>, int> serialization_index_to_pile_up;
+  absl::flat_hash_map<not_null<PileUp const*>, int>
+      serialization_index_to_pile_up;
   int serialization_index = 0;
   for (auto const* pile_up : pile_ups_) {
     serialization_index_to_pile_up[pile_up] = serialization_index++;
@@ -1503,7 +1506,7 @@ void Plugin::WriteToMessage(
         return serialization_index_to_pile_up.at(pile_up);
       };
 
-  std::map<not_null<Vessel const*>, GUID const> vessel_to_guid;
+  absl::flat_hash_map<not_null<Vessel const*>, GUID const> vessel_to_guid;
   for (auto const& [guid, vessel] : vessels_) {
     vessel_to_guid.emplace(vessel.get(), guid);
     auto* const vessel_message = message->add_vessel();

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -16,8 +16,8 @@
 #include <utility>
 #include <vector>
 
-#include "absl/containers/flat_hash_map.h"
-#include "absl/containers/flat_hash_set.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"

--- a/ksp_plugin/vessel.cpp
+++ b/ksp_plugin/vessel.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 #include <ranges>
-#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -16,6 +15,7 @@
 #include <vector>
 
 #include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -1344,7 +1344,7 @@ void Vessel::AttachPrediction(DiscreteTrajectory<Barycentric>&& trajectory) {
 
 bool Vessel::IsCollapsible() const {
   PileUp const* containing_pile_up = nullptr;
-  std::set<not_null<Part*>> parts;
+  absl::flat_hash_set<not_null<Part*>> parts;
   for (const auto& [_, part] : parts_) {
     // We expect parts to be piled up.
     CHECK(part->is_piled_up());

--- a/mathematica/retrobop_dynamical_stability.cpp
+++ b/mathematica/retrobop_dynamical_stability.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -556,7 +557,8 @@ void StatisticallyAnalyseStability() {
               Ephemeris<Barycentric>::NewtonianMotionEquation>(),
           step);
 
-  std::map<not_null<Ephemeris<Barycentric>*>, bool> numerically_unsound;
+  absl::flat_hash_map<not_null<Ephemeris<Barycentric>*>, bool>
+      numerically_unsound;
   for (auto const& ephemeris : perturbed_ephemerides) {
     CHECK_OK(ephemeris->Prolong(ksp_epoch));
     numerically_unsound[ephemeris.get()] = false;

--- a/nanobenchmarks/main.cpp
+++ b/nanobenchmarks/main.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <cstdio>
 #include <format>
-#include <map>
 #include <memory>
 #include <print>
 #include <ranges>
@@ -10,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -103,7 +103,8 @@ TSCCalibration CalibrateTSC(Logger* const logger) {
   std::size_t const name_width =
       std::ranges::max(reference_cycle_counts_widths);
 
-  std::map<Nanobenchmark<double, double> const*, LatencyDistributionTable>
+  absl::flat_hash_map<Nanobenchmark<double, double> const*,
+                      LatencyDistributionTable>
       reference_measurements;
   std::vprint_unicode(stdout,
                       "{:<" + std::to_string(name_width + 2) + "}{:8}{}\n",
@@ -153,7 +154,8 @@ double CalibrateOverhead(TSCCalibration const& calibration,
   std::size_t const name_width =
       std::ranges::max(reference_cycle_counts_widths);
 
-  std::map<Nanobenchmark<Value, Argument> const*, LatencyDistributionTable>
+  absl::flat_hash_map<Nanobenchmark<Value, Argument> const*,
+                      LatencyDistributionTable>
       reference_measurements;
   std::vprint_unicode(stdout,
                       "{:<" + std::to_string(name_width + 2) + "}{:8}{}\n",

--- a/physics/hierarchical_system.hpp
+++ b/physics/hierarchical_system.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "base/not_null.hpp"
 #include "physics/degrees_of_freedom.hpp"
 #include "physics/kepler_orbit.hpp"
@@ -94,7 +94,7 @@ class HierarchicalSystem final {
   System system_;
   // Invariant: `systems_[p]->primary.get() == p`.
   // None of these pointers should be null, but I want to use operator[].
-  std::map<not_null<MassiveBody const*>, System*> systems_;
+  absl::flat_hash_map<not_null<MassiveBody const*>, System*> systems_;
 };
 
 }  // namespace internal

--- a/physics/hierarchical_system_test.cpp
+++ b/physics/hierarchical_system_test.cpp
@@ -54,8 +54,8 @@ TEST_F(HierarchicalSystemTest, HierarchicalSystem) {
 
   auto const new_body = [&body_indices, &bodies](Mass const& mass) {
     auto body = make_not_null_unique<MassiveBody>(mass);
+    body_indices[body.get()] = bodies.size();
     bodies.emplace_back(body.get());
-    body_indices[body.get()] = body_indices.size();
     return body;
   };
 
@@ -111,8 +111,8 @@ TEST_F(HierarchicalSystemTest, FromMeanMotions) {
   auto const new_body = [&body_indices, &bodies]() {
     auto body =
         make_not_null_unique<MassiveBody>(si::Unit<GravitationalParameter>);
+    body_indices[body.get()] = bodies.size();
     bodies.emplace_back(body.get());
-    body_indices[body.get()] = body_indices.size();
     return body;
   };
 

--- a/physics/hierarchical_system_test.cpp
+++ b/physics/hierarchical_system_test.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <iterator>
-#include <map>
 #include <vector>
 
 #include "base/not_null.hpp"
@@ -50,7 +49,7 @@ TEST_F(HierarchicalSystemTest, HierarchicalSystem) {
   elements.mean_anomaly = 0 * Radian;
 
   // Invariant: `body_indices[bodies[i]] == i` for all `i`.
-  std::map<not_null<MassiveBody const*>, int> body_indices;
+  absl::flat_hash_map<not_null<MassiveBody const*>, int> body_indices;
   std::vector<not_null<MassiveBody const*>> bodies;
 
   auto const new_body = [&body_indices, &bodies](Mass const& mass) {
@@ -106,7 +105,7 @@ TEST_F(HierarchicalSystemTest, FromMeanMotions) {
 
 
   // Invariant: `body_indices[bodies[i]] == i` for all `i`.
-  std::map<not_null<MassiveBody const*>, int> body_indices;
+  absl::flat_hash_map<not_null<MassiveBody const*>, int> body_indices;
   std::vector<not_null<MassiveBody const*>> bodies;
 
   auto const new_body = [&body_indices, &bodies]() {

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -16,7 +16,7 @@ message NavigationFrameParameters {
 }
 
 message SphericalCoordinates {
-    option (is_public) = true;
+  option (is_public) = true;
   required double radius = 1;
   required double latitude_in_degrees = 2;
   required double longitude_in_degrees = 3;

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1436,7 +1436,9 @@ void JournalProtoProcessor::ProcessReturn(Descriptor const* descriptor) {
       "message.return_()." + std::string(result_field_descriptor->name()) +
       "()";
   Descriptor const* field_message_type =
-      result_field_descriptor->message_type();
+      result_field_descriptor->type() == FieldDescriptor::TYPE_MESSAGE
+          ? result_field_descriptor->message_type()
+          : nullptr;
   if (field_message_type != nullptr &&
       cxx_insert_definition_.contains(field_message_type)) {
     std::string const field_message_type_name(field_message_type->name());

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1614,12 +1614,6 @@ void JournalProtoProcessor::ProcessInterchangeMessage(
     // deserialization, generate it now.
     if (field_descriptor->type() == FieldDescriptor::TYPE_MESSAGE) {
       Descriptor const* field_message_type = field_descriptor->message_type();
-LOG(ERROR)<<field_message_type->full_name();
-LOG(ERROR)<<cxx_deserialization_storage_arguments_[field_message_type].size();
-LOG(ERROR)<<cxx_deserialization_storage_parameters_[field_message_type].size();
-LOG(ERROR)<<descriptor->full_name();
-LOG(ERROR)<<cxx_deserialization_storage_arguments_[descriptor].size();
-LOG(ERROR)<<cxx_deserialization_storage_parameters_[descriptor].size();
       if (cxx_deserialization_storage_arguments_.contains(field_message_type)) {
         cxx_deserialization_storage_arguments_[descriptor] +=
              cxx_deserialization_storage_arguments_[field_message_type];

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1422,6 +1422,7 @@ void JournalProtoProcessor::ProcessReturn(Descriptor const* descriptor) {
       result_field_descriptor = field_descriptor;
     }
   }
+  LOG(ERROR)<<descriptor->full_name()<<" "<<result_field_descriptor->full_name();
   CHECK(result_field_descriptor != nullptr)
       << descriptor->full_name()
       << " must have exactly one field without the (address_of) option";
@@ -1435,12 +1436,13 @@ void JournalProtoProcessor::ProcessReturn(Descriptor const* descriptor) {
   std::string const cxx_field_getter =
       "message.return_()." + std::string(result_field_descriptor->name()) +
       "()";
-  if (cxx_insert_definition_.contains(
-          result_field_descriptor->message_type())) {
-    Descriptor const* message_type = result_field_descriptor->message_type();
-    std::string const message_type_name(message_type->name());
-    cxx_run_body_epilog_[descriptor] += "  Insert" + message_type_name + "(" +
-                                        cxx_field_getter +
+  Descriptor const* field_message_type =
+      result_field_descriptor->message_type();
+  if (field_message_type != nullptr &&
+      cxx_insert_definition_.contains(field_message_type)) {
+    std::string const field_message_type_name(field_message_type->name());
+    cxx_run_body_epilog_[descriptor] += "  Insert" + field_message_type_name +
+                                        "(" + cxx_field_getter +
                                         ", *result, pointer_map);\n";
   }
   if (field_cxx_inserter_fn_.contains(result_field_descriptor)) {
@@ -1449,9 +1451,8 @@ void JournalProtoProcessor::ProcessReturn(Descriptor const* descriptor) {
                                                         "result");
   } else if (!result_field_options.HasExtension(
                  journal::serialization::omit_check)) {
-    Descriptor const* field_message_type =
-        result_field_descriptor->message_type();
-    if (cxx_deserialization_storage_declarations_.contains(
+    if (field_message_type != nullptr &&
+        cxx_deserialization_storage_declarations_.contains(
             field_message_type)) {
       cxx_run_body_epilog_[descriptor] +=
           cxx_deserialization_storage_declarations_[field_message_type];
@@ -1614,6 +1615,12 @@ void JournalProtoProcessor::ProcessInterchangeMessage(
     // deserialization, generate it now.
     if (field_descriptor->type() == FieldDescriptor::TYPE_MESSAGE) {
       Descriptor const* field_message_type = field_descriptor->message_type();
+LOG(ERROR)<<field_message_type->full_name();
+LOG(ERROR)<<cxx_deserialization_storage_arguments_[field_message_type].size();
+LOG(ERROR)<<cxx_deserialization_storage_parameters_[field_message_type].size();
+LOG(ERROR)<<descriptor->full_name();
+LOG(ERROR)<<cxx_deserialization_storage_arguments_[descriptor].size();
+LOG(ERROR)<<cxx_deserialization_storage_parameters_[descriptor].size();
       if (cxx_deserialization_storage_arguments_.contains(field_message_type)) {
         cxx_deserialization_storage_arguments_[descriptor] +=
              cxx_deserialization_storage_arguments_[field_message_type];
@@ -2159,6 +2166,42 @@ std::string JournalProtoProcessor::MarshalAs(
      _MSC_FULL_VER == 194'435'228)
   std::abort();
 #endif
+}
+
+template<typename T>
+bool JournalProtoProcessor::OrderByIndices<T>::operator()(
+    T const* const left,
+    T const* const right) const {
+  CHECK(left != nullptr);
+  CHECK(right != nullptr);
+  if (left == right) {
+    return false;
+  }
+
+  auto const get_indices = [](T const* const t) {
+    std::vector<int> indices;
+    indices.push_back(t->index());
+    Descriptor const* type = t->containing_type();
+    while (type != nullptr) {
+      indices.push_back(type->index());
+      type = type->containing_type();
+    }
+    std::reverse(indices.begin(), indices.end());
+    return indices;
+  };
+  //return left < right;
+  if (get_indices(left) < get_indices(right)) {
+    LOG(ERROR) << absl::StrJoin(get_indices(left), "/") << " "
+               << left->full_name() << " < "
+               << absl::StrJoin(get_indices(right), "/") << " "
+               << right->full_name();
+  } else {
+    LOG(ERROR) << absl::StrJoin(get_indices(left), "/") << " "
+               << left->full_name()
+               << " >= " << absl::StrJoin(get_indices(right), "/") << " "
+               << right->full_name();
+  }
+  return get_indices(left) < get_indices(right);
 }
 
 }  // namespace internal

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -4,7 +4,6 @@
 #include <cctype>
 #include <functional>
 #include <iostream>
-#include <iterator>
 #include <map>
 #include <ranges>
 #include <set>

--- a/tools/journal_proto_processor.cpp
+++ b/tools/journal_proto_processor.cpp
@@ -1422,7 +1422,6 @@ void JournalProtoProcessor::ProcessReturn(Descriptor const* descriptor) {
       result_field_descriptor = field_descriptor;
     }
   }
-  LOG(ERROR)<<descriptor->full_name()<<" "<<result_field_descriptor->full_name();
   CHECK(result_field_descriptor != nullptr)
       << descriptor->full_name()
       << " must have exactly one field without the (address_of) option";
@@ -2178,6 +2177,10 @@ bool JournalProtoProcessor::OrderByIndices<T>::operator()(
     return false;
   }
 
+  // A "path" of indices from the top-level message down to the individual
+  // declaration.  For instance, the indices for `CatchUpLaggingVessels.Out`
+  // might be {38, 1} if `CatchUpLaggingVessels` is the 39th message in the file
+  // and `Out` is its second nested message.
   auto const get_indices = [](T const* const t) {
     std::vector<int> indices;
     indices.push_back(t->index());
@@ -2189,18 +2192,7 @@ bool JournalProtoProcessor::OrderByIndices<T>::operator()(
     std::reverse(indices.begin(), indices.end());
     return indices;
   };
-  //return left < right;
-  if (get_indices(left) < get_indices(right)) {
-    LOG(ERROR) << absl::StrJoin(get_indices(left), "/") << " "
-               << left->full_name() << " < "
-               << absl::StrJoin(get_indices(right), "/") << " "
-               << right->full_name();
-  } else {
-    LOG(ERROR) << absl::StrJoin(get_indices(left), "/") << " "
-               << left->full_name()
-               << " >= " << absl::StrJoin(get_indices(right), "/") << " "
-               << right->full_name();
-  }
+
   return get_indices(left) < get_indices(right);
 }
 

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -103,6 +104,14 @@ class JournalProtoProcessor final {
 
   bool HasMarshaler(FieldDescriptor const* descriptor) const;
   std::string MarshalAs(FieldDescriptor const* descriptor) const;
+
+  // Some maps (the ones that contain code snippets, as opposed to internal
+  // data) are keyed by some descriptor pointers, and the order of these maps
+  // must be deterministic, and reflect the order of the source .proto file.
+  template<typename T>
+  struct OrderByIndices {
+    bool operator()(T const* left, T const* right) const;
+  };
 
   // As the recursive methods above traverse the protocol buffer type
   // declarations, they enter in the following maps (and set) various pieces of
@@ -298,22 +307,22 @@ class JournalProtoProcessor final {
 
   // The C#/C++ declaration of an interface method corresponding to a method
   // message.  The key is a descriptor for a method message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cs_interface_method_declaration_;
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cxx_interface_method_declaration_;
 
   // A partial declaration of the C# class Interface.Symbols containing the
   // declaration of the delegate corresponding to a method message.  The key is
   // a descriptor for a method message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cs_interface_symbol_declaration_;
 
   // A list of C#/C++ parameters for an interface method.  The key is a
   // descriptor for an In or Out message.  Produced but not used for Out
   // messages.
-  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
-      cs_interface_parameters_;
+  std::map<Descriptor const*, std::vector<std::string>,
+           OrderByIndices<Descriptor>> cs_interface_parameters_;
   absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
       cxx_interface_parameters_;
   // Same as `cs_interface_parameters_`, but with `MarshalAs` attributes.
@@ -341,16 +350,16 @@ class JournalProtoProcessor final {
 
   // The C#/C++ definition of a type corresponding to an interchange enum.  The
   // key is a descriptor for an interchange enum.
-  absl::flat_hash_map<EnumDescriptor const*, std::string>
+  std::map<EnumDescriptor const*, std::string, OrderByIndices<EnumDescriptor>>
       cs_interchange_enum_declaration_;
-  absl::flat_hash_map<EnumDescriptor const*, std::string>
+  std::map<EnumDescriptor const*, std::string, OrderByIndices<EnumDescriptor>>
       cxx_interchange_enum_declaration_;
 
   // The C#/C++ definition of a type corresponding to an interchange message.
   // The key is a descriptor for an interchange message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cs_interchange_type_declaration_;
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cxx_interchange_type_declaration_;
 
   // The full name of the C# class that implements a custom marshaler for an
@@ -359,7 +368,7 @@ class JournalProtoProcessor final {
 
   // The definition of the C# class that implements a custom marshaler for an
   // interchange message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cs_custom_marshaler_class_;
 
   // The C# declarations of fields in the Representation struct of a custom
@@ -379,10 +388,12 @@ class JournalProtoProcessor final {
   // The definitions of the Serialize, Deserialize and (if needed) Insert
   // functions for interchange messages.  The key is a descriptor for an
   // interchange message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cxx_deserialize_definition_;
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_serialize_definition_;
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_insert_definition_;
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
+      cxx_serialize_definition_;
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
+      cxx_insert_definition_;
 
   // For interchange messages that require deserialization storage, the
   // arguments for the storage in the call to the Deserialize function.  Starts
@@ -407,7 +418,8 @@ class JournalProtoProcessor final {
       cxx_deserialization_storage_parameters_;
 
   // The statements to be included in the body of the Play function.
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_play_statement_;
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
+      cxx_play_statement_;
 
   // The entire sequence of statements for the body of a Fill function.  The key
   // is a descriptor for an In or Out message.
@@ -430,12 +442,12 @@ class JournalProtoProcessor final {
 
   // A code snippet for the implementation of the Fill and Run functions.  The
   // key is a descriptor for a method message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cxx_functions_implementation_;
 
   // A code snippet for the declaration of the top-level struct for a method.
   // The key is a descriptor for a method message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  std::map<Descriptor const*, std::string, OrderByIndices<Descriptor>>
       cxx_toplevel_type_declaration_;
 
   // A code snippet for the declaration of a nested In or Out struct or a Return

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <functional>
-#include <set>
 #include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "google/protobuf/descriptor.h"
 
 namespace principia {
@@ -116,24 +116,24 @@ class JournalProtoProcessor final {
 
   // The fields that are in.  Note that the out fields present in `in_out_` are
   // not in `in_`.
-  std::set<FieldDescriptor const*> in_;
+  absl::flat_hash_set<FieldDescriptor const*> in_;
 
   // The fields that are in-out, i.e. for which fields of the same name exist in
   // both the In and the Out messages.  Note that both fields are present in
   // this set.  Those fields are transmitted through the interface with an extra
   // level of indirection.
-  std::set<FieldDescriptor const*> in_out_;
+  absl::flat_hash_set<FieldDescriptor const*> in_out_;
 
   // The fields that are out.  Those fields are transmitted through the
   // interface with an extra level of indirection.  Note that the in fields
   // present in `in_out_` are not in `out_`.
-  std::set<FieldDescriptor const*> out_;
+  absl::flat_hash_set<FieldDescriptor const*> out_;
 
   // The fields that are returned.
-  std::set<FieldDescriptor const*> return_;
+  absl::flat_hash_set<FieldDescriptor const*> return_;
 
   // The fields that are part of interchange messages.
-  std::set<FieldDescriptor const*> interchange_;
+  absl::flat_hash_set<FieldDescriptor const*> interchange_;
 
   // For a field that has an (address_of) option, field_cxx_address_of_ has that
   // field as a key and the field designated by the option as its value.
@@ -277,7 +277,7 @@ class JournalProtoProcessor final {
   // The fields that must be marshaled by simply copying their fields.  This is
   // useful for classes-within-classes when we don't need a level of
   // indirection.
-  std::set<FieldDescriptor const*> field_cs_marshal_by_copy_;
+  absl::flat_hash_set<FieldDescriptor const*> field_cs_marshal_by_copy_;
 
   // The C# type for a field, suitable for use in a private member when the
   // actual data cannot be exposed directly (think bool).
@@ -337,7 +337,7 @@ class JournalProtoProcessor final {
 
   // The interchange messages that are represented by a class (as opposed to a
   // struct) in the C# code.
-  std::set<Descriptor const*> cs_interchange_classes_;
+  absl::flat_hash_set<Descriptor const*> cs_interchange_classes_;
 
   // The C#/C++ definition of a type corresponding to an interchange enum.  The
   // key is a descriptor for an interchange enum.

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_map.h"
 #include "google/protobuf/descriptor.h"
@@ -115,13 +116,18 @@ class JournalProtoProcessor final {
     bool operator()(T const* left, T const* right) const;
   };
 
-  // IMPORTANT!  The hash maps in this code are `node_hash_map`s, not
-  // `flat_hash_map`s, because many of them are string-valued, and we
-  // extensively use `+=`.  This causes plague and pestilence if the map gets
-  // reshashed in the middle of the assignment, because `flat_hash_map` doesn't
-  // have pointer stability.  Technically we could use `flat_hash_map` for the
-  // maps that are not string-valued, but this would just be unnecessarily
-  // dangerous.
+  // IMPORTANT!
+  //
+  // The members that are pointer- or function-values hash maps are
+  // `flat_hash_map` because we probably don't need pointer stability (we should
+  // not retain pointers or references to pointers or functions).  All others
+  // are `node_hash_map`s.  To see why, consider the maps that are
+  // string-valued; we extensively use `+=` in conjuction with `[]`, which can
+  // cause rehashing in the middle of the assignment (evaluate the addres of the
+  // rhs, evaluate the address of the lhs, it's not in the map, insert, rehash).
+  //
+  // For local maps we generally use `flat_hash_map` because we can easily
+  // verify that pointer stability is not needed.
 
   // As the recursive methods above traverse the protocol buffer type
   // declarations, they enter in the following maps (and set) various pieces of
@@ -157,24 +163,24 @@ class JournalProtoProcessor final {
   // For a field that has an (address_of) option, field_cxx_address_of_ has that
   // field as a key and the field designated by the option as its value.
   // field_cxx_address_ is the inverse map.
-  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_address_of_;
-  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_address_;
 
   // For a field that has a (size_of) option, field_cxx_size_of_ has that field
   // as a key and the field designated by the option as its value.
   // field_cxx_size_ is the inverse map.
-  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_size_of_;
-  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_size_;
 
   // For all fields, a lambda that takes the name of a local variable containing
   // data extracted (and deserialized) from the field and returns a list of
   // expressions to be passed to the interface.  Deals with passing by reference
   // for fields that are in-out or optional.
-  absl::node_hash_map<
+  absl::flat_hash_map<
       FieldDescriptor const*,
       std::function<std::vector<std::string>(std::string const& identifier)>>
       field_cxx_arguments_fn_;
@@ -185,7 +191,7 @@ class JournalProtoProcessor final {
   // prefix of a call, i.e., it must be a pointer followed by "->" or a
   // reference followed by ".".  The lambda calls `field_cxx_serializer_fn_` to
   // serialize expressions as necessary; thus, `expr` must *not* be serialized.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& prefix,
                                                 std::string const& expr)>>
       field_cxx_assignment_fn_;
@@ -195,7 +201,7 @@ class JournalProtoProcessor final {
   // the pointer_map.  `expr` is a uint64 expression for the entry to be
   // removed (typically something like `message.in().bar()`).  No data for other
   // fields.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_deleter_fn_;
 
@@ -207,14 +213,14 @@ class JournalProtoProcessor final {
   // fields.
   // Note that for a field that is designated by a (size_of) field, the
   // (size_of) field is passed to this lambda instead of the field itself.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_deserializer_fn_;
 
   // For all fields, a lambda that takes an expression for a struct member and
   // returns an expression that dereferences it if the field uses a level of
   // indirection (e.g., is optional or in-out).
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_indirect_member_get_fn_;
 
@@ -224,33 +230,33 @@ class JournalProtoProcessor final {
   // of the pointer (typically something like `message.in().bar()`), `expr2` is
   // a pointer expression for the current value of the pointer (typically the
   // name of a local variable).  No data for other fields.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr1,
                                                 std::string const& expr2)>>
       field_cxx_inserter_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds a mode to it.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cs_mode_fn_;
   // For all fields, a lambda that takes a C++ parameter or member type as
   // stored in `field_cxx_type_`, and adds a mode to it.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cxx_mode_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds `this` to it if `is_subject`; the result can be
   // used to declare a parameter in an extension method.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cs_extension_method_parameter_fn_;
 
   // For all fields, a lambda that takes a pointer expression and a statement
   // generated by `field_cxx_assignment_fn_`.  If the field is optional, returns
   // an if statement that only executes `stmt` if `expr` in nonnull.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr,
                                                 std::string const& stmt)>>
       field_cxx_optional_assignment_fn_;
@@ -260,7 +266,7 @@ class JournalProtoProcessor final {
   // and a deserialized expression for reading the field (typically the result
   // of `field_cxx_deserializer_fn_`) and returns a conditional expression for
   // either a pointer to the deserialized value or nullptr.
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& condition,
                                                 std::string const& expr)>>
       field_cxx_optional_pointer_fn_;
@@ -269,18 +275,18 @@ class JournalProtoProcessor final {
   // variable (possibly with dereferencing) and returns a protocol buffer
   // expression suitable for assigning to some field either using set_bar() or
   // mutable_bar() (typically the result is a call to some Serialize function).
-  absl::node_hash_map<FieldDescriptor const*,
+  absl::flat_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_serializer_fn_;
 
   // For fields that are implemented using private members, a lambda that takes
   // the names of the members and returns the C# implementation of the getter
   // and setter.
-  absl::node_hash_map<
+  absl::flat_hash_map<
       FieldDescriptor const*,
       std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_getter_fn_;
-  absl::node_hash_map<
+  absl::flat_hash_map<
       FieldDescriptor const*,
       std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_setter_fn_;

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
 #include "google/protobuf/descriptor.h"
 
 namespace principia {
@@ -115,6 +115,14 @@ class JournalProtoProcessor final {
     bool operator()(T const* left, T const* right) const;
   };
 
+  // IMPORTANT!  The hash maps in this code are `node_hash_map`s, not
+  // `flat_hash_map`s, because many of them are string-valued, and we
+  // extensively use `+=`.  This causes plague and pestilence if the map gets
+  // reshashed in the middle of the assignment, because `flat_hash_map` doesn't
+  // have pointer stability.  Technically we could use `flat_hash_map` for the
+  // maps that are not string-valued, but this would just be unnecessarily
+  // dangerous.
+
   // As the recursive methods above traverse the protocol buffer type
   // declarations, they enter in the following maps (and set) various pieces of
   // information to help in generating C++ and C# code.  For the simplest use
@@ -149,24 +157,24 @@ class JournalProtoProcessor final {
   // For a field that has an (address_of) option, field_cxx_address_of_ has that
   // field as a key and the field designated by the option as its value.
   // field_cxx_address_ is the inverse map.
-  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_address_of_;
-  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_address_;
 
   // For a field that has a (size_of) option, field_cxx_size_of_ has that field
   // as a key and the field designated by the option as its value.
   // field_cxx_size_ is the inverse map.
-  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_size_of_;
-  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::node_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_size_;
 
   // For all fields, a lambda that takes the name of a local variable containing
   // data extracted (and deserialized) from the field and returns a list of
   // expressions to be passed to the interface.  Deals with passing by reference
   // for fields that are in-out or optional.
-  absl::flat_hash_map<
+  absl::node_hash_map<
       FieldDescriptor const*,
       std::function<std::vector<std::string>(std::string const& identifier)>>
       field_cxx_arguments_fn_;
@@ -177,7 +185,7 @@ class JournalProtoProcessor final {
   // prefix of a call, i.e., it must be a pointer followed by "->" or a
   // reference followed by ".".  The lambda calls `field_cxx_serializer_fn_` to
   // serialize expressions as necessary; thus, `expr` must *not* be serialized.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& prefix,
                                                 std::string const& expr)>>
       field_cxx_assignment_fn_;
@@ -187,7 +195,7 @@ class JournalProtoProcessor final {
   // the pointer_map.  `expr` is a uint64 expression for the entry to be
   // removed (typically something like `message.in().bar()`).  No data for other
   // fields.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_deleter_fn_;
 
@@ -199,14 +207,14 @@ class JournalProtoProcessor final {
   // fields.
   // Note that for a field that is designated by a (size_of) field, the
   // (size_of) field is passed to this lambda instead of the field itself.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_deserializer_fn_;
 
   // For all fields, a lambda that takes an expression for a struct member and
   // returns an expression that dereferences it if the field uses a level of
   // indirection (e.g., is optional or in-out).
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_indirect_member_get_fn_;
 
@@ -216,33 +224,33 @@ class JournalProtoProcessor final {
   // of the pointer (typically something like `message.in().bar()`), `expr2` is
   // a pointer expression for the current value of the pointer (typically the
   // name of a local variable).  No data for other fields.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr1,
                                                 std::string const& expr2)>>
       field_cxx_inserter_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds a mode to it.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cs_mode_fn_;
   // For all fields, a lambda that takes a C++ parameter or member type as
   // stored in `field_cxx_type_`, and adds a mode to it.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cxx_mode_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds `this` to it if `is_subject`; the result can be
   // used to declare a parameter in an extension method.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& type)>>
       field_cs_extension_method_parameter_fn_;
 
   // For all fields, a lambda that takes a pointer expression and a statement
   // generated by `field_cxx_assignment_fn_`.  If the field is optional, returns
   // an if statement that only executes `stmt` if `expr` in nonnull.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr,
                                                 std::string const& stmt)>>
       field_cxx_optional_assignment_fn_;
@@ -252,7 +260,7 @@ class JournalProtoProcessor final {
   // and a deserialized expression for reading the field (typically the result
   // of `field_cxx_deserializer_fn_`) and returns a conditional expression for
   // either a pointer to the deserialized value or nullptr.
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& condition,
                                                 std::string const& expr)>>
       field_cxx_optional_pointer_fn_;
@@ -261,18 +269,18 @@ class JournalProtoProcessor final {
   // variable (possibly with dereferencing) and returns a protocol buffer
   // expression suitable for assigning to some field either using set_bar() or
   // mutable_bar() (typically the result is a call to some Serialize function).
-  absl::flat_hash_map<FieldDescriptor const*,
+  absl::node_hash_map<FieldDescriptor const*,
                       std::function<std::string(std::string const& expr)>>
       field_cxx_serializer_fn_;
 
   // For fields that are implemented using private members, a lambda that takes
   // the names of the members and returns the C# implementation of the getter
   // and setter.
-  absl::flat_hash_map<
+  absl::node_hash_map<
       FieldDescriptor const*,
       std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_getter_fn_;
-  absl::flat_hash_map<
+  absl::node_hash_map<
       FieldDescriptor const*,
       std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_setter_fn_;
@@ -280,9 +288,9 @@ class JournalProtoProcessor final {
   // The C# class for marshalling a field.  This may be either a custom
   // marshaler (derived from ICustomMarshaler) or one predefined by .Net.  At
   // most one is set for a given field.
-  absl::flat_hash_map<FieldDescriptor const*, std::string>
+  absl::node_hash_map<FieldDescriptor const*, std::string>
       field_cs_custom_marshaler_;
-  absl::flat_hash_map<FieldDescriptor const*, std::string>
+  absl::node_hash_map<FieldDescriptor const*, std::string>
       field_cs_predefined_marshaler_;
 
   // The fields that must be marshaled by simply copying their fields.  This is
@@ -292,20 +300,20 @@ class JournalProtoProcessor final {
 
   // The C# type for a field, suitable for use in a private member when the
   // actual data cannot be exposed directly (think bool).
-  absl::flat_hash_map<FieldDescriptor const*, std::string>
+  absl::node_hash_map<FieldDescriptor const*, std::string>
       field_cs_private_type_;
 
   // For fields that require deserialization storage, the C++ type and name of
   // the storage object.
-  absl::flat_hash_map<FieldDescriptor const*, std::string>
+  absl::node_hash_map<FieldDescriptor const*, std::string>
       field_cxx_deserialization_storage_name_;
-  absl::flat_hash_map<FieldDescriptor const*, std::string>
+  absl::node_hash_map<FieldDescriptor const*, std::string>
       field_cxx_deserialization_storage_type_;
 
   // The C#/C++ type for a field, suitable for use in a member or parameter
   // declaration, in a typedef, etc.
-  absl::flat_hash_map<FieldDescriptor const*, std::string> field_cs_type_;
-  absl::flat_hash_map<FieldDescriptor const*, std::string> field_cxx_type_;
+  absl::node_hash_map<FieldDescriptor const*, std::string> field_cs_type_;
+  absl::node_hash_map<FieldDescriptor const*, std::string> field_cxx_type_;
 
   // The C#/C++ declaration of an interface method corresponding to a method
   // message.  The key is a descriptor for a method message.
@@ -325,25 +333,25 @@ class JournalProtoProcessor final {
   // messages.
   std::map<Descriptor const*, std::vector<std::string>,
            OrderByIndices<Descriptor>> cs_interface_parameters_;
-  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+  absl::node_hash_map<Descriptor const*, std::vector<std::string>>
       cxx_interface_parameters_;
   // Same as `cs_interface_parameters_`, but with `MarshalAs` attributes.
-  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+  absl::node_hash_map<Descriptor const*, std::vector<std::string>>
       cs_interface_marshaled_parameters_;
   // A list of arguments for a call to the interface method from C#, including
   // modes `out` or `ref`, with the same identifiers as the parameter names.
-  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+  absl::node_hash_map<Descriptor const*, std::vector<std::string>>
       cs_interface_arguments_;
 
   // The C#/C++ return type of an interface method.  The key is a descriptor for
   // a Return message.
-  absl::flat_hash_map<Descriptor const*, std::string> cs_interface_return_type_;
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string> cs_interface_return_type_;
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_interface_return_type_;
 
   // The C# attribute for marshalling the return value of an interface method.
   // The key is a descriptor for a Return message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cs_interface_return_marshal_;
 
   // The interchange messages that are represented by a class (as opposed to a
@@ -366,7 +374,7 @@ class JournalProtoProcessor final {
 
   // The full name of the C# class that implements a custom marshaler for an
   // interchange message.
-  absl::flat_hash_map<Descriptor const*, std::string> cs_custom_marshaler_name_;
+  absl::node_hash_map<Descriptor const*, std::string> cs_custom_marshaler_name_;
 
   // The definition of the C# class that implements a custom marshaler for an
   // interchange message.
@@ -375,16 +383,16 @@ class JournalProtoProcessor final {
 
   // The C# declarations of fields in the Representation struct of a custom
   // marshaler.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cs_representation_type_declaration_;
 
   // The C# statements in the CleanUpNative, MarshalManagedToNative and
   // MarshalNativeToManaged functions of a custom marshaller.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cs_clean_up_native_definition_;
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cs_managed_to_native_definition_;
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cs_native_to_managed_definition_;
 
   // The definitions of the Serialize, Deserialize and (if needed) Insert
@@ -400,23 +408,23 @@ class JournalProtoProcessor final {
   // For interchange messages that require deserialization storage, the
   // arguments for the storage in the call to the Deserialize function.  Starts
   // with a comma, arguments are comma-separated.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_arguments_;
 
   // For interchange messages that require deserialization storage, the
   // captures needed for lambdas to access the storage.  Starts with a comma,
   // captures are comma-separated.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_captures_;
 
   // For interchange messages that require deserialization storage, the
   // declaration of the storage in the caller of the Deserialize function.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_declarations_;
 
   // For interchange messages that require deserialization storage, the
   // parameters for the storage in the Deserialize function.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_parameters_;
 
   // The statements to be included in the body of the Play function.
@@ -425,22 +433,22 @@ class JournalProtoProcessor final {
 
   // The entire sequence of statements for the body of a Fill function.  The key
   // is a descriptor for an In or Out message.
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_fill_body_;
+  absl::node_hash_map<Descriptor const*, std::string> cxx_fill_body_;
 
   // A code snippet that goes before the call to the interface in the
   // body of the Run function.  The key is a descriptor for an In or Out
   // message.  Produced but not used for Out messages.
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_run_body_prolog_;
+  absl::node_hash_map<Descriptor const*, std::string> cxx_run_body_prolog_;
 
   // A list of code snippets for arguments to be passed to the interface in the
   // body of the Run function.
-  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+  absl::node_hash_map<Descriptor const*, std::vector<std::string>>
       cxx_run_arguments_;
 
   // A code snippet that goes after the call to the interface in the
   // body of the Run function.  The key is a descriptor for an In or Out
   // message.
-  absl::flat_hash_map<Descriptor const*, std::string> cxx_run_body_epilog_;
+  absl::node_hash_map<Descriptor const*, std::string> cxx_run_body_epilog_;
 
   // A code snippet for the implementation of the Fill and Run functions.  The
   // key is a descriptor for a method message.
@@ -454,7 +462,7 @@ class JournalProtoProcessor final {
 
   // A code snippet for the declaration of a nested In or Out struct or a Return
   // typedef.  The key is a descriptor for an In, Out or Return message.
-  absl::flat_hash_map<Descriptor const*, std::string>
+  absl::node_hash_map<Descriptor const*, std::string>
       cxx_nested_type_declaration_;
 };
 

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <functional>
-#include <map>
 #include <set>
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "google/protobuf/descriptor.h"
 
 namespace principia {
@@ -138,23 +138,26 @@ class JournalProtoProcessor final {
   // For a field that has an (address_of) option, field_cxx_address_of_ has that
   // field as a key and the field designated by the option as its value.
   // field_cxx_address_ is the inverse map.
-  std::map<FieldDescriptor const*, FieldDescriptor const*>
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
       field_cxx_address_of_;
-  std::map<FieldDescriptor const*, FieldDescriptor const*> field_cxx_address_;
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+      field_cxx_address_;
 
   // For a field that has a (size_of) option, field_cxx_size_of_ has that field
   // as a key and the field designated by the option as its value.
   // field_cxx_size_ is the inverse map.
-  std::map<FieldDescriptor const*, FieldDescriptor const*> field_cxx_size_of_;
-  std::map<FieldDescriptor const*, FieldDescriptor const*> field_cxx_size_;
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+      field_cxx_size_of_;
+  absl::flat_hash_map<FieldDescriptor const*, FieldDescriptor const*>
+      field_cxx_size_;
 
   // For all fields, a lambda that takes the name of a local variable containing
   // data extracted (and deserialized) from the field and returns a list of
   // expressions to be passed to the interface.  Deals with passing by reference
   // for fields that are in-out or optional.
-  std::map<FieldDescriptor const*,
-           std::function<std::vector<std::string>(
-                             std::string const& identifier)>>
+  absl::flat_hash_map<
+      FieldDescriptor const*,
+      std::function<std::vector<std::string>(std::string const& identifier)>>
       field_cxx_arguments_fn_;
 
   // For all fields, a lambda that takes a serialized expression `expr` and a
@@ -163,9 +166,9 @@ class JournalProtoProcessor final {
   // prefix of a call, i.e., it must be a pointer followed by "->" or a
   // reference followed by ".".  The lambda calls `field_cxx_serializer_fn_` to
   // serialize expressions as necessary; thus, `expr` must *not* be serialized.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& prefix,
-                                     std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& prefix,
+                                                std::string const& expr)>>
       field_cxx_assignment_fn_;
 
   // For fields that have an (is_consumed) or (is_consumed_if) option, a lambda
@@ -173,8 +176,8 @@ class JournalProtoProcessor final {
   // the pointer_map.  `expr` is a uint64 expression for the entry to be
   // removed (typically something like `message.in().bar()`).  No data for other
   // fields.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr)>>
       field_cxx_deleter_fn_;
 
   // For all fields, a lambda that takes an expression for reading a protobuf
@@ -185,15 +188,15 @@ class JournalProtoProcessor final {
   // fields.
   // Note that for a field that is designated by a (size_of) field, the
   // (size_of) field is passed to this lambda instead of the field itself.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr)>>
       field_cxx_deserializer_fn_;
 
   // For all fields, a lambda that takes an expression for a struct member and
   // returns an expression that dereferences it if the field uses a level of
   // indirection (e.g., is optional or in-out).
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr)>>
       field_cxx_indirect_member_get_fn_;
 
   // For fields that have an (is_produced) or (is_produced_if) option, a lambda
@@ -202,35 +205,35 @@ class JournalProtoProcessor final {
   // of the pointer (typically something like `message.in().bar()`), `expr2` is
   // a pointer expression for the current value of the pointer (typically the
   // name of a local variable).  No data for other fields.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr1,
-                                     std::string const& expr2)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr1,
+                                                std::string const& expr2)>>
       field_cxx_inserter_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds a mode to it.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& type)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& type)>>
       field_cs_mode_fn_;
   // For all fields, a lambda that takes a C++ parameter or member type as
   // stored in `field_cxx_type_`, and adds a mode to it.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& type)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& type)>>
       field_cxx_mode_fn_;
 
   // For all fields, a lambda that takes a C# parameter type as stored in
   // `field_cs_type_`, and adds `this` to it if `is_subject`; the result can be
   // used to declare a parameter in an extension method.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& type)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& type)>>
       field_cs_extension_method_parameter_fn_;
 
   // For all fields, a lambda that takes a pointer expression and a statement
   // generated by `field_cxx_assignment_fn_`.  If the field is optional, returns
   // an if statement that only executes `stmt` if `expr` in nonnull.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr,
-                                     std::string const& stmt)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr,
+                                                std::string const& stmt)>>
       field_cxx_optional_assignment_fn_;
 
   // For all fields, a lambda that takes a condition to check for the presence
@@ -238,36 +241,38 @@ class JournalProtoProcessor final {
   // and a deserialized expression for reading the field (typically the result
   // of `field_cxx_deserializer_fn_`) and returns a conditional expression for
   // either a pointer to the deserialized value or nullptr.
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& condition,
-                                     std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& condition,
+                                                std::string const& expr)>>
       field_cxx_optional_pointer_fn_;
 
   // For all fields, a lambda that takes an expression for reading a local
   // variable (possibly with dereferencing) and returns a protocol buffer
   // expression suitable for assigning to some field either using set_bar() or
   // mutable_bar() (typically the result is a call to some Serialize function).
-  std::map<FieldDescriptor const*,
-           std::function<std::string(std::string const& expr)>>
+  absl::flat_hash_map<FieldDescriptor const*,
+                      std::function<std::string(std::string const& expr)>>
       field_cxx_serializer_fn_;
 
   // For fields that are implemented using private members, a lambda that takes
   // the names of the members and returns the C# implementation of the getter
   // and setter.
-  std::map<FieldDescriptor const*,
-           std::function<
-              std::string(std::vector<std::string> const& identifiers)>>
+  absl::flat_hash_map<
+      FieldDescriptor const*,
+      std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_getter_fn_;
-  std::map<FieldDescriptor const*,
-           std::function<
-              std::string(std::vector<std::string> const& identifiers)>>
+  absl::flat_hash_map<
+      FieldDescriptor const*,
+      std::function<std::string(std::vector<std::string> const& identifiers)>>
       field_cs_private_setter_fn_;
 
   // The C# class for marshalling a field.  This may be either a custom
   // marshaler (derived from ICustomMarshaler) or one predefined by .Net.  At
   // most one is set for a given field.
-  std::map<FieldDescriptor const*, std::string> field_cs_custom_marshaler_;
-  std::map<FieldDescriptor const*, std::string> field_cs_predefined_marshaler_;
+  absl::flat_hash_map<FieldDescriptor const*, std::string>
+      field_cs_custom_marshaler_;
+  absl::flat_hash_map<FieldDescriptor const*, std::string>
+      field_cs_predefined_marshaler_;
 
   // The fields that must be marshaled by simply copying their fields.  This is
   // useful for classes-within-classes when we don't need a level of
@@ -276,52 +281,59 @@ class JournalProtoProcessor final {
 
   // The C# type for a field, suitable for use in a private member when the
   // actual data cannot be exposed directly (think bool).
-  std::map<FieldDescriptor const*, std::string> field_cs_private_type_;
+  absl::flat_hash_map<FieldDescriptor const*, std::string>
+      field_cs_private_type_;
 
   // For fields that require deserialization storage, the C++ type and name of
   // the storage object.
-  std::map<FieldDescriptor const*, std::string>
+  absl::flat_hash_map<FieldDescriptor const*, std::string>
       field_cxx_deserialization_storage_name_;
-  std::map<FieldDescriptor const*, std::string>
+  absl::flat_hash_map<FieldDescriptor const*, std::string>
       field_cxx_deserialization_storage_type_;
 
   // The C#/C++ type for a field, suitable for use in a member or parameter
   // declaration, in a typedef, etc.
-  std::map<FieldDescriptor const*, std::string> field_cs_type_;
-  std::map<FieldDescriptor const*, std::string> field_cxx_type_;
+  absl::flat_hash_map<FieldDescriptor const*, std::string> field_cs_type_;
+  absl::flat_hash_map<FieldDescriptor const*, std::string> field_cxx_type_;
 
   // The C#/C++ declaration of an interface method corresponding to a method
   // message.  The key is a descriptor for a method message.
-  std::map<Descriptor const*, std::string> cs_interface_method_declaration_;
-  std::map<Descriptor const*, std::string> cxx_interface_method_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_interface_method_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_interface_method_declaration_;
 
   // A partial declaration of the C# class Interface.Symbols containing the
   // declaration of the delegate corresponding to a method message.  The key is
   // a descriptor for a method message.
-  std::map<Descriptor const*, std::string> cs_interface_symbol_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_interface_symbol_declaration_;
 
   // A list of C#/C++ parameters for an interface method.  The key is a
   // descriptor for an In or Out message.  Produced but not used for Out
   // messages.
-  std::map<Descriptor const*, std::vector<std::string>>
+  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
       cs_interface_parameters_;
-  std::map<Descriptor const*, std::vector<std::string>>
+  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
       cxx_interface_parameters_;
   // Same as `cs_interface_parameters_`, but with `MarshalAs` attributes.
-  std::map<Descriptor const*, std::vector<std::string>>
+  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
       cs_interface_marshaled_parameters_;
   // A list of arguments for a call to the interface method from C#, including
   // modes `out` or `ref`, with the same identifiers as the parameter names.
-  std::map<Descriptor const*, std::vector<std::string>> cs_interface_arguments_;
+  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+      cs_interface_arguments_;
 
   // The C#/C++ return type of an interface method.  The key is a descriptor for
   // a Return message.
-  std::map<Descriptor const*, std::string> cs_interface_return_type_;
-  std::map<Descriptor const*, std::string> cxx_interface_return_type_;
+  absl::flat_hash_map<Descriptor const*, std::string> cs_interface_return_type_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_interface_return_type_;
 
   // The C# attribute for marshalling the return value of an interface method.
   // The key is a descriptor for a Return message.
-  std::map<Descriptor const*, std::string> cs_interface_return_marshal_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_interface_return_marshal_;
 
   // The interchange messages that are represented by a class (as opposed to a
   // struct) in the C# code.
@@ -329,94 +341,107 @@ class JournalProtoProcessor final {
 
   // The C#/C++ definition of a type corresponding to an interchange enum.  The
   // key is a descriptor for an interchange enum.
-  std::map<EnumDescriptor const*, std::string> cs_interchange_enum_declaration_;
-  std::map<EnumDescriptor const*, std::string>
+  absl::flat_hash_map<EnumDescriptor const*, std::string>
+      cs_interchange_enum_declaration_;
+  absl::flat_hash_map<EnumDescriptor const*, std::string>
       cxx_interchange_enum_declaration_;
 
   // The C#/C++ definition of a type corresponding to an interchange message.
   // The key is a descriptor for an interchange message.
-  std::map<Descriptor const*, std::string> cs_interchange_type_declaration_;
-  std::map<Descriptor const*, std::string> cxx_interchange_type_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_interchange_type_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_interchange_type_declaration_;
 
   // The full name of the C# class that implements a custom marshaler for an
   // interchange message.
-  std::map<Descriptor const*, std::string> cs_custom_marshaler_name_;
+  absl::flat_hash_map<Descriptor const*, std::string> cs_custom_marshaler_name_;
 
   // The definition of the C# class that implements a custom marshaler for an
   // interchange message.
-  std::map<Descriptor const*, std::string> cs_custom_marshaler_class_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_custom_marshaler_class_;
 
   // The C# declarations of fields in the Representation struct of a custom
   // marshaler.
-  std::map<Descriptor const*, std::string> cs_representation_type_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_representation_type_declaration_;
 
   // The C# statements in the CleanUpNative, MarshalManagedToNative and
   // MarshalNativeToManaged functions of a custom marshaller.
-  std::map<Descriptor const*, std::string> cs_clean_up_native_definition_;
-  std::map<Descriptor const*, std::string> cs_managed_to_native_definition_;
-  std::map<Descriptor const*, std::string> cs_native_to_managed_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_clean_up_native_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_managed_to_native_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cs_native_to_managed_definition_;
 
   // The definitions of the Serialize, Deserialize and (if needed) Insert
   // functions for interchange messages.  The key is a descriptor for an
   // interchange message.
-  std::map<Descriptor const*, std::string> cxx_deserialize_definition_;
-  std::map<Descriptor const*, std::string> cxx_serialize_definition_;
-  std::map<Descriptor const*, std::string> cxx_insert_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_deserialize_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_serialize_definition_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_insert_definition_;
 
   // For interchange messages that require deserialization storage, the
   // arguments for the storage in the call to the Deserialize function.  Starts
   // with a comma, arguments are comma-separated.
-  std::map<Descriptor const*, std::string>
+  absl::flat_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_arguments_;
 
   // For interchange messages that require deserialization storage, the
   // captures needed for lambdas to access the storage.  Starts with a comma,
   // captures are comma-separated.
-  std::map<Descriptor const*, std::string>
+  absl::flat_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_captures_;
 
   // For interchange messages that require deserialization storage, the
   // declaration of the storage in the caller of the Deserialize function.
-  std::map<Descriptor const*, std::string>
+  absl::flat_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_declarations_;
 
   // For interchange messages that require deserialization storage, the
   // parameters for the storage in the Deserialize function.
-  std::map<Descriptor const*, std::string>
+  absl::flat_hash_map<Descriptor const*, std::string>
       cxx_deserialization_storage_parameters_;
 
   // The statements to be included in the body of the Play function.
-  std::map<Descriptor const*, std::string> cxx_play_statement_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_play_statement_;
 
   // The entire sequence of statements for the body of a Fill function.  The key
   // is a descriptor for an In or Out message.
-  std::map<Descriptor const*, std::string> cxx_fill_body_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_fill_body_;
 
   // A code snippet that goes before the call to the interface in the
   // body of the Run function.  The key is a descriptor for an In or Out
   // message.  Produced but not used for Out messages.
-  std::map<Descriptor const*, std::string> cxx_run_body_prolog_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_run_body_prolog_;
 
   // A list of code snippets for arguments to be passed to the interface in the
   // body of the Run function.
-  std::map<Descriptor const*, std::vector<std::string>> cxx_run_arguments_;
+  absl::flat_hash_map<Descriptor const*, std::vector<std::string>>
+      cxx_run_arguments_;
 
   // A code snippet that goes after the call to the interface in the
   // body of the Run function.  The key is a descriptor for an In or Out
   // message.
-  std::map<Descriptor const*, std::string> cxx_run_body_epilog_;
+  absl::flat_hash_map<Descriptor const*, std::string> cxx_run_body_epilog_;
 
   // A code snippet for the implementation of the Fill and Run functions.  The
   // key is a descriptor for a method message.
-  std::map<Descriptor const*, std::string> cxx_functions_implementation_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_functions_implementation_;
 
   // A code snippet for the declaration of the top-level struct for a method.
   // The key is a descriptor for a method message.
-  std::map<Descriptor const*, std::string> cxx_toplevel_type_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_toplevel_type_declaration_;
 
   // A code snippet for the declaration of a nested In or Out struct or a Return
   // typedef.  The key is a descriptor for an In, Out or Return message.
-  std::map<Descriptor const*, std::string> cxx_nested_type_declaration_;
+  absl::flat_hash_map<Descriptor const*, std::string>
+      cxx_nested_type_declaration_;
 };
 
 }  // namespace internal

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -118,13 +118,14 @@ class JournalProtoProcessor final {
 
   // IMPORTANT!
   //
-  // The members that are pointer- or function-values hash maps are
+  // The members that are pointer- or function-valued hash maps are
   // `flat_hash_map` because we probably don't need pointer stability (we should
   // not retain pointers or references to pointers or functions).  All others
   // are `node_hash_map`s.  To see why, consider the maps that are
-  // string-valued; we extensively use `+=` in conjuction with `[]`, which can
-  // cause rehashing in the middle of the assignment (evaluate the addres of the
-  // rhs, evaluate the address of the lhs, it's not in the map, insert, rehash).
+  // string-valued; we extensively use `+=` in conjunction with `[]`, which can
+  // cause rehashing in the middle of the assignment (evaluate the address of
+  // the rhs, evaluate the address of the lhs, it's not in the map, insert,
+  // rehash).
   //
   // For local maps we generally use `flat_hash_map` because we can easily
   // verify that pointer stability is not needed.

--- a/tools/journal_proto_processor.hpp
+++ b/tools/journal_proto_processor.hpp
@@ -107,7 +107,9 @@ class JournalProtoProcessor final {
 
   // Some maps (the ones that contain code snippets, as opposed to internal
   // data) are keyed by some descriptor pointers, and the order of these maps
-  // must be deterministic, and reflect the order of the source .proto file.
+  // must be deterministic and reflect that of the .proto file.  This comparator
+  // achives this by constructing a "path" of indices from the top of the file
+  // to the innermost declaration.
   template<typename T>
   struct OrderByIndices {
     bool operator()(T const* left, T const* right) const;


### PR DESCRIPTION
This should be more cache-friendly, and also the randomization could help us find unwarranted dependencies on ordering.

The members that are pointer- or function-valued hash maps are `flat_hash_map` because we probably don't need pointer stability (we should not retain pointers or references to pointers or functions).  All others are `node_hash_map`s.  To see why, consider maps that are string-valued, and say that we use `+=` in conjunction with `[]`, which can cause rehashing in the middle of the assignment (evaluate the address of the rhs, evaluate the address of the lhs, it's not in the map, insert, rehash).  In such a case we need pointer stability.

For local maps we generally use `flat_hash_map` because we can easilyverify that pointer stability is not needed.

This uncovered the fact that the generator depended on the order of allocation of the descriptors, so I am fixing the code to be deterministic.