### PR TITLE
Check at startup that KSP and Principia agree on the solar system

### DIFF
--- a/ksp_plugin/interface.cpp
+++ b/ksp_plugin/interface.cpp
@@ -387,67 +387,6 @@ void __cdecl principia__CatchUpLaggingVessels(
   return m.Return();
 }
 
-// Calls `plugin->CelestialFromParent` with the arguments given.
-// `plugin` must not be null.  No transfer of ownership.
-QP __cdecl principia__CelestialFromParent(Plugin const* const plugin,
-                                          int const celestial_index) {
-  journal::Method<journal::CelestialFromParent> m({plugin, celestial_index});
-  CHECK(plugin != nullptr);
-  return m.Return(ToQP(plugin->CelestialFromParent(celestial_index)));
-}
-
-double __cdecl principia__CelestialInitialRotationInDegrees(
-    Plugin const* const plugin,
-    int const celestial_index) {
-  journal::Method<journal::CelestialInitialRotationInDegrees> m(
-      {plugin, celestial_index});
-  CHECK(plugin != nullptr);
-  return m.Return(plugin->CelestialInitialRotation(celestial_index) / Degree);
-}
-
-WXYZ __cdecl principia__CelestialRotation(Plugin const* const plugin,
-                                          int const index) {
-  journal::Method<journal::CelestialRotation> m({plugin, index});
-  CHECK(plugin != nullptr);
-  return m.Return(ToWXYZ(plugin->CelestialRotation(index).quaternion()));
-}
-
-double __cdecl principia__CelestialRotationPeriod(
-    Plugin const* const plugin,
-    int const celestial_index) {
-  journal::Method<journal::CelestialRotationPeriod> m(
-      {plugin, celestial_index});
-  CHECK(plugin != nullptr);
-  return m.Return(plugin->CelestialRotationPeriod(celestial_index) / Second);
-}
-
-WXYZ __cdecl principia__CelestialSphereRotation(Plugin const* const plugin) {
-  journal::Method<journal::CelestialSphereRotation> m({plugin});
-  CHECK(plugin != nullptr);
-  return m.Return(ToWXYZ(plugin->CelestialSphereRotation().quaternion()));
-}
-
-QP __cdecl principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
-                                                     int const index,
-                                                     Origin const origin,
-                                                     double const time) {
-  journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
-      {plugin, index, origin, time});
-  CHECK(plugin != nullptr);
-  return m.Return(ToQP(
-      plugin->CelestialWorldDegreesOfFreedom(
-          index,
-          plugin->BarycentricToWorld(
-              origin.reference_part_is_unmoving,
-              origin.reference_part_id,
-              origin.reference_part_is_at_origin
-                  ? std::nullopt
-                  : std::make_optional(
-                        FromXYZ<Position<World>>(
-                            origin.main_body_centre_in_world))),
-          FromGameTime(*plugin, time))));
-}
-
 void __cdecl principia__ClearFlags() {
   journal::Method<journal::ClearFlags> m;
   Flags::Clear();
@@ -633,15 +572,15 @@ int __cdecl principia__GetBufferedLogging() {
                                        : file_log_sink->buffered_level()));
 }
 
-int __cdecl principia__GetStderrLogging() {
-  journal::Method<journal::GetStderrLogging> m;
-  return m.Return(static_cast<int>(absl::StderrThreshold()));
-}
-
 void __cdecl principia__GetCPUIDFeatureFlags(bool* const has_avx,
                                              bool* const has_fma) {
   *has_avx = CPUIDFeatureFlag::AVX.IsSet();
   *has_fma = CPUIDFeatureFlag::FMA.IsSet();
+}
+
+int __cdecl principia__GetStderrLogging() {
+  journal::Method<journal::GetStderrLogging> m;
+  return m.Return(static_cast<int>(absl::StderrThreshold()));
 }
 
 int __cdecl principia__GetSuppressedLogging() {

--- a/ksp_plugin/interface_celestial.cpp
+++ b/ksp_plugin/interface_celestial.cpp
@@ -1,0 +1,91 @@
+#include "ksp_plugin/interface.hpp"
+
+#include <string>
+#include <vector>
+
+#include "journal/method.hpp"
+#include "journal/profiles.hpp"  // 🧙 For generated profiles.
+#include "ksp_plugin/iterators.hpp"
+
+namespace principia {
+namespace interface {
+
+using namespace principia::journal::_method;
+using namespace principia::ksp_plugin::_iterators;
+
+Iterator* __cdecl principia__CelestialGetAllNames(
+    Plugin const* const plugin) {
+  journal::Method<journal::CelestialGetAllNames> m({plugin});
+  CHECK(plugin != nullptr);
+  auto const celestials = plugin->GetAllCelestials();
+  std::vector<std::string> names;
+  names.reserve(celestials.size());
+  for (auto const& celestial : celestials) {
+    names.push_back(celestial->body()->name());
+  }
+  return m.Return(new TypedIterator<std::vector<std::string>>(names, plugin));
+}
+
+// Calls `plugin->CelestialFromParent` with the arguments given.
+// `plugin` must not be null.  No transfer of ownership.
+QP __cdecl principia__CelestialFromParent(Plugin const* const plugin,
+                                          int const celestial_index) {
+  journal::Method<journal::CelestialFromParent> m({plugin, celestial_index});
+  CHECK(plugin != nullptr);
+  return m.Return(ToQP(plugin->CelestialFromParent(celestial_index)));
+}
+
+double __cdecl principia__CelestialInitialRotationInDegrees(
+    Plugin const* const plugin,
+    int const celestial_index) {
+  journal::Method<journal::CelestialInitialRotationInDegrees> m(
+      {plugin, celestial_index});
+  CHECK(plugin != nullptr);
+  return m.Return(plugin->CelestialInitialRotation(celestial_index) / Degree);
+}
+
+WXYZ __cdecl principia__CelestialRotation(Plugin const* const plugin,
+                                          int const index) {
+  journal::Method<journal::CelestialRotation> m({plugin, index});
+  CHECK(plugin != nullptr);
+  return m.Return(ToWXYZ(plugin->CelestialRotation(index).quaternion()));
+}
+
+double __cdecl principia__CelestialRotationPeriod(
+    Plugin const* const plugin,
+    int const celestial_index) {
+  journal::Method<journal::CelestialRotationPeriod> m(
+      {plugin, celestial_index});
+  CHECK(plugin != nullptr);
+  return m.Return(plugin->CelestialRotationPeriod(celestial_index) / Second);
+}
+
+WXYZ __cdecl principia__CelestialSphereRotation(Plugin const* const plugin) {
+  journal::Method<journal::CelestialSphereRotation> m({plugin});
+  CHECK(plugin != nullptr);
+  return m.Return(ToWXYZ(plugin->CelestialSphereRotation().quaternion()));
+}
+
+QP __cdecl principia__CelestialWorldDegreesOfFreedom(Plugin const* const plugin,
+                                                     int const index,
+                                                     Origin const origin,
+                                                     double const time) {
+  journal::Method<journal::CelestialWorldDegreesOfFreedom> m(
+      {plugin, index, origin, time});
+  CHECK(plugin != nullptr);
+  return m.Return(ToQP(
+      plugin->CelestialWorldDegreesOfFreedom(
+          index,
+          plugin->BarycentricToWorld(
+              origin.reference_part_is_unmoving,
+              origin.reference_part_id,
+              origin.reference_part_is_at_origin
+                  ? std::nullopt
+                  : std::make_optional(
+                        FromXYZ<Position<World>>(
+                            origin.main_body_centre_in_world))),
+          FromGameTime(*plugin, time))));
+}
+
+}  // namespace interface
+}  // namespace principia

--- a/ksp_plugin/interface_iterator.cpp
+++ b/ksp_plugin/interface_iterator.cpp
@@ -1,5 +1,6 @@
 #include "ksp_plugin/interface.hpp"
 
+#include <string>
 #include <vector>
 
 #include "absl/log/check.h"
@@ -38,6 +39,17 @@ void __cdecl principia__IteratorDelete(Iterator** const iterator) {
   journal::Method<journal::IteratorDelete> m({iterator}, {iterator});
   TakeOwnership(iterator);
   return m.Return();
+}
+
+char const* __cdecl principia__IteratorGetCelestialName(
+    Iterator const* const iterator) {
+  journal::Method<journal::IteratorGetCelestialName> m({iterator});
+  auto const typed_iterator = check_not_null(
+      dynamic_cast<TypedIterator<std::vector<std::string>> const*>(iterator));
+  return m.Return(typed_iterator->Get<char const*>(
+      [](std::string const& name) -> char const* {
+        return name.c_str();
+      }));
 }
 
 QP __cdecl principia__IteratorGetDiscreteTrajectoryQP(

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="identification.cpp" />
     <ClCompile Include="integrators.cpp" />
     <ClCompile Include="interface.cpp" />
+    <ClCompile Include="interface_celestial.cpp" />
     <ClCompile Include="interface_collision.cpp" />
     <ClCompile Include="interface_flight_plan.cpp" />
     <ClCompile Include="interface_future.cpp" />

--- a/ksp_plugin/ksp_plugin.vcxproj.filters
+++ b/ksp_plugin/ksp_plugin.vcxproj.filters
@@ -181,6 +181,9 @@
     <ClCompile Include="plugin_reader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="interface_celestial.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="principia.manifest" />

--- a/ksp_plugin/plugin.cpp
+++ b/ksp_plugin/plugin.cpp
@@ -1181,6 +1181,14 @@ Celestial const& Plugin::GetCelestial(Index const index) const {
   return *FindOrDie(celestials_, index);
 }
 
+std::vector<not_null<Celestial const*>> Plugin::GetAllCelestials() const {
+  std::vector<not_null<Celestial const*>> celestials;
+  for (auto const& [_, celestial] : celestials_) {
+    celestials.push_back(celestial.get());
+  }
+  return celestials;
+}
+
 bool Plugin::HasVessel(GUID const& vessel_guid) const {
   return vessels_.contains(vessel_guid);
 }

--- a/ksp_plugin/plugin.hpp
+++ b/ksp_plugin/plugin.hpp
@@ -407,6 +407,7 @@ class Plugin {
 
   virtual bool HasCelestial(Index index) const;
   virtual Celestial const& GetCelestial(Index index) const;
+  virtual std::vector<not_null<Celestial const*>> GetAllCelestials() const;
 
   virtual bool HasVessel(GUID const& vessel_guid) const;
   virtual not_null<Vessel*> GetVessel(GUID const& vessel_guid) const;

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -956,6 +956,43 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
       Log.Warning("No principia state found, creating one");
       ResetPlugin();
     }
+
+    // Check that the user didn't mess with the solar system.
+    var ksp_celestial_names = new SortedSet<string>();
+    var ksp_not_in_principia = new SortedSet<string>();
+    foreach (CelestialBody celestial in FlightGlobals.Bodies) {
+      ksp_celestial_names.Add(celestial.name);
+      ksp_not_in_principia.Add(celestial.name);
+    }
+    using (DisposableIterator all_celestial_names =
+           plugin_.CelestialGetAllNames()) {
+      var principia_celestial_names = new SortedSet<string>();
+      var principia_not_in_ksp = new SortedSet<string>();
+      for (;
+           !all_celestial_names.IteratorAtEnd();
+           all_celestial_names.IteratorIncrement()) {
+        string celestial_name = all_celestial_names.IteratorGetCelestialName();
+        principia_celestial_names.Add(celestial_name);
+        principia_not_in_ksp.Add(celestial_name);
+      }
+      ksp_not_in_principia.ExceptWith(principia_celestial_names);
+      if (ksp_not_in_principia.Count > 0) {
+        Log.Error("Principia does not know about the following KSP celestial " +
+                  "bodies: " +
+                  string.Join(", ", ksp_not_in_principia.ToArray()));
+      }
+      principia_not_in_ksp.ExceptWith(ksp_celestial_names);
+      if (principia_not_in_ksp.Count > 0) {
+        Log.Error("KSP does not know about the following Principia celestial " +
+                  "bodies: " +
+                  string.Join(", ", principia_not_in_ksp.ToArray()));
+      }
+      if (ksp_not_in_principia.Count > 0 || principia_not_in_ksp.Count > 0) {
+        Log.Fatal("KSP and Principia disagree on the solar system; " +
+                  "you have probably changed the solar system since creating " +
+                  "the Principia save.");
+      }
+    }
   }
 
   #endregion

--- a/ksp_plugin_adapter/ksp_plugin_adapter.cs
+++ b/ksp_plugin_adapter/ksp_plugin_adapter.cs
@@ -2881,8 +2881,9 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           // GetUniqueValue resp. GetAtMostOneValue corresponding to required
           // resp. optional in principia.serialization.GravityModel.Body.
           var body_parameters =
-              ConfigNodeParsers.NewCartesianBodyParameters(body,
-                body_gravity_model);
+              ConfigNodeParsers.NewCartesianBodyParameters(
+                  body,
+                  body_gravity_model);
           // GetUniqueValue since these are all required fields in
           // principia.serialization.InitialState.Cartesian.Body.
           plugin_.InsertCelestialAbsoluteCartesian(
@@ -2918,8 +2919,9 @@ public partial class PrincipiaPluginAdapter : ScenarioModule,
           Orbit orbit = unmodified_orbits_.GetValueOrNull(body);
           body.initialRotation = unmodified_initial_rotations_[body];
           var body_parameters =
-              ConfigNodeParsers.NewKeplerianBodyParameters(body,
-                body_gravity_model);
+              ConfigNodeParsers.NewKeplerianBodyParameters(
+                  body,
+                  body_gravity_model);
           plugin_.InsertCelestialJacobiKeplerian(
               celestial_index    : body.flightGlobalsIndex,
               parent_index       : orbit?.referenceBody.flightGlobalsIndex,

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\ksp_plugin\identification.cpp" />
     <ClCompile Include="..\ksp_plugin\integrators.cpp" />
     <ClCompile Include="..\ksp_plugin\interface.cpp" />
+    <ClCompile Include="..\ksp_plugin\interface_celestial.cpp" />
     <ClCompile Include="..\ksp_plugin\interface_collision.cpp" />
     <ClCompile Include="..\ksp_plugin\interface_flight_plan.cpp" />
     <ClCompile Include="..\ksp_plugin\interface_future.cpp" />

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj.filters
@@ -176,6 +176,12 @@
     <ClCompile Include="..\ksp_plugin\interface_graph.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ksp_plugin\plugin_reader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ksp_plugin\interface_celestial.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_plugin.hpp">

--- a/serialization/journal.proto
+++ b/serialization/journal.proto
@@ -306,7 +306,7 @@ message OrbitAnalysis {
 }
 
 message Method {
-  extensions 5000 to 5999;  // Last used: 5221.
+  extensions 5000 to 5999;  // Last used: 5223.
 }
 
 message ActivatePlayer {
@@ -396,6 +396,23 @@ message CelestialFromParent {
   }
   message Return {
     required QP result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
+}
+
+message CelestialGetAllNames {
+  extend Method {
+    optional CelestialGetAllNames extension = 5222;
+  }
+  message In {
+    required fixed64 plugin = 1 [(pointer_to) = "Plugin const",
+                                 (is_subject) = true];
+  }
+  message Return {
+    required fixed64 result = 1 [(pointer_to) = "Iterator",
+                                 (disposable) = "DisposableIterator",
+                                 (is_produced) = true];
   }
   optional In in = 1;
   optional Return return = 3;
@@ -1783,6 +1800,22 @@ message IteratorDelete {
   }
   optional In in = 1;
   optional Out out = 2;
+}
+
+message IteratorGetCelestialName {
+  extend Method {
+    optional IteratorGetCelestialName extension = 5223;
+  }
+  message In {
+    required fixed64 iterator = 1 [(pointer_to) = "Iterator const",
+                                   (disposable) = "DisposableIterator",
+                                   (is_subject) = true];
+  }
+  message Return {
+    required string result = 1;
+  }
+  optional In in = 1;
+  optional Return return = 3;
 }
 
 message IteratorGetDiscreteTrajectoryQP {


### PR DESCRIPTION
With this PR, loading the save from #4666 fails with:
```
E0824 19:07:16.089949   34308 ksp_plugin_adapter.cs:987] KSP does not know about the following Principia celestial bodies: Ahtpan, Anehta, Anneheg, AralcA, AralcB, Arorua, Dipuc, Efil, Elad, Eulb, Iomena, Kerbol, Maelg, Mehtna, Meiuqer, Noi, Noira, Norihc, Noyreg, Onrefni, Rouqea, Sedah, Sera, Simeht, Simetra, Suluco, Sunorc, Tot, Uleg
F0824 19:07:16.090105   34308 ksp_plugin_adapter.cs:992] KSP and Principia disagree on the solar system; you have probably changed the solar system since creating the Principia save.
```
Fix #4666.