### PR TITLE
Remove the parameter t_max from ComputeApsides and ComputeNodes

### DIFF
--- a/astronomy/lunar_orbit_test.cpp
+++ b/astronomy/lunar_orbit_test.cpp
@@ -402,7 +402,6 @@ TEST_P(LunarOrbitTest, NearCircularRepeatGroundTrackOrbit) {
   EXPECT_OK(ComputeNodes(surface_trajectory,
                          surface_trajectory.begin(),
                          surface_trajectory.end(),
-                         /*t_max=*/InfiniteFuture,
                          /*north=*/Vector<double, LunarSurface>({0, 0, 1}),
                          /*max_points=*/std::numeric_limits<int>::max(),
                          ascending_nodes,

--- a/astronomy/lunar_orbit_test.cpp
+++ b/astronomy/lunar_orbit_test.cpp
@@ -413,7 +413,6 @@ TEST_P(LunarOrbitTest, NearCircularRepeatGroundTrackOrbit) {
                  trajectory,
                  trajectory.begin(),
                  trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/std::numeric_limits<int>::max(),
                  apoapsides,
                  periapsides);

--- a/astronomy/orbit_ground_track_body.hpp
+++ b/astronomy/orbit_ground_track_body.hpp
@@ -136,7 +136,6 @@ absl::StatusOr<OrbitGroundTrack> OrbitGroundTrack::ForTrajectory(
   RETURN_IF_ERROR(ComputeNodes(trajectory,
                                trajectory.begin(),
                                trajectory.end(),
-                               /*t_max=*/InfiniteFuture,
                                Vector<double, PrimaryCentred>({0, 0, 1}),
                                /*max_points=*/std::numeric_limits<int>::max(),
                                ascending_nodes,

--- a/benchmarks/apsides_benchmark.cpp
+++ b/benchmarks/apsides_benchmark.cpp
@@ -146,7 +146,6 @@ BENCHMARK_F(ApsidesBenchmark, ComputeApsides)(benchmark::State& state) {
                    *ilrsa_lageos2_trajectory_icrs_,
                    ilrsa_lageos2_trajectory_icrs_->begin(),
                    ilrsa_lageos2_trajectory_icrs_->end(),
-                   /*t_max=*/InfiniteFuture,
                    /*max_points=*/std::numeric_limits<int>::max(),
                    apoapsides,
                    periapsides);

--- a/benchmarks/apsides_benchmark.cpp
+++ b/benchmarks/apsides_benchmark.cpp
@@ -162,7 +162,6 @@ BENCHMARK_F(ApsidesBenchmark, ComputeNodes)(benchmark::State& state) {
     CHECK_OK(ComputeNodes(*ilrsa_lageos2_trajectory_gcrs_,
                           ilrsa_lageos2_trajectory_gcrs_->begin(),
                           ilrsa_lageos2_trajectory_gcrs_->end(),
-                          /*t_max=*/InfiniteFuture,
                           Vector<double, GCRS>({0, 0, 1}),
                           /*max_points=*/std::numeric_limits<int>::max(),
                           ascending,

--- a/ksp_plugin/flight_plan_optimizer.cpp
+++ b/ksp_plugin/flight_plan_optimizer.cpp
@@ -565,7 +565,6 @@ FlightPlanOptimizer::EvaluateClosestPeriapsis(
                    vessel_trajectory,
                    vessel_trajectory.lower_bound(begin_time),
                    vessel_trajectory.end(),
-                   /*t_max=*/InfiniteFuture,
                    max_apsides,
                    apoapsides,
                    periapsides);

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -573,8 +573,10 @@ void __cdecl principia__FlightPlanRenderedApsides(
     plugin->ComputeAndRenderApsides(
         celestial_index,
         flight_plan,
-        segment.begin(), segment.end(),
-        t_max == nullptr ? InfiniteFuture : FromGameTime(*plugin, *t_max),
+        /*begin=*/segment.begin(),
+        /*end=*/t_max == nullptr
+            ? segment.end()
+            : segment.upper_bound(FromGameTime(*plugin, *t_max)),
         FromXYZ<Position<World>>(sun_world_position),
         max_points,
         segment_rendered_apoapsides,

--- a/ksp_plugin/interface_flight_plan.cpp
+++ b/ksp_plugin/interface_flight_plan.cpp
@@ -640,8 +640,10 @@ void __cdecl principia__FlightPlanRenderedNodes(Plugin const* const plugin,
     std::vector<Renderer::Node> segment_rendered_ascending;
     std::vector<Renderer::Node> segment_rendered_descending;
     plugin->ComputeAndRenderNodes(
-        segment.begin(), segment.end(),
-        t_max == nullptr ? InfiniteFuture : FromGameTime(*plugin, *t_max),
+        /*begin=*/segment.begin(),
+        /*end=*/t_max == nullptr
+            ? segment.end()
+            : segment.upper_bound(FromGameTime(*plugin, *t_max)),
         FromXYZ<Position<World>>(sun_world_position),
         max_points,
         segment_rendered_ascending,

--- a/ksp_plugin/interface_renderer.cpp
+++ b/ksp_plugin/interface_renderer.cpp
@@ -117,8 +117,10 @@ void __cdecl principia__RenderedPredictionNodes(Plugin const* const plugin,
   std::vector<Renderer::Node> rendered_ascending;
   std::vector<Renderer::Node> rendered_descending;
   plugin->ComputeAndRenderNodes(
-      prediction->begin(), prediction->end(),
-      t_max == nullptr ? InfiniteFuture : FromGameTime(*plugin, *t_max),
+      /*begin=*/prediction->begin(),
+      /*end=*/t_max == nullptr
+          ? prediction->end()
+          : prediction->upper_bound(FromGameTime(*plugin, *t_max)),
       FromXYZ<Position<World>>(sun_world_position),
       max_points,
       rendered_ascending,

--- a/ksp_plugin/interface_renderer.cpp
+++ b/ksp_plugin/interface_renderer.cpp
@@ -62,8 +62,10 @@ void __cdecl principia__RenderedPredictionApsides(
   plugin->ComputeAndRenderApsides(
       celestial_index,
       *prediction,
-      prediction->begin(), prediction->end(),
-      t_max == nullptr ? InfiniteFuture : FromGameTime(*plugin, *t_max),
+      /*begin=*/prediction->begin(),
+      /*end=*/t_max == nullptr
+          ? prediction->end()
+          : prediction->upper_bound(FromGameTime(*plugin, *t_max)),
       FromXYZ<Position<World>>(sun_world_position),
       max_points,
       rendered_apoapsides,

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1010,7 +1010,6 @@ void Plugin::ComputeAndRenderApsides(
     Trajectory<Barycentric> const& trajectory,
     DiscreteTrajectory<Barycentric>::iterator const& begin,
     DiscreteTrajectory<Barycentric>::iterator const& end,
-    Instant const& t_max,
     Position<World> const& sun_world_position,
     int const max_points,
     DistinguishedPoints<World>& apoapsides,
@@ -1020,7 +1019,6 @@ void Plugin::ComputeAndRenderApsides(
   ComputeApsides(FindOrDie(celestials_, celestial_index)->trajectory(),
                  trajectory,
                  begin, end,
-                 t_max,
                  max_points,
                  barycentric_apoapsides,
                  barycentric_periapsides);
@@ -1058,7 +1056,6 @@ Plugin::ComputeAndRenderFirstCollision(
   ComputeApsides(celestial_trajectory,
                  trajectory,
                  begin, end,
-                 /*t_max=*/InfiniteFuture,
                  max_points,
                  apoapsides,
                  periapsides);
@@ -1113,7 +1110,6 @@ void Plugin::ComputeAndRenderClosestApproaches(
   ComputeApsides(*renderer_->GetTargetVessel().prediction(),
                  trajectory,
                  begin, end,
-                 /*t_max=*/InfiniteFuture,
                  max_points,
                  apoapsides,
                  periapsides);

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1129,7 +1129,6 @@ void Plugin::ComputeAndRenderClosestApproaches(
 void Plugin::ComputeAndRenderNodes(
     DiscreteTrajectory<Barycentric>::iterator const& begin,
     DiscreteTrajectory<Barycentric>::iterator const& end,
-    Instant const& t_max,
     Position<World> const& sun_world_position,
     int const max_points,
     std::vector<Renderer::Node>& ascending,
@@ -1160,7 +1159,6 @@ void Plugin::ComputeAndRenderNodes(
   ComputeNodes(trajectory_in_plotting,
                trajectory_in_plotting.begin(),
                trajectory_in_plotting.end(),
-               t_max,
                Vector<double, Navigation>({0, 0, 1}),
                max_points,
                plotting_ascending,

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -401,7 +401,6 @@ class Plugin {
   virtual void ComputeAndRenderNodes(
       DiscreteTrajectory<Barycentric>::iterator const& begin,
       DiscreteTrajectory<Barycentric>::iterator const& end,
-      Instant const& t_max,
       Position<World> const& sun_world_position,
       int max_points,
       std::vector<Renderer::Node>& ascending,

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -367,7 +367,6 @@ class Plugin {
       Trajectory<Barycentric> const& trajectory,
       DiscreteTrajectory<Barycentric>::iterator const& begin,
       DiscreteTrajectory<Barycentric>::iterator const& end,
-      Instant const& t_max,
       Position<World> const& sun_world_position,
       int max_points,
       DistinguishedPoints<World>& apoapsides,

--- a/ksp_plugin_test/flight_plan_optimizer_test.cpp
+++ b/ksp_plugin_test/flight_plan_optimizer_test.cpp
@@ -118,7 +118,6 @@ class FlightPlanOptimizerTest : public testing::Test {
                    flight_plan_trajectory,
                    flight_plan_trajectory.begin(),
                    flight_plan_trajectory.end(),
-                   /*t_max=*/InfiniteFuture,
                    /*max_points=*/100,
                    apoapsides,
                    periapsides);

--- a/ksp_plugin_test/plugin_compatibility_test.cpp
+++ b/ksp_plugin_test/plugin_compatibility_test.cpp
@@ -282,7 +282,6 @@ TEST_F(PluginCompatibilityTest, Reach) {
                    flight_plan_trajectory,
                    flight_plan_trajectory.upper_bound("1970-08-15T00:00:00"_TT),
                    flight_plan_trajectory.end(),
-                   /*t_max=*/InfiniteFuture,
                    /*max_points=*/100,
                    apoapsides,
                    periapsides);

--- a/physics/apsides.hpp
+++ b/physics/apsides.hpp
@@ -82,7 +82,6 @@ template<typename Frame, typename Predicate = ConstantFunction<bool>>
 absl::Status ComputeNodes(Trajectory<Frame> const& trajectory,
                           typename DiscreteTrajectory<Frame>::iterator begin,
                           typename DiscreteTrajectory<Frame>::iterator end,
-                          Instant const& t_max,
                           Vector<double, Frame> const& north,
                           int max_points,
                           DistinguishedPoints<Frame>& ascending,

--- a/physics/apsides.hpp
+++ b/physics/apsides.hpp
@@ -41,7 +41,6 @@ void ComputeApsides(Trajectory<Frame> const& reference,
                     Trajectory<Frame> const& trajectory,
                     typename DiscreteTrajectory<Frame>::iterator begin,
                     typename DiscreteTrajectory<Frame>::iterator end,
-                    Instant const& t_max,
                     int max_points,
                     DistinguishedPoints<Frame>& apoapsides,
                     DistinguishedPoints<Frame>& periapsides);

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -58,7 +58,6 @@ void ComputeApsides(Trajectory<Frame> const& reference,
                     Trajectory<Frame> const& trajectory,
                     typename DiscreteTrajectory<Frame>::iterator const begin,
                     typename DiscreteTrajectory<Frame>::iterator const end,
-                    Instant const& t_max,
                     int const max_points,
                     DistinguishedPoints<Frame>& apoapsides,
                     DistinguishedPoints<Frame>& periapsides) {
@@ -68,14 +67,14 @@ void ComputeApsides(Trajectory<Frame> const& reference,
   std::optional<Variation<Square<Length>>>
       previous_squared_distance_derivative;
 
-  Instant const effective_t_min = reference.t_min();
-  Instant const effective_t_max = std::min(t_max, reference.t_max());
+  Instant const reference_t_min = reference.t_min();
+  Instant const reference_t_max = reference.t_max();
   for (auto it = begin; it != end; ++it) {
     auto const& [time, degrees_of_freedom] = *it;
-    if (time < effective_t_min) {
+    if (time < reference_t_min) {
       continue;
     }
-    if (time > effective_t_max) {
+    if (time > reference_t_max) {
       break;
     }
     DegreesOfFreedom<Frame> const body_degrees_of_freedom =

--- a/physics/apsides_body.hpp
+++ b/physics/apsides_body.hpp
@@ -475,7 +475,6 @@ absl::Status ComputeNodes(
     Trajectory<Frame> const& trajectory,
     typename DiscreteTrajectory<Frame>::iterator const begin,
     typename DiscreteTrajectory<Frame>::iterator const end,
-    Instant const& t_max,
     Vector<double, Frame> const& north,
     int const max_points,
     DistinguishedPoints<Frame>& ascending,
@@ -494,9 +493,6 @@ absl::Status ComputeNodes(
   for (auto it = begin; it != end; ++it) {
     RETURN_IF_STOPPED;
     auto const& [time, degrees_of_freedom] = *it;
-    if (time > t_max) {
-      break;
-    }
     Length const z =
         (degrees_of_freedom.position() - Frame::origin).coordinates().z;
     Speed const z_speed = degrees_of_freedom.velocity().coordinates().z;

--- a/physics/apsides_test.cpp
+++ b/physics/apsides_test.cpp
@@ -141,7 +141,6 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory) {
                  trajectory,
                  trajectory.begin(),
                  trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/std::numeric_limits<int>::max(),
                  apoapsides,
                  periapsides);
@@ -207,7 +206,6 @@ TEST_F(ApsidesTest, ComputeApsidesDiscreteTrajectory_Circular) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -316,7 +314,6 @@ TEST_F(ApsidesTest, ComputeFirstCollision) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -416,7 +413,6 @@ TEST_F(ApsidesTest, ComputeNodes) {
   EXPECT_OK(ComputeNodes(trajectory,
                          trajectory.begin(),
                          trajectory.end(),
-                         /*t_max=*/InfiniteFuture,
                          north,
                          /*max_points=*/std::numeric_limits<int>::max(),
                          ascending_nodes,
@@ -458,7 +454,6 @@ TEST_F(ApsidesTest, ComputeNodes) {
   EXPECT_OK(ComputeNodes(trajectory,
                          trajectory.begin(),
                          trajectory.end(),
-                         /*t_max=*/InfiniteFuture,
                          mostly_south,
                          /*max_points=*/std::numeric_limits<int>::max(),
                          south_ascending_nodes,
@@ -553,7 +548,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OnePeriapsisBelowMaxRadius) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -594,7 +588,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OnePeriapsisAboveMaxRadius) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -631,7 +624,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, NoPeriapsis) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -681,7 +673,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OneApoapsisBelowMaxRadius) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -734,7 +725,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OneApoapsisAboveMaxRadius) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -791,7 +781,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals,
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -848,7 +837,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals,
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -904,7 +892,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OnePeriapsisOneApoapsis) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -945,7 +932,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, InitialApoapsisOnePeriapsis) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);
@@ -986,7 +972,6 @@ TEST_F(ApsidesTest_ComputeCollisionIntervals, OnePeriapsisFinalApoapsis) {
                  vessel_trajectory,
                  vessel_trajectory.begin(),
                  vessel_trajectory.end(),
-                 /*t_max=*/InfiniteFuture,
                  /*max_points=*/10,
                  apoapsides,
                  periapsides);


### PR DESCRIPTION
Having a mix of iterators and times is conceptually messy, and it will become even more problematic once we want to plot only a range of the trajectories.  It's cleaner to let the client call `upper_bound` when needed.

#4624.