### PR TITLE
Reduce the recompilation impact of changes to version.generated.cc

### DIFF
--- a/Principia.sln
+++ b/Principia.sln
@@ -206,6 +206,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "functions", "shared\functio
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "graphics", "graphics\graphics.vcxproj", "{20C9D292-5155-4E8A-9C6C-FFB761EA2C5D}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "version.generated", "shared\version.generated.vcxitems", "{36291755-D6D8-42AE-B40C-C97EE6412A73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -619,6 +621,7 @@ Global
 		{C59F84DA-2F82-43DD-BBA4-5A469B32557C} = {6722AD00-0A85-4156-B912-38E99A12AE75}
 		{2E39517A-4713-455F-8C78-610DDFD8EA99} = {6722AD00-0A85-4156-B912-38E99A12AE75}
 		{680F2F63-5CE1-4F32-8332-83F2E3D7B920} = {6722AD00-0A85-4156-B912-38E99A12AE75}
+		{36291755-D6D8-42AE-B40C-C97EE6412A73} = {6722AD00-0A85-4156-B912-38E99A12AE75}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {332981CB-A6C7-4BD0-9EE0-8E8C6FB4E01A}
@@ -636,6 +639,7 @@ Global
 		shared\geometry.vcxitems*{2e28828e-8364-4962-a9ff-c20a72eb884c}*SharedItemsImports = 4
 		shared\numerics.vcxitems*{2e28828e-8364-4962-a9ff-c20a72eb884c}*SharedItemsImports = 4
 		shared\testing_utilities.vcxitems*{2e39517a-4713-455f-8c78-610ddfd8ea99}*SharedItemsImports = 9
+		shared\version.generated.vcxitems*{36291755-d6d8-42ae-b40c-c97ee6412a73}*SharedItemsImports = 9
 		shared\journal.vcxitems*{388cbea7-7bc1-4146-8813-66b951e63a96}*SharedItemsImports = 9
 		shared\base.vcxitems*{41332e9a-729c-45c4-bde1-a567608dadf2}*SharedItemsImports = 4
 		shared\geometry.vcxitems*{41332e9a-729c-45c4-bde1-a567608dadf2}*SharedItemsImports = 4
@@ -664,6 +668,7 @@ Global
 		shared\numerics.vcxitems*{873680b3-2406-4a30-9ee7-569e9b9da661}*SharedItemsImports = 4
 		shared\base.vcxitems*{972e4e09-3b2c-4a23-9338-74d97d589207}*SharedItemsImports = 4
 		shared\numerics.vcxitems*{972e4e09-3b2c-4a23-9338-74d97d589207}*SharedItemsImports = 4
+		shared\version.generated.vcxitems*{972e4e09-3b2c-4a23-9338-74d97d589207}*SharedItemsImports = 4
 		shared\base.vcxitems*{9e0ae155-47b1-4090-af00-038af87a876d}*SharedItemsImports = 4
 		shared\functions\functions.vcxitems*{9e0ae155-47b1-4090-af00-038af87a876d}*SharedItemsImports = 4
 		shared\geometry.vcxitems*{9e0ae155-47b1-4090-af00-038af87a876d}*SharedItemsImports = 4
@@ -673,12 +678,14 @@ Global
 		shared\geometry.vcxitems*{a3f94607-2666-408f-af98-0e47d61c98bb}*SharedItemsImports = 4
 		shared\journal.vcxitems*{a3f94607-2666-408f-af98-0e47d61c98bb}*SharedItemsImports = 4
 		shared\numerics.vcxitems*{a3f94607-2666-408f-af98-0e47d61c98bb}*SharedItemsImports = 4
+		shared\version.generated.vcxitems*{a3f94607-2666-408f-af98-0e47d61c98bb}*SharedItemsImports = 4
 		shared\base.vcxitems*{a82cb04c-42e1-4ebe-9816-6fc033a9c2b5}*SharedItemsImports = 9
 		shared\astronomy.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
 		shared\base.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
 		shared\geometry.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
 		shared\journal.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
 		shared\numerics.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
+		shared\version.generated.vcxitems*{a942adf0-62f4-435c-85b2-934d5b666db8}*SharedItemsImports = 4
 		shared\numerics.vcxitems*{c59f84da-2f82-43dd-bba4-5a469b32557c}*SharedItemsImports = 9
 	EndGlobalSection
 EndGlobal

--- a/journal/journal.vcxproj
+++ b/journal/journal.vcxproj
@@ -8,6 +8,7 @@
   <ImportGroup Label="Shared">
     <Import Project="..\shared\base.vcxitems" Label="Shared" />
     <Import Project="..\shared\numerics.vcxitems" Label="Shared" />
+    <Import Project="..\shared\version.generated.vcxitems" Label="Shared" />
   </ImportGroup>
   <ItemGroup>
     <ClInclude Include="concepts.hpp" />

--- a/ksp_plugin/ksp_plugin.vcxproj
+++ b/ksp_plugin/ksp_plugin.vcxproj
@@ -11,6 +11,7 @@
     <Import Project="..\shared\journal.vcxitems" Label="Shared" />
     <Import Project="..\shared\numerics.vcxitems" Label="Shared" />
     <Import Project="..\shared\astronomy.vcxitems" Label="Shared" />
+    <Import Project="..\shared\version.generated.vcxitems" Label="Shared" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/ksp_plugin_test/ksp_plugin_test.vcxproj
+++ b/ksp_plugin_test/ksp_plugin_test.vcxproj
@@ -11,6 +11,7 @@
     <Import Project="..\shared\numerics.vcxitems" Label="Shared" />
     <Import Project="..\shared\journal.vcxitems" Label="Shared" />
     <Import Project="..\shared\astronomy.vcxitems" Label="Shared" />
+    <Import Project="..\shared\version.generated.vcxitems" Label="Shared" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/shared/version.generated.vcxitems
+++ b/shared/version.generated.vcxitems
@@ -3,7 +3,7 @@
   <PropertyGroup Label="Globals">
     <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
-    <ItemsProjectGuid>{a82cb04c-42e1-4ebe-9816-6fc033a9c2b5}</ItemsProjectGuid>
+    <ItemsProjectGuid>{36291755-D6D8-42AE-B40C-C97EE6412A73}</ItemsProjectGuid>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -14,11 +14,6 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\bundle.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\cpuid.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\file_log_sink.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\flags.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\string_log_sink.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\zfp_compressor.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\base\version.generated.cc" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Prior to this PR, any change to `version.generated.cc` (i.e., any commit or any "dirtying" of the branch) would result in `tools.exe` being recompiled (because it depended on the `base` shared item).  This in turn caused `generate_profile` to be rerun as part of the custom build event for `tools`.  Even though the output files were generally not touched (see #4630), the compiler would assume that all the dependents of the output files needed to be recompiled, and trigger massive recompilation in `journal`, `ksp_plugin` and `ksp_plugin_test`.

With this PR the `base` shared item no longer contains `version.generated.cc`, which now live in its own shared item.  Therefore, `tools` is not recompiled (and rerun) when the version changes.  The only thing that need to happen in that case is to relink the projects that actually pull the `version.generated` shared item.